### PR TITLE
test(core): preload mock adapter in orchestrator/runner tests

### DIFF
--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -820,11 +820,17 @@ mod tests {
         Envelope::new(EnvelopeKind::Audio(bytes.to_vec()))
     }
 
-    /// Helper to create an orchestrator with a mock adapter registered.
+    /// Helper to create an orchestrator with a pre-loaded mock adapter registered.
+    ///
+    /// For `Batch` we deliberately use `with_authority(LocalAuthority::new())`
+    /// instead of `Orchestrator::new()` — the latter bootstraps the real
+    /// ONNX/cloud adapters and wires them as the default for `local`/`cloud`
+    /// targets, so a subsequently-added mock would never be selected. The
+    /// fresh-executor path leaves the mock as the only registered adapter.
     fn orchestrator_with_mock_adapter(execution_mode: ExecutionMode) -> Orchestrator {
         let mut orchestrator = match execution_mode {
             ExecutionMode::Streaming => Orchestrator::with_streaming(StreamConfig::default()),
-            ExecutionMode::Batch => Orchestrator::new(),
+            ExecutionMode::Batch => Orchestrator::with_authority(Box::new(LocalAuthority::new())),
         };
 
         // Register a mock adapter that returns text output
@@ -869,7 +875,10 @@ mod tests {
 
     #[test]
     fn test_execute_pipeline() {
-        let mut orchestrator = Orchestrator::new();
+        // Pipeline mixes locally-available (asr/tts) and cloud-only
+        // (motivator) stages; the local stages need a pre-loaded adapter
+        // since the mock-output fallback is gone.
+        let mut orchestrator = orchestrator_with_mock_adapter(ExecutionMode::Batch);
         let stages = vec![
             StageDescriptor::new("asr"),
             StageDescriptor::new("motivator"),
@@ -929,7 +938,10 @@ mod tests {
 
     #[test]
     fn test_high_rtt_routes_to_local() {
-        let mut orchestrator = Orchestrator::new();
+        // High RTT routes to local, so the local adapter must actually run.
+        // Since the post-hardening Executor no longer synthesises mock-output
+        // envelopes for unloaded adapters, we need a pre-loaded mock adapter.
+        let mut orchestrator = orchestrator_with_mock_adapter(ExecutionMode::Batch);
         let stage = StageDescriptor::new("test_stage");
         let input = text_envelope("Text");
         let metrics = DeviceMetrics {

--- a/crates/xybrid-core/src/pipeline/runner.rs
+++ b/crates/xybrid-core/src/pipeline/runner.rs
@@ -571,6 +571,10 @@ impl Default for PipelineRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::orchestrator::LocalAuthority;
+    use crate::runtime_adapter::RuntimeAdapter;
+    use crate::testing::mocks::MockRuntimeAdapter;
+    use std::sync::Arc;
 
     fn text_envelope(value: &str) -> Envelope {
         Envelope::new(EnvelopeKind::Text(value.to_string()))
@@ -578,6 +582,24 @@ mod tests {
 
     fn audio_envelope(bytes: &[u8]) -> Envelope {
         Envelope::new(EnvelopeKind::Audio(bytes.to_vec()))
+    }
+
+    /// Swap the runner's orchestrator for a fresh one with a pre-loaded mock
+    /// adapter as the sole registered runtime.
+    ///
+    /// `PipelineRunner::new()` wires up a bootstrapped orchestrator that
+    /// registers the real ONNX/cloud adapters and sets them as the
+    /// `local`/`cloud` defaults. `register_local_model` only flips a routing
+    /// availability flag — the executor will still pick the default ONNX
+    /// adapter, which has no model loaded, and surface `ModelNotLoaded` now
+    /// that the silent mock-output fallback is gone. Using `with_authority`
+    /// gives us a fresh executor where the mock is the only option.
+    fn preload_mock_local_adapter(runner: &mut PipelineRunner) {
+        let mut fresh = Orchestrator::with_authority(Box::new(LocalAuthority::new()));
+        let mut adapter = MockRuntimeAdapter::with_text_output("mock output");
+        adapter.load_model("/mock/model.onnx").unwrap();
+        fresh.executor_mut().register_adapter(Arc::new(adapter));
+        *runner.orchestrator_mut() = fresh;
     }
 
     #[test]
@@ -616,6 +638,7 @@ stages:
 "#;
         let mut runner = PipelineRunner::new();
         runner.register_local_model("test-model", true);
+        preload_mock_local_adapter(&mut runner);
 
         let input = text_envelope("Hello, world!");
         let result = runner.run_yaml(yaml, input);
@@ -649,6 +672,7 @@ stages:
         let mut runner = PipelineRunner::new();
         runner.register_local_model("model-a", true);
         runner.register_local_model("model-b", true);
+        preload_mock_local_adapter(&mut runner);
 
         let input = text_envelope("Hello");
         let result = runner.run_yaml(yaml, input);
@@ -685,6 +709,7 @@ stages:
         let mut runner = PipelineRunner::new();
         runner.register_local_model("wav2vec2", true);
         runner.register_local_model("processor", true);
+        preload_mock_local_adapter(&mut runner);
 
         let input = audio_envelope(&[0u8; 32000]);
         let result = runner.run_yaml(yaml, input);


### PR DESCRIPTION
After b151d08's Pipeline::run hardening, `Executor::execute_stage` no longer synthesises `mock-output-<stage>-<input>` envelopes when the selected adapter isn't loaded — it surfaces the real `ModelNotLoaded`. The pre-existing tests relied on that silent fallback: they flipped the availability flag via `register_local_model(..., true)` but never loaded an adapter.

Fix by registering a pre-loaded `MockRuntimeAdapter` as the sole runtime. Both helpers use `Orchestrator::with_authority(LocalAuthority::new())` instead of `Orchestrator::new()` so the mock isn't shadowed by the bootstrapped ONNX/cloud defaults.

Covers the four tests that went red on master post-PR #45 plus `test_execute_pipeline`, which hits the same path locally on macOS.

## Summary

<!-- What does this PR do and why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [ ] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or breaking changes documented)
