### PR TITLE
feat(sdk): LLM streaming telemetry (TTFT, decode/prefill TPS, ITL)

### DIFF
--- a/crates/xybrid-cli/src/commands/run.rs
+++ b/crates/xybrid-cli/src/commands/run.rs
@@ -524,6 +524,7 @@ pub(crate) fn run_bundle(
     let (output, elapsed) = run_inference(&extract_dir, &metadata, &input, trace_enabled)?;
 
     print_inference_results(&metadata, &output, elapsed, output_path)?;
+    print_llm_trace_block(&output, trace_enabled);
     emit_pipeline_complete_event(&metadata, &output, elapsed);
 
     if trace_enabled {
@@ -532,6 +533,43 @@ pub(crate) fn run_bundle(
     }
 
     Ok(())
+}
+
+/// Print the per-inference LLM telemetry block populated by the adapter's
+/// streaming path. Keys match `runtime_adapter/llm.rs`'s envelope metadata
+/// inserts. Non-LLM stages (no `ttft_ms`) emit nothing so ASR/TTS runs stay
+/// quiet under `--trace`.
+fn print_llm_trace_block(output: &Envelope, trace_enabled: bool) {
+    if !trace_enabled || !output.metadata.contains_key("ttft_ms") {
+        return;
+    }
+    let m = &output.metadata;
+    println!();
+    println!("LLM Trace");
+    println!("{}", "-".repeat(60));
+    let rows: &[(&str, &str, &str)] = &[
+        ("ttft_ms", "TTFT", " ms"),
+        ("decode_tps", "Decode TPS", " tok/s"),
+        ("prefill_tps", "Prefill TPS", " tok/s"),
+        ("tokens_per_second", "Wallclock TPS", " tok/s"),
+        ("mean_itl_ms", "Mean ITL", " ms"),
+        ("p95_itl_ms", "p95 ITL", " ms"),
+        ("emitted_chunks", "Emitted chunks", ""),
+        ("tokens_generated", "Tokens generated", ""),
+        ("finish_reason", "Finish reason", ""),
+    ];
+    for (key, label, suffix) in rows {
+        let present = m.contains_key(*key);
+        let val = m.get(*key).map(|s| s.as_str()).unwrap_or("—");
+        println!(
+            "  {:<22}: {}{}",
+            label,
+            val,
+            if present { suffix } else { "" }
+        );
+    }
+    println!("{}", "-".repeat(60));
+    println!();
 }
 
 /// Run inference on a model directly from the registry.
@@ -651,6 +689,7 @@ pub(crate) fn run_model(
     let (output, elapsed) = run_inference(&extract_dir, &metadata, &input, trace_enabled)?;
 
     print_inference_results(&metadata, &output, elapsed, output_path)?;
+    print_llm_trace_block(&output, trace_enabled);
     emit_pipeline_complete_event(&metadata, &output, elapsed);
 
     if trace_enabled {
@@ -703,6 +742,7 @@ pub(crate) fn run_directory(
     let (output, elapsed) = run_inference(dir, &metadata, &input, trace_enabled)?;
 
     print_inference_results(&metadata, &output, elapsed, output_path)?;
+    print_llm_trace_block(&output, trace_enabled);
     emit_pipeline_complete_event(&metadata, &output, elapsed);
 
     if trace_enabled {
@@ -769,6 +809,7 @@ pub(crate) fn run_huggingface(
     let (output, elapsed) = run_inference(&cache_dir, &metadata, &input, trace_enabled)?;
 
     print_inference_results(&metadata, &output, elapsed, output_path)?;
+    print_llm_trace_block(&output, trace_enabled);
     emit_pipeline_complete_event(&metadata, &output, elapsed);
 
     if trace_enabled {
@@ -863,6 +904,7 @@ pub(crate) fn run_model_file(
     let (output, elapsed) = run_inference(parent_dir, &metadata, &input, trace_enabled)?;
 
     print_inference_results(&metadata, &output, elapsed, output_path)?;
+    print_llm_trace_block(&output, trace_enabled);
     emit_pipeline_complete_event(&metadata, &output, elapsed);
 
     if trace_enabled {

--- a/crates/xybrid-core/examples/llm_streaming_metrics.rs
+++ b/crates/xybrid-core/examples/llm_streaming_metrics.rs
@@ -1,0 +1,213 @@
+//! LLM streaming telemetry metrics — TTFT, TPS, ITL.
+//!
+//! Runs a local GGUF LLM through the standard `TemplateExecutor` path and
+//! reports the streaming-derived telemetry fields (time-to-first-token,
+//! mean / p95 inter-chunk latency, emitted chunk count) alongside the
+//! existing aggregate metrics.
+//!
+//! Run with:
+//!   cargo run --example llm_streaming_metrics -p xybrid-core --features llm-mistral --release
+//!
+//! To also export telemetry to a local ingest service, set:
+//!   XYBRID_API_KEY=<your-api-key> \
+//!   XYBRID_INGEST_URL=http://localhost:8081 \
+//!   cargo run --example llm_streaming_metrics -p xybrid-core --features llm-mistral --release
+//!
+//! Reuses the `integration-tests/fixtures/models/qwen2.5-0.5b-instruct/`
+//! fixture. See `integration-tests/download.sh` for download instructions
+//! if the model isn't present locally.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use xybrid_core::execution_template::ModelMetadata;
+use xybrid_core::ir::{Envelope, EnvelopeKind};
+use xybrid_core::template_executor::TemplateExecutor;
+
+// For telemetry export and trace ID generation.
+extern crate serde_json;
+extern crate uuid;
+extern crate xybrid_sdk;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("═══════════════════════════════════════════════════════");
+    println!("  LLM Streaming Metrics — TTFT / TPS / ITL");
+    println!("═══════════════════════════════════════════════════════");
+    println!();
+
+    // Initialize platform telemetry if XYBRID_API_KEY is set.
+    // This sends telemetry events to the ingest service (local or prod)
+    // so the dashboard can display the LLM metrics.
+    let telemetry_enabled = xybrid_sdk::init_platform_telemetry_from_env();
+    if telemetry_enabled {
+        println!(
+            "📡 Platform telemetry enabled (sending to {})",
+            std::env::var("XYBRID_INGEST_URL").unwrap_or_else(|_| "default endpoint".into())
+        );
+        // Set a trace ID so the exporter can group the event.
+        let trace_id = uuid::Uuid::new_v4();
+        xybrid_sdk::set_telemetry_pipeline_context(None, Some(trace_id));
+    } else {
+        println!("ℹ️  Platform telemetry disabled (set XYBRID_API_KEY to enable)");
+    }
+    println!();
+
+    let model_dir = PathBuf::from("integration-tests/fixtures/models/qwen2.5-0.5b-instruct");
+    if !model_dir.exists() {
+        eprintln!("❌ Model directory not found: {}", model_dir.display());
+        eprintln!("   Run `integration-tests/download.sh qwen2.5-0.5b-instruct` first.");
+        return Err("Model not found".into());
+    }
+
+    let metadata_path = model_dir.join("model_metadata.json");
+    let metadata: ModelMetadata = serde_json::from_str(&std::fs::read_to_string(&metadata_path)?)?;
+
+    let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
+
+    // Force `max_tokens` high enough that multi-chunk output is the common
+    // case — otherwise a too-short reply can legitimately arrive as a single
+    // chunk, in which case ITL summaries are correctly `None`.
+    let mut envelope_metadata = HashMap::new();
+    envelope_metadata.insert(
+        "system_prompt".to_string(),
+        "You are a helpful assistant.".to_string(),
+    );
+    envelope_metadata.insert("max_tokens".to_string(), "64".to_string());
+    envelope_metadata.insert("temperature".to_string(), "0.7".to_string());
+
+    let prompt = "List five interesting facts about the city of Lisbon.";
+    let input = Envelope {
+        kind: EnvelopeKind::Text(prompt.to_string()),
+        metadata: envelope_metadata,
+    };
+
+    println!("💬 Prompt: {}", prompt);
+    println!("🔄 Running streaming inference (first run loads the model)...");
+    println!();
+
+    let output = executor.execute(&metadata, &input, None)?;
+
+    let response_text = match &output.kind {
+        EnvelopeKind::Text(t) => t.clone(),
+        _ => return Err("expected text output from LLM".into()),
+    };
+
+    println!("═══════════════════════════════════════════════════════");
+    println!("📤 Response:");
+    println!("═══════════════════════════════════════════════════════");
+    println!("{}", response_text);
+    println!("═══════════════════════════════════════════════════════");
+    println!();
+
+    let m = &output.metadata;
+
+    println!("📊 Aggregate metrics:");
+    println!(
+        "   tokens_generated   : {}",
+        m.get("tokens_generated").map(|s| s.as_str()).unwrap_or("?")
+    );
+    println!(
+        "   generation_time_ms : {}",
+        m.get("generation_time_ms")
+            .map(|s| s.as_str())
+            .unwrap_or("?")
+    );
+    println!(
+        "   tokens_per_second  : {}",
+        m.get("tokens_per_second")
+            .map(|s| s.as_str())
+            .unwrap_or("?")
+    );
+    println!(
+        "   finish_reason      : {}",
+        m.get("finish_reason").map(|s| s.as_str()).unwrap_or("?")
+    );
+    println!();
+
+    println!("📊 Streaming metrics:");
+    let ttft = m.get("ttft_ms");
+    let mean_itl = m.get("mean_itl_ms");
+    let p95_itl = m.get("p95_itl_ms");
+    let emitted_chunks: Option<u32> = m.get("emitted_chunks").and_then(|s| s.parse().ok());
+    println!(
+        "   ttft_ms            : {}",
+        ttft.map(|s| s.as_str()).unwrap_or("(unset)")
+    );
+    println!(
+        "   emitted_chunks     : {}",
+        emitted_chunks
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "(unset)".into())
+    );
+    println!(
+        "   mean_itl_ms        : {}",
+        mean_itl.map(|s| s.as_str()).unwrap_or("(none)")
+    );
+    println!(
+        "   p95_itl_ms         : {}",
+        p95_itl.map(|s| s.as_str()).unwrap_or("(none)")
+    );
+    println!();
+
+    // Soft assertions (per plan): TTFT must be present whenever at least one
+    // chunk arrived; ITL summaries are only required when multiple chunks
+    // were emitted (a one-chunk reply is a legitimate degenerate case).
+    assert!(
+        ttft.is_some(),
+        "TTFT must be measured whenever at least one chunk arrives"
+    );
+    if emitted_chunks.unwrap_or(0) > 1 {
+        assert!(
+            mean_itl.is_some(),
+            "mean_itl_ms must be present when multiple chunks were emitted"
+        );
+        assert!(
+            p95_itl.is_some(),
+            "p95_itl_ms must be present when multiple chunks were emitted"
+        );
+    }
+
+    println!("🎯 VALIDATION:");
+    println!("   ✅ TTFT measured");
+    if emitted_chunks.unwrap_or(0) > 1 {
+        println!("   ✅ Mean / p95 ITL measured");
+    } else {
+        println!("   ℹ️  Single-chunk reply — ITL summaries legitimately absent");
+    }
+    println!();
+
+    // Publish a ModelComplete event so the exporter converts it to a
+    // PlatformEvent with stages (including LLM span metadata).
+    // The exporter calls core_tracing::get_stages_json() on
+    // PipelineComplete / ModelComplete events to attach span data.
+    if telemetry_enabled {
+        let elapsed_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        xybrid_sdk::publish_telemetry_event(xybrid_sdk::TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("qwen2.5-0.5b-instruct".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: m.get("generation_time_ms").and_then(|s| s.parse().ok()),
+            error: None,
+            data: Some(
+                serde_json::json!({
+                    "model_id": "qwen2.5-0.5b-instruct",
+                    "output_type": "Text",
+                })
+                .to_string(),
+            ),
+            timestamp_ms: elapsed_ms,
+        });
+
+        println!("📡 Flushing telemetry...");
+        // Small delay to let the exporter batch pick up the event.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        xybrid_sdk::flush_platform_telemetry();
+        xybrid_sdk::shutdown_platform_telemetry();
+        println!("   ✅ Telemetry sent to ingest");
+    }
+
+    Ok(())
+}

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -920,10 +920,7 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert(
-            "finish_reason".to_string(),
-            output.finish_reason.clone(),
-        );
+        response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
         mirror_llm_metrics_to_span(&output);
 
@@ -1007,10 +1004,7 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert(
-            "finish_reason".to_string(),
-            output.finish_reason.clone(),
-        );
+        response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
         mirror_llm_metrics_to_span(&output);
 
@@ -1099,10 +1093,7 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert(
-            "finish_reason".to_string(),
-            output.finish_reason.clone(),
-        );
+        response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
         mirror_llm_metrics_to_span(&output);
 
@@ -1254,10 +1245,7 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert(
-            "finish_reason".to_string(),
-            output.finish_reason.clone(),
-        );
+        response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
         mirror_llm_metrics_to_span(&output);
 
@@ -1998,10 +1986,7 @@ fn mirror_llm_metrics_to_span(output: &crate::runtime_adapter::llm::GenerationOu
     // `PlatformEvent.stages[].spans[].metadata` (populated by
     // `xybrid_core::tracing::add_metadata` on the currently active span).
     xybrid_trace::add_metadata("tokens_generated", output.tokens_generated.to_string());
-    xybrid_trace::add_metadata(
-        "generation_time_ms",
-        output.generation_time_ms.to_string(),
-    );
+    xybrid_trace::add_metadata("generation_time_ms", output.generation_time_ms.to_string());
     xybrid_trace::add_metadata(
         "tokens_per_second",
         format!("{:.2}", output.tokens_per_second),

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -920,7 +920,12 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert("finish_reason".to_string(), output.finish_reason);
+        response_metadata.insert(
+            "finish_reason".to_string(),
+            output.finish_reason.clone(),
+        );
+        insert_llm_streaming_metrics(&mut response_metadata, &output);
+        mirror_llm_metrics_to_span(&output);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1002,7 +1007,12 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert("finish_reason".to_string(), output.finish_reason);
+        response_metadata.insert(
+            "finish_reason".to_string(),
+            output.finish_reason.clone(),
+        );
+        insert_llm_streaming_metrics(&mut response_metadata, &output);
+        mirror_llm_metrics_to_span(&output);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1089,7 +1099,12 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert("finish_reason".to_string(), output.finish_reason);
+        response_metadata.insert(
+            "finish_reason".to_string(),
+            output.finish_reason.clone(),
+        );
+        insert_llm_streaming_metrics(&mut response_metadata, &output);
+        mirror_llm_metrics_to_span(&output);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1239,7 +1254,12 @@ impl TemplateExecutor {
             "tokens_per_second".to_string(),
             format!("{:.2}", output.tokens_per_second),
         );
-        response_metadata.insert("finish_reason".to_string(), output.finish_reason);
+        response_metadata.insert(
+            "finish_reason".to_string(),
+            output.finish_reason.clone(),
+        );
+        insert_llm_streaming_metrics(&mut response_metadata, &output);
+        mirror_llm_metrics_to_span(&output);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1929,6 +1949,85 @@ fn crossfade_audio_chunks(chunks: &[Vec<f32>], crossfade_len: usize) -> Vec<f32>
 impl Default for TemplateExecutor {
     fn default() -> Self {
         Self::new("")
+    }
+}
+
+// =============================================================================
+// LLM streaming-telemetry helpers
+// =============================================================================
+//
+// The executor's four LLM execution paths (`execute_llm`,
+// `execute_llm_streaming`, `execute_llm_with_messages`,
+// `execute_llm_streaming_with_messages`) all call
+// `adapter.backend().generate(...)` directly, bypassing
+// `runtime_adapter::llm::LlmRuntimeAdapter::execute()` where the telemetry
+// extraction originally lived. These helpers re-apply the same contract at
+// the executor layer so all four paths surface the 9 LLM scalars expected
+// by the platform ingest (repos/xybrid-platform/ingest/src/tinybird.rs).
+//
+// Keys match the Tinybird `telemetry_spans` datasource columns exactly.
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn insert_llm_streaming_metrics(
+    response_metadata: &mut HashMap<String, String>,
+    output: &crate::runtime_adapter::llm::GenerationOutput,
+) {
+    if let Some(v) = output.ttft_ms {
+        response_metadata.insert("ttft_ms".to_string(), v.to_string());
+    }
+    if let Some(v) = output.mean_itl_ms {
+        response_metadata.insert("mean_itl_ms".to_string(), format!("{:.4}", v));
+    }
+    if let Some(v) = output.p95_itl_ms {
+        response_metadata.insert("p95_itl_ms".to_string(), v.to_string());
+    }
+    if let Some(v) = output.emitted_chunks {
+        response_metadata.insert("emitted_chunks".to_string(), v.to_string());
+    }
+    if let Some(v) = output.decode_tps {
+        response_metadata.insert("decode_tps".to_string(), format!("{:.4}", v));
+    }
+    if let Some(v) = output.prefill_tps {
+        response_metadata.insert("prefill_tps".to_string(), format!("{:.4}", v));
+    }
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn mirror_llm_metrics_to_span(output: &crate::runtime_adapter::llm::GenerationOutput) {
+    // Always-present scalars. These reach the platform via
+    // `PlatformEvent.stages[].spans[].metadata` (populated by
+    // `xybrid_core::tracing::add_metadata` on the currently active span).
+    xybrid_trace::add_metadata("tokens_generated", output.tokens_generated.to_string());
+    xybrid_trace::add_metadata(
+        "generation_time_ms",
+        output.generation_time_ms.to_string(),
+    );
+    xybrid_trace::add_metadata(
+        "tokens_per_second",
+        format!("{:.2}", output.tokens_per_second),
+    );
+    xybrid_trace::add_metadata("finish_reason", &output.finish_reason);
+
+    // Streaming-derived scalars. Only mirror when the backend reported them;
+    // the `Option<_>` + `nonzero` filter in mistral keeps misleading zeros
+    // out of the dashboard.
+    if let Some(v) = output.ttft_ms {
+        xybrid_trace::add_metadata("ttft_ms", v.to_string());
+    }
+    if let Some(v) = output.mean_itl_ms {
+        xybrid_trace::add_metadata("mean_itl_ms", format!("{:.4}", v));
+    }
+    if let Some(v) = output.p95_itl_ms {
+        xybrid_trace::add_metadata("p95_itl_ms", v.to_string());
+    }
+    if let Some(v) = output.emitted_chunks {
+        xybrid_trace::add_metadata("emitted_chunks", v.to_string());
+    }
+    if let Some(v) = output.decode_tps {
+        xybrid_trace::add_metadata("decode_tps", format!("{:.4}", v));
+    }
+    if let Some(v) = output.prefill_tps {
+        xybrid_trace::add_metadata("prefill_tps", format!("{:.4}", v));
     }
 }
 

--- a/crates/xybrid-core/src/execution/strategies/llm.rs
+++ b/crates/xybrid-core/src/execution/strategies/llm.rs
@@ -274,8 +274,7 @@ impl Default for DefaultLlmInference {
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 impl LlmInference for DefaultLlmInference {
     fn load_model(&mut self, config: &LlmModelConfig) -> ExecutorResult<()> {
-        use crate::runtime_adapter::llm::LlmRuntimeAdapter;
-        use crate::runtime_adapter::RuntimeAdapter;
+        use crate::runtime_adapter::llm::{LlmConfig, LlmRuntimeAdapter};
 
         // Determine backend hint
         let hint = config
@@ -283,9 +282,18 @@ impl LlmInference for DefaultLlmInference {
             .as_deref()
             .or(self.backend_hint.as_deref());
 
+        // Build the rich LlmConfig so chat_template and context_length
+        // reach the backend instead of being dropped by the trait
+        // `load_model(path)` wrapper.
+        let mut llm_config = LlmConfig::new(&config.model_path);
+        llm_config.context_length = config.context_length;
+        if let Some(template_path) = config.chat_template.as_ref() {
+            llm_config = llm_config.with_chat_template(template_path.clone());
+        }
+
         // Create adapter with backend hint
         let mut adapter = LlmRuntimeAdapter::with_backend_hint(hint)?;
-        adapter.load_model(&config.model_path)?;
+        adapter.load_model_with_config(&llm_config)?;
 
         self.adapter = Some(adapter);
         Ok(())

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -50,7 +50,8 @@ fn strip_thinking_tags(text: &str) -> String {
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
 };
-use crate::runtime_adapter::llm_telemetry::itl_stats;
+#[cfg(feature = "llm-llamacpp")]
+use crate::runtime_adapter::llm_telemetry::StreamingTelemetry;
 use crate::runtime_adapter::AdapterError;
 use std::sync::Mutex;
 #[cfg(feature = "llm-llamacpp")]
@@ -295,12 +296,15 @@ impl LlmBackend for LlamaCppBackend {
             config.repetition_penalty,
             &config.stop_sequences,
             |_token_id, _token_text| {
-                chunk_timestamps.push(std::time::Instant::now());
+                tel.record_chunk();
                 Ok(())
             },
         )?;
 
-        let elapsed = start.elapsed();
+        // Finalize telemetry before the post-processing work below so
+        // `generation_time_ms` reflects pure generation wallclock and is
+        // not inflated by detokenization / stop-sequence scanning.
+        let fields = tel.finalize(output_tokens.len());
 
         // Log generated token count and last few tokens for debugging
         log::debug!(
@@ -371,70 +375,26 @@ impl LlmBackend for LlamaCppBackend {
         // Trim any trailing whitespace from the response
         let text = text.trim().to_string();
 
-        let tokens_generated = output_tokens.len();
-        let tokens_per_second = if elapsed.as_secs_f32() > 0.0 {
-            tokens_generated as f32 / elapsed.as_secs_f32()
-        } else {
-            0.0
         };
-
-        // Streaming-derived telemetry from per-token timestamps.
-        // First timestamp marks end-of-prefill / start-of-decode, so
-        // `ttft_ms` captures the prefill phase and the inter-chunk gaps
-        // that follow are the steady-state decode cadence.
-        let ttft_ms = chunk_timestamps
-            .first()
-            .map(|t0| t0.duration_since(start).as_millis() as u64);
-        let inter_chunk_ms: Vec<u32> = chunk_timestamps
-            .windows(2)
-            .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
-            .collect();
-        let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
-
-        // Derive decode_tps and prefill_tps from signals we already have.
-        // llama.cpp's sys bindings don't expose `llama_perf_context`'s
-        // `t_p_eval_ms` / `t_eval_ms`, so these are inferred rather than
-        // reported by the engine — document the semantics inline.
-        //
-        // decode_tps: inverse of mean inter-chunk latency. This is the
-        // textbook definition of steady-state decode throughput — every
-        // inter-token gap is a decode step, so `1000 / mean_gap_ms` is
-        // tokens/sec during the decode phase (excluding prefill).
-        let decode_tps = mean_itl_ms.and_then(|mean| {
-            if mean > 0.0 {
-                Some(1000.0 / mean)
-            } else {
-                None
-            }
-        });
-        // prefill_tps: prompt tokens / TTFT. TTFT covers prompt evaluation
-        // plus one token's worth of sampling; on prompts long enough for
-        // prefill to dominate, this approximates the prefill throughput
-        // mistralrs reports directly. For very short prompts the sampler
-        // overhead biases the number downward, which matches mistral's
-        // own "below timing resolution → None" semantics via the zero
-        // filter below.
-        let prefill_tps = ttft_ms.and_then(|ttft| {
-            if ttft > 0 && !tokens.is_empty() {
-                Some(tokens.len() as f32 * 1000.0 / ttft as f32)
-            } else {
-                None
-            }
-        });
-
+        // Telemetry derivation (TTFT, mean/p95 ITL, decode_tps, prefill_tps)
+        // lives in `llm_telemetry::StreamingTelemetry` and is shared with
+        // the mistral backend — llama.cpp's sys bindings don't expose
+        // `llama_perf_context`'s `t_p_eval_ms` / `t_eval_ms`, so the
+        // numbers are derived from per-chunk timestamps. See
+        // `compute_streaming_fields` for formula semantics.
         Ok(GenerationOutput {
             text,
-            tokens_generated,
-            generation_time_ms: elapsed.as_millis() as u64,
-            tokens_per_second,
+            tokens_generated: output_tokens.len(),
+            generation_time_ms: fields.generation_time_ms,
+            tokens_per_second: fields.tokens_per_second,
             finish_reason,
-            ttft_ms,
-            mean_itl_ms,
-            p95_itl_ms,
-            emitted_chunks: Some(chunk_timestamps.len() as u32),
-            inter_chunk_ms,
-            decode_tps,
-            prefill_tps,
+            ttft_ms: fields.ttft_ms,
+            mean_itl_ms: fields.mean_itl_ms,
+            p95_itl_ms: fields.p95_itl_ms,
+            emitted_chunks: fields.emitted_chunks,
+            inter_chunk_ms: fields.inter_chunk_ms,
+            decode_tps: fields.decode_tps,
+            prefill_tps: fields.prefill_tps,
         })
     }
 
@@ -546,18 +506,20 @@ impl LlmBackend for LlamaCppBackend {
             )));
         }
 
-        let start = std::time::Instant::now();
-
-        // Per-callback timestamps for streaming telemetry (TTFT, ITL, chunk
-        // count). Recorded on every invocation of the C-layer callback
-        // regardless of whether the token was emitted to the external
-        // `on_token` — the stream itself is what's being measured, not
-        // user-visible output.
-        let mut chunk_timestamps: Vec<std::time::Instant> = Vec::new();
-
-        // Track cumulative text and what we've safely emitted
-        let mut cumulative_text = String::new();
-        let mut last_emitted_len = 0usize;
+        // Shared streaming state: telemetry recorder + text filter.
+        // The filter owns cumulative text, think-block state, stop-pattern
+        // detection, and safe-prefix buffering — this backend just feeds
+        // raw chunks in and emits whatever comes out. See
+        // `streaming_postprocess` for the contract.
+        //
+        // Stop patterns are cloned once so the filter can own them while
+        // the C layer and final-text cleanup keep a reference. The
+        // `_BROKEN` variants are intentionally excluded from streaming
+        // (they false-positive on legitimate text) — they only run in
+        // the final cleanup pass below.
+        let mut tel = StreamingTelemetry::new(tokens.len());
+        let stop_patterns = merge_stop_patterns(&config.stop_sequences, CHAT_STOP_PATTERNS);
+        let mut filter = StreamingTextFilter::new(stop_patterns.clone());
         let mut token_index = 0usize;
         let mut hit_stop_pattern = false;
         let mut inside_think_block = false;
@@ -659,6 +621,10 @@ impl LlmBackend for LlamaCppBackend {
                 // Find the safe portion to emit (excluding potential stop sequence starts)
                 let safe_end =
                     find_potential_stop_start(&cumulative_text).unwrap_or(cumulative_text.len());
+                // Timestamp every C-layer callback, before any filtering —
+                // the stream itself is what's being measured, not the
+                // user-visible emission.
+                tel.record_chunk();
 
                 // Only emit if we have new safe content
                 if safe_end > last_emitted_len {
@@ -679,9 +645,11 @@ impl LlmBackend for LlamaCppBackend {
             },
         )?;
 
-        let elapsed = start.elapsed();
-
-        // Decode tokens to text (for final output)
+        // Finalize telemetry before post-processing so `generation_time_ms`
+        // reflects only the generation loop, not detokenization or
+        // stop-pattern cleanup. Shared with `generate()` — see
+        // `compute_streaming_fields`.
+        let fields = tel.finalize(output_tokens.len());
         let mut text = sys::llama_detokenize(model, &output_tokens)?;
 
         // Apply stop sequence truncation (safety net - streaming callback already truncated)
@@ -732,13 +700,6 @@ impl LlmBackend for LlamaCppBackend {
 
         let text = text.trim().to_string();
 
-        let tokens_generated = output_tokens.len();
-        let tokens_per_second = if elapsed.as_secs_f32() > 0.0 {
-            tokens_generated as f32 / elapsed.as_secs_f32()
-        } else {
-            0.0
-        };
-
         // Send final token with finish reason
         if token_index > 0 {
             let final_partial = PartialToken::new(String::new(), token_index, text.clone())
@@ -748,45 +709,19 @@ impl LlmBackend for LlamaCppBackend {
             let _ = on_token(final_partial);
         }
 
-        // Streaming-derived telemetry — same contract as `generate()`'s
-        // non-streaming path. Timestamps came from the C-layer callback
-        // on every token (see `chunk_timestamps` initialization above).
-        let ttft_ms = chunk_timestamps
-            .first()
-            .map(|t0| t0.duration_since(start).as_millis() as u64);
-        let inter_chunk_ms: Vec<u32> = chunk_timestamps
-            .windows(2)
-            .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
-            .collect();
-        let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
-        let decode_tps = mean_itl_ms.and_then(|mean| {
-            if mean > 0.0 {
-                Some(1000.0 / mean)
-            } else {
-                None
-            }
-        });
-        let prefill_tps = ttft_ms.and_then(|ttft| {
-            if ttft > 0 && !tokens.is_empty() {
-                Some(tokens.len() as f32 * 1000.0 / ttft as f32)
-            } else {
-                None
-            }
-        });
-
         Ok(GenerationOutput {
             text,
-            tokens_generated,
-            generation_time_ms: elapsed.as_millis() as u64,
-            tokens_per_second,
+            tokens_generated: output_tokens.len(),
+            generation_time_ms: fields.generation_time_ms,
+            tokens_per_second: fields.tokens_per_second,
             finish_reason,
-            ttft_ms,
-            mean_itl_ms,
-            p95_itl_ms,
-            emitted_chunks: Some(chunk_timestamps.len() as u32),
-            inter_chunk_ms,
-            decode_tps,
-            prefill_tps,
+            ttft_ms: fields.ttft_ms,
+            mean_itl_ms: fields.mean_itl_ms,
+            p95_itl_ms: fields.p95_itl_ms,
+            emitted_chunks: fields.emitted_chunks,
+            inter_chunk_ms: fields.inter_chunk_ms,
+            decode_tps: fields.decode_tps,
+            prefill_tps: fields.prefill_tps,
         })
     }
 

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -26,32 +26,16 @@ mod sys;
 // Re-export log control functions for external use
 pub use sys::{llama_log_get_verbosity, llama_log_set_verbosity};
 
-/// Strip thinking/reasoning tags from model output.
-///
-/// Models like Qwen 3.5 emit `<think>...</think>` blocks before the actual
-/// response. This function removes those blocks so only the user-facing
-/// content remains.
-fn strip_thinking_tags(text: &str) -> String {
-    let mut result = text.to_string();
-    // Remove all <think>...</think> blocks (greedy within each block)
-    while let Some(start) = result.find("<think>") {
-        if let Some(end) = result[start..].find("</think>") {
-            let end_absolute = start + end + "</think>".len();
-            result.replace_range(start..end_absolute, "");
-        } else {
-            // Opening tag without closing — strip from <think> to end
-            result.truncate(start);
-            break;
-        }
-    }
-    result
-}
-
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
 };
 #[cfg(feature = "llm-llamacpp")]
 use crate::runtime_adapter::llm_telemetry::StreamingTelemetry;
+#[cfg(feature = "llm-llamacpp")]
+use crate::runtime_adapter::streaming_postprocess::{
+    merge_stop_patterns, strip_thinking_tags, trim_partial_stop_suffix, truncate_at_first_stop,
+    StreamingTextFilter, CHAT_STOP_PATTERNS, CHAT_STOP_PATTERNS_BROKEN,
+};
 use crate::runtime_adapter::AdapterError;
 use std::sync::Mutex;
 #[cfg(feature = "llm-llamacpp")]
@@ -276,14 +260,12 @@ impl LlmBackend for LlamaCppBackend {
             )));
         }
 
-        let start = std::time::Instant::now();
-
-        // Use the streaming API internally so we can capture per-token
-        // timestamps for TTFT + inter-token-latency telemetry. The closure
-        // is observation-only (no external emission) — generation still
-        // returns the full token vector like `llama_generate_with_stops`
-        // did. Keeps the non-streaming contract of this function intact.
-        let mut chunk_timestamps: Vec<std::time::Instant> = Vec::new();
+        // Per-chunk timestamps capture the streaming cadence for TTFT +
+        // inter-token-latency telemetry. The closure is observation-only
+        // (no external emission) — generation still returns the full
+        // token vector like `llama_generate_with_stops` did. Keeps the
+        // non-streaming contract of this function intact.
+        let mut tel = StreamingTelemetry::new(tokens.len());
         let (output_tokens, _stopped_by_callback) = sys::llama_generate_streaming(
             context,
             model,
@@ -321,61 +303,20 @@ impl LlmBackend for LlamaCppBackend {
         log::debug!(target: "xybrid_core", "LLM raw output ({} chars): {:?}", text.len(), &text[..text.len().min(200)]);
         log::debug!(target: "xybrid_core", "First 100 bytes: {:?}", text.as_bytes().iter().take(100).collect::<Vec<_>>());
 
-        // Apply stop sequence truncation
-        // Find the earliest occurrence of any stop sequence and truncate there
-        let mut finish_reason = "length".to_string();
-
-        // Build list of patterns to check - include config stop sequences plus common markers
-        let mut stop_patterns: Vec<&str> =
-            config.stop_sequences.iter().map(|s| s.as_str()).collect();
-        // Always check for these common markers even if not in config
-        // Note: <end_of_turn> is Gemma's stop token, <|im_end|> is ChatML (Qwen, Phi)
-        // Also include partial markers without "<" for models using ChatML fallback
-        let extra_patterns = [
-            "<|im_end|>",
-            "<|im_start|>",
-            "<|endoftext|>",
-            "</s>",
-            "<end_of_turn>",
-            "|im_end|>",
-            "|im_start|>",
-            "|endoftext|>",
-            "end_of_turn>",
-        ];
-        for p in &extra_patterns {
-            if !stop_patterns.contains(p) {
-                stop_patterns.push(p);
-            }
-        }
-
-        log::debug!(target: "xybrid_core", "Searching for stop patterns: {:?}", stop_patterns);
-
-        let mut earliest_pos: Option<usize> = None;
-        for stop_seq in &stop_patterns {
-            if let Some(pos) = text.find(stop_seq) {
-                log::debug!(target: "xybrid_core", "Found '{}' at position {}", stop_seq, pos);
-                match earliest_pos {
-                    None => earliest_pos = Some(pos),
-                    Some(current) if pos < current => earliest_pos = Some(pos),
-                    _ => {}
-                }
-            }
-        }
-        if let Some(pos) = earliest_pos {
-            log::debug!(target: "xybrid_core", "Truncating at position {}", pos);
-            text.truncate(pos);
-            finish_reason = "stop".to_string();
-        } else {
-            log::debug!(target: "xybrid_core", "No stop pattern found in text");
-        }
-
-        // Strip thinking tags (e.g., Qwen 3.5 <think>...</think> blocks)
-        let text = strip_thinking_tags(&text);
-
-        // Trim any trailing whitespace from the response
-        let text = text.trim().to_string();
-
+        // Stop-pattern truncation + think-tag stripping live in
+        // `streaming_postprocess`. The `*_BROKEN` patterns cover
+        // tokenizers that split the leading `<` off a chat-template
+        // marker — safe only for final-text cleanup, not streaming.
+        let final_stop_patterns = {
+            let mut extras: Vec<&str> = CHAT_STOP_PATTERNS.to_vec();
+            extras.extend_from_slice(CHAT_STOP_PATTERNS_BROKEN);
+            merge_stop_patterns(&config.stop_sequences, &extras)
         };
+        log::debug!(target: "xybrid_core", "Searching for stop patterns: {:?}", final_stop_patterns);
+        let stopped = truncate_at_first_stop(&mut text, &final_stop_patterns);
+        let text = strip_thinking_tags(&text).trim().to_string();
+        let finish_reason = if stopped { "stop" } else { "length" }.to_string();
+
         // Telemetry derivation (TTFT, mean/p95 ITL, decode_tps, prefill_tps)
         // lives in `llm_telemetry::StreamingTelemetry` and is shared with
         // the mistral backend — llama.cpp's sys bindings don't expose
@@ -521,44 +462,7 @@ impl LlmBackend for LlamaCppBackend {
         let stop_patterns = merge_stop_patterns(&config.stop_sequences, CHAT_STOP_PATTERNS);
         let mut filter = StreamingTextFilter::new(stop_patterns.clone());
         let mut token_index = 0usize;
-        let mut hit_stop_pattern = false;
-        let mut inside_think_block = false;
 
-        // Build stop patterns list for early detection during streaming
-        // Note: <end_of_turn> is Gemma's stop token, <|im_end|> is ChatML (Qwen, Phi)
-        let streaming_stop_patterns: Vec<String> = {
-            let mut patterns: Vec<String> = config.stop_sequences.clone();
-            for p in [
-                "<|im_end|>",
-                "<|im_start|>",
-                "<|endoftext|>",
-                "</s>",
-                "<end_of_turn>",
-            ] {
-                if !patterns.iter().any(|s| s == p) {
-                    patterns.push(p.to_string());
-                }
-            }
-            patterns
-        };
-
-        // Helper: find if text ends with a PREFIX of any stop pattern.
-        // Returns the position where the potential stop sequence starts, or None.
-        // This holds back partial matches so they aren't emitted before the
-        // full pattern is accumulated and caught.
-        let find_potential_stop_start = |text: &str| -> Option<usize> {
-            for pattern in &streaming_stop_patterns {
-                for prefix_len in 1..=pattern.len() {
-                    let prefix = &pattern[..prefix_len];
-                    if text.ends_with(prefix) {
-                        return Some(text.len() - prefix_len);
-                    }
-                }
-            }
-            None
-        };
-
-        // Generate with streaming callback
         let (output_tokens, _stopped_by_callback) = sys::llama_generate_streaming(
             context,
             model,
@@ -569,74 +473,20 @@ impl LlmBackend for LlamaCppBackend {
             config.min_p,
             config.top_k,
             config.repetition_penalty,
-            &streaming_stop_patterns, // Pass full stop patterns to C layer
+            &stop_patterns, // C layer uses these for early stop / llama_vocab_is_eog
             |token_id, token_text| {
-                // Record the timestamp on every C-layer callback, before
-                // any stop-pattern filtering. This keeps the stream-level
-                // timing independent of what actually made it to the
-                // external `on_token` consumer.
-                chunk_timestamps.push(std::time::Instant::now());
-
-                // Once we hit a stop pattern, don't emit any more tokens
-                if hit_stop_pattern {
-                    return Ok(());
-                }
-
-                cumulative_text.push_str(token_text);
-
-                // Handle <think>...</think> blocks: suppress streaming output
-                // while inside a thinking block (Qwen 3.5, etc.)
-                if !inside_think_block && cumulative_text[last_emitted_len..].contains("<think>") {
-                    inside_think_block = true;
-                    // Move emitted pointer past any content before <think>
-                    if let Some(pos) = cumulative_text.find("<think>") {
-                        last_emitted_len = pos;
-                    }
-                }
-                if inside_think_block {
-                    if cumulative_text.contains("</think>") {
-                        inside_think_block = false;
-                        // Strip the think block from cumulative text
-                        cumulative_text = strip_thinking_tags(&cumulative_text);
-                        // Reset emitted length to current cleaned text length
-                        // (nothing new to emit yet, next token will trigger emission)
-                        last_emitted_len = last_emitted_len.min(cumulative_text.len());
-                    }
-                    return Ok(());
-                }
-
-                // Check if any COMPLETE stop pattern is now in the cumulative text
-                for pattern in &streaming_stop_patterns {
-                    if cumulative_text.contains(pattern.as_str()) {
-                        log::debug!(target: "xybrid_core", "Streaming: detected stop pattern '{}', stopping token emission", pattern);
-                        hit_stop_pattern = true;
-                        // Truncate the cumulative text at the stop pattern
-                        if let Some(pos) = cumulative_text.find(pattern.as_str()) {
-                            cumulative_text.truncate(pos);
-                        }
-                        return Ok(());
-                    }
-                }
-
-                // Find the safe portion to emit (excluding potential stop sequence starts)
-                let safe_end =
-                    find_potential_stop_start(&cumulative_text).unwrap_or(cumulative_text.len());
                 // Timestamp every C-layer callback, before any filtering —
                 // the stream itself is what's being measured, not the
                 // user-visible emission.
                 tel.record_chunk();
 
-                // Only emit if we have new safe content
-                if safe_end > last_emitted_len {
-                    let safe_text = &cumulative_text[last_emitted_len..safe_end];
+                if let Some(safe_text) = filter.push(token_text) {
                     let partial = PartialToken::new(
-                        safe_text.to_string(),
+                        safe_text,
                         token_index,
-                        cumulative_text[..safe_end].to_string(),
+                        filter.cumulative_emitted().to_string(),
                     )
                     .with_token_id(token_id as i64);
-
-                    last_emitted_len = safe_end;
                     token_index += 1;
                     on_token(partial)?;
                 }
@@ -650,62 +500,37 @@ impl LlmBackend for LlamaCppBackend {
         // stop-pattern cleanup. Shared with `generate()` — see
         // `compute_streaming_fields`.
         let fields = tel.finalize(output_tokens.len());
-        let mut text = sys::llama_detokenize(model, &output_tokens)?;
 
-        // Apply stop sequence truncation (safety net - streaming callback already truncated)
-        let mut finish_reason = if hit_stop_pattern {
+        // Final-output cleanup: detokenize the full token vector (rather
+        // than using the filter's cumulative text) as a belt-and-braces
+        // guard against chunk-boundary UTF-8 edge cases, then run the
+        // same truncate / trim-partial / strip-think passes used by the
+        // non-streaming path. The `_BROKEN` fallback patterns are
+        // included here because this is final-text only — no streaming
+        // false-positive risk.
+        let final_patterns = {
+            let mut extras: Vec<&str> = CHAT_STOP_PATTERNS.to_vec();
+            extras.extend_from_slice(CHAT_STOP_PATTERNS_BROKEN);
+            merge_stop_patterns(&config.stop_sequences, &extras)
+        };
+        let mut text = sys::llama_detokenize(model, &output_tokens)?;
+        let stopped_full = truncate_at_first_stop(&mut text, &final_patterns);
+        let trimmed_partial = trim_partial_stop_suffix(&mut text, &final_patterns);
+        let text = strip_thinking_tags(&text).trim().to_string();
+        let finish_reason = if filter.is_stopped() || stopped_full || trimmed_partial {
             "stop".to_string()
         } else {
             "length".to_string()
         };
 
-        // Use streaming_stop_patterns (already built above) for final text cleanup
-        let mut earliest_pos: Option<usize> = None;
-        for pattern in &streaming_stop_patterns {
-            if let Some(pos) = text.find(pattern.as_str()) {
-                match earliest_pos {
-                    None => earliest_pos = Some(pos),
-                    Some(current) if pos < current => earliest_pos = Some(pos),
-                    _ => {}
-                }
-            }
-        }
-        if let Some(pos) = earliest_pos {
-            text.truncate(pos);
-            finish_reason = "stop".to_string();
-        }
-
-        // Clean up trailing partial stop tokens.
-        // With llama_vocab_is_eog() catching model stop tokens at the C layer,
-        // we only need to check for partial prefixes of our known stop patterns.
-        for pattern in &streaming_stop_patterns {
-            // Check if text ends with any suffix that is a prefix of a stop pattern.
-            // E.g., text ending with "<|im_" when the stop pattern is "<|im_end|>".
-            for prefix_len in 1..pattern.len() {
-                let prefix = &pattern[..prefix_len];
-                if text.ends_with(prefix) {
-                    log::debug!(target: "xybrid_core", "Cleaning up partial stop token: '{}'", prefix);
-                    text.truncate(text.len() - prefix_len);
-                    finish_reason = "stop".to_string();
-                    break;
-                }
-            }
-            if finish_reason == "stop" {
-                break;
-            }
-        }
-
-        // Strip thinking tags (e.g., Qwen 3.5 <think>...</think> blocks)
-        let text = strip_thinking_tags(&text);
-
-        let text = text.trim().to_string();
-
-        // Send final token with finish reason
+        // Send final empty token with finish_reason — matches the
+        // pre-refactor contract so downstream consumers see a
+        // terminal signal. Guarded on `token_index > 0` to avoid
+        // emitting a stray terminal chunk when nothing was ever
+        // emitted (e.g. immediate stop).
         if token_index > 0 {
             let final_partial = PartialToken::new(String::new(), token_index, text.clone())
                 .with_finish_reason(&finish_reason);
-
-            // Ignore error on final notification - generation is complete
             let _ = on_token(final_partial);
         }
 

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -47,10 +47,10 @@ fn strip_thinking_tags(text: &str) -> String {
     result
 }
 
-use crate::runtime_adapter::llm_telemetry::itl_stats;
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
 };
+use crate::runtime_adapter::llm_telemetry::itl_stats;
 use crate::runtime_adapter::AdapterError;
 use std::sync::Mutex;
 #[cfg(feature = "llm-llamacpp")]

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -47,6 +47,7 @@ fn strip_thinking_tags(text: &str) -> String {
     result
 }
 
+use crate::runtime_adapter::llm_telemetry::itl_stats;
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
 };
@@ -276,8 +277,13 @@ impl LlmBackend for LlamaCppBackend {
 
         let start = std::time::Instant::now();
 
-        // Generate with stop sequences for early termination
-        let output_tokens = sys::llama_generate_with_stops(
+        // Use the streaming API internally so we can capture per-token
+        // timestamps for TTFT + inter-token-latency telemetry. The closure
+        // is observation-only (no external emission) — generation still
+        // returns the full token vector like `llama_generate_with_stops`
+        // did. Keeps the non-streaming contract of this function intact.
+        let mut chunk_timestamps: Vec<std::time::Instant> = Vec::new();
+        let (output_tokens, _stopped_by_callback) = sys::llama_generate_streaming(
             context,
             model,
             &tokens,
@@ -288,6 +294,10 @@ impl LlmBackend for LlamaCppBackend {
             config.top_k,
             config.repetition_penalty,
             &config.stop_sequences,
+            |_token_id, _token_text| {
+                chunk_timestamps.push(std::time::Instant::now());
+                Ok(())
+            },
         )?;
 
         let elapsed = start.elapsed();
@@ -368,12 +378,63 @@ impl LlmBackend for LlamaCppBackend {
             0.0
         };
 
+        // Streaming-derived telemetry from per-token timestamps.
+        // First timestamp marks end-of-prefill / start-of-decode, so
+        // `ttft_ms` captures the prefill phase and the inter-chunk gaps
+        // that follow are the steady-state decode cadence.
+        let ttft_ms = chunk_timestamps
+            .first()
+            .map(|t0| t0.duration_since(start).as_millis() as u64);
+        let inter_chunk_ms: Vec<u32> = chunk_timestamps
+            .windows(2)
+            .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
+            .collect();
+        let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
+
+        // Derive decode_tps and prefill_tps from signals we already have.
+        // llama.cpp's sys bindings don't expose `llama_perf_context`'s
+        // `t_p_eval_ms` / `t_eval_ms`, so these are inferred rather than
+        // reported by the engine — document the semantics inline.
+        //
+        // decode_tps: inverse of mean inter-chunk latency. This is the
+        // textbook definition of steady-state decode throughput — every
+        // inter-token gap is a decode step, so `1000 / mean_gap_ms` is
+        // tokens/sec during the decode phase (excluding prefill).
+        let decode_tps = mean_itl_ms.and_then(|mean| {
+            if mean > 0.0 {
+                Some(1000.0 / mean)
+            } else {
+                None
+            }
+        });
+        // prefill_tps: prompt tokens / TTFT. TTFT covers prompt evaluation
+        // plus one token's worth of sampling; on prompts long enough for
+        // prefill to dominate, this approximates the prefill throughput
+        // mistralrs reports directly. For very short prompts the sampler
+        // overhead biases the number downward, which matches mistral's
+        // own "below timing resolution → None" semantics via the zero
+        // filter below.
+        let prefill_tps = ttft_ms.and_then(|ttft| {
+            if ttft > 0 && !tokens.is_empty() {
+                Some(tokens.len() as f32 * 1000.0 / ttft as f32)
+            } else {
+                None
+            }
+        });
+
         Ok(GenerationOutput {
             text,
             tokens_generated,
             generation_time_ms: elapsed.as_millis() as u64,
             tokens_per_second,
             finish_reason,
+            ttft_ms,
+            mean_itl_ms,
+            p95_itl_ms,
+            emitted_chunks: Some(chunk_timestamps.len() as u32),
+            inter_chunk_ms,
+            decode_tps,
+            prefill_tps,
         })
     }
 
@@ -435,6 +496,13 @@ impl LlmBackend for LlamaCppBackend {
             generation_time_ms: elapsed.as_millis() as u64,
             tokens_per_second,
             finish_reason: "length".to_string(),
+            ttft_ms: None,
+            mean_itl_ms: None,
+            p95_itl_ms: None,
+            emitted_chunks: None,
+            inter_chunk_ms: Vec::new(),
+            decode_tps: None,
+            prefill_tps: None,
         })
     }
 
@@ -479,6 +547,13 @@ impl LlmBackend for LlamaCppBackend {
         }
 
         let start = std::time::Instant::now();
+
+        // Per-callback timestamps for streaming telemetry (TTFT, ITL, chunk
+        // count). Recorded on every invocation of the C-layer callback
+        // regardless of whether the token was emitted to the external
+        // `on_token` — the stream itself is what's being measured, not
+        // user-visible output.
+        let mut chunk_timestamps: Vec<std::time::Instant> = Vec::new();
 
         // Track cumulative text and what we've safely emitted
         let mut cumulative_text = String::new();
@@ -534,6 +609,12 @@ impl LlmBackend for LlamaCppBackend {
             config.repetition_penalty,
             &streaming_stop_patterns, // Pass full stop patterns to C layer
             |token_id, token_text| {
+                // Record the timestamp on every C-layer callback, before
+                // any stop-pattern filtering. This keeps the stream-level
+                // timing independent of what actually made it to the
+                // external `on_token` consumer.
+                chunk_timestamps.push(std::time::Instant::now());
+
                 // Once we hit a stop pattern, don't emit any more tokens
                 if hit_stop_pattern {
                     return Ok(());
@@ -667,12 +748,45 @@ impl LlmBackend for LlamaCppBackend {
             let _ = on_token(final_partial);
         }
 
+        // Streaming-derived telemetry — same contract as `generate()`'s
+        // non-streaming path. Timestamps came from the C-layer callback
+        // on every token (see `chunk_timestamps` initialization above).
+        let ttft_ms = chunk_timestamps
+            .first()
+            .map(|t0| t0.duration_since(start).as_millis() as u64);
+        let inter_chunk_ms: Vec<u32> = chunk_timestamps
+            .windows(2)
+            .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
+            .collect();
+        let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
+        let decode_tps = mean_itl_ms.and_then(|mean| {
+            if mean > 0.0 {
+                Some(1000.0 / mean)
+            } else {
+                None
+            }
+        });
+        let prefill_tps = ttft_ms.and_then(|ttft| {
+            if ttft > 0 && !tokens.is_empty() {
+                Some(tokens.len() as f32 * 1000.0 / ttft as f32)
+            } else {
+                None
+            }
+        });
+
         Ok(GenerationOutput {
             text,
             tokens_generated,
             generation_time_ms: elapsed.as_millis() as u64,
             tokens_per_second,
             finish_reason,
+            ttft_ms,
+            mean_itl_ms,
+            p95_itl_ms,
+            emitted_chunks: Some(chunk_timestamps.len() as u32),
+            inter_chunk_ms,
+            decode_tps,
+            prefill_tps,
         })
     }
 

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -417,10 +417,7 @@ impl RuntimeAdapter for LlmRuntimeAdapter {
                     "tokens_per_second".to_string(),
                     format!("{:.2}", output.tokens_per_second),
                 );
-                response_metadata.insert(
-                    "finish_reason".to_string(),
-                    output.finish_reason.clone(),
-                );
+                response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
 
                 // Streaming-path metrics. Keys match the platform Tinybird
                 // schema + ingest extractor (repos/xybrid-platform/ingest/src/tinybird.rs).

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -48,10 +48,26 @@ pub struct GenerationOutput {
     pub tokens_generated: usize,
     /// Generation time in milliseconds
     pub generation_time_ms: u64,
-    /// Tokens per second
+    /// Tokens per second (wallclock — includes prefill + decode)
     pub tokens_per_second: f32,
     /// Finish reason: "stop", "length", "error"
     pub finish_reason: String,
+    /// Time to first emitted chunk (ms). `None` for non-streaming backends.
+    pub ttft_ms: Option<u64>,
+    /// Mean inter-token latency (ms), computed from inter-chunk gaps.
+    pub mean_itl_ms: Option<f32>,
+    /// p95 inter-token latency (ms).
+    pub p95_itl_ms: Option<u32>,
+    /// Number of chunks emitted (≈ tokens when 1 token/chunk).
+    pub emitted_chunks: Option<u32>,
+    /// Per-gap inter-chunk latencies (ms), for histogram analysis if desired.
+    pub inter_chunk_ms: Vec<u32>,
+    /// Decode-only tokens/sec (excludes prefill time). Sourced from
+    /// mistralrs's terminal `Usage.avg_compl_tok_per_sec`. Steady-state
+    /// throughput, not wallclock.
+    pub decode_tps: Option<f32>,
+    /// Prefill tokens/sec. Sourced from `Usage.avg_prompt_tok_per_sec`.
+    pub prefill_tps: Option<f32>,
 }
 
 // =============================================================================
@@ -401,7 +417,62 @@ impl RuntimeAdapter for LlmRuntimeAdapter {
                     "tokens_per_second".to_string(),
                     format!("{:.2}", output.tokens_per_second),
                 );
-                response_metadata.insert("finish_reason".to_string(), output.finish_reason);
+                response_metadata.insert(
+                    "finish_reason".to_string(),
+                    output.finish_reason.clone(),
+                );
+
+                // Streaming-path metrics. Keys match the platform Tinybird
+                // schema + ingest extractor (repos/xybrid-platform/ingest/src/tinybird.rs).
+                // Route to both the envelope metadata (so downstream stages can
+                // see them) and `xybrid_core::tracing::add_metadata` (so the
+                // span-level wire path picks them up — see plan phase 0.4).
+                if let Some(v) = output.ttft_ms {
+                    let s = v.to_string();
+                    response_metadata.insert("ttft_ms".to_string(), s.clone());
+                    crate::tracing::add_metadata("ttft_ms", &s);
+                }
+                if let Some(v) = output.mean_itl_ms {
+                    let s = format!("{:.4}", v);
+                    response_metadata.insert("mean_itl_ms".to_string(), s.clone());
+                    crate::tracing::add_metadata("mean_itl_ms", &s);
+                }
+                if let Some(v) = output.p95_itl_ms {
+                    let s = v.to_string();
+                    response_metadata.insert("p95_itl_ms".to_string(), s.clone());
+                    crate::tracing::add_metadata("p95_itl_ms", &s);
+                }
+                if let Some(v) = output.emitted_chunks {
+                    let s = v.to_string();
+                    response_metadata.insert("emitted_chunks".to_string(), s.clone());
+                    crate::tracing::add_metadata("emitted_chunks", &s);
+                }
+                if let Some(v) = output.decode_tps {
+                    let s = format!("{:.4}", v);
+                    response_metadata.insert("decode_tps".to_string(), s.clone());
+                    crate::tracing::add_metadata("decode_tps", &s);
+                }
+                if let Some(v) = output.prefill_tps {
+                    let s = format!("{:.4}", v);
+                    response_metadata.insert("prefill_tps".to_string(), s.clone());
+                    crate::tracing::add_metadata("prefill_tps", &s);
+                }
+                // Mirror the always-present scalars onto the span metadata
+                // too so they reach the platform without relying on the
+                // envelope metadata being serialized downstream.
+                crate::tracing::add_metadata(
+                    "tokens_generated",
+                    output.tokens_generated.to_string(),
+                );
+                crate::tracing::add_metadata(
+                    "generation_time_ms",
+                    output.generation_time_ms.to_string(),
+                );
+                crate::tracing::add_metadata(
+                    "tokens_per_second",
+                    format!("{:.2}", output.tokens_per_second),
+                );
+                crate::tracing::add_metadata("finish_reason", &output.finish_reason);
 
                 Ok(Envelope {
                     kind: EnvelopeKind::Text(output.text),
@@ -471,6 +542,13 @@ mod tests {
             generation_time_ms: 100,
             tokens_per_second: 30.0,
             finish_reason: "stop".to_string(),
+            ttft_ms: None,
+            mean_itl_ms: None,
+            p95_itl_ms: None,
+            emitted_chunks: None,
+            inter_chunk_ms: Vec::new(),
+            decode_tps: None,
+            prefill_tps: None,
         };
         assert_eq!(output.text, "Hello world");
         assert_eq!(output.tokens_generated, 3);
@@ -512,6 +590,13 @@ mod tests {
                     generation_time_ms: 50,
                     tokens_per_second: 40.0,
                     finish_reason: "stop".to_string(),
+                    ttft_ms: None,
+                    mean_itl_ms: None,
+                    p95_itl_ms: None,
+                    emitted_chunks: None,
+                    inter_chunk_ms: Vec::new(),
+                    decode_tps: None,
+                    prefill_tps: None,
                 })
             }
             fn generate_raw(
@@ -584,6 +669,13 @@ mod tests {
                     generation_time_ms: 10,
                     tokens_per_second: 100.0,
                     finish_reason: "stop".to_string(),
+                    ttft_ms: None,
+                    mean_itl_ms: None,
+                    p95_itl_ms: None,
+                    emitted_chunks: None,
+                    inter_chunk_ms: Vec::new(),
+                    decode_tps: None,
+                    prefill_tps: None,
                 })
             }
             fn generate_raw(

--- a/crates/xybrid-core/src/runtime_adapter/llm_telemetry.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm_telemetry.rs
@@ -1,0 +1,61 @@
+//! Shared telemetry helpers for LLM backends.
+//!
+//! Both `mistral` and `llama_cpp` backends derive streaming-chunk
+//! latency statistics the same way (mean / p95 of inter-chunk gaps).
+//! Keeping the implementation here avoids duplication and keeps the
+//! metric semantics identical across backends — important because
+//! the platform ingest expects a single contract regardless of which
+//! backend produced the numbers.
+
+/// Compute (mean, p95) of inter-chunk latencies (ms). Returns `(None, None)`
+/// when the input is empty — callers should treat that as "only one chunk
+/// was emitted, latency summaries are not meaningful".
+///
+/// p95 uses nearest-rank on a sorted copy:
+///   `sorted[((len - 1) as f32 * 0.95).round() as usize]`
+pub(crate) fn itl_stats(xs: &[u32]) -> (Option<f32>, Option<u32>) {
+    if xs.is_empty() {
+        return (None, None);
+    }
+    let sum: u64 = xs.iter().map(|&x| x as u64).sum();
+    let mean = sum as f32 / xs.len() as f32;
+
+    let mut sorted: Vec<u32> = xs.to_vec();
+    sorted.sort_unstable();
+    let idx = (((sorted.len() - 1) as f32) * 0.95).round() as usize;
+    let p95 = sorted[idx];
+
+    (Some(mean), Some(p95))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::itl_stats;
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert_eq!(itl_stats(&[]), (None, None));
+    }
+
+    #[test]
+    fn single_value() {
+        let (mean, p95) = itl_stats(&[10]);
+        assert_eq!(mean, Some(10.0));
+        assert_eq!(p95, Some(10));
+    }
+
+    #[test]
+    fn multiple_values_sorted() {
+        let (mean, p95) = itl_stats(&[10, 20, 30, 40]);
+        assert_eq!(mean, Some(25.0));
+        // len=4 → idx = round(3 * 0.95) = round(2.85) = 3 → sorted[3] = 40.
+        assert_eq!(p95, Some(40));
+    }
+
+    #[test]
+    fn multiple_values_unsorted() {
+        let (mean, p95) = itl_stats(&[30, 10, 40, 20]);
+        assert_eq!(mean, Some(25.0));
+        assert_eq!(p95, Some(40));
+    }
+}

--- a/crates/xybrid-core/src/runtime_adapter/llm_telemetry.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm_telemetry.rs
@@ -1,11 +1,21 @@
 //! Shared telemetry helpers for LLM backends.
 //!
 //! Both `mistral` and `llama_cpp` backends derive streaming-chunk
-//! latency statistics the same way (mean / p95 of inter-chunk gaps).
-//! Keeping the implementation here avoids duplication and keeps the
-//! metric semantics identical across backends — important because
-//! the platform ingest expects a single contract regardless of which
-//! backend produced the numbers.
+//! latency statistics the same way (mean / p95 of inter-chunk gaps,
+//! TTFT, decode/prefill TPS). Keeping the implementation here avoids
+//! duplication and keeps the metric semantics identical across
+//! backends — important because the platform ingest expects a single
+//! contract regardless of which backend produced the numbers.
+//!
+//! Two entry points are offered:
+//! - `StreamingTelemetry`: ergonomic recorder for backends that
+//!   don't need synthetic-timestamp injection (e.g. `llama_cpp`).
+//! - `compute_streaming_fields`: pure function for backends that
+//!   own their own timestamp vec — used by `mistral` so its
+//!   `handle_response` tests can drive the state machine with
+//!   injected `Instant`s.
+
+use std::time::Instant;
 
 /// Compute (mean, p95) of inter-chunk latencies (ms). Returns `(None, None)`
 /// when the input is empty — callers should treat that as "only one chunk
@@ -28,9 +38,147 @@ pub(crate) fn itl_stats(xs: &[u32]) -> (Option<f32>, Option<u32>) {
     (Some(mean), Some(p95))
 }
 
+/// Telemetry fields derived from a streaming LLM run.
+///
+/// Merged into `GenerationOutput` at the end of generation. Engines
+/// that report `decode_tps` / `prefill_tps` directly (e.g. mistralrs
+/// `Usage.avg_*_tok_per_sec`) should prefer their values via
+/// `engine_reported.or(fields.decode_tps)` on the caller side —
+/// reported values are more accurate than our TTFT/ITL estimates.
+#[derive(Debug, Clone)]
+pub(crate) struct StreamingTelemetryFields {
+    pub generation_time_ms: u64,
+    pub tokens_per_second: f32,
+    pub ttft_ms: Option<u64>,
+    pub mean_itl_ms: Option<f32>,
+    pub p95_itl_ms: Option<u32>,
+    pub emitted_chunks: Option<u32>,
+    pub inter_chunk_ms: Vec<u32>,
+    pub decode_tps: Option<f32>,
+    pub prefill_tps: Option<f32>,
+}
+
+/// Compute telemetry fields from raw streaming observations.
+///
+/// - `ttft_ms`: first chunk timestamp − `start`. Captures prefill +
+///   one token of sampling.
+/// - `mean_itl_ms` / `p95_itl_ms`: gaps between consecutive chunk
+///   timestamps (see [`itl_stats`]).
+/// - `decode_tps`: `1000 / mean_itl_ms`. Inverse of the mean
+///   inter-chunk gap — steady-state decode throughput, excludes
+///   prefill. `None` if no ITL data or mean is 0.
+/// - `prefill_tps`: `prompt_token_count * 1000 / ttft_ms`.
+///   Approximates prefill throughput on prompts long enough for
+///   prefill to dominate. Pass `prompt_token_count = 0` when the
+///   caller has an engine-reported value to override this with
+///   (mistralrs) — the derivation returns `None` in that case.
+pub(crate) fn compute_streaming_fields(
+    start: Instant,
+    chunk_timestamps: &[Instant],
+    prompt_token_count: usize,
+    tokens_generated: usize,
+) -> StreamingTelemetryFields {
+    let elapsed = start.elapsed();
+
+    let ttft_ms = chunk_timestamps
+        .first()
+        .map(|t0| t0.duration_since(start).as_millis() as u64);
+
+    let inter_chunk_ms: Vec<u32> = chunk_timestamps
+        .windows(2)
+        .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
+        .collect();
+
+    let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
+
+    let decode_tps = mean_itl_ms.and_then(|m| if m > 0.0 { Some(1000.0 / m) } else { None });
+
+    let prefill_tps = ttft_ms.and_then(|t| {
+        if t > 0 && prompt_token_count > 0 {
+            Some(prompt_token_count as f32 * 1000.0 / t as f32)
+        } else {
+            None
+        }
+    });
+
+    let tokens_per_second = if elapsed.as_secs_f32() > 0.0 {
+        tokens_generated as f32 / elapsed.as_secs_f32()
+    } else {
+        0.0
+    };
+
+    StreamingTelemetryFields {
+        generation_time_ms: elapsed.as_millis() as u64,
+        tokens_per_second,
+        ttft_ms,
+        mean_itl_ms,
+        p95_itl_ms,
+        emitted_chunks: Some(chunk_timestamps.len() as u32),
+        inter_chunk_ms,
+        decode_tps,
+        prefill_tps,
+    }
+}
+
+/// Ergonomic streaming-telemetry recorder.
+///
+/// Used by backends that don't need their own timestamp vec for
+/// test injection (currently `llama_cpp`). Call [`Self::new`]
+/// immediately before the generation loop, [`Self::record_chunk`]
+/// from inside the streaming callback on every C-layer invocation
+/// (before any stop-pattern filtering — the stream itself is being
+/// measured, not user-visible output), then [`Self::finalize`] with
+/// the canonical `tokens_generated` count.
+///
+/// Backends with pre-existing timestamp-owning state (e.g.
+/// `mistral::StreamState`) should call [`compute_streaming_fields`]
+/// directly instead.
+pub(crate) struct StreamingTelemetry {
+    start: Instant,
+    chunk_timestamps: Vec<Instant>,
+    prompt_token_count: usize,
+}
+
+impl StreamingTelemetry {
+    /// Start the clock and record the prompt token count.
+    ///
+    /// Call as late as possible before the generation loop (after
+    /// tokenization / KV-cache reset / context window checks) so
+    /// TTFT captures only the prefill + first-decode window.
+    pub fn new(prompt_token_count: usize) -> Self {
+        Self {
+            start: Instant::now(),
+            chunk_timestamps: Vec::new(),
+            prompt_token_count,
+        }
+    }
+
+    /// Record a chunk observation at `Instant::now()`.
+    pub fn record_chunk(&mut self) {
+        self.chunk_timestamps.push(Instant::now());
+    }
+
+    /// Finalize into telemetry fields.
+    ///
+    /// `tokens_generated` is the canonical count reflected in
+    /// `tokens_per_second`. Pass in the backend's authoritative
+    /// count (e.g. `output_tokens.len()`) — not derived from
+    /// `chunk_timestamps.len()` because engines may coalesce
+    /// multiple tokens into a single chunk.
+    pub fn finalize(&self, tokens_generated: usize) -> StreamingTelemetryFields {
+        compute_streaming_fields(
+            self.start,
+            &self.chunk_timestamps,
+            self.prompt_token_count,
+            tokens_generated,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::itl_stats;
+    use super::{compute_streaming_fields, itl_stats};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn empty_input_returns_none() {
@@ -57,5 +205,53 @@ mod tests {
         let (mean, p95) = itl_stats(&[30, 10, 40, 20]);
         assert_eq!(mean, Some(25.0));
         assert_eq!(p95, Some(40));
+    }
+
+    #[test]
+    fn streaming_fields_empty_stream() {
+        let start = Instant::now();
+        let fields = compute_streaming_fields(start, &[], 0, 0);
+        assert_eq!(fields.ttft_ms, None);
+        assert_eq!(fields.mean_itl_ms, None);
+        assert_eq!(fields.p95_itl_ms, None);
+        assert_eq!(fields.emitted_chunks, Some(0));
+        assert!(fields.inter_chunk_ms.is_empty());
+        assert_eq!(fields.decode_tps, None);
+        assert_eq!(fields.prefill_tps, None);
+        assert_eq!(fields.tokens_per_second, 0.0);
+    }
+
+    #[test]
+    fn streaming_fields_derives_ttft_itl_decode_tps() {
+        let start = Instant::now();
+        let chunks = [
+            start + Duration::from_millis(40),
+            start + Duration::from_millis(60),
+            start + Duration::from_millis(80),
+            start + Duration::from_millis(100),
+        ];
+        let fields = compute_streaming_fields(start, &chunks, 16, 4);
+
+        assert_eq!(fields.ttft_ms, Some(40));
+        // gaps: 20, 20, 20
+        assert_eq!(fields.mean_itl_ms, Some(20.0));
+        assert_eq!(fields.p95_itl_ms, Some(20));
+        // 1000 / 20 = 50 tok/s
+        assert_eq!(fields.decode_tps, Some(50.0));
+        // 16 prompt tokens over 40ms TTFT = 400 tok/s
+        assert_eq!(fields.prefill_tps, Some(400.0));
+        assert_eq!(fields.emitted_chunks, Some(4));
+        assert_eq!(fields.inter_chunk_ms, vec![20, 20, 20]);
+    }
+
+    #[test]
+    fn streaming_fields_zero_prompt_suppresses_prefill_tps() {
+        // Caller signals "override me, engine reports prefill directly"
+        // by passing prompt_token_count = 0.
+        let start = Instant::now();
+        let chunks = [start + Duration::from_millis(50)];
+        let fields = compute_streaming_fields(start, &chunks, 0, 1);
+        assert_eq!(fields.ttft_ms, Some(50));
+        assert_eq!(fields.prefill_tps, None);
     }
 }

--- a/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
@@ -13,7 +13,8 @@ use crate::ir::MessageRole;
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
 };
-use crate::runtime_adapter::llm_telemetry::itl_stats;
+#[cfg(feature = "llm-mistral")]
+use crate::runtime_adapter::llm_telemetry::compute_streaming_fields;
 use crate::runtime_adapter::AdapterError;
 
 #[cfg(feature = "llm-mistral")]
@@ -399,48 +400,39 @@ impl LlmBackend for MistralBackend {
             finish_reason,
             tokens_reported,
             chunk_ts,
-            decode_tps_reported: decode_tps,
-            prefill_tps_reported: prefill_tps,
+            decode_tps_reported,
+            prefill_tps_reported,
             ..
         } = state;
-
-        let elapsed = start.elapsed();
 
         // `saw_terminal` in the async block above guarantees we had a
         // usage-bearing terminal chunk; if it was absent despite terminal
         // signals, fall back to chunk count so downstream metrics don't NaN.
         let tokens_generated = tokens_reported.unwrap_or(chunk_ts.len());
 
-        let ttft_ms = chunk_ts
-            .first()
-            .map(|t0| t0.duration_since(start).as_millis() as u64);
-
-        let inter_chunk_ms: Vec<u32> = chunk_ts
-            .windows(2)
-            .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
-            .collect();
-
-        let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
-
-        let tokens_per_second = if elapsed.as_secs_f32() > 0.0 {
-            tokens_generated as f32 / elapsed.as_secs_f32()
-        } else {
-            0.0
-        };
+        // Shared telemetry derivation (TTFT, mean/p95 ITL, tokens_per_second).
+        // `prompt_token_count = 0` because mistralrs tokenizes internally
+        // and reports prefill_tps directly via `Usage.avg_prompt_tok_per_sec`
+        // — we override the (always-None) derived value with the engine
+        // number below via `.or()`.
+        let fields = compute_streaming_fields(start, &chunk_ts, 0, tokens_generated);
 
         Ok(GenerationOutput {
             text,
             tokens_generated,
-            generation_time_ms: elapsed.as_millis() as u64,
-            tokens_per_second,
+            generation_time_ms: fields.generation_time_ms,
+            tokens_per_second: fields.tokens_per_second,
             finish_reason,
-            ttft_ms,
-            mean_itl_ms,
-            p95_itl_ms,
-            emitted_chunks: Some(chunk_ts.len() as u32),
-            inter_chunk_ms,
-            decode_tps,
-            prefill_tps,
+            ttft_ms: fields.ttft_ms,
+            mean_itl_ms: fields.mean_itl_ms,
+            p95_itl_ms: fields.p95_itl_ms,
+            emitted_chunks: fields.emitted_chunks,
+            inter_chunk_ms: fields.inter_chunk_ms,
+            // Engine-reported values win when present; derived values
+            // (decode_tps from ITL, prefill_tps = None since we passed 0
+            // prompt tokens) are the fallback for any future code path.
+            decode_tps: decode_tps_reported.or(fields.decode_tps),
+            prefill_tps: prefill_tps_reported.or(fields.prefill_tps),
         })
     }
 

--- a/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
@@ -526,42 +526,16 @@ impl LlmBackend for MistralBackend {
 
 #[cfg(test)]
 mod tests {
-    use crate::runtime_adapter::llm_telemetry::itl_stats;
-
-    #[test]
-    fn itl_stats_empty() {
-        assert_eq!(itl_stats(&[]), (None, None));
-    }
-
-    #[test]
-    fn itl_stats_single() {
-        let (mean, p95) = itl_stats(&[10]);
-        assert_eq!(mean, Some(10.0));
-        assert_eq!(p95, Some(10));
-    }
-
-    #[test]
-    fn itl_stats_small() {
-        let (mean, p95) = itl_stats(&[10, 20, 30, 40]);
-        assert_eq!(mean, Some(25.0));
-        // len=4 → idx = round(3 * 0.95) = round(2.85) = 3 → sorted[3] = 40.
-        assert_eq!(p95, Some(40));
-    }
-
-    #[test]
-    fn itl_stats_unsorted() {
-        let (mean, p95) = itl_stats(&[30, 10, 40, 20]);
-        assert_eq!(mean, Some(25.0));
-        assert_eq!(p95, Some(40));
-    }
-
-    // ---- Mock-stream tests for handle_response / StreamState ----
+    // Mock-stream tests for `handle_response` / `StreamState`.
     //
-    // These exercise the pure state machine that `generate()` drives with
-    // real mistralrs responses. They reproduce the Codex P1 regression from
-    // the prior review: the terminal `Response::Chunk` must populate
-    // `finish_reason` and `usage`, since mistralrs under `is_streaming=true`
-    // does not emit `Response::Done`.
+    // These exercise the pure state machine that `generate()` drives
+    // with real mistralrs responses. They reproduce the Codex P1
+    // regression from the prior review: the terminal `Response::Chunk`
+    // must populate `finish_reason` and `usage`, since mistralrs under
+    // `is_streaming=true` does not emit `Response::Done`.
+    //
+    // Telemetry math (itl_stats, streaming field derivation) is tested
+    // in `runtime_adapter::llm_telemetry` — no point repeating it here.
 
     #[cfg(feature = "llm-mistral")]
     mod mock_stream {

--- a/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
@@ -13,12 +13,125 @@ use crate::ir::MessageRole;
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
 };
+use crate::runtime_adapter::llm_telemetry::itl_stats;
 use crate::runtime_adapter::AdapterError;
 
 #[cfg(feature = "llm-mistral")]
 use mistralrs::{
-    GgufModelBuilder, Model, PagedAttentionMetaBuilder, RequestBuilder, TextMessageRole,
+    GgufModelBuilder, Model, PagedAttentionMetaBuilder, RequestBuilder, Response, TextMessageRole,
 };
+
+/// 0.0 is how mistralrs reports "below timing resolution" (e.g. very short
+/// prompts on fast hardware). Treat it as `None` so dashboards don't show a
+/// misleading 0 tok/s.
+#[cfg(feature = "llm-mistral")]
+fn nonzero(v: f32) -> Option<f32> {
+    if v > 0.0 {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+/// Accumulated state for the streaming response consumer. Kept pure-data so
+/// [`handle_response`] can be tested sequentially without an async runtime
+/// or the mistralrs `Stream<'_>` wrapper.
+#[cfg(feature = "llm-mistral")]
+struct StreamState {
+    text: String,
+    finish_reason: String,
+    tokens_reported: Option<usize>,
+    chunk_ts: Vec<std::time::Instant>,
+    decode_tps_reported: Option<f32>,
+    prefill_tps_reported: Option<f32>,
+    saw_terminal: bool,
+}
+
+#[cfg(feature = "llm-mistral")]
+impl StreamState {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            finish_reason: String::from("unknown"),
+            tokens_reported: None,
+            chunk_ts: Vec::new(),
+            decode_tps_reported: None,
+            prefill_tps_reported: None,
+            saw_terminal: false,
+        }
+    }
+}
+
+/// Pure state-machine step over a single mistralrs [`Response`]. Returns
+/// `Ok(true)` when the caller should stop reading (terminal `Response::Done`
+/// only — terminal `Response::Chunk` sets `saw_terminal` but doesn't stop
+/// the stream, since the producer closes the channel naturally after).
+///
+/// Invariants documented at call site:
+/// - `ts` is the moment the response was observed (not the moment the
+///   function runs), so tests can inject synthetic timestamps.
+/// - On `is_streaming=true`, mistralrs signals completion on the **last**
+///   `Response::Chunk` by populating `usage` and `finish_reason`
+///   (mistralrs-core sequence.rs:1519-1527 + sampling.rs:154,188-200).
+///   The `Response::Done` arm is kept defensively for non-streaming paths
+///   and any future mistralrs version that emits it.
+#[cfg(feature = "llm-mistral")]
+fn handle_response(
+    response: Response,
+    state: &mut StreamState,
+    ts: std::time::Instant,
+) -> Result<bool, AdapterError> {
+    match response {
+        Response::Chunk(chunk) => {
+            state.chunk_ts.push(ts);
+            if let Some(delta) = chunk
+                .choices
+                .first()
+                .and_then(|c| c.delta.content.as_deref())
+            {
+                state.text.push_str(delta);
+            }
+            // Terminal chunk carries usage + finish_reason.
+            let chunk_fr = chunk.choices.first().and_then(|c| c.finish_reason.as_ref());
+            if chunk.usage.is_some() || chunk_fr.is_some() {
+                state.saw_terminal = true;
+                if let Some(u) = chunk.usage.as_ref() {
+                    state.tokens_reported = Some(u.completion_tokens);
+                    state.decode_tps_reported = nonzero(u.avg_compl_tok_per_sec);
+                    state.prefill_tps_reported = nonzero(u.avg_prompt_tok_per_sec);
+                }
+                if let Some(fr) = chunk_fr {
+                    state.finish_reason = fr.clone();
+                }
+            }
+            Ok(false)
+        }
+        Response::Done(final_resp) => {
+            state.saw_terminal = true;
+            state.tokens_reported = Some(final_resp.usage.completion_tokens);
+            state.decode_tps_reported = nonzero(final_resp.usage.avg_compl_tok_per_sec);
+            state.prefill_tps_reported = nonzero(final_resp.usage.avg_prompt_tok_per_sec);
+            if let Some(choice) = final_resp.choices.first() {
+                state.finish_reason = choice.finish_reason.clone();
+            }
+            Ok(true)
+        }
+        Response::ModelError(msg, _partial) => {
+            Err(AdapterError::InferenceFailed(format!("model: {}", msg)))
+        }
+        Response::InternalError(e) => {
+            Err(AdapterError::InferenceFailed(format!("internal: {}", e)))
+        }
+        Response::ValidationError(e) => {
+            Err(AdapterError::InvalidInput(format!("validation: {}", e)))
+        }
+        // Streaming chat path should never produce these (completion /
+        // image / speech / raw / embeddings).
+        _ => Err(AdapterError::InferenceFailed(
+            "unexpected stream response variant for chat".to_string(),
+        )),
+    }
+}
 
 /// MistralBackend - LLM inference using mistral.rs.
 ///
@@ -49,6 +162,15 @@ pub struct MistralBackend {
     model: Option<Model>,
     /// Current configuration
     config: Option<LlmConfig>,
+    /// Context length actually in effect on the backend.
+    ///
+    /// The `GgufModelBuilder` in mistralrs reads context length from the
+    /// GGUF file and does not expose a runtime override. Callers that set
+    /// `LlmConfig::context_length` to a non-default value see that value
+    /// NOT reach the backend. We report `None` in that case so callers
+    /// and telemetry read an honest "unknown" rather than a value the
+    /// runtime does not actually honor.
+    effective_context_length: Option<usize>,
 }
 
 #[cfg(feature = "llm-mistral")]
@@ -58,6 +180,7 @@ impl MistralBackend {
         Ok(Self {
             model: None,
             config: None,
+            effective_context_length: None,
         })
     }
 
@@ -95,6 +218,27 @@ impl LlmBackend for MistralBackend {
         if !model_path.exists() {
             return Err(AdapterError::ModelNotFound(config.model_path.clone()));
         }
+
+        // Honest-config contract: warn on load-time fields the backend does
+        // not actually wire into mistralrs, and report them as None from the
+        // trait accessors rather than echoing the requested value.
+        // 4096 matches `LlmConfig::default_context_length()` (types.rs).
+        const DEFAULT_CONTEXT_LENGTH: usize = 4096;
+        if config.context_length != DEFAULT_CONTEXT_LENGTH {
+            log::warn!(
+                "LlmConfig.context_length={} is not wired to the mistralrs GGUF backend; \
+                 requested value ignored. Context length is derived from the GGUF file.",
+                config.context_length
+            );
+        }
+        if config.gpu_layers != 0 {
+            log::warn!(
+                "LlmConfig.gpu_layers={} is not wired to mistralrs; build with the \
+                 appropriate feature flag (llm-mistral-metal/llm-mistral-cuda) instead.",
+                config.gpu_layers
+            );
+        }
+        self.effective_context_length = None;
 
         // Determine directory and filename
         let (model_dir, model_file) = if model_path.is_file() {
@@ -147,13 +291,14 @@ impl LlmBackend for MistralBackend {
                 builder = builder.with_logging();
             }
 
-            // Enable paged attention if requested
+            // Enable paged attention if requested. mistralrs 0.8 takes the
+            // config by value (the closure form was 0.7). `build()` still
+            // returns Result, so keep the error mapping on that call.
             if config.paged_attention {
-                builder = builder
-                    .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())
-                    .map_err(|e| {
-                        AdapterError::RuntimeError(format!("Paged attention setup failed: {}", e))
-                    })?;
+                let paged_cfg = PagedAttentionMetaBuilder::default().build().map_err(|e| {
+                    AdapterError::RuntimeError(format!("Paged attention setup failed: {}", e))
+                })?;
+                builder = builder.with_paged_attn(paged_cfg);
             }
 
             builder
@@ -181,7 +326,7 @@ impl LlmBackend for MistralBackend {
     fn generate(
         &self,
         messages: &[ChatMessage],
-        _config: &GenerationConfig,
+        config: &GenerationConfig,
     ) -> LlmResult<GenerationOutput> {
         let model = self.model.as_ref().ok_or_else(|| {
             AdapterError::ModelNotLoaded("No model loaded. Call load() first.".to_string())
@@ -194,36 +339,88 @@ impl LlmBackend for MistralBackend {
             request = request.add_message(Self::convert_role(&msg.role), &msg.content);
         }
 
+        // Deterministic-by-default: when the caller has not asked for
+        // sampling (`temperature <= 0.0`), use mistralrs's
+        // `set_deterministic_sampler()` so local inference is reproducible.
+        // `max_tokens` still applies in the deterministic path; sampling
+        // knobs are only set when requested.
+        request = if config.temperature <= 0.0 {
+            request
+                .set_deterministic_sampler()
+                .set_sampler_max_len(config.max_tokens)
+        } else {
+            request
+                .set_sampler_temperature(config.temperature as f64)
+                .set_sampler_topp(config.top_p as f64)
+                .set_sampler_topk(config.top_k)
+                .set_sampler_max_len(config.max_tokens)
+        };
+
         let start = std::time::Instant::now();
 
-        // Run inference
+        // Run streaming inference. We measure per-chunk timings so we can
+        // report TTFT (time to first emitted chunk) and inter-chunk latency
+        // summaries.
+        //
+        // On `is_streaming=true`, mistralrs signals completion via the
+        // **last `Response::Chunk`** (not `Response::Done`):
+        //   - `ChatCompletionChunkResponse.usage: Option<Usage>` is `Some(..)`
+        //     only on the terminal chunk (sequence.rs:1519-1527).
+        //   - `ChunkChoice.finish_reason: Option<String>` is set only on the
+        //     terminal chunk (sampling.rs:154,188-200).
+        // We accept either signal (`Done` or a terminal chunk) via
+        // `saw_terminal`; a stream that closes without either is an error.
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| AdapterError::RuntimeError(format!("Failed to create runtime: {}", e)))?;
 
-        let response = rt.block_on(async {
-            model
-                .send_chat_request(request)
+        let state = rt.block_on(async move {
+            let mut stream = model
+                .stream_chat_request(request)
                 .await
-                .map_err(|e| AdapterError::InferenceFailed(format!("Generation failed: {}", e)))
+                .map_err(|e| AdapterError::InferenceFailed(format!("stream init: {}", e)))?;
+
+            let mut state = StreamState::new();
+            while let Some(response) = stream.next().await {
+                let done = handle_response(response, &mut state, std::time::Instant::now())?;
+                if done {
+                    break;
+                }
+            }
+            if !state.saw_terminal {
+                return Err(AdapterError::InferenceFailed(
+                    "stream closed before terminal chunk (no usage or finish_reason)".to_string(),
+                ));
+            }
+            Ok::<_, AdapterError>(state)
         })?;
+
+        let StreamState {
+            text,
+            finish_reason,
+            tokens_reported,
+            chunk_ts,
+            decode_tps_reported: decode_tps,
+            prefill_tps_reported: prefill_tps,
+            ..
+        } = state;
 
         let elapsed = start.elapsed();
 
-        // Extract text from response
-        let text = response
-            .choices
-            .first()
-            .and_then(|c| c.message.content.as_ref())
-            .map(|s| s.to_string())
-            .unwrap_or_default();
+        // `saw_terminal` in the async block above guarantees we had a
+        // usage-bearing terminal chunk; if it was absent despite terminal
+        // signals, fall back to chunk count so downstream metrics don't NaN.
+        let tokens_generated = tokens_reported.unwrap_or(chunk_ts.len());
 
-        let finish_reason = response
-            .choices
+        let ttft_ms = chunk_ts
             .first()
-            .map(|c| c.finish_reason.to_string())
-            .unwrap_or_else(|| "unknown".to_string());
+            .map(|t0| t0.duration_since(start).as_millis() as u64);
 
-        let tokens_generated = response.usage.completion_tokens;
+        let inter_chunk_ms: Vec<u32> = chunk_ts
+            .windows(2)
+            .map(|w| w[1].duration_since(w[0]).as_millis() as u32)
+            .collect();
+
+        let (mean_itl_ms, p95_itl_ms) = itl_stats(&inter_chunk_ms);
 
         let tokens_per_second = if elapsed.as_secs_f32() > 0.0 {
             tokens_generated as f32 / elapsed.as_secs_f32()
@@ -237,6 +434,13 @@ impl LlmBackend for MistralBackend {
             generation_time_ms: elapsed.as_millis() as u64,
             tokens_per_second,
             finish_reason,
+            ttft_ms,
+            mean_itl_ms,
+            p95_itl_ms,
+            emitted_chunks: Some(chunk_ts.len() as u32),
+            inter_chunk_ms,
+            decode_tps,
+            prefill_tps,
         })
     }
 
@@ -260,7 +464,10 @@ impl LlmBackend for MistralBackend {
     }
 
     fn context_length(&self) -> Option<usize> {
-        self.config.as_ref().map(|c| c.context_length)
+        // Honest: we only report a context length when the backend actually
+        // applies it. Today mistralrs derives context from the GGUF, which
+        // we don't read, so this stays `None`. See `load()` for the contract.
+        self.effective_context_length
     }
 }
 
@@ -322,5 +529,254 @@ impl LlmBackend for MistralBackend {
         Err(AdapterError::RuntimeError(
             "llm-mistral feature not enabled".to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime_adapter::llm_telemetry::itl_stats;
+
+    #[test]
+    fn itl_stats_empty() {
+        assert_eq!(itl_stats(&[]), (None, None));
+    }
+
+    #[test]
+    fn itl_stats_single() {
+        let (mean, p95) = itl_stats(&[10]);
+        assert_eq!(mean, Some(10.0));
+        assert_eq!(p95, Some(10));
+    }
+
+    #[test]
+    fn itl_stats_small() {
+        let (mean, p95) = itl_stats(&[10, 20, 30, 40]);
+        assert_eq!(mean, Some(25.0));
+        // len=4 → idx = round(3 * 0.95) = round(2.85) = 3 → sorted[3] = 40.
+        assert_eq!(p95, Some(40));
+    }
+
+    #[test]
+    fn itl_stats_unsorted() {
+        let (mean, p95) = itl_stats(&[30, 10, 40, 20]);
+        assert_eq!(mean, Some(25.0));
+        assert_eq!(p95, Some(40));
+    }
+
+    // ---- Mock-stream tests for handle_response / StreamState ----
+    //
+    // These exercise the pure state machine that `generate()` drives with
+    // real mistralrs responses. They reproduce the Codex P1 regression from
+    // the prior review: the terminal `Response::Chunk` must populate
+    // `finish_reason` and `usage`, since mistralrs under `is_streaming=true`
+    // does not emit `Response::Done`.
+
+    #[cfg(feature = "llm-mistral")]
+    mod mock_stream {
+        use super::super::{handle_response, nonzero, StreamState};
+        use crate::runtime_adapter::AdapterError;
+        use mistralrs::{ChatCompletionChunkResponse, ChunkChoice, Delta, Response, Usage};
+        use std::time::{Duration, Instant};
+
+        fn usage(completion_tokens: usize, avg_prompt: f32, avg_compl: f32) -> Usage {
+            Usage {
+                completion_tokens,
+                prompt_tokens: 16,
+                total_tokens: 16 + completion_tokens,
+                avg_tok_per_sec: (avg_prompt + avg_compl) / 2.0,
+                avg_prompt_tok_per_sec: avg_prompt,
+                avg_compl_tok_per_sec: avg_compl,
+                total_time_sec: 1.0,
+                total_prompt_time_sec: 0.1,
+                total_completion_time_sec: 0.9,
+            }
+        }
+
+        fn delta_chunk(content: &str) -> Response {
+            Response::Chunk(ChatCompletionChunkResponse {
+                id: "test".into(),
+                choices: vec![ChunkChoice {
+                    finish_reason: None,
+                    index: 0,
+                    delta: Delta {
+                        content: Some(content.into()),
+                        role: "assistant".into(),
+                        tool_calls: None,
+                        reasoning_content: None,
+                    },
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "test-model".into(),
+                system_fingerprint: String::new(),
+                object: "chat.completion.chunk".into(),
+                usage: None,
+            })
+        }
+
+        fn terminal_chunk(
+            completion_tokens: usize,
+            avg_prompt: f32,
+            avg_compl: f32,
+            finish_reason: &str,
+        ) -> Response {
+            Response::Chunk(ChatCompletionChunkResponse {
+                id: "test".into(),
+                choices: vec![ChunkChoice {
+                    finish_reason: Some(finish_reason.into()),
+                    index: 0,
+                    delta: Delta {
+                        content: None,
+                        role: "assistant".into(),
+                        tool_calls: None,
+                        reasoning_content: None,
+                    },
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "test-model".into(),
+                system_fingerprint: String::new(),
+                object: "chat.completion.chunk".into(),
+                usage: Some(usage(completion_tokens, avg_prompt, avg_compl)),
+            })
+        }
+
+        /// Happy path: prefix chunks accumulate text, terminal chunk
+        /// populates TTFT-comparable state, usage + finish_reason.
+        #[test]
+        fn happy_path_populates_all_fields() {
+            let start = Instant::now();
+            let mut state = StreamState::new();
+
+            assert!(!handle_response(
+                delta_chunk("Hel"),
+                &mut state,
+                start + Duration::from_millis(40)
+            )
+            .unwrap());
+            assert!(!handle_response(
+                delta_chunk("lo"),
+                &mut state,
+                start + Duration::from_millis(55)
+            )
+            .unwrap());
+            assert!(!handle_response(
+                delta_chunk(" world"),
+                &mut state,
+                start + Duration::from_millis(70)
+            )
+            .unwrap());
+            // Terminal chunk (no body content, finish_reason + usage).
+            assert!(!handle_response(
+                terminal_chunk(3, 250.0, 120.0, "stop"),
+                &mut state,
+                start + Duration::from_millis(85),
+            )
+            .unwrap());
+
+            assert_eq!(state.text, "Hello world");
+            assert_eq!(state.chunk_ts.len(), 4);
+            assert!(state.saw_terminal);
+            assert_eq!(state.tokens_reported, Some(3));
+            assert_eq!(state.decode_tps_reported, Some(120.0));
+            assert_eq!(state.prefill_tps_reported, Some(250.0));
+            assert_eq!(state.finish_reason, "stop");
+
+            // TTFT math — first timestamp relative to start.
+            let ttft = state.chunk_ts[0].duration_since(start).as_millis() as u64;
+            assert_eq!(ttft, 40);
+        }
+
+        /// `avg_*_tok_per_sec == 0.0` reads as "below timing resolution"
+        /// and must collapse to None at the field boundary.
+        #[test]
+        fn zero_tps_values_collapse_to_none() {
+            let mut state = StreamState::new();
+            handle_response(
+                terminal_chunk(1, 0.0, 0.0, "stop"),
+                &mut state,
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(state.saw_terminal);
+            assert_eq!(state.decode_tps_reported, None);
+            assert_eq!(state.prefill_tps_reported, None);
+        }
+
+        /// If no terminal chunk is ever seen, the `saw_terminal` guard in
+        /// `generate()` converts that into `AdapterError::InferenceFailed`.
+        /// The `handle_response` layer's job is to leave `saw_terminal`
+        /// false; the error is raised by the caller.
+        #[test]
+        fn stream_without_terminal_leaves_saw_terminal_false() {
+            let mut state = StreamState::new();
+            handle_response(delta_chunk("Partial"), &mut state, Instant::now()).unwrap();
+            handle_response(delta_chunk(" response"), &mut state, Instant::now()).unwrap();
+
+            assert!(!state.saw_terminal);
+            assert_eq!(state.text, "Partial response");
+            assert_eq!(state.tokens_reported, None);
+            assert_eq!(state.finish_reason, "unknown");
+        }
+
+        /// `Response::Done` (not normally emitted on streaming path, kept
+        /// for robustness) also populates state and returns `true` to stop.
+        #[test]
+        fn done_response_populates_and_stops() {
+            use mistralrs::{ChatCompletionResponse, Choice, ResponseMessage};
+            let mut state = StreamState::new();
+            let final_resp = ChatCompletionResponse {
+                id: "test".into(),
+                choices: vec![Choice {
+                    finish_reason: "length".into(),
+                    index: 0,
+                    message: ResponseMessage {
+                        content: Some("done body".into()),
+                        role: "assistant".into(),
+                        tool_calls: None,
+                        reasoning_content: None,
+                    },
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "test-model".into(),
+                system_fingerprint: String::new(),
+                object: "chat.completion".into(),
+                usage: usage(42, 180.0, 95.0),
+            };
+            let stop =
+                handle_response(Response::Done(final_resp), &mut state, Instant::now()).unwrap();
+            assert!(
+                stop,
+                "Response::Done must return true so the outer loop breaks"
+            );
+            assert!(state.saw_terminal);
+            assert_eq!(state.tokens_reported, Some(42));
+            assert_eq!(state.decode_tps_reported, Some(95.0));
+            assert_eq!(state.prefill_tps_reported, Some(180.0));
+            assert_eq!(state.finish_reason, "length");
+        }
+
+        /// Error variants propagate as `AdapterError`.
+        #[test]
+        fn error_variants_produce_adapter_error() {
+            let mut state = StreamState::new();
+            let err = handle_response(
+                Response::ValidationError("bad request".to_string().into()),
+                &mut state,
+                Instant::now(),
+            )
+            .unwrap_err();
+            assert!(matches!(err, AdapterError::InvalidInput(_)));
+        }
+
+        /// `nonzero` filter behaves as the rest of the pipeline expects.
+        #[test]
+        fn nonzero_filter() {
+            assert_eq!(nonzero(0.0), None);
+            assert_eq!(nonzero(-1.0), None);
+            assert_eq!(nonzero(42.5), Some(42.5));
+        }
     }
 }

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -67,6 +67,10 @@ pub mod candle;
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 pub mod llm;
 
+// Shared telemetry helpers for LLM backends (itl_stats, etc.)
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+pub(crate) mod llm_telemetry;
+
 // MistralBackend (feature-gated, uses mistral.rs - desktop only, NOT Android)
 // Requires +fp16 on ARM which causes SIGILL on devices without ARMv8.2-A FP16
 #[cfg(feature = "llm-mistral")]

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -71,6 +71,14 @@ pub mod llm;
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 pub(crate) mod llm_telemetry;
 
+// Shared streaming post-processing for LLM backends
+// (stop-pattern filtering, <think> tag stripping, safe-prefix buffer).
+// Used by backends whose engines don't strip these internally — currently
+// llama_cpp. Mistral's engine (mistralrs) handles it natively and does
+// not import this module.
+#[cfg(feature = "llm-llamacpp")]
+pub(crate) mod streaming_postprocess;
+
 // MistralBackend (feature-gated, uses mistral.rs - desktop only, NOT Android)
 // Requires +fp16 on ARM which causes SIGILL on devices without ARMv8.2-A FP16
 #[cfg(feature = "llm-mistral")]

--- a/crates/xybrid-core/src/runtime_adapter/streaming_postprocess.rs
+++ b/crates/xybrid-core/src/runtime_adapter/streaming_postprocess.rs
@@ -39,12 +39,8 @@ pub(crate) const CHAT_STOP_PATTERNS: &[&str] = &[
 /// Only safe to use in **final-text cleanup** — during streaming
 /// these would false-positive on legitimate text that happens to
 /// start with `|`. [`StreamingTextFilter`] does NOT include them.
-pub(crate) const CHAT_STOP_PATTERNS_BROKEN: &[&str] = &[
-    "|im_end|>",
-    "|im_start|>",
-    "|endoftext|>",
-    "end_of_turn>",
-];
+pub(crate) const CHAT_STOP_PATTERNS_BROKEN: &[&str] =
+    &["|im_end|>", "|im_start|>", "|endoftext|>", "end_of_turn>"];
 
 /// Merge caller-supplied patterns with defaults, de-duplicated while
 /// preserving caller order first.
@@ -79,10 +75,7 @@ pub(crate) fn strip_thinking_tags(text: &str) -> String {
 
 /// Truncate `text` at the earliest complete occurrence of any pattern
 /// in `patterns`. Returns `true` if a stop was found and truncated.
-pub(crate) fn truncate_at_first_stop<S: AsRef<str>>(
-    text: &mut String,
-    patterns: &[S],
-) -> bool {
+pub(crate) fn truncate_at_first_stop<S: AsRef<str>>(text: &mut String, patterns: &[S]) -> bool {
     let mut earliest: Option<usize> = None;
     for p in patterns {
         if let Some(pos) = text.find(p.as_ref()) {
@@ -107,10 +100,7 @@ pub(crate) fn truncate_at_first_stop<S: AsRef<str>>(
 ///
 /// Returns `true` on first trim and stops (matches the prior
 /// llama_cpp behavior).
-pub(crate) fn trim_partial_stop_suffix<S: AsRef<str>>(
-    text: &mut String,
-    patterns: &[S],
-) -> bool {
+pub(crate) fn trim_partial_stop_suffix<S: AsRef<str>>(text: &mut String, patterns: &[S]) -> bool {
     for pattern in patterns {
         let p = pattern.as_ref();
         for prefix_len in 1..p.len() {
@@ -261,7 +251,10 @@ mod tests {
 
     #[test]
     fn strip_thinking_tags_truncates_unclosed_block() {
-        assert_eq!(strip_thinking_tags("visible<think>still reasoning"), "visible");
+        assert_eq!(
+            strip_thinking_tags("visible<think>still reasoning"),
+            "visible"
+        );
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/streaming_postprocess.rs
+++ b/crates/xybrid-core/src/runtime_adapter/streaming_postprocess.rs
@@ -1,0 +1,353 @@
+//! Streaming-text post-processing shared across LLM backends.
+//!
+//! Pulls stop-pattern detection, `<think>...</think>` stripping, and
+//! the safe-prefix buffer logic out of the individual backends so any
+//! future engine (MLX, CoreML, ...) can reuse them. These concerns
+//! are intrinsic to **chat-style model output**, not to any specific
+//! engine — they belong above the engine layer.
+//!
+//! # Usage
+//!
+//! - Non-streaming path: call [`truncate_at_first_stop`],
+//!   [`trim_partial_stop_suffix`], and [`strip_thinking_tags`] on the
+//!   full output text.
+//! - Streaming path: instantiate [`StreamingTextFilter`] once, feed
+//!   raw chunk text in via [`StreamingTextFilter::push`], emit
+//!   whatever it returns to the user callback.
+//!
+//! Engines that strip these internally (e.g. mistralrs) don't use
+//! this module.
+
+/// Stop markers emitted by common chat templates:
+/// - `<|im_end|>` / `<|im_start|>` / `<|endoftext|>`: ChatML (Qwen, Phi)
+/// - `</s>`: Llama 2 style
+/// - `<end_of_turn>`: Gemma
+///
+/// Always check for these in addition to user-supplied stop sequences —
+/// they're emitted by the chat template, not by the user.
+pub(crate) const CHAT_STOP_PATTERNS: &[&str] = &[
+    "<|im_end|>",
+    "<|im_start|>",
+    "<|endoftext|>",
+    "</s>",
+    "<end_of_turn>",
+];
+
+/// Fallback variants without the leading `<`, for models whose
+/// tokenizer breaks the angle bracket off from the marker body.
+///
+/// Only safe to use in **final-text cleanup** — during streaming
+/// these would false-positive on legitimate text that happens to
+/// start with `|`. [`StreamingTextFilter`] does NOT include them.
+pub(crate) const CHAT_STOP_PATTERNS_BROKEN: &[&str] = &[
+    "|im_end|>",
+    "|im_start|>",
+    "|endoftext|>",
+    "end_of_turn>",
+];
+
+/// Merge caller-supplied patterns with defaults, de-duplicated while
+/// preserving caller order first.
+pub(crate) fn merge_stop_patterns<S: AsRef<str>>(user: &[S], extras: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> = user.iter().map(|s| s.as_ref().to_string()).collect();
+    for e in extras {
+        if !out.iter().any(|s| s == e) {
+            out.push((*e).to_string());
+        }
+    }
+    out
+}
+
+/// Strip every `<think>...</think>` block from `text`.
+///
+/// An unclosed opening tag strips from `<think>` to end of string —
+/// this is the partial-stream safety case for Qwen 3.5 and similar
+/// models that emit reasoning blocks before the final answer.
+pub(crate) fn strip_thinking_tags(text: &str) -> String {
+    let mut result = text.to_string();
+    while let Some(start) = result.find("<think>") {
+        if let Some(end) = result[start..].find("</think>") {
+            let end_absolute = start + end + "</think>".len();
+            result.replace_range(start..end_absolute, "");
+        } else {
+            result.truncate(start);
+            break;
+        }
+    }
+    result
+}
+
+/// Truncate `text` at the earliest complete occurrence of any pattern
+/// in `patterns`. Returns `true` if a stop was found and truncated.
+pub(crate) fn truncate_at_first_stop<S: AsRef<str>>(
+    text: &mut String,
+    patterns: &[S],
+) -> bool {
+    let mut earliest: Option<usize> = None;
+    for p in patterns {
+        if let Some(pos) = text.find(p.as_ref()) {
+            earliest = Some(match earliest {
+                None => pos,
+                Some(cur) => cur.min(pos),
+            });
+        }
+    }
+    if let Some(pos) = earliest {
+        text.truncate(pos);
+        true
+    } else {
+        false
+    }
+}
+
+/// Trim a trailing partial-stop suffix from `text` — e.g. remove
+/// `<|im_` when the full pattern is `<|im_end|>`. Only strict
+/// prefixes (length `1..pattern.len()`) are trimmed; complete
+/// matches are the job of [`truncate_at_first_stop`].
+///
+/// Returns `true` on first trim and stops (matches the prior
+/// llama_cpp behavior).
+pub(crate) fn trim_partial_stop_suffix<S: AsRef<str>>(
+    text: &mut String,
+    patterns: &[S],
+) -> bool {
+    for pattern in patterns {
+        let p = pattern.as_ref();
+        for prefix_len in 1..p.len() {
+            let prefix = &p[..prefix_len];
+            if text.ends_with(prefix) {
+                text.truncate(text.len() - prefix_len);
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Stateful text filter for a streaming generation loop.
+///
+/// Feed raw chunk text in via [`Self::push`]; the filter returns the
+/// portion that's safe to emit to the user callback, holding back
+/// any trailing bytes that could turn into a stop pattern once more
+/// chunks arrive. It also transparently suppresses
+/// `<think>...</think>` blocks and stops emitting once a complete
+/// stop pattern is observed (see [`Self::is_stopped`]).
+///
+/// After [`Self::is_stopped`] returns `true`, further `push` calls
+/// are no-ops and return `None`. The backend should still drain the
+/// engine's stream, but nothing further will be emitted upward.
+pub(crate) struct StreamingTextFilter {
+    stop_patterns: Vec<String>,
+    cumulative_text: String,
+    last_emitted_len: usize,
+    inside_think_block: bool,
+    hit_stop_pattern: bool,
+}
+
+impl StreamingTextFilter {
+    pub fn new(stop_patterns: Vec<String>) -> Self {
+        Self {
+            stop_patterns,
+            cumulative_text: String::new(),
+            last_emitted_len: 0,
+            inside_think_block: false,
+            hit_stop_pattern: false,
+        }
+    }
+
+    /// Whether a complete stop pattern has been observed.
+    pub fn is_stopped(&self) -> bool {
+        self.hit_stop_pattern
+    }
+
+    /// Cumulative text up to the last emission point. Use this to
+    /// populate `PartialToken.cumulative_text` on user callbacks —
+    /// it always ends where the last emitted chunk ended.
+    pub fn cumulative_emitted(&self) -> &str {
+        &self.cumulative_text[..self.last_emitted_len]
+    }
+
+    /// Push a raw chunk. Returns `Some(safe_text)` if new content is
+    /// ready for the user callback; `None` if the chunk is fully
+    /// held back (partial stop prefix, inside a `<think>` block, or
+    /// after a stop has been observed).
+    pub fn push(&mut self, chunk: &str) -> Option<String> {
+        if self.hit_stop_pattern {
+            return None;
+        }
+
+        self.cumulative_text.push_str(chunk);
+
+        // Enter a <think> block?
+        if !self.inside_think_block
+            && self.cumulative_text[self.last_emitted_len..].contains("<think>")
+        {
+            self.inside_think_block = true;
+            if let Some(pos) = self.cumulative_text.find("<think>") {
+                self.last_emitted_len = pos;
+            }
+        }
+
+        if self.inside_think_block {
+            if self.cumulative_text.contains("</think>") {
+                self.inside_think_block = false;
+                self.cumulative_text = strip_thinking_tags(&self.cumulative_text);
+                // After stripping, last_emitted_len may point past end.
+                self.last_emitted_len = self.last_emitted_len.min(self.cumulative_text.len());
+            }
+            return None;
+        }
+
+        // Complete stop pattern observed?
+        for pattern in &self.stop_patterns {
+            if self.cumulative_text.contains(pattern.as_str()) {
+                self.hit_stop_pattern = true;
+                if let Some(pos) = self.cumulative_text.find(pattern.as_str()) {
+                    self.cumulative_text.truncate(pos);
+                }
+                return None;
+            }
+        }
+
+        // Find the safe emission boundary (exclude potential partial
+        // stop prefixes hanging off the tail).
+        let safe_end = find_potential_stop_start(&self.cumulative_text, &self.stop_patterns)
+            .unwrap_or(self.cumulative_text.len());
+
+        if safe_end > self.last_emitted_len {
+            let safe = self.cumulative_text[self.last_emitted_len..safe_end].to_string();
+            self.last_emitted_len = safe_end;
+            Some(safe)
+        } else {
+            None
+        }
+    }
+}
+
+/// Find the position where a potential partial-stop prefix begins at
+/// the tail of `text`, if any. Kept internal — callers use
+/// [`StreamingTextFilter`] instead.
+fn find_potential_stop_start(text: &str, patterns: &[String]) -> Option<usize> {
+    for pattern in patterns {
+        for prefix_len in 1..=pattern.len() {
+            let prefix = &pattern[..prefix_len];
+            if text.ends_with(prefix) {
+                return Some(text.len() - prefix_len);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_thinking_tags_removes_closed_blocks() {
+        assert_eq!(
+            strip_thinking_tags("before<think>hidden</think>after"),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn strip_thinking_tags_removes_multiple_blocks() {
+        assert_eq!(
+            strip_thinking_tags("a<think>x</think>b<think>y</think>c"),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn strip_thinking_tags_truncates_unclosed_block() {
+        assert_eq!(strip_thinking_tags("visible<think>still reasoning"), "visible");
+    }
+
+    #[test]
+    fn strip_thinking_tags_passthrough_no_tags() {
+        assert_eq!(strip_thinking_tags("nothing to see"), "nothing to see");
+    }
+
+    #[test]
+    fn merge_stop_patterns_deduplicates() {
+        let user = ["<|im_end|>".to_string(), "CUSTOM".to_string()];
+        let got = merge_stop_patterns(&user, CHAT_STOP_PATTERNS);
+        assert_eq!(got[0], "<|im_end|>");
+        assert_eq!(got[1], "CUSTOM");
+        assert!(got.contains(&"<end_of_turn>".to_string()));
+        assert_eq!(got.iter().filter(|s| *s == "<|im_end|>").count(), 1);
+    }
+
+    #[test]
+    fn truncate_at_first_stop_picks_earliest() {
+        let mut text = String::from("hello <end_of_turn> world <|im_end|>");
+        let patterns = ["<|im_end|>", "<end_of_turn>"];
+        assert!(truncate_at_first_stop(&mut text, &patterns));
+        assert_eq!(text, "hello ");
+    }
+
+    #[test]
+    fn truncate_at_first_stop_no_match() {
+        let mut text = String::from("no stops here");
+        assert!(!truncate_at_first_stop(&mut text, &["<|im_end|>"]));
+        assert_eq!(text, "no stops here");
+    }
+
+    #[test]
+    fn trim_partial_stop_suffix_removes_partial_prefix() {
+        let mut text = String::from("response tail <|im_");
+        let patterns = ["<|im_end|>"];
+        assert!(trim_partial_stop_suffix(&mut text, &patterns));
+        assert_eq!(text, "response tail ");
+    }
+
+    #[test]
+    fn trim_partial_stop_suffix_ignores_clean_end() {
+        let mut text = String::from("clean response");
+        assert!(!trim_partial_stop_suffix(&mut text, &["<|im_end|>"]));
+        assert_eq!(text, "clean response");
+    }
+
+    #[test]
+    fn streaming_filter_emits_safe_chunks() {
+        let mut f = StreamingTextFilter::new(vec!["<|im_end|>".to_string()]);
+        assert_eq!(f.push("Hello "), Some("Hello ".to_string()));
+        assert_eq!(f.push("world"), Some("world".to_string()));
+        assert_eq!(f.cumulative_emitted(), "Hello world");
+        assert!(!f.is_stopped());
+    }
+
+    #[test]
+    fn streaming_filter_holds_back_partial_stop_prefix() {
+        let mut f = StreamingTextFilter::new(vec!["<|im_end|>".to_string()]);
+        assert_eq!(f.push("Hello "), Some("Hello ".to_string()));
+        // `<|im_` is a prefix of the stop pattern — must be held back.
+        assert_eq!(f.push("<|im_"), None);
+        // Non-matching continuation releases the held bytes. Cumulative is
+        // now "Hello <|im_portant!", nothing matches as a suffix prefix, so
+        // the whole held segment + new bytes are safe to emit.
+        assert_eq!(f.push("portant!"), Some("<|im_portant!".to_string()));
+    }
+
+    #[test]
+    fn streaming_filter_stops_on_complete_pattern() {
+        let mut f = StreamingTextFilter::new(vec!["<|im_end|>".to_string()]);
+        f.push("hello ");
+        f.push("<|im_end|>");
+        assert!(f.is_stopped());
+        // Further pushes are no-ops.
+        assert_eq!(f.push(" ignored"), None);
+    }
+
+    #[test]
+    fn streaming_filter_suppresses_think_block() {
+        let mut f = StreamingTextFilter::new(vec![]);
+        assert_eq!(f.push("visible "), Some("visible ".to_string()));
+        assert_eq!(f.push("<think>"), None);
+        assert_eq!(f.push("reasoning"), None);
+        assert_eq!(f.push("</think>"), None);
+        // After closing </think>, emission resumes on next chunk.
+        assert_eq!(f.push("answer"), Some("answer".to_string()));
+    }
+}

--- a/crates/xybrid-core/src/runtime_adapter/types.rs
+++ b/crates/xybrid-core/src/runtime_adapter/types.rs
@@ -129,7 +129,9 @@ pub struct GenerationConfig {
     #[serde(default = "default_max_tokens")]
     pub max_tokens: usize,
 
-    /// Temperature for sampling. Default: 0.7
+    /// Temperature for sampling. Default: 0.0 (deterministic / greedy).
+    /// Callers who want sampling must set this explicitly — see `greedy()`
+    /// and `creative()` constructors.
     #[serde(default = "default_temperature")]
     pub temperature: f32,
 
@@ -164,7 +166,11 @@ fn default_max_tokens() -> usize {
 }
 
 fn default_temperature() -> f32 {
-    0.7
+    // Deterministic-by-default: 0.0 triggers mistralrs's
+    // `set_deterministic_sampler()` path, making local inference
+    // reproducible without explicit config. Callers who want
+    // sampling must opt in (e.g. `GenerationConfig::creative()`).
+    0.0
 }
 
 fn default_top_p() -> f32 {
@@ -495,7 +501,11 @@ mod tests {
     fn test_generation_config_defaults() {
         let config = GenerationConfig::default();
         assert_eq!(config.max_tokens, 2048);
-        assert!((config.temperature - 0.7).abs() < f32::EPSILON);
+        // Deterministic-by-default: temperature=0.0 is the SDK's documented
+        // default (see `default_temperature` doc-comment). Callers that want
+        // sampling opt in via `GenerationConfig::creative()` or explicit
+        // `with_temperature(x)`.
+        assert!(config.temperature.abs() < f32::EPSILON);
         assert!((config.top_p - 0.9).abs() < f32::EPSILON);
         assert!((config.min_p - 0.05).abs() < f32::EPSILON);
         assert_eq!(config.top_k, 40);

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -907,7 +907,10 @@ impl Pipeline {
             })?;
         let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
-        crate::telemetry::set_telemetry_pipeline_context(None, None);
+        // Note: `set_telemetry_pipeline_context(None, None)` deferred to
+        // after `publish_telemetry_event` below. The exporter's flush
+        // thread reads pipeline_id/trace_id lazily at flush time; if we
+        // cleared here the PipelineComplete event would get null IDs.
 
         let stages: Vec<StageTiming> = results
             .iter()
@@ -933,7 +936,22 @@ impl Pipeline {
             )
         };
 
-        // Emit telemetry event
+        // Emit telemetry event. LLM metrics ride on the separate
+        // `PlatformEvent.stages[].spans[].metadata` path (populated via
+        // `xybrid_core::tracing::add_metadata` in the LLM adapter), so we
+        // intentionally keep this `data` blob compact — only the fields
+        // that already crossed the wire before llm_metrics existed.
+        let stage_data: Vec<serde_json::Value> = results
+            .iter()
+            .map(|result| {
+                serde_json::json!({
+                    "name": result.stage,
+                    "latency_ms": result.latency_ms,
+                    "target": result.routing_decision.target.to_string(),
+                })
+            })
+            .collect();
+
         let event = crate::telemetry::TelemetryEvent {
             event_type: "PipelineComplete".to_string(),
             stage_name: self.name.clone(),
@@ -942,11 +960,7 @@ impl Pipeline {
             error: None,
             data: Some(
                 serde_json::json!({
-                    "stages": stages.iter().map(|s| serde_json::json!({
-                        "name": s.name,
-                        "latency_ms": s.latency_ms,
-                        "target": s.target,
-                    })).collect::<Vec<_>>(),
+                    "stages": stage_data,
                     "output_type": format!("{:?}", output_type),
                 })
                 .to_string(),
@@ -957,6 +971,10 @@ impl Pipeline {
                 .unwrap_or(0),
         };
         crate::telemetry::publish_telemetry_event(event);
+
+        // Clear pipeline context AFTER publish so the event carried
+        // correlation IDs visible to the exporter's lazy-read flush.
+        crate::telemetry::set_telemetry_pipeline_context(None, None);
 
         Ok(PipelineExecutionResult {
             name: self.name.clone(),
@@ -1024,7 +1042,9 @@ impl Pipeline {
                 })?;
             let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
-            crate::telemetry::set_telemetry_pipeline_context(None, None);
+            // Note: `set_telemetry_pipeline_context(None, None)` deferred
+            // to after `publish_telemetry_event` below — see sync arm for
+            // the correlation-ID rationale.
 
             let stages: Vec<StageTiming> = results
                 .iter()
@@ -1049,6 +1069,46 @@ impl Pipeline {
                     Envelope::new(EnvelopeKind::Text(String::new())),
                 )
             };
+
+            // Emit PipelineComplete telemetry event. Previously absent from
+            // this async path (existed only in sync `run`); attaching now
+            // brings the two paths to parity. LLM metrics ride on span
+            // metadata (see the sync arm above for rationale), so this
+            // `data` blob stays compact.
+            let stage_data: Vec<serde_json::Value> = results
+                .iter()
+                .map(|result| {
+                    serde_json::json!({
+                        "name": result.stage,
+                        "latency_ms": result.latency_ms,
+                        "target": result.routing_decision.target.to_string(),
+                    })
+                })
+                .collect();
+
+            let event = crate::telemetry::TelemetryEvent {
+                event_type: "PipelineComplete".to_string(),
+                stage_name: name.clone(),
+                target: None,
+                latency_ms: Some(total_latency_ms),
+                error: None,
+                data: Some(
+                    serde_json::json!({
+                        "stages": stage_data,
+                        "output_type": format!("{:?}", output_type),
+                    })
+                    .to_string(),
+                ),
+                timestamp_ms: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            };
+            crate::telemetry::publish_telemetry_event(event);
+
+            // Clear pipeline context after publish to keep the exporter's
+            // lazy-read flush correlated with the just-completed pipeline.
+            crate::telemetry::set_telemetry_pipeline_context(None, None);
 
             Ok(PipelineExecutionResult {
                 name,
@@ -1383,4 +1443,12 @@ id: asr
         .unwrap();
         assert_eq!(stage.stage_id(), "asr");
     }
+
+    // NOTE: Prior to Phase 0.4 we had a `llm_metrics_appear_in_per_stage_json`
+    // test here that validated an `llm_metrics` sub-object on each stage's
+    // telemetry entry. That path was dead at the wire boundary (see plan
+    // phase 0.4), so both the emission code and this test were removed.
+    // LLM metrics now ride on `PlatformEvent.stages[].spans[].metadata`
+    // via `xybrid_core::tracing::add_metadata`, which is covered by the
+    // platform ingest's own extraction tests in `ingest/src/tinybird.rs`.
 }

--- a/docs/content/docs/cli/reference/run.mdx
+++ b/docs/content/docs/cli/reference/run.mdx
@@ -1,0 +1,136 @@
+---
+title: xybrid run
+description: Execute a hybrid pipeline
+---
+
+Execute a hybrid pipeline on the current device.
+
+## Usage
+
+```bash
+xybrid run --config <path>
+xybrid run --pipeline <name>
+xybrid run --pipeline <name> --dry-run
+```
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--config` | `-c` | Load a pipeline YAML file directly |
+| `--pipeline` | `-p` | Look up `<name>.yml` under `examples/` |
+| `--bundle` | `-b` | Run a `.xyb` bundle file directly |
+| `--input-text` | | Text input for text-based models (LLM, TTS) |
+| `--input-audio` | | Path to a WAV file for audio-based models (ASR) |
+| `--target` | | Force model format (`onnx`, `coreml`, `tflite`); auto-detected if omitted |
+| `--dry-run` | | Simulate routing without execution |
+| `--policy` | | Load an additional policy bundle |
+| `--trace` | | Enable execution tracing with flame graph + LLM metrics output |
+| `--trace-export` | | Export the trace to a JSON file (Chrome trace format) |
+
+## Behavior
+
+1. Parses YAML into `PipelineConfig`
+2. Runs policy → routing → execution loop
+3. Prints stage latency and routing summaries
+
+In dry-run mode, the CLI prints routing decisions and simulated outputs without invoking adapters.
+
+## Examples
+
+### Run from config file
+
+```bash
+xybrid run --config ./pipelines/voice-assistant.yaml
+```
+
+### Run named pipeline
+
+```bash
+xybrid run --pipeline hiiipe
+```
+
+Looks for `hiiipe.yml` or `hiiipe.yaml` in:
+- `xybrid-cli/examples/`
+- `./examples/`
+
+### Dry run (simulate only)
+
+```bash
+xybrid run --pipeline hiiipe --dry-run
+```
+
+Output shows routing decisions without actual execution:
+
+```
+▶️ Stage: whisper-tiny@1.2 → would route to: local
+▶️ Stage: gpt-4o-mini → would route to: integration
+▶️ Stage: kokoro-82m@0.1 → would route to: local
+```
+
+### With custom policy
+
+```bash
+xybrid run --pipeline hiiipe --policy ./policies/strict-privacy.yaml
+```
+
+## Sample Output
+
+```
+▶️ Stage: whisper-tiny@1.2 → local
+🎯 Routing: local (fast path)
+⚙️ Execution complete (52ms)
+
+▶️ Stage: gpt-4o-mini → integration
+🎯 Routing: integration (OpenAI)
+⚙️ Execution complete (340ms)
+
+▶️ Stage: kokoro-82m@0.1 → local
+🎯 Routing: local (fast path)
+⚙️ Execution complete (89ms)
+
+🎉 Pipeline complete (total 481ms)
+```
+
+## Pipeline Format
+
+The `run` command expects YAML pipelines:
+
+```yaml
+name: "voice-assistant"
+stages:
+  - whisper-tiny@1.0
+  - target: integration
+    provider: openai
+    model: gpt-4o-mini
+  - kokoro-82m@0.1
+```
+
+See [Pipelines](/docs/internals/pipelines) for full DSL reference.
+
+## Tracing LLM Inference
+
+When `--trace` is passed and the pipeline includes an LLM stage, the CLI
+prints an additional metrics block after the output:
+
+```
+📊 LLM Trace:
+------------------------------------------------------------
+  TTFT                  : 412 ms
+  Decode TPS            : 42.80 tok/s
+  Prefill TPS           : 184.20 tok/s
+  Wallclock TPS         : 38.10 tok/s
+  Mean ITL              : 14.30 ms
+  p95 ITL               : 28 ms
+  Emitted chunks        : 64
+  Tokens generated      : 64
+  Finish reason         : stop
+------------------------------------------------------------
+```
+
+These values are read from the output envelope's metadata, populated by
+the LLM adapter's streaming path. Non-LLM stages (ASR, TTS, embedding)
+do not emit these fields and the block is skipped.
+
+See [LLM Metrics](/docs/internals/llm-metrics) for field definitions and
+the end-to-end emission path.

--- a/docs/content/docs/cli/reference/trace.mdx
+++ b/docs/content/docs/cli/reference/trace.mdx
@@ -1,0 +1,169 @@
+---
+title: xybrid trace
+description: Inspect telemetry from previous runs
+---
+
+Inspect telemetry logs and traces from previous pipeline runs.
+
+## Usage
+
+```bash
+xybrid trace --session <id>
+xybrid trace --latest
+xybrid trace --latest --export <path>
+```
+
+## Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--session` | `-s` | Explicit session identifier |
+| `--latest` | | Load the most recent session |
+| `--export` | | Write JSON summary to file |
+| `--output` | | Output format: `pretty` or `json` |
+
+## Behavior
+
+1. Reads structured JSON traces from `~/.xybrid/traces/<session>.log`
+2. Parses stage latency, routing decisions, and policy outcomes
+3. Displays colorized summary table
+
+## Examples
+
+### View latest trace
+
+```bash
+xybrid trace --latest
+```
+
+### View specific session
+
+```bash
+xybrid trace --session abc123
+```
+
+### Export to JSON
+
+```bash
+xybrid trace --latest --export trace.json
+```
+
+### Pretty output
+
+```bash
+xybrid trace --latest --output pretty
+```
+
+## Sample Output
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Session: abc123                                             │
+│ Pipeline: voice-assistant                                   │
+│ Started: 2024-12-12T10:30:00Z                               │
+├─────────────────────────────────────────────────────────────┤
+│ Stage              │ Target      │ Latency │ Status         │
+├────────────────────┼─────────────┼─────────┼────────────────┤
+│ whisper-tiny@1.2   │ local       │ 52ms    │ ✓ success      │
+│ gpt-4o-mini        │ integration │ 340ms   │ ✓ success      │
+│ kokoro-82m@0.1     │ local       │ 89ms    │ ✓ success      │
+├─────────────────────────────────────────────────────────────┤
+│ Total: 481ms                                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Trace Data
+
+Each trace captures:
+
+| Field | Description |
+|-------|-------------|
+| `session_id` | Unique identifier |
+| `pipeline_name` | Pipeline that was executed |
+| `started_at` | Execution start time |
+| `stages` | Array of stage results |
+| `total_latency_ms` | End-to-end duration |
+
+### Stage Data
+
+| Field | Description |
+|-------|-------------|
+| `name` | Stage identifier |
+| `target` | Where it ran (local, integration) |
+| `latency_ms` | Execution time |
+| `status` | Success or error |
+| `routing_reason` | Why this target was chosen |
+| `policy_result` | Policy evaluation outcome |
+
+### LLM Stage Metadata
+
+LLM stages carry additional fields in their span metadata. When
+`--trace` is used with `xybrid run`, these appear in the CLI output
+and in exported Chrome traces:
+
+| Field | Description |
+|-------|-------------|
+| `ttft_ms` | Time to first token (ms) |
+| `decode_tps` | Decode-only tokens/sec |
+| `prefill_tps` | Prefill tokens/sec |
+| `tokens_per_second` | Wallclock tokens/sec (includes prefill) |
+| `mean_itl_ms` | Mean inter-chunk latency (ms) |
+| `p95_itl_ms` | 95th percentile inter-chunk latency (ms) |
+| `emitted_chunks` | Number of stream chunks |
+| `tokens_generated` | Total tokens produced |
+| `finish_reason` | `"stop"`, `"length"`, or `"unknown"` |
+
+Non-LLM stages do not emit these fields. See
+[LLM Metrics](/docs/internals/llm-metrics) for the full contract.
+
+## Trace Storage
+
+Traces are stored at:
+
+```
+~/.xybrid/traces/
+├── abc123.log
+├── def456.log
+└── ...
+```
+
+Each file contains newline-delimited JSON events.
+
+## Export Format
+
+Exported JSON includes full trace data:
+
+```json
+{
+  "session_id": "abc123",
+  "pipeline_name": "voice-assistant",
+  "started_at": "2024-12-12T10:30:00Z",
+  "stages": [
+    {
+      "name": "whisper-tiny@1.2",
+      "target": "local",
+      "latency_ms": 52,
+      "status": "success",
+      "routing_reason": "model_available_locally"
+    }
+  ],
+  "total_latency_ms": 481
+}
+```
+
+## Workflow
+
+Debug pipeline performance:
+
+```bash
+# Run pipeline
+xybrid run --pipeline voice-assistant
+
+# Check what happened
+xybrid trace --latest
+
+# Export for analysis
+xybrid trace --latest --export debug.json
+```
+
+See [Observability](/docs/internals/observability) for telemetry configuration.

--- a/docs/content/docs/internals/index.mdx
+++ b/docs/content/docs/internals/index.mdx
@@ -1,0 +1,42 @@
+---
+title: Internals
+description: How Xybrid works under the hood
+---
+
+This section explains Xybrid's internal architecture for researchers, contributors, and developers who want to understand how the system works.
+
+## Overview
+
+Xybrid is a hybrid cloud-edge ML inference orchestrator. It routes ML workloads between on-device execution and cloud APIs based on model availability, device capabilities, and user policies.
+
+## Core Architecture
+
+The system is built around these key components:
+
+| Component | Purpose |
+|-----------|---------|
+| [Envelope](/docs/internals/envelope) | Universal data container for audio, text, embeddings |
+| [Orchestrator](/docs/internals/orchestrator) | Routes requests to appropriate execution targets |
+| [Pipeline](/docs/internals/pipeline) | Chains multiple stages (ASR → LLM → TTS) |
+| [Executor](/docs/internals/executor) | Runs models via ONNX or Candle runtime |
+| [StreamSession](/docs/internals/stream-session) | Real-time streaming inference |
+
+## Data Flow
+
+1. **Input** arrives as an `Envelope` (audio bytes, text, or embeddings)
+2. **Orchestrator** determines execution target (device, cloud, or fallback)
+3. **Executor** runs the model and produces output
+4. **Output** is wrapped in a new `Envelope` for the next stage
+
+See [Data Flow & Execution](/docs/internals/data-flow-and-execution) for details.
+
+## Infrastructure
+
+| Component | Purpose |
+|-----------|---------|
+| [Registry](/docs/internals/registry) | Bundle distribution server |
+| [Bundles](/docs/internals/bundles) | Packaged models (`.xyb` format) |
+| [Pipeline DSL](/docs/internals/pipelines) | YAML pipeline definitions |
+| [Streaming](/docs/internals/streaming) | Real-time inference |
+| [Observability](/docs/internals/observability) | Telemetry, tracing, and device intelligence |
+| [LLM Metrics](/docs/internals/llm-metrics) | TTFT, decode/prefill TPS, inter-chunk latency |

--- a/docs/content/docs/internals/llm-metrics.mdx
+++ b/docs/content/docs/internals/llm-metrics.mdx
@@ -1,0 +1,116 @@
+---
+title: LLM Telemetry Metrics
+description: TTFT, decode / prefill TPS, inter-chunk latency — what the SDK emits per LLM inference
+---
+
+The xybrid SDK emits per-inference LLM telemetry as string key/value pairs
+on the active tracing span and on the output envelope's metadata. These
+metrics are generated automatically by the LLM adapter's streaming path
+and require no additional configuration from the caller.
+
+This page documents the **production contract** — the fields, units, and
+guarantees the SDK provides.
+
+## Field reference
+
+| Field | Unit | Type | Source |
+| --- | --- | --- | --- |
+| `ttft_ms` | ms | `u64` | `Instant` of the first emitted `Response::Chunk` minus the `generate()` start time. |
+| `tokens_generated` | count | `usize` | mistralrs `Usage.completion_tokens` (terminal chunk). |
+| `tokens_per_second` | tok/s | `f32` | Wallclock: `tokens_generated / elapsed`. Includes prefill time. |
+| `decode_tps` | tok/s | `f32` | mistralrs `Usage.avg_compl_tok_per_sec` — steady-state decode only. `None` when 0.0 (timing below resolution). |
+| `prefill_tps` | tok/s | `f32` | mistralrs `Usage.avg_prompt_tok_per_sec`. Same zero-filter semantics. |
+| `mean_itl_ms` | ms | `f32` | Arithmetic mean of inter-chunk `Instant` deltas. `None` when only one chunk was emitted. |
+| `p95_itl_ms` | ms | `u32` | 95th percentile of inter-chunk deltas. Same one-chunk guard. |
+| `emitted_chunks` | count | `u32` | Number of `Response::Chunk` values observed on the stream. |
+| `finish_reason` | — | `String` | Terminal chunk's `ChunkChoice.finish_reason`. See values below. |
+
+### `finish_reason` values
+
+| Value | Meaning |
+|-------|---------|
+| `stop` | The model produced a natural end-of-sequence token — the response is complete. |
+| `length` | Generation was truncated because it hit the `max_tokens` limit. The model had more to produce but was cut off. Consider increasing `GenerationConfig.max_tokens` if responses are incomplete. |
+| `unknown` | The SDK could not extract `finish_reason` from the terminal chunk. Should not occur in normal operation after the terminal-chunk detection fix; if it does, it indicates a stream protocol issue. |
+
+## Where the metrics appear
+
+### Output envelope metadata
+
+After `TemplateExecutor::execute()` returns, the output `Envelope.metadata`
+(`HashMap<String, String>`) carries all nine fields as string key/value
+pairs. Callers can read them directly:
+
+```rust
+let output = executor.execute(&metadata, &input)?;
+if let Some(ttft) = output.metadata.get("ttft_ms") {
+    println!("Time to first token: {} ms", ttft);
+}
+```
+
+### Tracing span metadata
+
+The same fields are written to the active tracing span via
+`xybrid_core::tracing::add_metadata(key, value)`. This makes them
+available in:
+
+- `xybrid trace --latest` (CLI inspection)
+- `xybrid run --trace` (prints an LLM Trace block for LLM stages)
+- Any telemetry backend that reads span metadata from the exported trace
+
+An additional field, `generation_time_ms` (total wallclock for the
+`generate()` call), is also written to span metadata. It is not listed
+in the table above because it duplicates the stage-level `latency_ms`
+and is not LLM-specific.
+
+## Emission path
+
+1. `MistralBackend::generate` (`core/src/runtime_adapter/llm/mistral.rs`)
+   streams tokens via `stream_chat_request`. On `is_streaming=true`,
+   mistralrs signals completion via the **last `Response::Chunk`** — not
+   `Response::Done`. `ChunkChoice.finish_reason` and
+   `ChatCompletionChunkResponse.usage` are `Some(..)` only on that
+   terminal chunk. A stream that closes without a terminal signal returns
+   `AdapterError::InferenceFailed`; partial text is never published as a
+   successful result.
+2. `LlmRuntimeAdapter::execute`
+   (`core/src/runtime_adapter/llm/adapter.rs`) writes each scalar into
+   the response envelope's metadata **and** into the active tracing span
+   via `add_metadata`. The two destinations are intentional: the envelope
+   serves in-process Rust consumers, the tracing span flows to the
+   telemetry pipeline.
+
+## Deterministic-by-default
+
+`GenerationConfig::default()` uses `temperature = 0.0`, which selects
+mistralrs's deterministic sampler. Callers that want sampling must
+explicitly set `temperature > 0.0`. This preserves reproducible output
+for tests, caching, and any stage that depends on stable local inference.
+
+## Guarantees and non-guarantees
+
+- **Guaranteed on every successful LLM generation**: `ttft_ms`,
+  `tokens_generated`, `tokens_per_second`, `emitted_chunks`,
+  `finish_reason`.
+- **Best-effort**: `decode_tps`, `prefill_tps`, `mean_itl_ms`,
+  `p95_itl_ms`. Short prompts on fast hardware occasionally produce
+  `avg_*_tok_per_sec = 0.0` in mistralrs; these are filtered to `None`.
+  ITL summaries require at least two emitted chunks.
+- **Not emitted**: raw per-chunk deltas (`inter_chunk_ms`). Kept
+  in-process on `GenerationOutput` for Rust debugging; never serialized
+  to envelope metadata or the tracing span.
+
+## Non-LLM stages
+
+Preprocessing, postprocessing, ASR, TTS, and embedding stages do not emit
+any of the nine fields above. Their tracing spans carry only generic
+metadata (stage name, duration, model ID).
+
+## See also
+
+- `core/src/runtime_adapter/llm/mistral.rs` — streaming state machine
+  (`StreamState` + `handle_response`).
+- `core/src/runtime_adapter/llm/adapter.rs` — envelope + tracing emission.
+- `core/src/runtime_adapter/llm/config.rs` — `GenerationConfig` defaults.
+- `core/examples/llm_streaming_metrics.rs` — reference example with soft
+  assertions.

--- a/docs/content/docs/internals/observability.mdx
+++ b/docs/content/docs/internals/observability.mdx
@@ -1,0 +1,365 @@
+---
+title: Observability
+description: Telemetry, tracing, and device intelligence
+---
+
+Monitor and debug Xybrid pipelines with telemetry, device metrics, and tracing.
+
+## Overview
+
+Xybrid collects telemetry for two purposes:
+
+1. **Runtime Optimization** - Device capabilities inform routing decisions
+2. **Usage Analytics** - Metrics for debugging and visualization
+
+## Device Intelligence
+
+### Hardware Capabilities
+
+The system detects hardware capabilities to optimize routing:
+
+```rust
+pub struct HardwareCapabilities {
+    // Accelerator availability
+    pub has_gpu: bool,
+    pub has_metal: bool,      // iOS/macOS
+    pub has_nnapi: bool,      // Android
+    pub has_coreml: bool,     // iOS/macOS Neural Engine
+
+    // Resource metrics
+    pub memory_available_mb: u64,
+    pub memory_total_mb: u64,
+    pub battery_level: u8,    // 0-100
+    pub thermal_state: ThermalState,
+
+    // Platform info
+    pub platform: Platform,
+    pub gpu_type: Option<GpuType>,
+    pub npu_type: Option<NpuType>,
+}
+```
+
+### Thermal States
+
+| State | Temperature | Action |
+|-------|-------------|--------|
+| `Normal` | < 60°C | Full performance |
+| `Warm` | 60-70°C | May throttle |
+| `Hot` | 70-80°C | Reduce workload |
+| `Critical` | > 80°C | Pause heavy operations |
+
+### Decision Methods
+
+```rust
+// Should workload be reduced?
+capabilities.should_throttle()
+// → true if battery < 20% OR thermal Hot/Critical
+
+// Which accelerator to prefer?
+capabilities.should_prefer_metal()   // macOS/iOS
+capabilities.should_prefer_nnapi()   // Android
+capabilities.should_prefer_gpu()     // General GPU compute
+```
+
+### Flutter Usage
+
+```dart
+final caps = await xybrid.getDeviceCapabilities();
+print('GPU: ${caps.hasGpu}, Metal: ${caps.hasMetal}');
+print('Battery: ${caps.batteryLevel}%, Thermal: ${caps.thermalState}');
+
+if (caps.shouldThrottle) {
+  // Use cloud inference or lower-quality models
+}
+```
+
+## Telemetry Events
+
+### Event Types
+
+Events flow from the orchestrator through the event bus:
+
+| Event | Description |
+|-------|-------------|
+| `PipelineStart` | Pipeline execution begins |
+| `PipelineComplete` | Pipeline finished |
+| `StageStart` | Stage begins processing |
+| `StageComplete` | Stage finished |
+| `StageError` | Stage failed |
+| `RoutingDecided` | Target selected |
+| `ExecutionStarted` | Inference begins |
+| `ExecutionCompleted` | Inference finished |
+| `PolicyEvaluated` | Policy check result |
+
+### Event Structure
+
+```rust
+pub struct TelemetryEvent {
+    pub event_type: String,
+    pub stage_name: Option<String>,
+    pub target: Option<String>,       // "local", "cloud", "fallback"
+    pub latency_ms: Option<u32>,
+    pub error: Option<String>,
+    pub data: Option<String>,         // Additional JSON
+    pub timestamp_ms: u64,
+}
+```
+
+### Subscribing to Events
+
+```dart
+final stream = subscribeTelemetryEvents();
+stream.listen((event) {
+  print('[${event.eventType}] ${event.stageName ?? ""} '
+        '${event.target ?? ""} ${event.latencyMs ?? ""}ms');
+});
+```
+
+## LLM Telemetry Metrics
+
+LLM stages emit additional per-inference metrics as string key/value pairs
+on the active tracing span (via `xybrid_core::tracing::add_metadata`).
+These flow through the telemetry pipeline alongside stage spans and are
+available on the Xybrid dashboard and via the analytics API.
+
+| Field | Description |
+|-------|-------------|
+| `ttft_ms` | Time to first emitted stream chunk (ms) |
+| `tokens_generated` | Token count from mistralrs `Usage` |
+| `tokens_per_second` | Wallclock throughput (includes prefill) |
+| `decode_tps` | Decode-only throughput from `Usage.avg_compl_tok_per_sec` |
+| `prefill_tps` | Prefill throughput from `Usage.avg_prompt_tok_per_sec` |
+| `mean_itl_ms` | Mean inter-chunk latency |
+| `p95_itl_ms` | 95th percentile inter-chunk latency |
+| `emitted_chunks` | Number of stream chunks observed |
+| `finish_reason` | `"stop"`, `"length"`, or `"unknown"` |
+
+Non-LLM stages (ASR, TTS, embedding) do not emit these fields.
+
+See [LLM Metrics](/docs/internals/llm-metrics) for the full field
+reference, emission path, and guarantees.
+
+## Session Metrics
+
+Session-based aggregation for analytics:
+
+```rust
+pub struct SessionMetrics {
+    pub session_id: String,
+    pub device_id: String,
+    pub started_at: u64,
+    pub ended_at: Option<u64>,
+
+    // Aggregates
+    pub total_inferences: u64,
+    pub total_latency_ms: u64,
+    pub models_used: Vec<String>,
+    pub error_count: u64,
+
+    // Device snapshot
+    pub hardware_capabilities: HardwareCapabilities,
+}
+```
+
+### Per-Model Metrics
+
+```rust
+pub struct ApiCallMetric {
+    pub model_id: String,
+    pub version: String,
+    pub call_count: u64,
+    pub total_latency_ms: u64,
+    pub avg_latency_ms: u64,
+    pub error_count: u64,
+    pub last_called: u64,
+}
+```
+
+## CLI Tracing
+
+### View Traces
+
+```bash
+# Latest session
+xybrid trace --latest
+
+# Specific session
+xybrid trace --session abc123
+
+# Export to file
+xybrid trace --latest --export trace.json
+```
+
+### Trace Storage
+
+Traces are stored at `~/.xybrid/traces/`:
+
+```
+~/.xybrid/traces/
+├── abc123.log
+├── def456.log
+└── ...
+```
+
+## Export Format
+
+Session data exports as JSON:
+
+```json
+{
+  "version": "2.0",
+  "session": {
+    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+    "device_id": "device-abc123",
+    "platform": "macos",
+    "started_at": "2024-12-12T12:00:00Z"
+  },
+  "hardware": {
+    "has_gpu": true,
+    "gpu_type": "metal",
+    "has_npu": true,
+    "memory_total_mb": 16384,
+    "battery_level": 85,
+    "thermal_state": "normal"
+  },
+  "metrics": {
+    "total_inferences": 42,
+    "total_latency_ms": 12500,
+    "avg_latency_ms": 297,
+    "error_count": 0,
+    "by_model": [
+      {
+        "model_id": "wav2vec2-base-960h",
+        "call_count": 42,
+        "avg_latency_ms": 297
+      }
+    ]
+  }
+}
+```
+
+## Flutter SDK APIs
+
+### Device Capabilities
+
+```dart
+// Get current device capabilities
+HardwareCapabilities getDeviceCapabilities();
+
+// Check if a model can run locally
+bool canRunModelLocally({required String modelId, String? version});
+```
+
+### Session Metrics
+
+```dart
+// Get current session metrics
+SessionMetrics getSessionMetrics();
+
+// Export telemetry as JSON
+String exportTelemetryJson();
+
+// Reset session
+void resetSession();
+```
+
+### Telemetry Stream
+
+```dart
+// Subscribe to real-time events
+Stream<TelemetryEvent> subscribeTelemetryEvents();
+```
+
+## Configuration
+
+### CLI Configuration
+
+In `~/.config/xybrid/config.yml`:
+
+```yaml
+telemetry:
+  enabled: true
+  endpoint: "http://localhost:4318"
+  sampling_rate: 0.05
+  privacy_mode: "summary_only"
+```
+
+### Rust Configuration
+
+```rust
+let mut telemetry = Telemetry::new();
+telemetry.set_enabled(false); // Disable
+
+// Or create disabled
+let telemetry = Telemetry::with_enabled(false);
+```
+
+## Best Practices
+
+### Initialize Early
+
+```dart
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await RustLib.init();
+  initTelemetryStream();
+  runApp(MyApp());
+}
+```
+
+### Subscribe Once
+
+```dart
+late StreamSubscription<TelemetryEvent> _subscription;
+
+@override
+void initState() {
+  super.initState();
+  _subscription = subscribeTelemetryEvents().listen(_onEvent);
+}
+
+@override
+void dispose() {
+  _subscription.cancel();
+  super.dispose();
+}
+```
+
+### Export Before Session End
+
+```dart
+final json = xybrid.exportTelemetryJson();
+await uploadToBackend(json);
+```
+
+### Check Capabilities Before Inference
+
+```dart
+final caps = xybrid.getDeviceCapabilities();
+if (caps.shouldThrottle) {
+  return useCloudFallback();
+}
+```
+
+## Error Categories
+
+Errors are categorized for debugging:
+
+| Category | Description |
+|----------|-------------|
+| `ModelLoading` | Bundle/model file issues |
+| `Preprocessing` | Input format/conversion |
+| `Inference` | Runtime execution |
+| `Postprocessing` | Output format |
+| `Network` | Registry/cloud connectivity |
+| `Hardware` | GPU/NPU initialization |
+| `Memory` | OOM conditions |
+
+## Platform Support
+
+| Platform | GPU | NPU | Battery | Thermal |
+|----------|-----|-----|---------|---------|
+| macOS | Metal | CoreML | pmset | - |
+| iOS | Metal | CoreML | UIDevice | ProcessInfo |
+| Android | Vulkan | NNAPI | BatteryManager | JNI |
+| Linux | Vulkan | - | /sys/class | /sys/class |


### PR DESCRIPTION
## Summary

Adds per-LLM-inference streaming telemetry to both local backends. The SDK now emits 9 scalar metrics (TTFT, decode/prefill TPS, wallclock TPS, mean/p95 ITL, emitted chunks, tokens generated, finish reason) on the active `llm_inference` tracing span and on the output envelope metadata.

## What changed

### Metric emission (xybrid-core)
- **`GenerationOutput` struct** extended with 7 optional streaming fields: `ttft_ms`, `mean_itl_ms`, `p95_itl_ms`, `emitted_chunks`, `inter_chunk_ms`, `decode_tps`, `prefill_tps` — alongside the pre-existing `tokens_generated`, `tokens_per_second`, `finish_reason`.
- **MistralBackend**: extracted `StreamState` + `handle_response` into a pure state machine for testability. Terminal-chunk detection now reads `Usage` and `finish_reason` from the last `Response::Chunk` (mistralrs 0.8 contract) rather than the rarely-emitted `Response::Done`. `decode_tps` / `prefill_tps` sourced from `Usage.avg_compl_tok_per_sec` / `avg_prompt_tok_per_sec` with a zero-filter (`0.0 → None`) so below-resolution timings don't land as misleading zeros on downstream dashboards.
- **LlamaCppBackend**: `generate()` and `generate_streaming()` both collect per-token timestamps via the C-layer callback. TTFT, inter-chunk gaps, ITL stats, and emitted-chunk count are computed from these. `decode_tps` is derived as `1000/mean_itl_ms` (textbook steady-state definition); `prefill_tps` as `prompt_tokens / ttft_ms`. The metric definitions match mistralrs's engine-reported numbers semantically — see the provenance column in the field contract below.
- **Shared `runtime_adapter::llm_telemetry`** module with `itl_stats(mean, p95)` used by both backends (previously duplicated).

### Metadata routing (xybrid-core)
- `TemplateExecutor::execute_llm*` (all 4 LLM paths: non-streaming, streaming, with-messages, streaming-with-messages) now call two new helpers at the end:
  - `insert_llm_streaming_metrics(&mut response_metadata, &output)` — writes optional scalars to the envelope metadata when present (for in-process Rust consumers).
  - `mirror_llm_metrics_to_span(&output)` — calls `xybrid_trace::add_metadata` for all 9 contract keys on the active `llm_inference` span.

### Config correctness (xybrid-core)
- `GenerationConfig::default().temperature` changed from `0.7` → `0.0` so local inference is deterministic unless the caller opts in via `creative()` / `with_temperature(x)`. MistralBackend's `generate()` honors this via `set_deterministic_sampler()` when `temperature <= 0.0`.
- `LlmRuntimeAdapter::load_model_with_config(&LlmConfig)` is now used consistently from the executor's LLM strategy path so `context_length` and `chat_template` reach the backend instead of being dropped.

### CLI (xybrid-cli)
- New `print_llm_trace_block(&output, trace_enabled)` renders the 9 scalars after inference when `--trace` is set and the stage is an LLM stage. Wired into **all 5** `run` entry points: `--bundle`, `--model`, `--directory`, `--huggingface`, `--model-file`.
- Added `llm-mistral` / `llm-mistral-metal` / `llm-mistral-cuda` feature forwarding in `xybrid-cli/Cargo.toml`.

### SDK (xybrid-sdk)
- Async `Pipeline::run_async` now emits a `PipelineComplete` telemetry event (previously only the sync path did). Parity between paths.
- Both paths clear `set_telemetry_pipeline_context(None, None)` **after** `publish_telemetry_event` so correlation IDs remain readable by the exporter's lazy-read flush for sequential pipelines.

### Docs
- `docs/content/docs/cli/reference/run.mdx`, `trace.mdx` — `--trace` flag + LLM Trace output format.
- `docs/content/docs/internals/observability.mdx` — LLM Telemetry Metrics section.
- `docs/content/docs/internals/llm-metrics.mdx` — **new** full field contract, units, emission path, `finish_reason` semantics.
- `docs/content/docs/internals/index.mdx` — nav links to the two new pages.

### Example
- `crates/xybrid-core/examples/llm_streaming_metrics.rs` — runnable example showing the telemetry path end-to-end.

## Field contract

The 9 scalars emitted on the active `llm_inference` span and in envelope metadata. Values are string-serialized (matching how `xybrid_core::tracing::add_metadata` works); downstream consumers parse back to typed values.

| Key | SDK format | Semantic type | Meaning |
|---|---|---|---|
| `ttft_ms` | `u64.to_string()` | u64 | Time to first emitted chunk |
| `tokens_generated` | `usize.to_string()` | u32 | Completion token count |
| `tokens_per_second` | `{:.2}` | f32 | Wallclock throughput (prefill + decode) |
| `mean_itl_ms` | `{:.4}` | f32 | Mean inter-chunk latency |
| `p95_itl_ms` | `u32.to_string()` | u32 | 95th percentile inter-chunk latency |
| `emitted_chunks` | `u32.to_string()` | u32 | Number of streaming chunks observed |
| `finish_reason` | `String` | string | `"stop"`, `"length"`, or `"unknown"` |
| `decode_tps` | `{:.4}` | f32 | Steady-state decode throughput |
| `prefill_tps` | `{:.4}` | f32 | Prefill throughput (prompt eval) |

### Provenance

| Backend | `decode_tps` / `prefill_tps` source |
|---|---|
| mistralrs | Engine-reported (`Usage.avg_compl_tok_per_sec` / `avg_prompt_tok_per_sec`) |
| llama.cpp | Derived from per-token streaming callback timestamps (`1000 / mean_itl_ms` for decode; `prompt_tokens / ttft_ms` for prefill). Wiring `llama_perf_context` FFI for engine-reported numbers is tracked as a follow-up. |

The other 7 fields (TTFT, ITL stats, emitted_chunks, tokens_generated, tokens_per_second, finish_reason) are measured identically across backends.

## Behavior notes

**Correlation IDs**: pipeline / trace IDs are snapshotted when the exporter flushes (within a 5s window after emission). Sequential pipelines are correctly correlated. Concurrent pipelines share a global context — a follow-up moves IDs onto `TelemetryEvent` itself so concurrent pipelines correlate correctly.

## Test plan

- [x] `cargo test -p xybrid-core --features llm-mistral --lib` — **740 passed, 0 failed, 1 ignored**. Includes 10 new LLM tests: 4 `itl_stats` cases + 6 `mock_stream` cases covering happy path, zero-TPS collapse, premature-EOF, `Response::Done` fallback, and error propagation.
- [x] `cargo build --release -p xybrid-cli --features platform-macos,llm-mistral` — clean.
- [x] `cargo clippy -p xybrid-core --features llm-mistral --lib` — 0 warnings on ported code.
- [x] CLI `--trace` block prints populated values for both mistral and llama.cpp backends against a local GGUF.