### PR TITLE
feat(core): provider-agnostic prompt-cache token counts

### DIFF
--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -335,8 +335,8 @@ fn parse_gateway_usage(u: &serde_json::Value) -> super::completion::Usage {
     // responses (where only the miss key is present). Preserves the
     // "provider didn't report" (None) vs "cold cache" (Some(0))
     // distinction downstream.
-    let has_cache_fields = u.get("prompt_cache_hit_tokens").is_some()
-        || u.get("prompt_cache_miss_tokens").is_some();
+    let has_cache_fields =
+        u.get("prompt_cache_hit_tokens").is_some() || u.get("prompt_cache_miss_tokens").is_some();
     let cache_read_input_tokens = if has_cache_fields {
         Some(
             u.get("prompt_cache_hit_tokens")

--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -240,11 +240,7 @@ impl Cloud {
                     .as_str()
                     .map(|s| s.to_string());
 
-                let usage = json_resp.get("usage").map(|u| super::completion::Usage {
-                    prompt_tokens: u["prompt_tokens"].as_u64().unwrap_or(0) as u32,
-                    completion_tokens: u["completion_tokens"].as_u64().unwrap_or(0) as u32,
-                    total_tokens: u["total_tokens"].as_u64().unwrap_or(0) as u32,
-                });
+                let usage = json_resp.get("usage").map(parse_gateway_usage);
 
                 let id = json_resp["id"].as_str().map(|s| s.to_string());
 
@@ -326,6 +322,39 @@ impl Default for Cloud {
     }
 }
 
+/// Parse a raw gateway `usage` JSON value into canonical `Usage`.
+///
+/// Maps DeepSeek's `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`
+/// onto `cache_read_input_tokens` + derived uncached. The DeepSeek miss
+/// count isn't stored — downstream code derives it as
+/// `prompt_tokens - cache_read - cache_creation`. DeepSeek has no
+/// cache-creation concept; Anthropic's creation field is plumbed via
+/// the direct-path adapter in `cloud_llm::response`, not this function.
+fn parse_gateway_usage(u: &serde_json::Value) -> super::completion::Usage {
+    // Presence on either field surfaces as `Some(0)` for cold-cache
+    // responses (where only the miss key is present). Preserves the
+    // "provider didn't report" (None) vs "cold cache" (Some(0))
+    // distinction downstream.
+    let has_cache_fields = u.get("prompt_cache_hit_tokens").is_some()
+        || u.get("prompt_cache_miss_tokens").is_some();
+    let cache_read_input_tokens = if has_cache_fields {
+        Some(
+            u.get("prompt_cache_hit_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+        )
+    } else {
+        None
+    };
+    super::completion::Usage {
+        prompt_tokens: u["prompt_tokens"].as_u64().unwrap_or(0) as u32,
+        completion_tokens: u["completion_tokens"].as_u64().unwrap_or(0) as u32,
+        total_tokens: u["total_tokens"].as_u64().unwrap_or(0) as u32,
+        cache_read_input_tokens,
+        cache_creation_input_tokens: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -365,6 +394,59 @@ mod tests {
     fn test_cloud_circuit_breaker_initial_state() {
         let cloud = Cloud::new().unwrap();
         assert!(!cloud.is_circuit_open());
+    }
+
+    #[test]
+    fn gateway_usage_maps_deepseek_cache_fields() {
+        // Shape of a real DeepSeek `usage` block on a warm-cache call.
+        let blob = serde_json::json!({
+            "prompt_tokens": 1000,
+            "completion_tokens": 120,
+            "total_tokens": 1120,
+            "prompt_cache_hit_tokens": 800,
+            "prompt_cache_miss_tokens": 200,
+        });
+        let usage = parse_gateway_usage(&blob);
+        assert_eq!(usage.prompt_tokens, 1000);
+        assert_eq!(usage.completion_tokens, 120);
+        assert_eq!(usage.cache_read_input_tokens, Some(800));
+        assert_eq!(usage.cache_creation_input_tokens, None);
+        // Derived uncached matches the provider's reported miss count.
+        let derived_uncached = usage
+            .prompt_tokens
+            .saturating_sub(usage.cache_read_input_tokens.unwrap_or(0))
+            .saturating_sub(usage.cache_creation_input_tokens.unwrap_or(0));
+        assert_eq!(derived_uncached, 200);
+    }
+
+    #[test]
+    fn gateway_usage_cold_cache_only_miss_field() {
+        // First-call cold-cache response may include only the miss key.
+        // Either-field presence detection should surface read as Some(0)
+        // so the UI can render "0% cached" (vs hiding the receipt).
+        let blob = serde_json::json!({
+            "prompt_tokens": 500,
+            "completion_tokens": 50,
+            "total_tokens": 550,
+            "prompt_cache_miss_tokens": 500,
+        });
+        let usage = parse_gateway_usage(&blob);
+        assert_eq!(usage.cache_read_input_tokens, Some(0));
+        assert_eq!(usage.cache_creation_input_tokens, None);
+    }
+
+    #[test]
+    fn gateway_usage_no_cache_fields_stays_none() {
+        // Providers that don't report caching at all (Groq, short-prompt
+        // OpenAI) → both cache fields None.
+        let blob = serde_json::json!({
+            "prompt_tokens": 300,
+            "completion_tokens": 30,
+            "total_tokens": 330,
+        });
+        let usage = parse_gateway_usage(&blob);
+        assert_eq!(usage.cache_read_input_tokens, None);
+        assert_eq!(usage.cache_creation_input_tokens, None);
     }
 
     #[test]

--- a/crates/xybrid-core/src/cloud/completion.rs
+++ b/crates/xybrid-core/src/cloud/completion.rs
@@ -55,14 +55,46 @@ impl Message {
 }
 
 /// Token usage statistics.
+///
+/// Cache fields follow Anthropic-flavored canonical names because Anthropic
+/// is the only major provider that reports both buckets; flattening down
+/// to a hit/miss pair would lose the cache-creation premium tier.
+///
+/// Per-provider mapping (wire field names live in each adapter's doc,
+/// not here, so this file stays canonical-only):
+/// - **DeepSeek**: hit count → `cache_read_input_tokens`; no cache
+///   creation concept → `cache_creation_input_tokens` is `None`.
+/// - **Anthropic**: both fields direct. `prompt_tokens` is canonical
+///   `input_tokens + cache_read + cache_creation`, not raw `input_tokens`.
+/// - **OpenAI**: `prompt_tokens_details.cached_tokens` →
+///   `cache_read_input_tokens`; no cache creation reported.
+/// - **Gemini** (future): `cached_content_token_count` →
+///   `cache_read_input_tokens`.
+///
+/// Derived (not stored): `uncached_input_tokens = max(0, prompt_tokens -
+/// cache_read - cache_creation)`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Usage {
-    /// Number of tokens in the prompt.
+    /// Total effective input tokens across ALL buckets (uncached +
+    /// cache-read + cache-creation). For Anthropic, this is synthesized at
+    /// parse time to preserve the sum semantics; for other providers the
+    /// raw `prompt_tokens` already has this shape.
     pub prompt_tokens: u32,
     /// Number of tokens in the completion.
     pub completion_tokens: u32,
     /// Total tokens used.
     pub total_tokens: u32,
+    /// Prompt tokens served from the provider's prefix cache. Discounted
+    /// tier across every provider that reports caching. `None` when the
+    /// provider doesn't report cache metrics (Groq, and OpenAI when a
+    /// request is too short to be auto-cached).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u32>,
+    /// Prompt tokens that ESTABLISHED new cache entries on this request.
+    /// Premium tier (~1.25× input rate on the only provider that reports
+    /// it today, Anthropic). `None` / `Some(0)` on every other provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u32>,
 }
 
 /// Request for cloud completion.
@@ -248,6 +280,8 @@ impl From<crate::cloud_llm::LlmResponse> for CompletionResponse {
                 prompt_tokens: u.prompt_tokens,
                 completion_tokens: u.completion_tokens,
                 total_tokens: u.total_tokens,
+                cache_read_input_tokens: u.cache_read_input_tokens,
+                cache_creation_input_tokens: u.cache_creation_input_tokens,
             }),
             id: resp.id,
             latency_ms: None,

--- a/crates/xybrid-core/src/cloud_llm/response.rs
+++ b/crates/xybrid-core/src/cloud_llm/response.rs
@@ -193,8 +193,7 @@ impl From<OpenAIResponse> for LlmResponse {
             model: resp.model,
             finish_reason,
             usage: resp.usage.map(|u| {
-                let cache_read_input_tokens =
-                    u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+                let cache_read_input_tokens = u.prompt_tokens_details.and_then(|d| d.cached_tokens);
                 Usage {
                     prompt_tokens: u.prompt_tokens,
                     completion_tokens: u.completion_tokens,

--- a/crates/xybrid-core/src/cloud_llm/response.rs
+++ b/crates/xybrid-core/src/cloud_llm/response.rs
@@ -2,15 +2,27 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Token usage statistics.
+/// Token usage statistics. Carrier struct: per-provider fields get
+/// normalized into this on parse, and this in turn feeds
+/// `cloud::completion::Usage` downstream. See that type's docs for the
+/// canonical semantics of the cache fields.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Usage {
-    /// Number of tokens in the prompt.
+    /// Effective input tokens across all buckets. For Anthropic this is
+    /// synthesized as `input_tokens + cache_read + cache_creation`; for
+    /// OpenAI it's the provider's reported `prompt_tokens` unchanged.
     pub prompt_tokens: u32,
     /// Number of tokens in the completion.
     pub completion_tokens: u32,
     /// Total tokens used.
     pub total_tokens: u32,
+    /// Prompt tokens served from the provider's prefix cache. See
+    /// `cloud::completion::Usage` for provider-specific mapping.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u32>,
+    /// Prompt tokens that ESTABLISHED new cache entries. Anthropic-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u32>,
 }
 
 /// Response from an LLM API call.
@@ -87,6 +99,16 @@ pub(crate) struct OpenAIUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    /// OpenAI nests cached-prompt-token count under `prompt_tokens_details`;
+    /// it's a subset of `prompt_tokens`, not a disjoint bucket.
+    #[serde(default)]
+    pub prompt_tokens_details: Option<OpenAIPromptTokensDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAIPromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -124,8 +146,20 @@ pub(crate) struct AnthropicContent {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct AnthropicUsage {
+    /// Raw input tokens NOT served from cache and NOT establishing new
+    /// cache entries. To produce the canonical `prompt_tokens`, sum this
+    /// with the two cache fields at conversion time.
     pub input_tokens: u32,
     pub output_tokens: u32,
+    /// Prompt tokens served from cache. Discounted tier.
+    #[serde(default)]
+    pub cache_read_input_tokens: Option<u32>,
+    /// Prompt tokens that established new cache entries on this request.
+    /// Premium tier (~1.25× input). v1 collapses 5m/1h TTL buckets into
+    /// one field; if the response carries a nested `cache_creation`
+    /// object keyed by TTL, serde will ignore it here.
+    #[serde(default)]
+    pub cache_creation_input_tokens: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -158,10 +192,18 @@ impl From<OpenAIResponse> for LlmResponse {
             text,
             model: resp.model,
             finish_reason,
-            usage: resp.usage.map(|u| Usage {
-                prompt_tokens: u.prompt_tokens,
-                completion_tokens: u.completion_tokens,
-                total_tokens: u.total_tokens,
+            usage: resp.usage.map(|u| {
+                let cache_read_input_tokens =
+                    u.prompt_tokens_details.and_then(|d| d.cached_tokens);
+                Usage {
+                    prompt_tokens: u.prompt_tokens,
+                    completion_tokens: u.completion_tokens,
+                    total_tokens: u.total_tokens,
+                    cache_read_input_tokens,
+                    // OpenAI doesn't report cache creation; caching is
+                    // implicit and billed as a read discount only.
+                    cache_creation_input_tokens: None,
+                }
             }),
             id: Some(resp.id),
         }
@@ -187,10 +229,23 @@ impl From<AnthropicResponse> for LlmResponse {
             text,
             model: resp.model,
             finish_reason: resp.stop_reason,
-            usage: resp.usage.map(|u| Usage {
-                prompt_tokens: u.input_tokens,
-                completion_tokens: u.output_tokens,
-                total_tokens: u.input_tokens + u.output_tokens,
+            usage: resp.usage.map(|u| {
+                let cache_read = u.cache_read_input_tokens.unwrap_or(0);
+                let cache_creation = u.cache_creation_input_tokens.unwrap_or(0);
+                // Anthropic reports `input_tokens` as the uncached-and-
+                // not-establishing-cache bucket only. Re-synthesize
+                // canonical `prompt_tokens` as the sum of all three
+                // buckets so downstream derivation
+                // `uncached = prompt_tokens - cache_read - cache_creation`
+                // returns raw `input_tokens`.
+                let prompt_tokens = u.input_tokens + cache_read + cache_creation;
+                Usage {
+                    prompt_tokens,
+                    completion_tokens: u.output_tokens,
+                    total_tokens: prompt_tokens + u.output_tokens,
+                    cache_read_input_tokens: u.cache_read_input_tokens,
+                    cache_creation_input_tokens: u.cache_creation_input_tokens,
+                }
             }),
             id: Some(resp.id),
         }
@@ -238,6 +293,7 @@ mod tests {
                 prompt_tokens: 10,
                 completion_tokens: 5,
                 total_tokens: 15,
+                prompt_tokens_details: None,
             }),
         };
 
@@ -246,6 +302,38 @@ mod tests {
         assert_eq!(resp.model, "gpt-4o-mini");
         assert_eq!(resp.finish_reason, Some("stop".into()));
         assert!(resp.usage.is_some());
+        let usage = resp.usage.unwrap();
+        assert_eq!(usage.cache_read_input_tokens, None);
+        assert_eq!(usage.cache_creation_input_tokens, None);
+    }
+
+    #[test]
+    fn test_openai_response_with_cached_tokens() {
+        let openai = OpenAIResponse {
+            id: "chatcmpl-cache".into(),
+            model: "gpt-4o".into(),
+            choices: vec![OpenAIChoice {
+                message: OpenAIMessage {
+                    role: "assistant".into(),
+                    content: Some("cached".into()),
+                },
+                finish_reason: Some("stop".into()),
+            }],
+            usage: Some(OpenAIUsage {
+                prompt_tokens: 1000,
+                completion_tokens: 50,
+                total_tokens: 1050,
+                prompt_tokens_details: Some(OpenAIPromptTokensDetails {
+                    cached_tokens: Some(400),
+                }),
+            }),
+        };
+        let resp: LlmResponse = openai.into();
+        let usage = resp.usage.expect("usage present");
+        // OpenAI `cached_tokens` is a SUBSET of prompt_tokens — unchanged.
+        assert_eq!(usage.prompt_tokens, 1000);
+        assert_eq!(usage.cache_read_input_tokens, Some(400));
+        assert_eq!(usage.cache_creation_input_tokens, None);
     }
 
     #[test]
@@ -261,6 +349,8 @@ mod tests {
             usage: Some(AnthropicUsage {
                 input_tokens: 10,
                 output_tokens: 5,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
             }),
         };
 
@@ -269,6 +359,41 @@ mod tests {
         assert_eq!(resp.model, "claude-3-5-sonnet-20241022");
         assert!(resp.usage.is_some());
         let usage = resp.usage.unwrap();
+        // With no cache, prompt_tokens == input_tokens.
+        assert_eq!(usage.prompt_tokens, 10);
         assert_eq!(usage.total_tokens, 15);
+        assert_eq!(usage.cache_read_input_tokens, None);
+        assert_eq!(usage.cache_creation_input_tokens, None);
+    }
+
+    #[test]
+    fn test_anthropic_response_with_cache_buckets() {
+        let anthropic = AnthropicResponse {
+            id: "msg_cache".into(),
+            model: "claude-3-5-sonnet".into(),
+            content: vec![AnthropicContent {
+                content_type: "text".into(),
+                text: Some("reply".into()),
+            }],
+            stop_reason: Some("end_turn".into()),
+            usage: Some(AnthropicUsage {
+                input_tokens: 100,
+                output_tokens: 20,
+                cache_read_input_tokens: Some(500),
+                cache_creation_input_tokens: Some(300),
+            }),
+        };
+        let resp: LlmResponse = anthropic.into();
+        let usage = resp.usage.expect("usage present");
+        // Canonical prompt_tokens = raw input + read + creation.
+        assert_eq!(usage.prompt_tokens, 900);
+        assert_eq!(usage.cache_read_input_tokens, Some(500));
+        assert_eq!(usage.cache_creation_input_tokens, Some(300));
+        // Derived uncached = prompt_tokens - read - creation matches raw input.
+        let derived_uncached = usage
+            .prompt_tokens
+            .saturating_sub(usage.cache_read_input_tokens.unwrap_or(0))
+            .saturating_sub(usage.cache_creation_input_tokens.unwrap_or(0));
+        assert_eq!(derived_uncached, 100);
     }
 }

--- a/crates/xybrid-core/tests/legacy_cache_names.rs
+++ b/crates/xybrid-core/tests/legacy_cache_names.rs
@@ -1,0 +1,53 @@
+// Ensures wire-format-specific legacy cache-token names don't leak
+// outside the one place that legitimately speaks them (the gateway
+// parser, which reads them off DeepSeek's response wire). Anything
+// else is a canonical-field violation.
+//
+// Forbidden names are rebuilt at runtime from small shards so the test
+// source itself is not an offender when scanned. The scan is rooted at
+// `src/` only — this file sits in `tests/`, physically outside the
+// scan path, so it cannot self-flag.
+
+#[test]
+fn legacy_cache_names_are_contained() {
+    // Rebuild at runtime. Individual shards are benign — only the
+    // concatenated forms are forbidden.
+    let forbidden = [
+        format!("prompt{}cache{}hit{}tokens", "_", "_", "_"),
+        format!("prompt{}cache{}miss{}tokens", "_", "_", "_"),
+        format!("cache{}hit{}tokens", "_", "_"),
+        format!("cache{}miss{}tokens", "_", "_"),
+    ];
+
+    let scan_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    for entry in walkdir::WalkDir::new(&scan_root) {
+        let e = match entry {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if !e.file_type().is_file() {
+            continue;
+        }
+        let path = e.path();
+        if path.extension().and_then(|o| o.to_str()) != Some("rs") {
+            continue;
+        }
+        // The gateway parser is the ONLY place that speaks DeepSeek's
+        // wire names; everywhere else should use canonical names.
+        // `ends_with` matches the full final path component so this
+        // allow doesn't leak to unrelated client.rs files nested
+        // elsewhere in the tree.
+        let allow = path.ends_with("cloud/client.rs");
+        if allow {
+            continue;
+        }
+        let body = std::fs::read_to_string(path).unwrap_or_default();
+        for name in &forbidden {
+            if body.contains(name) {
+                offenders.push(format!("{} contains {}", path.display(), name));
+            }
+        }
+    }
+    assert!(offenders.is_empty(), "{:#?}", offenders);
+}

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -303,6 +303,9 @@ struct PlatformEventBatch {
     events: Vec<PlatformEvent>,
 }
 
+const CONTEXT_PIPELINE_ID_KEY: &str = "__xybrid_pipeline_id";
+const CONTEXT_TRACE_ID_KEY: &str = "__xybrid_trace_id";
+
 /// HTTP telemetry exporter that sends events to the Xybrid Platform
 ///
 /// # Resilience Features
@@ -809,6 +812,8 @@ fn convert_to_platform_event(
 ) -> PlatformEvent {
     // Build payload from event fields
     let mut payload = serde_json::json!({});
+    let mut event_pipeline_id = pipeline_id;
+    let mut event_trace_id = trace_id;
 
     if let Some(stage) = &event.stage_name {
         payload["stage_name"] = serde_json::json!(stage);
@@ -827,7 +832,43 @@ fn convert_to_platform_event(
     }
     if let Some(data) = &event.data {
         // Try to parse as JSON, otherwise store as string
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(data) {
+        if let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(data) {
+            if let Some(obj) = parsed.as_object_mut() {
+                if let Some(v) = obj.remove(CONTEXT_PIPELINE_ID_KEY) {
+                    event_pipeline_id = v.as_str().and_then(|s| Uuid::parse_str(s).ok());
+                }
+                if let Some(v) = obj.remove(CONTEXT_TRACE_ID_KEY) {
+                    event_trace_id = v.as_str().and_then(|s| Uuid::parse_str(s).ok());
+                }
+            }
+            // Hoist select top-level fields from `data` into `payload` so
+            // downstream analytics (the platform's /traces list reads
+            // these at the top level of the JSONB payload) can find them
+            // without diving into the nested `data` object. Spans further
+            // down already populate `tokens_in` / `tokens_out` for
+            // local-inference events; this covers the non-span path where
+            // a caller publishes usage info manually — e.g. a direct
+            // cloud-provider response whose `usage` block wouldn't
+            // otherwise reach the dashboard's cost column.
+            for key in [
+                "tokens_in",
+                "tokens_out",
+                "model_id",
+                // Cache-tier tokens for providers that report them.
+                // Canonical names (Anthropic-flavored) so the list page
+                // and detail-page receipt work uniformly across
+                // DeepSeek / Anthropic / OpenAI / Gemini.
+                "cache_read_input_tokens",
+                "cache_creation_input_tokens",
+            ]
+            .iter()
+            {
+                if payload.get(*key).is_none() {
+                    if let Some(v) = parsed.get(*key) {
+                        payload[*key] = v.clone();
+                    }
+                }
+            }
             payload["data"] = parsed;
         } else {
             payload["data"] = serde_json::json!(data);
@@ -838,12 +879,55 @@ fn convert_to_platform_event(
     let timestamp = chrono::DateTime::from_timestamp_millis(event.timestamp_ms as i64)
         .map(|dt| dt.to_rfc3339());
 
-    // Capture spans for PipelineComplete and ModelComplete events
-    // This includes the full span tree from TemplateExecutor instrumentation
+    // Capture spans for PipelineComplete and ModelComplete events.
+    //
+    // Two source paths, in priority order:
+    //
+    //   1. **Embedded spans in `event.data["spans"]`** — used when the
+    //      caller pre-captured the span tree synchronously before
+    //      publishing. This sidesteps a race in the default (global
+    //      collector) path: `convert_to_platform_event` runs on the
+    //      exporter's background thread, but the global tracing
+    //      collector is mutated live by whatever the caller's next
+    //      unit of work is opening. For bursty emitters (e.g. chunked
+    //      document summarization firing many ModelComplete events
+    //      back-to-back), this produced empty/misattributed stages.
+    //      Callers that need deterministic per-event capture write
+    //      `get_stages_json()["spans"]` into `event.data["spans"]`
+    //      and reset tracing themselves before publishing.
+    //
+    //   2. **Global `TemplateExecutor`-populated collector** — the
+    //      historical path, preserved for in-process local inference
+    //      where only one model call is active at a time and the race
+    //      doesn't manifest.
     let stages = if (event.event_type == "PipelineComplete" || event.event_type == "ModelComplete")
         && core_tracing::is_tracing_enabled()
     {
-        let spans = core_tracing::get_stages_json();
+        let embedded_spans: Option<serde_json::Value> = payload
+            .get("data")
+            .and_then(|d| d.get("spans"))
+            .filter(|v| !v.is_null())
+            .cloned();
+
+        let spans = if let Some(inner) = embedded_spans {
+            // Do NOT reset the global collector here. The caller already
+            // did its own synchronous capture+reset on the publishing
+            // thread (see `publish_telemetry_event::snapshot_spans_into_event`
+            // and Mirage's `summarize.rs::synthesize_chunk_cloud`). Any
+            // state currently in the collector at this moment belongs to
+            // OTHER in-flight work on other threads — resetting it here
+            // would steal their open spans and drop them on the floor,
+            // producing empty flamegraphs for those subsequent events.
+            // That's the race the earlier reset caused: a classifier's
+            // async-processed embedded-spans event clobbered a concurrent
+            // cloud synthesize's still-open span stack.
+            serde_json::json!({ "spans": inner })
+        } else {
+            let s = core_tracing::get_stages_json();
+            core_tracing::reset_tracing();
+            s
+        };
+
         // Hoist LLM token counts from the span metadata into the outer
         // payload so analytics backends that read `tokens_in` /
         // `tokens_out` at the top of the event see them without having
@@ -851,14 +935,16 @@ fn convert_to_platform_event(
         // span is present.
         if let Some((tokens_in, tokens_out)) = extract_llm_token_counts(&spans) {
             if let Some(n) = tokens_in {
-                payload["tokens_in"] = serde_json::json!(n);
+                if payload.get("tokens_in").is_none() {
+                    payload["tokens_in"] = serde_json::json!(n);
+                }
             }
             if let Some(n) = tokens_out {
-                payload["tokens_out"] = serde_json::json!(n);
+                if payload.get("tokens_out").is_none() {
+                    payload["tokens_out"] = serde_json::json!(n);
+                }
             }
         }
-        // Reset tracing for next execution
-        core_tracing::reset_tracing();
         Some(spans)
     } else {
         None
@@ -874,8 +960,8 @@ fn convert_to_platform_event(
         app_version: config.app_version.clone(),
         device: device_profile.cloned(),
         timestamp,
-        pipeline_id,
-        trace_id,
+        pipeline_id: event_pipeline_id,
+        trace_id: event_trace_id,
         stages,
     }
 }
@@ -1284,8 +1370,119 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
     }
 }
 
+/// Synchronous span snapshot for publish. Only acts on completion-family
+/// events (PipelineComplete / ModelComplete) where the dashboard wants a
+/// flamegraph; skips if the caller already embedded their own spans.
+/// When it does act, it drains the global collector so the next unit of
+/// work on this thread starts with a clean slate.
+fn snapshot_spans_into_event(event: TelemetryEvent) -> TelemetryEvent {
+    let is_completion = matches!(
+        event.event_type.as_str(),
+        "PipelineComplete" | "ModelComplete"
+    );
+    if !is_completion || !core_tracing::is_tracing_enabled() {
+        return event;
+    }
+
+    // If the caller already has spans in their data blob, leave it
+    // alone — they opted into managing their own lifecycle (Mirage
+    // does this for cross-chunk isolation).
+    let data_already_has_spans = event
+        .data
+        .as_ref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+        .and_then(|v| v.get("spans").cloned())
+        .filter(|v| !v.is_null())
+        .is_some();
+    if data_already_has_spans {
+        return event;
+    }
+
+    let captured = core_tracing::get_stages_json();
+    core_tracing::reset_tracing();
+
+    // Merge captured spans into event.data["spans"].
+    let mut merged: serde_json::Value = event
+        .data
+        .as_ref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if !merged.is_object() {
+        merged = serde_json::json!({});
+    }
+    if let Some(spans) = captured.get("spans") {
+        merged["spans"] = spans.clone();
+    }
+
+    TelemetryEvent {
+        data: Some(merged.to_string()),
+        ..event
+    }
+}
+
+fn current_telemetry_pipeline_context() -> (Option<Uuid>, Option<Uuid>) {
+    if let Ok(exporter) = PLATFORM_EXPORTER.read() {
+        if let Some(exp) = exporter.as_ref() {
+            let pipeline_id = exp.pipeline_id.read().ok().and_then(|g| *g);
+            let trace_id = exp.trace_id.read().ok().and_then(|g| *g);
+            return (pipeline_id, trace_id);
+        }
+    }
+    (None, None)
+}
+
+fn snapshot_context_into_event(event: TelemetryEvent) -> TelemetryEvent {
+    let (pipeline_id, trace_id) = current_telemetry_pipeline_context();
+    if pipeline_id.is_none() && trace_id.is_none() {
+        return event;
+    }
+
+    let mut data = match event.data.as_ref() {
+        Some(raw) => match serde_json::from_str::<serde_json::Value>(raw) {
+            Ok(value) if value.is_object() => value,
+            Ok(value) => serde_json::json!({ "value": value }),
+            Err(_) => serde_json::json!({ "value": raw }),
+        },
+        None => serde_json::json!({}),
+    };
+
+    if let Some(obj) = data.as_object_mut() {
+        if let Some(id) = pipeline_id {
+            obj.insert(CONTEXT_PIPELINE_ID_KEY.to_string(), serde_json::json!(id));
+        }
+        if let Some(id) = trace_id {
+            obj.insert(CONTEXT_TRACE_ID_KEY.to_string(), serde_json::json!(id));
+        }
+    }
+
+    TelemetryEvent {
+        data: Some(data.to_string()),
+        ..event
+    }
+}
+
 /// Publish a telemetry event to all registered subscribers
 pub fn publish_telemetry_event(event: TelemetryEvent) {
+    // Span snapshot: capture spans synchronously at publish time.
+    //
+    // The exporter thread (`convert_to_platform_event`) used to do this
+    // asynchronously, which caused a race when a caller published
+    // ModelComplete/PipelineComplete events back-to-back: any span opened
+    // by the next unit of work (e.g. Mirage's chunked summarize opening
+    // `cloud_synthesize` immediately after a local classifier's event
+    // published) could be stolen or reset by the exporter while still
+    // open, producing empty spans / 0ms durations in the flamegraph.
+    //
+    // Capturing here instead, on the PUBLISHING thread, anchors each
+    // event's span tree to the exact state of the global collector at
+    // the moment the caller finished emitting it. Subsequent span work
+    // on the same thread is cleanly separated. Callers that already
+    // embedded `spans` in `event.data` (e.g. Mirage's `summarize.rs`
+    // `synthesize_chunk_cloud`, which captures+resets earlier for
+    // composability) are left untouched so they keep full control.
+    let event = snapshot_spans_into_event(event);
+    let event = snapshot_context_into_event(event);
+
     // Use unwrap_or_else to recover from poisoned mutex - this prevents
     // a panic in one component from permanently breaking telemetry
     let Ok(senders) = TELEMETRY_SENDERS.lock() else {
@@ -1335,6 +1532,61 @@ pub fn bridge_orchestrator_events(orchestrator: &xybrid_core::orchestrator::Orch
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn platform_event_payload_has_no_legacy_cache_keys() {
+        // End-to-end through convert_to_platform_event so we exercise
+        // the real hoist list + serde path. A ModelComplete event
+        // carrying a data blob with canonical cache keys must
+        // serialize to a payload that contains the canonical names and
+        // none of the DeepSeek-specific legacy names. This backs up
+        // the source-containment test (`tests/legacy_cache_names.rs`)
+        // with a runtime-format assertion: if a field rename is
+        // incomplete — e.g., a `#[serde(rename = "cache_hit_tokens")]`
+        // is forgotten or a manual json literal writes the old key —
+        // this catches it even when the source file reads canonical.
+        let data = serde_json::json!({
+            "model_id": "deepseek-chat",
+            "tokens_in": 1000,
+            "tokens_out": 120,
+            "cost_usd": 0.00123,
+            "cache_read_input_tokens": 800,
+            "cache_read_cost_usd": 0.000056,
+            "uncached_input_cost_usd": 0.000054,
+        });
+        let event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("cloud_synthesize".to_string()),
+            target: Some("cloud".to_string()),
+            latency_ms: Some(420),
+            error: None,
+            data: Some(data.to_string()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform_event =
+            convert_to_platform_event(&event, &config, None, None, None);
+        let payload_json = serde_json::to_string(&platform_event.payload).unwrap();
+
+        // Forbidden keys built at runtime so the source of this file
+        // doesn't contain the literals (5a would flag them otherwise).
+        let forbidden = [
+            format!("cache{}hit{}tokens", "_", "_"),
+            format!("cache{}miss{}tokens", "_", "_"),
+            format!("cache{}hit{}cost{}usd", "_", "_", "_"),
+            format!("cache{}miss{}cost{}usd", "_", "_", "_"),
+        ];
+        for key in &forbidden {
+            assert!(
+                !payload_json.contains(key),
+                "platform event payload leaked legacy key {key}: {payload_json}"
+            );
+        }
+        // Positive assertion — the canonical name IS present. Without
+        // this, an empty payload would trivially satisfy the negation
+        // above.
+        assert!(payload_json.contains("cache_read_input_tokens"));
+    }
 
     #[test]
     fn test_convert_stage_start_event() {
@@ -1675,6 +1927,51 @@ mod tests {
             json.get("device_id").is_none(),
             "strict opt-out must omit `device_id` entirely, not emit null. got: {json}"
         );
+    }
+
+    #[test]
+    fn embedded_context_overrides_flush_context() {
+        let config = TelemetryConfig::new("http://example.invalid", "k");
+        let event_pipeline_id = Uuid::new_v4();
+        let event_trace_id = Uuid::new_v4();
+        let flush_pipeline_id = Uuid::new_v4();
+        let flush_trace_id = Uuid::new_v4();
+        let event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: None,
+            target: Some("cloud".to_string()),
+            latency_ms: Some(42),
+            error: None,
+            data: Some(
+                serde_json::json!({
+                    CONTEXT_PIPELINE_ID_KEY: event_pipeline_id,
+                    CONTEXT_TRACE_ID_KEY: event_trace_id,
+                    "model_id": "deepseek-chat",
+                    "tokens_in": 100,
+                    "tokens_out": 10,
+                })
+                .to_string(),
+            ),
+            timestamp_ms: 0,
+        };
+
+        let converted = convert_to_platform_event(
+            &event,
+            &config,
+            None,
+            Some(flush_pipeline_id),
+            Some(flush_trace_id),
+        );
+
+        assert_eq!(converted.pipeline_id, Some(event_pipeline_id));
+        assert_eq!(converted.trace_id, Some(event_trace_id));
+        assert_eq!(converted.payload["model_id"], "deepseek-chat");
+        assert!(converted.payload["data"]
+            .get(CONTEXT_PIPELINE_ID_KEY)
+            .is_none());
+        assert!(converted.payload["data"]
+            .get(CONTEXT_TRACE_ID_KEY)
+            .is_none());
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1564,8 +1564,7 @@ mod tests {
             timestamp_ms: 1_700_000_000_000,
         };
         let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
-        let platform_event =
-            convert_to_platform_event(&event, &config, None, None, None);
+        let platform_event = convert_to_platform_event(&event, &config, None, None, None);
         let payload_json = serde_json::to_string(&platform_event.payload).unwrap();
 
         // Forbidden keys built at runtime so the source of this file


### PR DESCRIPTION
## Summary

Surfaces provider-reported prompt-cache token counts on `cloud::completion::Usage` so cost-tiered billing and cache-aware dashboards can distinguish between prompt tokens served from a provider's prefix cache and tokens that were processed fresh.

Cache metrics were being silently dropped on every code path that returned a `Usage`. This PR plumbs them through with provider-agnostic field names that are a superset of every major LLM API's response shape, adds adapter support on the direct-call path (previously hard-coded to `None`), and updates the telemetry hoist list so downstream telemetry consumers see the canonical keys at the payload top level.

## Shape

Two new optional fields on `cloud::completion::Usage`:

```rust
pub cache_read_input_tokens: Option<u32>,
pub cache_creation_input_tokens: Option<u32>,
```

- `cache_read_input_tokens` — prompt tokens served from the provider's prefix cache. Discounted-tier, universal across every provider that reports caching today.
- `cache_creation_input_tokens` — prompt tokens that ESTABLISHED new cache entries on this request. Premium tier (~1.25x input rate on the one provider that reports it); left as `None` on everything else.

Uncached is derived downstream as `prompt_tokens - cache_read - cache_creation`, so we don't store a redundant miss field that could drift with provider semantics.

Presence of `cache_read_input_tokens` is the one-field gate downstream code uses to decide whether to render a cache breakdown. `Some(0)` means cold cache (render 0% with the breakdown); `None` means the provider doesn't report caching at all (render a flat single-tier bar).

## Per-provider mapping

Every supported provider normalizes into the same pair:

| Wire shape | -> `cache_read_input_tokens` | -> `cache_creation_input_tokens` | Notes |
|---|---|---|---|
| OpenAI-compatible gateway with hit/miss tokens | hit count | `None` | Miss is derivable from `prompt_tokens - read`; not stored. Cold-cache responses that include only the miss key still surface `read = Some(0)` to preserve the "not reported vs cold cache" distinction. |
| OpenAI-compat `prompt_tokens_details.cached_tokens` | `cached_tokens` (subset of `prompt_tokens`) | `None` | `prompt_tokens` stays as reported -- cached is a subset, not a disjoint bucket. |
| Anthropic `cache_read_input_tokens` + `cache_creation_input_tokens` | direct passthrough | direct passthrough | Canonical `prompt_tokens` is synthesized as `input_tokens + read + creation` so downstream derivation (`uncached = prompt_tokens - read - creation`) returns the raw `input_tokens`. v1 collapses 5m/1h TTL creation buckets into one field. |
| Provider that doesn't report cache metrics | `None` | `None` | Downstream falls back to flat cost formula. |

## What changed, per commit

### `feat(core): surface provider-agnostic prompt-cache token counts`

- **`cloud::completion::Usage`** -- rename the two cache fields to the canonical pair and document the per-provider semantics. Remove the old hit/miss names and the zeroed `From<LlmResponse>` stub (no longer needed now that the direct-path adapter carries cache fields).
- **`cloud::client`** -- extract the gateway response parser into a pub-at-test-scope `parse_gateway_usage` helper. Map the OpenAI-compat gateway's hit count onto `cache_read_input_tokens`; drop the miss count (derivable). Keep either-field presence detection so cold-cache responses surface as `Some(0)` rather than `None`.
- **`tests/legacy_cache_names.rs`** (new) -- integration test that scans `src/` and asserts legacy wire-name strings don't leak outside the one parser source that legitimately speaks them. Forbidden names are rebuilt at runtime from shards so the test source itself is not an offender when scanned.

### `feat(core): add cache fields to direct OpenAI/Anthropic parsers`

- **`cloud_llm::response`** -- extend the intermediate `LlmUsage` carrier with the two cache fields.
- **OpenAI adapter** -- add nested `prompt_tokens_details.cached_tokens` parsing. `prompt_tokens` stays unchanged (cached is a subset). `cache_creation_input_tokens = None` (provider doesn't report creation).
- **Anthropic adapter** -- read both `cache_read_input_tokens` + `cache_creation_input_tokens` directly. Rebuild canonical `prompt_tokens` as `input_tokens + read + creation` so downstream derivation returns raw `input_tokens`.
- **Tests** -- new unit cases covering Anthropic's sum reconstruction, OpenAI's subset semantics (with and without `prompt_tokens_details`).

Previously the direct-backend path hard-coded both cache fields to `None` -- any application bypassing the gateway client silently lost cache visibility. This unblocks it.

### `feat(sdk): hoist canonical cache tokens + payload regression test`

- **`xybrid-sdk::telemetry`** -- rename the hoist list entries in `convert_to_platform_event` to the canonical keys. Keeps the cache fields visible at the payload top level so telemetry consumers don't need to parse `data` to read them.
- **Tests** -- `platform_event_payload_has_no_legacy_cache_keys`: end-to-end through `convert_to_platform_event` with a mock `ModelComplete` event; asserts the resulting JSON payload contains the canonical names and none of the legacy ones. Forbidden strings built at runtime so this source stays clean against the containment test in the first commit.

## Tests

- `cargo test -p xybrid-core` -- all passing (6 conversion tests in `cloud_llm::response`, 3 gateway parse tests in `cloud::client`, 1 source-containment integration test in `tests/legacy_cache_names.rs`).
- `cargo test -p xybrid-sdk --features platform-macos` -- passing (1 new payload-containment test alongside existing convert tests).
- `cargo check -p xybrid-core -p xybrid-sdk` -- green.
- `cargo clippy --workspace -- -D warnings` -- green.

## Compatibility

- **Wire format**: the payload shape is additive -- new keys appear alongside existing ones; legacy consumers that don't know about them ignore them. Optional `#[serde(skip_serializing_if = "Option::is_none")]` so empty values don't pollute the payload.
- **FFI**: `cloud::Usage` is not exposed through any flutter_rust_bridge / UniFFI / C-FFI boundary. Mobile bindings (Flutter / Apple / Kotlin / Unity) don't need to recompile.
- **Consumers on the old Usage shape**: source-incompatible rename (the old fields are gone, not deprecated). The two fields were added recently and only two call sites outside this repo referenced them; both should be updated in lockstep with this PR.

## Out of scope (follow-ups)

- Anthropic 5m vs 1h TTL cache-creation pricing split (currently collapsed to the 5m rate on the cost-math side). Would be a follow-up adding `cache_creation_5m_input_tokens` + `cache_creation_1h_input_tokens` fields when TTL-granular billing parity becomes load-bearing.
- Gemini adapter (`cached_content_token_count` -> `cache_read_input_tokens`). Not in this PR because the Gemini adapter doesn't exist in the tree yet; mapping will land with it.