### PR TITLE
feat(core,sdk): per-inference resource telemetry foundation

### DIFF
--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -129,6 +129,10 @@ required-features = ["llm-llamacpp"]
 name = "inference_backends"
 harness = false
 
+[[bench]]
+name = "resource_telemetry"
+harness = false
+
 # Platform-specific ureq dependencies
 # Non-Android: Use default ureq with TLS
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/crates/xybrid-core/benches/resource_telemetry.rs
+++ b/crates/xybrid-core/benches/resource_telemetry.rs
@@ -1,0 +1,66 @@
+//! Criterion bench for the resource-telemetry monitor (INF-32).
+//!
+//! SLO gates defended:
+//!   * cached snapshot read:     < 100 µs
+//!   * cache-miss refresh:       < 1 ms (warm `System`)
+//!   * Boundary mode, per run:   < 1 ms
+//!   * Summary @ 1000 ms:        < 1 % throughput hit vs Off
+//!
+//! Run with:
+//!   cargo bench -p xybrid-core --bench resource_telemetry
+
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use xybrid_core::device::{ResourceMonitor, ResourceTelemetryMode};
+
+fn bench_cached_snapshot(c: &mut Criterion) {
+    let monitor = ResourceMonitor::new();
+    monitor.prewarm();
+    c.bench_function("resource_snapshot::cached_500ms", |b| {
+        b.iter(|| {
+            let _ = monitor.current_snapshot(Duration::from_millis(500));
+        });
+    });
+}
+
+fn bench_refresh_snapshot(c: &mut Criterion) {
+    let monitor = ResourceMonitor::new();
+    monitor.prewarm();
+    c.bench_function("resource_snapshot::cache_miss_refresh", |b| {
+        b.iter(|| {
+            // max_age == 0 forces a refresh every call.
+            let _ = monitor.current_snapshot(Duration::ZERO);
+        });
+    });
+}
+
+fn bench_begin_run_off(c: &mut Criterion) {
+    let monitor = ResourceMonitor::new();
+    c.bench_function("resource_run::off", |b| {
+        b.iter(|| {
+            let guard = monitor.begin_run(ResourceTelemetryMode::Off);
+            let _ = guard.finish();
+        });
+    });
+}
+
+fn bench_begin_run_boundary(c: &mut Criterion) {
+    let monitor = ResourceMonitor::new();
+    monitor.prewarm();
+    c.bench_function("resource_run::boundary", |b| {
+        b.iter(|| {
+            let guard = monitor.begin_run(ResourceTelemetryMode::Boundary);
+            let _ = guard.finish();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_cached_snapshot,
+    bench_refresh_snapshot,
+    bench_begin_run_off,
+    bench_begin_run_boundary,
+);
+criterion_main!(benches);

--- a/crates/xybrid-core/benches/resource_telemetry.rs
+++ b/crates/xybrid-core/benches/resource_telemetry.rs
@@ -56,11 +56,41 @@ fn bench_begin_run_boundary(c: &mut Criterion) {
     });
 }
 
+fn bench_begin_run_summary_1000(c: &mut Criterion) {
+    // Dominated by sampler-thread spawn + stop overhead plus two
+    // ResourceSnapshot reads. Real inferences run far longer than a
+    // single tick; the SLO defended here is per-run bookkeeping, not
+    // sampler-window throughput.
+    let monitor = ResourceMonitor::new();
+    monitor.prewarm();
+    c.bench_function("resource_run::summary_1000ms", |b| {
+        b.iter(|| {
+            let guard = monitor.begin_run(ResourceTelemetryMode::Summary { interval_ms: 1000 });
+            let _ = guard.finish();
+        });
+    });
+}
+
+fn bench_begin_run_summary_250_stress(c: &mut Criterion) {
+    // MIN_SAMPLE_INTERVAL_MS floor. Documents overhead at the most
+    // aggressive legal configuration — not a default.
+    let monitor = ResourceMonitor::new();
+    monitor.prewarm();
+    c.bench_function("resource_run::summary_250ms_stress", |b| {
+        b.iter(|| {
+            let guard = monitor.begin_run(ResourceTelemetryMode::Summary { interval_ms: 250 });
+            let _ = guard.finish();
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_cached_snapshot,
     bench_refresh_snapshot,
     bench_begin_run_off,
     bench_begin_run_boundary,
+    bench_begin_run_summary_1000,
+    bench_begin_run_summary_250_stress,
 );
 criterion_main!(benches);

--- a/crates/xybrid-core/src/device/mod.rs
+++ b/crates/xybrid-core/src/device/mod.rs
@@ -48,6 +48,10 @@ pub mod capabilities;
 // Telemetry-facing device profile (chip, RAM, OS, for wire events)
 pub mod profile;
 
+// Per-inference resource monitor + sampler (INF-23 epic).
+// See `docs/sdk/resource-telemetry.md` for the public contract.
+pub mod resource;
+
 // Platform tests
 #[cfg(test)]
 mod tests;
@@ -55,6 +59,10 @@ mod tests;
 // Re-exports for convenience
 pub use capabilities::detect_capabilities;
 pub use profile::DeviceProfile;
+pub use resource::{
+    MemoryPressure, ResourceMonitor, ResourceSnapshot, ResourceTelemetryMode, ResourceUsageSummary,
+    RunGuard,
+};
 pub use types::{
     DetectionConfidence, DetectionSource, GpuType, HardwareCapabilities, NpuType, Platform,
     ThermalState,

--- a/crates/xybrid-core/src/device/mod.rs
+++ b/crates/xybrid-core/src/device/mod.rs
@@ -48,7 +48,7 @@ pub mod capabilities;
 // Telemetry-facing device profile (chip, RAM, OS, for wire events)
 pub mod profile;
 
-// Per-inference resource monitor + sampler (INF-23 epic).
+// Per-inference resource monitor + sampler.
 // See `docs/sdk/resource-telemetry.md` for the public contract.
 pub mod resource;
 

--- a/crates/xybrid-core/src/device/resource/mod.rs
+++ b/crates/xybrid-core/src/device/resource/mod.rs
@@ -1,0 +1,791 @@
+//! Resource telemetry primitive.
+//!
+//! Provides one retained [`sysinfo::System`] behind a process-wide
+//! [`ResourceMonitor`]. Two producers sit on top:
+//!
+//! - [`ResourceMonitor::current_snapshot`] — synchronous TTL-cached read used
+//!   on the inference hot path by adaptive execution (INF-30).
+//! - [`ResourceMonitor::begin_run`] — per-run sampler that produces one
+//!   [`ResourceUsageSummary`] and attaches it to the outgoing telemetry
+//!   event (INF-29).
+//!
+//! The full contract lives in `docs/sdk/resource-telemetry.md`. Thresholds,
+//! SLOs, and the privacy posture are defined there; this module implements
+//! them.
+
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
+use super::types::ThermalState;
+
+pub mod pressure;
+
+pub use pressure::MemoryPressure;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// How much resource data to collect per inference, and whether to keep raw
+/// samples locally. Default is [`ResourceTelemetryMode::Off`] so existing
+/// callers see no behavior change.
+///
+/// This enum is SDK-runtime state; the serialized wire form for the summary's
+/// `sampling_mode` field is a flat label string (see [`Self::label`]) + a
+/// separate `sampling_interval_ms` to match the dashboard's low-cardinality
+/// column contract. This type itself doesn't participate in the wire payload.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum ResourceTelemetryMode {
+    /// Disabled. No samples, no summary.
+    #[default]
+    Off,
+    /// Start + end snapshots only. No background task.
+    Boundary,
+    /// Active sampling during inference. One background task per process.
+    Summary { interval_ms: u32 },
+    /// Same as `Summary`, plus raw samples retained locally. Never uploaded.
+    DebugLocal { interval_ms: u32 },
+}
+
+impl ResourceTelemetryMode {
+    /// Default summary interval (1 s). Tuned by INF-32 benchmarks; if that
+    /// ticket changes it, update this constant and the spec doc together.
+    pub const DEFAULT_SUMMARY_INTERVAL_MS: u32 = 1000;
+    /// Minimum allowed sample interval. The PRD pins the floor at 250 ms:
+    /// anything below was not validated for overhead and would invalidate
+    /// the bench assumptions. Values below are clamped up at config time.
+    pub const MIN_SAMPLE_INTERVAL_MS: u32 = 250;
+
+    /// Convenience constructor with the default interval.
+    pub fn summary() -> Self {
+        Self::Summary {
+            interval_ms: Self::DEFAULT_SUMMARY_INTERVAL_MS,
+        }
+    }
+
+    /// Clamp any configured interval to the [`MIN_SAMPLE_INTERVAL_MS`] floor.
+    /// Off / Boundary pass through unchanged.
+    pub fn normalized(self) -> Self {
+        match self {
+            Self::Summary { interval_ms } => Self::Summary {
+                interval_ms: interval_ms.max(Self::MIN_SAMPLE_INTERVAL_MS),
+            },
+            Self::DebugLocal { interval_ms } => Self::DebugLocal {
+                interval_ms: interval_ms.max(Self::MIN_SAMPLE_INTERVAL_MS),
+            },
+            other => other,
+        }
+    }
+
+    pub fn is_off(&self) -> bool {
+        matches!(self, Self::Off)
+    }
+
+    /// Does this mode need a background sampler task?
+    pub fn needs_sampler(&self) -> bool {
+        matches!(self, Self::Summary { .. } | Self::DebugLocal { .. })
+    }
+
+    /// `None` for modes without a periodic interval (Off / Boundary).
+    pub fn interval_ms(&self) -> Option<u32> {
+        match self {
+            Self::Summary { interval_ms } | Self::DebugLocal { interval_ms } => Some(*interval_ms),
+            _ => None,
+        }
+    }
+
+    /// Flat string label for the dashboard's `sampling_mode` column and the
+    /// on-wire `resource_summary.sampling_mode` field. Matches the variant
+    /// names used in `docs/sdk/resource-telemetry.md` exactly.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Boundary => "boundary",
+            Self::Summary { .. } => "summary",
+            Self::DebugLocal { .. } => "debug_local",
+        }
+    }
+}
+
+/// Point-in-time observation of device resource state. See
+/// `docs/sdk/resource-telemetry.md#field-reference` for field semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ResourceSnapshot {
+    pub cpu_pct: Option<f32>,
+    pub process_rss_mb: Option<u32>,
+    pub available_mem_mb: Option<u32>,
+    pub total_mem_mb: Option<u32>,
+    pub memory_pressure: MemoryPressure,
+    pub thermal_state: ThermalState,
+    pub battery_pct: Option<u8>,
+    pub captured_at_ms: u64,
+}
+
+impl ResourceSnapshot {
+    /// All-unknown snapshot. Returned when the monitor is misconfigured or
+    /// a refresh fails; callers should never fail inference because a
+    /// snapshot came back empty.
+    pub fn unknown() -> Self {
+        Self {
+            cpu_pct: None,
+            process_rss_mb: None,
+            available_mem_mb: None,
+            total_mem_mb: None,
+            memory_pressure: MemoryPressure::Unknown,
+            thermal_state: ThermalState::Normal,
+            battery_pct: None,
+            captured_at_ms: now_ms(),
+        }
+    }
+}
+
+/// Aggregate observation across a single `ModelComplete` / `PipelineComplete`
+/// run. Attached to `event.data.resource_summary` and hoisted to the
+/// platform-event payload top level by the SDK. The wire shape is flat
+/// (no nested enum) so the Tinybird `LowCardinality(String)` column for
+/// `sampling_mode` can extract cleanly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResourceUsageSummary {
+    pub cpu_avg_pct: Option<f32>,
+    pub cpu_peak_pct: Option<f32>,
+    pub process_rss_peak_mb: Option<u32>,
+    pub available_mem_min_mb: Option<u32>,
+    pub memory_pressure_peak: MemoryPressure,
+    pub thermal_state_peak: ThermalState,
+    pub battery_pct_end: Option<u8>,
+    pub sample_count: u32,
+    /// Label matching `ResourceTelemetryMode::label()`: `"off"`, `"boundary"`,
+    /// `"summary"`, or `"debug_local"`. The dashboard's low-cardinality
+    /// column stores this verbatim.
+    pub sampling_mode: String,
+    /// Configured sample interval for Summary / DebugLocal modes. `None`
+    /// for Off / Boundary so the JSON payload stays compact on the 99 %
+    /// cold path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sampling_interval_ms: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Aggregator
+// ---------------------------------------------------------------------------
+
+/// Collapses a stream of [`ResourceSnapshot`]s into a [`ResourceUsageSummary`]
+/// in place. Used by both the `Boundary` path (2 snapshots) and the `Summary`
+/// sampler (N snapshots).
+#[derive(Debug)]
+struct Aggregator {
+    cpu_sum: f64,
+    cpu_samples: u32,
+    cpu_peak: Option<f32>,
+    rss_peak: Option<u32>,
+    mem_avail_min: Option<u32>,
+    pressure_peak: MemoryPressure,
+    thermal_peak: ThermalState,
+    latest_battery: Option<u8>,
+    sample_count: u32,
+}
+
+impl Aggregator {
+    fn new() -> Self {
+        Self {
+            cpu_sum: 0.0,
+            cpu_samples: 0,
+            cpu_peak: None,
+            rss_peak: None,
+            mem_avail_min: None,
+            pressure_peak: MemoryPressure::Unknown,
+            thermal_peak: ThermalState::Normal,
+            latest_battery: None,
+            sample_count: 0,
+        }
+    }
+
+    fn observe(&mut self, s: &ResourceSnapshot) {
+        self.sample_count = self.sample_count.saturating_add(1);
+
+        if let Some(cpu) = s.cpu_pct {
+            self.cpu_sum += cpu as f64;
+            self.cpu_samples = self.cpu_samples.saturating_add(1);
+            self.cpu_peak = Some(match self.cpu_peak {
+                Some(peak) if peak >= cpu => peak,
+                _ => cpu,
+            });
+        }
+        if let Some(rss) = s.process_rss_mb {
+            self.rss_peak = Some(match self.rss_peak {
+                Some(peak) if peak >= rss => peak,
+                _ => rss,
+            });
+        }
+        if let Some(avail) = s.available_mem_mb {
+            self.mem_avail_min = Some(match self.mem_avail_min {
+                Some(min) if min <= avail => min,
+                _ => avail,
+            });
+        }
+        self.pressure_peak = self.pressure_peak.worse_of(s.memory_pressure);
+        self.thermal_peak = thermal_worse_of(self.thermal_peak, s.thermal_state);
+        if s.battery_pct.is_some() {
+            self.latest_battery = s.battery_pct;
+        }
+    }
+
+    fn finish(self, mode: ResourceTelemetryMode) -> ResourceUsageSummary {
+        let cpu_avg_pct = if self.cpu_samples > 0 {
+            Some((self.cpu_sum / self.cpu_samples as f64) as f32)
+        } else {
+            None
+        };
+        ResourceUsageSummary {
+            cpu_avg_pct,
+            cpu_peak_pct: self.cpu_peak,
+            process_rss_peak_mb: self.rss_peak,
+            available_mem_min_mb: self.mem_avail_min,
+            memory_pressure_peak: self.pressure_peak,
+            thermal_state_peak: self.thermal_peak,
+            battery_pct_end: self.latest_battery,
+            sample_count: self.sample_count,
+            sampling_mode: mode.label().to_string(),
+            sampling_interval_ms: mode.interval_ms(),
+        }
+    }
+}
+
+/// `ThermalState` doesn't implement Ord (variant order reads as severity but
+/// that's not guaranteed long-term), so collapse explicitly.
+fn thermal_worse_of(a: ThermalState, b: ThermalState) -> ThermalState {
+    fn rank(t: ThermalState) -> u8 {
+        match t {
+            ThermalState::Normal => 0,
+            ThermalState::Warm => 1,
+            ThermalState::Hot => 2,
+            ThermalState::Critical => 3,
+        }
+    }
+    if rank(b) > rank(a) {
+        b
+    } else {
+        a
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ResourceMonitor
+// ---------------------------------------------------------------------------
+
+/// Process-wide holder for a single retained [`sysinfo::System`] + its
+/// TTL-cached snapshot. Cheap to clone — it's an `Arc` internally.
+#[derive(Debug, Clone)]
+pub struct ResourceMonitor {
+    inner: Arc<Mutex<Inner>>,
+    /// Current process id, resolved once at construction. `None` means
+    /// `sysinfo::get_current_pid()` refused to answer, in which case process
+    /// RSS stays `None` for every snapshot.
+    pid: Option<Pid>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    system: System,
+    cached: Option<ResourceSnapshot>,
+    cached_at: Option<Instant>,
+    /// Caches `total_memory` after the first refresh — it doesn't change for
+    /// a process lifetime and avoids re-reading on every cache-miss.
+    total_mem_mb: Option<u32>,
+}
+
+impl ResourceMonitor {
+    /// Build a monitor without touching the global singleton. Useful in tests
+    /// that want isolation. Production code should use [`ResourceMonitor::global`].
+    pub fn new() -> Self {
+        let system = System::new();
+        let pid = sysinfo::get_current_pid().ok();
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                system,
+                cached: None,
+                cached_at: None,
+                total_mem_mb: None,
+            })),
+            pid,
+        }
+    }
+
+    /// Process-wide monitor. First caller pays the initialization cost; every
+    /// later caller gets the same `Arc`.
+    pub fn global() -> Arc<Self> {
+        static MONITOR: OnceLock<Arc<ResourceMonitor>> = OnceLock::new();
+        MONITOR.get_or_init(|| Arc::new(Self::new())).clone()
+    }
+
+    /// Pre-warm the monitor so the first inference doesn't pay the
+    /// `sysinfo::System::refresh` cold-read cost. Safe to call repeatedly.
+    pub fn prewarm(&self) {
+        let _ = self.refresh_locked();
+    }
+
+    /// Return a snapshot no older than `max_age`. Pass `Duration::ZERO` to
+    /// force a refresh. The cached read targets `< 100 µs`; a cache-miss
+    /// refresh targets `< 1 ms` on a warm `System`.
+    pub fn current_snapshot(&self, max_age: Duration) -> ResourceSnapshot {
+        // Fast path: read the cached snapshot under the lock and return it
+        // without calling into sysinfo.
+        {
+            let inner = match self.inner.lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if let (Some(snap), Some(at)) = (inner.cached, inner.cached_at) {
+                if at.elapsed() <= max_age {
+                    return snap;
+                }
+            }
+        }
+        // Slow path: refresh and cache.
+        self.refresh_locked()
+    }
+
+    /// Start a per-run monitor scope. The returned [`RunGuard`] captures a
+    /// start snapshot (for Boundary / Summary / DebugLocal modes) and begins
+    /// sampling if the mode needs it. Dropping or `finish()`-ing the guard
+    /// produces the final `ResourceUsageSummary`.
+    pub fn begin_run(&self, mode: ResourceTelemetryMode) -> RunGuard {
+        let mode = mode.normalized();
+        if mode.is_off() {
+            return RunGuard::disabled(mode);
+        }
+        let monitor = self.clone();
+        let start = monitor.current_snapshot(Duration::ZERO);
+        let mut aggregator = Aggregator::new();
+        aggregator.observe(&start);
+
+        let sampler = if mode.needs_sampler() {
+            // Sampler wires up on `start_sampler`, which is only available
+            // when tokio is available in the caller's context. We spawn
+            // eagerly so the sample stream begins right away; aggregation
+            // happens inside the guard on finish/drop.
+            sampler::start(monitor.clone(), mode)
+        } else {
+            None
+        };
+
+        RunGuard {
+            monitor: Some(monitor),
+            mode,
+            aggregator: Some(aggregator),
+            sampler,
+        }
+    }
+
+    // -- private helpers --
+
+    fn refresh_locked(&self) -> ResourceSnapshot {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        // Cross-platform refreshes available on all sysinfo-supported targets.
+        inner.system.refresh_memory();
+        inner.system.refresh_cpu_all();
+        if let Some(pid) = self.pid {
+            // sysinfo 0.32 replaced `refresh_process(pid)` with the plural
+            // form; the second bool prunes dead processes from the cache.
+            inner
+                .system
+                .refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+        }
+
+        let total_bytes = inner.system.total_memory();
+        let total_mb = bytes_to_mb(total_bytes);
+        if total_mb.is_some() && inner.total_mem_mb.is_none() {
+            inner.total_mem_mb = total_mb;
+        }
+        let available_mb = bytes_to_mb(inner.system.available_memory());
+        let cpu = inner.system.global_cpu_usage();
+        let cpu_pct = if cpu.is_finite() && cpu >= 0.0 {
+            Some(cpu.min(100.0))
+        } else {
+            None
+        };
+        let process_rss_mb = self.pid.and_then(|pid| {
+            inner
+                .system
+                .process(pid)
+                .map(|p| bytes_to_mb_u64(p.memory()))
+                .unwrap_or(None)
+        });
+
+        let snap = ResourceSnapshot {
+            cpu_pct,
+            process_rss_mb,
+            available_mem_mb: available_mb,
+            total_mem_mb: inner.total_mem_mb.or(total_mb),
+            memory_pressure: MemoryPressure::derive(
+                available_mb,
+                inner.total_mem_mb.or(total_mb),
+            ),
+            // Thermal + battery come from platform-specific bridges in
+            // Slice 4 (INF-26). For now desktop/server report Normal thermal
+            // and no battery — see spec's availability table.
+            thermal_state: ThermalState::Normal,
+            battery_pct: None,
+            captured_at_ms: now_ms(),
+        };
+        inner.cached = Some(snap);
+        inner.cached_at = Some(Instant::now());
+        snap
+    }
+}
+
+impl Default for ResourceMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RunGuard
+// ---------------------------------------------------------------------------
+
+/// Lifetime-scoped handle returned by [`ResourceMonitor::begin_run`]. Call
+/// [`RunGuard::finish`] when the inference completes to collect the summary,
+/// or let the guard drop — in which case any in-progress sampler is cancelled
+/// and the summary is discarded.
+pub struct RunGuard {
+    monitor: Option<ResourceMonitor>,
+    mode: ResourceTelemetryMode,
+    aggregator: Option<Aggregator>,
+    sampler: Option<sampler::Handle>,
+}
+
+impl RunGuard {
+    /// Disabled guard — no snapshots, no summary.
+    fn disabled(mode: ResourceTelemetryMode) -> Self {
+        Self {
+            monitor: None,
+            mode,
+            aggregator: None,
+            sampler: None,
+        }
+    }
+
+    /// Produce the final [`ResourceUsageSummary`]. Returns `None` when the
+    /// guard was built with `Off` mode. Safe to call exactly once.
+    pub fn finish(mut self) -> Option<ResourceUsageSummary> {
+        let monitor = self.monitor.take()?;
+        let mut aggregator = self.aggregator.take()?;
+
+        // Drain any samples that the background task collected. `sampler` is
+        // `None` in Boundary mode.
+        if let Some(sampler) = self.sampler.take() {
+            for snap in sampler.stop() {
+                aggregator.observe(&snap);
+            }
+        }
+
+        // End snapshot — always captured, including in Boundary mode.
+        let end = monitor.current_snapshot(Duration::ZERO);
+        aggregator.observe(&end);
+        Some(aggregator.finish(self.mode))
+    }
+}
+
+impl Drop for RunGuard {
+    fn drop(&mut self) {
+        // Drop path: cancel the sampler without producing a summary. This
+        // runs if the caller never called `finish()` — for example if the
+        // surrounding inference panicked. We don't emit telemetry from here.
+        if let Some(sampler) = self.sampler.take() {
+            let _ = sampler.stop();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sampler (background thread)
+// ---------------------------------------------------------------------------
+
+mod sampler {
+    //! Background sampling thread for Summary / DebugLocal modes.
+    //!
+    //! Uses `std::thread` rather than a tokio task so the sampler works
+    //! identically whether the caller sits inside a tokio runtime or in a
+    //! plain synchronous context — the sync `XybridModel::run` and
+    //! `Pipeline::run` paths (the common case) would otherwise never see
+    //! their sampler start. Stops on demand via an `AtomicBool`.
+    //!
+    //! The polling slice (25 ms) is shorter than the full sampling period
+    //! so `stop()` is observed promptly even when a long interval is
+    //! configured; inference that completes mid-interval is cancelled
+    //! within at most one poll slice.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use super::{ResourceMonitor, ResourceSnapshot, ResourceTelemetryMode};
+
+    /// How often the sampler thread wakes to check the stop flag. Short
+    /// enough that cancellation is effectively immediate regardless of
+    /// the configured sampling period.
+    const POLL_SLICE_MS: u64 = 25;
+
+    pub(super) struct Handle {
+        shared: Arc<Shared>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    struct Shared {
+        stop: AtomicBool,
+        samples: Mutex<Vec<ResourceSnapshot>>,
+    }
+
+    pub(super) fn start(
+        monitor: ResourceMonitor,
+        mode: ResourceTelemetryMode,
+    ) -> Option<Handle> {
+        let interval_ms = mode.interval_ms()?;
+        let shared = Arc::new(Shared {
+            stop: AtomicBool::new(false),
+            samples: Mutex::new(Vec::new()),
+        });
+        let thread_shared = Arc::clone(&shared);
+        let thread = thread::Builder::new()
+            .name("xybrid-resource-sampler".to_string())
+            .spawn(move || {
+                let period = Duration::from_millis(interval_ms as u64);
+                let poll_slice = Duration::from_millis(POLL_SLICE_MS);
+                while !thread_shared.stop.load(Ordering::Relaxed) {
+                    let deadline = Instant::now() + period;
+                    // Sleep in short slices so `stop()` cancels within
+                    // POLL_SLICE_MS regardless of how large `period` is.
+                    while Instant::now() < deadline {
+                        if thread_shared.stop.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        thread::sleep(poll_slice);
+                    }
+                    if thread_shared.stop.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    let snap = monitor.current_snapshot(Duration::ZERO);
+                    if let Ok(mut samples) = thread_shared.samples.lock() {
+                        samples.push(snap);
+                    }
+                }
+            })
+            .ok()?;
+
+        Some(Handle {
+            shared,
+            thread: Some(thread),
+        })
+    }
+
+    impl Handle {
+        /// Signal the thread to stop, join it, and take the buffered
+        /// samples. Safe to call exactly once.
+        pub(super) fn stop(mut self) -> Vec<ResourceSnapshot> {
+            self.shared.stop.store(true, Ordering::Relaxed);
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+            match self.shared.samples.lock() {
+                Ok(mut g) => std::mem::take(&mut *g),
+                Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn bytes_to_mb(bytes: u64) -> Option<u32> {
+    if bytes == 0 {
+        None
+    } else {
+        Some((bytes / (1024 * 1024)) as u32)
+    }
+}
+
+fn bytes_to_mb_u64(bytes: u64) -> Option<u32> {
+    bytes_to_mb(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_normalizes_interval_floor() {
+        let m = ResourceTelemetryMode::Summary { interval_ms: 10 }.normalized();
+        assert_eq!(
+            m,
+            ResourceTelemetryMode::Summary {
+                interval_ms: ResourceTelemetryMode::MIN_SAMPLE_INTERVAL_MS
+            }
+        );
+
+        let boundary = ResourceTelemetryMode::Boundary.normalized();
+        assert_eq!(boundary, ResourceTelemetryMode::Boundary);
+    }
+
+    #[test]
+    fn aggregator_tracks_peak_avg_min() {
+        let mut agg = Aggregator::new();
+        agg.observe(&ResourceSnapshot {
+            cpu_pct: Some(10.0),
+            process_rss_mb: Some(100),
+            available_mem_mb: Some(8000),
+            total_mem_mb: Some(16000),
+            memory_pressure: MemoryPressure::Normal,
+            thermal_state: ThermalState::Normal,
+            battery_pct: Some(80),
+            captured_at_ms: 0,
+        });
+        agg.observe(&ResourceSnapshot {
+            cpu_pct: Some(90.0),
+            process_rss_mb: Some(500),
+            available_mem_mb: Some(1000),
+            total_mem_mb: Some(16000),
+            memory_pressure: MemoryPressure::Warn,
+            thermal_state: ThermalState::Hot,
+            battery_pct: Some(78),
+            captured_at_ms: 1_000,
+        });
+        let summary = agg.finish(ResourceTelemetryMode::Boundary);
+        assert_eq!(summary.cpu_peak_pct, Some(90.0));
+        assert!((summary.cpu_avg_pct.unwrap() - 50.0).abs() < 0.01);
+        assert_eq!(summary.process_rss_peak_mb, Some(500));
+        assert_eq!(summary.available_mem_min_mb, Some(1000));
+        assert_eq!(summary.memory_pressure_peak, MemoryPressure::Warn);
+        assert_eq!(summary.thermal_state_peak, ThermalState::Hot);
+        assert_eq!(summary.battery_pct_end, Some(78));
+        assert_eq!(summary.sample_count, 2);
+    }
+
+    #[test]
+    fn aggregator_handles_all_missing_cpu() {
+        let mut agg = Aggregator::new();
+        agg.observe(&ResourceSnapshot::unknown());
+        agg.observe(&ResourceSnapshot::unknown());
+        let summary = agg.finish(ResourceTelemetryMode::Boundary);
+        assert_eq!(summary.cpu_avg_pct, None);
+        assert_eq!(summary.cpu_peak_pct, None);
+        assert_eq!(summary.sample_count, 2);
+    }
+
+    #[test]
+    fn monitor_current_snapshot_is_cached_within_max_age() {
+        let monitor = ResourceMonitor::new();
+        let first = monitor.current_snapshot(Duration::ZERO);
+        // Any non-zero max_age larger than our refresh window should hit the
+        // cache. Use a generous 10 s to keep the test deterministic.
+        let second = monitor.current_snapshot(Duration::from_secs(10));
+        assert_eq!(first.captured_at_ms, second.captured_at_ms);
+    }
+
+    #[test]
+    fn monitor_current_snapshot_refreshes_when_ttl_expires() {
+        let monitor = ResourceMonitor::new();
+        let first = monitor.current_snapshot(Duration::ZERO);
+        // Force a refresh with max_age == 0 (strict less-than-or-equal).
+        std::thread::sleep(Duration::from_millis(2));
+        let second = monitor.current_snapshot(Duration::ZERO);
+        assert!(second.captured_at_ms >= first.captured_at_ms);
+    }
+
+    #[test]
+    fn begin_run_off_returns_no_summary() {
+        let monitor = ResourceMonitor::new();
+        let guard = monitor.begin_run(ResourceTelemetryMode::Off);
+        assert!(guard.finish().is_none());
+    }
+
+    #[test]
+    fn begin_run_boundary_produces_two_sample_summary() {
+        let monitor = ResourceMonitor::new();
+        let guard = monitor.begin_run(ResourceTelemetryMode::Boundary);
+        let summary = guard.finish().expect("Boundary mode produces a summary");
+        assert_eq!(summary.sample_count, 2);
+        assert_eq!(summary.sampling_mode, "boundary");
+        assert_eq!(summary.sampling_interval_ms, None);
+    }
+
+    #[test]
+    fn begin_run_summary_mode_collects_interval_samples() {
+        // Sampler uses std::thread, so no tokio runtime is required. Sleep
+        // on the thread directly. Interval is the normalized floor
+        // (250 ms); 700 ms gives ~2 mid-samples even on slow schedulers.
+        let monitor = ResourceMonitor::new();
+        let guard = monitor.begin_run(ResourceTelemetryMode::Summary { interval_ms: 250 });
+        std::thread::sleep(Duration::from_millis(700));
+        let summary = guard.finish().expect("Summary mode produces a summary");
+        assert!(
+            summary.sample_count >= 3,
+            "expected at least start + 1 mid + end samples, got {}",
+            summary.sample_count
+        );
+        assert_eq!(summary.sampling_mode, "summary");
+        assert_eq!(summary.sampling_interval_ms, Some(250));
+    }
+
+    #[test]
+    fn dropping_guard_without_finish_does_not_emit() {
+        let monitor = ResourceMonitor::new();
+        {
+            let _guard = monitor.begin_run(ResourceTelemetryMode::Boundary);
+            // Drop without calling finish().
+        }
+        // The monitor itself still works after a guard drop — no deadlock
+        // from the sampler cancellation path.
+        let snap = monitor.current_snapshot(Duration::ZERO);
+        assert!(snap.captured_at_ms > 0);
+    }
+
+    #[test]
+    fn global_monitor_is_shared() {
+        let a = ResourceMonitor::global();
+        let b = ResourceMonitor::global();
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn concurrent_snapshots_share_one_system() {
+        // Several threads hammering `current_snapshot` should not panic on
+        // poisoned locks or construct multiple `sysinfo::System`s. We can't
+        // assert on the number of sysinfo instances directly, but we can
+        // assert that all threads get plausible data and don't deadlock.
+        let monitor = ResourceMonitor::global();
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let m = monitor.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..32 {
+                        let s = m.current_snapshot(Duration::from_millis(100));
+                        assert!(s.captured_at_ms > 0);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+}

--- a/crates/xybrid-core/src/device/resource/mod.rs
+++ b/crates/xybrid-core/src/device/resource/mod.rs
@@ -4,10 +4,10 @@
 //! [`ResourceMonitor`]. Two producers sit on top:
 //!
 //! - [`ResourceMonitor::current_snapshot`] — synchronous TTL-cached read used
-//!   on the inference hot path by adaptive execution (INF-30).
+//!   on the inference hot path by adaptive execution.
 //! - [`ResourceMonitor::begin_run`] — per-run sampler that produces one
 //!   [`ResourceUsageSummary`] and attaches it to the outgoing telemetry
-//!   event (INF-29).
+//!   event.
 //!
 //! The full contract lives in `docs/sdk/resource-telemetry.md`. Thresholds,
 //! SLOs, and the privacy posture are defined there; this module implements
@@ -51,8 +51,9 @@ pub enum ResourceTelemetryMode {
 }
 
 impl ResourceTelemetryMode {
-    /// Default summary interval (1 s). Tuned by INF-32 benchmarks; if that
-    /// ticket changes it, update this constant and the spec doc together.
+    /// Default summary interval (1 s). Tuned by the resource-telemetry bench
+    /// suite; if benchmarks argue for a different default, update this constant
+    /// and the spec doc together.
     pub const DEFAULT_SUMMARY_INTERVAL_MS: u32 = 1000;
     /// Minimum allowed sample interval. The PRD pins the floor at 250 ms:
     /// anything below was not validated for overhead and would invalidate
@@ -427,9 +428,10 @@ impl ResourceMonitor {
                 available_mb,
                 inner.total_mem_mb.or(total_mb),
             ),
-            // Thermal + battery come from platform-specific bridges in
-            // Slice 4 (INF-26). For now desktop/server report Normal thermal
-            // and no battery — see spec's availability table.
+            // Thermal + battery come from platform-specific bridges in a
+            // later slice (iOS thermal state, Android power manager, etc.).
+            // For now desktop/server report Normal thermal and no battery —
+            // see the spec's availability table.
             thermal_state: ThermalState::Normal,
             battery_pct: None,
             captured_at_ms: now_ms(),

--- a/crates/xybrid-core/src/device/resource/mod.rs
+++ b/crates/xybrid-core/src/device/resource/mod.rs
@@ -145,8 +145,8 @@ impl ResourceSnapshot {
 /// Aggregate observation across a single `ModelComplete` / `PipelineComplete`
 /// run. Attached to `event.data.resource_summary` and hoisted to the
 /// platform-event payload top level by the SDK. The wire shape is flat
-/// (no nested enum) so the Tinybird `LowCardinality(String)` column for
-/// `sampling_mode` can extract cleanly.
+/// (no nested enum) so the analytics backend's low-cardinality string
+/// column for `sampling_mode` can extract cleanly.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResourceUsageSummary {
     pub cpu_avg_pct: Option<f32>,

--- a/crates/xybrid-core/src/device/resource/mod.rs
+++ b/crates/xybrid-core/src/device/resource/mod.rs
@@ -424,10 +424,7 @@ impl ResourceMonitor {
             process_rss_mb,
             available_mem_mb: available_mb,
             total_mem_mb: inner.total_mem_mb.or(total_mb),
-            memory_pressure: MemoryPressure::derive(
-                available_mb,
-                inner.total_mem_mb.or(total_mb),
-            ),
+            memory_pressure: MemoryPressure::derive(available_mb, inner.total_mem_mb.or(total_mb)),
             // Thermal + battery come from platform-specific bridges in a
             // later slice (iOS thermal state, Android power manager, etc.).
             // For now desktop/server report Normal thermal and no battery —
@@ -545,10 +542,7 @@ mod sampler {
         samples: Mutex<Vec<ResourceSnapshot>>,
     }
 
-    pub(super) fn start(
-        monitor: ResourceMonitor,
-        mode: ResourceTelemetryMode,
-    ) -> Option<Handle> {
+    pub(super) fn start(monitor: ResourceMonitor, mode: ResourceTelemetryMode) -> Option<Handle> {
         let interval_ms = mode.interval_ms()?;
         let shared = Arc::new(Shared {
             stop: AtomicBool::new(false),

--- a/crates/xybrid-core/src/device/resource/mod.rs
+++ b/crates/xybrid-core/src/device/resource/mod.rs
@@ -763,6 +763,41 @@ mod tests {
     }
 
     #[test]
+    fn summary_run_shorter_than_sampler_tick_still_produces_summary() {
+        // Sampler can't tick before a near-instant inference returns —
+        // the guard must still produce a well-formed summary from the
+        // start+end bookends rather than failing the run. This is the
+        // graceful-degradation promise for Summary mode: even if zero
+        // samples come from the background thread, sample_count >= 2.
+        let monitor = ResourceMonitor::new();
+        monitor.prewarm();
+        let guard = monitor.begin_run(ResourceTelemetryMode::Summary { interval_ms: 1000 });
+        let summary = guard
+            .finish()
+            .expect("Summary mode should produce a summary even without sampler ticks");
+        assert!(summary.sample_count >= 2);
+        assert_eq!(summary.sampling_mode, "summary");
+        assert_eq!(summary.sampling_interval_ms, Some(1000));
+    }
+
+    #[test]
+    fn run_guard_drop_without_finish_stops_sampler_cleanly() {
+        // Abandoning a guard (e.g. surrounding inference panicked)
+        // must cancel the sampler without panicking or leaking the
+        // thread. We can't observe join() state externally, so verify
+        // by running many short drops back-to-back — if the sampler
+        // didn't stop, the thread count would grow without bound and
+        // the test would eventually allocate-deadlock or panic.
+        let monitor = ResourceMonitor::new();
+        monitor.prewarm();
+        for _ in 0..64 {
+            let guard = monitor.begin_run(ResourceTelemetryMode::Summary { interval_ms: 250 });
+            drop(guard);
+        }
+        // If we got here, the drop path works.
+    }
+
+    #[test]
     fn concurrent_snapshots_share_one_system() {
         // Several threads hammering `current_snapshot` should not panic on
         // poisoned locks or construct multiple `sysinfo::System`s. We can't

--- a/crates/xybrid-core/src/device/resource/pressure.rs
+++ b/crates/xybrid-core/src/device/resource/pressure.rs
@@ -1,0 +1,163 @@
+//! Memory-pressure derivation.
+//!
+//! `MemoryPressure` is derived from the available/total memory ratio; it is
+//! not sampled directly. Thresholds are intentionally coarse — they exist to
+//! classify device state, not to surface precise measurements. See
+//! `docs/sdk/resource-telemetry.md` for the public semantics.
+
+use serde::{Deserialize, Serialize};
+
+/// Derived classification of system memory pressure.
+///
+/// Ordered so that [`MemoryPressure::worse_of`] can collapse a stream of
+/// snapshots into the peak pressure observed across a run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryPressure {
+    #[default]
+    Unknown,
+    Normal,
+    Warn,
+    Critical,
+}
+
+impl MemoryPressure {
+    /// Thresholds are `< 5 %` critical / `< 15 %` warn / else normal. `None`
+    /// on either input returns `Unknown` so downstream code can distinguish
+    /// "didn't measure" from "measured, pressure is fine".
+    pub fn derive(available_mb: Option<u32>, total_mb: Option<u32>) -> Self {
+        let (Some(avail), Some(total)) = (available_mb, total_mb) else {
+            return Self::Unknown;
+        };
+        if total == 0 {
+            return Self::Unknown;
+        }
+        let ratio = avail as f64 / total as f64;
+        if ratio < 0.05 {
+            Self::Critical
+        } else if ratio < 0.15 {
+            Self::Warn
+        } else {
+            Self::Normal
+        }
+    }
+
+    /// Collapse two pressure readings to the worst of the two. `Unknown` is
+    /// the baseline so a real reading always wins over a missing one.
+    pub fn worse_of(self, other: Self) -> Self {
+        // Can't derive Ord because the variant order is insertion order
+        // (Unknown first) rather than severity order. Hand-rank here.
+        fn rank(p: MemoryPressure) -> u8 {
+            match p {
+                MemoryPressure::Unknown => 0,
+                MemoryPressure::Normal => 1,
+                MemoryPressure::Warn => 2,
+                MemoryPressure::Critical => 3,
+            }
+        }
+        if rank(other) > rank(self) {
+            other
+        } else {
+            self
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MemoryPressure::Unknown => "unknown",
+            MemoryPressure::Normal => "normal",
+            MemoryPressure::Warn => "warn",
+            MemoryPressure::Critical => "critical",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_unknown_when_either_none() {
+        assert_eq!(MemoryPressure::derive(None, None), MemoryPressure::Unknown);
+        assert_eq!(
+            MemoryPressure::derive(Some(1024), None),
+            MemoryPressure::Unknown
+        );
+        assert_eq!(
+            MemoryPressure::derive(None, Some(8192)),
+            MemoryPressure::Unknown
+        );
+    }
+
+    #[test]
+    fn derive_unknown_when_total_zero() {
+        assert_eq!(
+            MemoryPressure::derive(Some(0), Some(0)),
+            MemoryPressure::Unknown
+        );
+    }
+
+    #[test]
+    fn derive_critical_under_5pct() {
+        // 200 / 8192 = 2.44 %
+        assert_eq!(
+            MemoryPressure::derive(Some(200), Some(8192)),
+            MemoryPressure::Critical
+        );
+        // exactly 5% — boundary goes to Warn, not Critical.
+        assert_eq!(
+            MemoryPressure::derive(Some(410), Some(8192)),
+            MemoryPressure::Warn
+        );
+    }
+
+    #[test]
+    fn derive_warn_5_to_15pct() {
+        // 10 %
+        assert_eq!(
+            MemoryPressure::derive(Some(800), Some(8000)),
+            MemoryPressure::Warn
+        );
+        // exactly 15 % — boundary goes to Normal.
+        assert_eq!(
+            MemoryPressure::derive(Some(1200), Some(8000)),
+            MemoryPressure::Normal
+        );
+    }
+
+    #[test]
+    fn derive_normal_above_15pct() {
+        assert_eq!(
+            MemoryPressure::derive(Some(4096), Some(8192)),
+            MemoryPressure::Normal
+        );
+    }
+
+    #[test]
+    fn worse_of_picks_higher_severity() {
+        assert_eq!(
+            MemoryPressure::Normal.worse_of(MemoryPressure::Warn),
+            MemoryPressure::Warn
+        );
+        assert_eq!(
+            MemoryPressure::Warn.worse_of(MemoryPressure::Critical),
+            MemoryPressure::Critical
+        );
+        assert_eq!(
+            MemoryPressure::Critical.worse_of(MemoryPressure::Normal),
+            MemoryPressure::Critical
+        );
+    }
+
+    #[test]
+    fn worse_of_prefers_real_reading_over_unknown() {
+        assert_eq!(
+            MemoryPressure::Unknown.worse_of(MemoryPressure::Normal),
+            MemoryPressure::Normal
+        );
+        assert_eq!(
+            MemoryPressure::Normal.worse_of(MemoryPressure::Unknown),
+            MemoryPressure::Normal
+        );
+    }
+}

--- a/crates/xybrid-core/src/device/types.rs
+++ b/crates/xybrid-core/src/device/types.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// This enum represents the thermal state of a device, which affects
 /// performance and battery consumption decisions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ThermalState {
     /// Normal operating temperature (< 60°C)
     Normal,

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -130,7 +130,10 @@ pub use xybrid_core::bundler;
 pub use xybrid_core::cache_provider::CacheProvider;
 pub use xybrid_core::context;
 pub use xybrid_core::conversation::ConversationContext;
-pub use xybrid_core::device::DeviceProfile;
+pub use xybrid_core::device::{
+    DeviceProfile, MemoryPressure, ResourceMonitor, ResourceSnapshot, ResourceTelemetryMode,
+    ResourceUsageSummary, RunGuard as ResourceRunGuard,
+};
 pub use xybrid_core::execution;
 pub use xybrid_core::ir;
 pub use xybrid_core::orchestrator;

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1308,6 +1308,12 @@ impl XybridModel {
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
         let start = Instant::now();
+        // Begin a resource-telemetry scope for this run. When
+        // `resource_telemetry_mode()` is `Off` the guard is a no-op; otherwise
+        // it captures start snapshots (and launches a sampler for Summary /
+        // DebugLocal). Summary is produced by
+        // `publish_with_resource_summary` at the end of this function.
+        let resource_guard = crate::telemetry::begin_resource_run();
 
         // Recover from poisoned RwLock to prevent permanent lock errors
         let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
@@ -1345,7 +1351,7 @@ impl XybridModel {
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
         };
-        crate::telemetry::publish_telemetry_event(event);
+        crate::telemetry::publish_with_resource_summary(event, resource_guard);
 
         Ok(InferenceResult::new(output, &self.model_id, latency_ms))
     }
@@ -1396,6 +1402,7 @@ impl XybridModel {
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
         let start = Instant::now();
+        let resource_guard = crate::telemetry::begin_resource_run();
 
         // Recover from poisoned RwLock to prevent permanent lock errors
         let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
@@ -1434,7 +1441,7 @@ impl XybridModel {
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
         };
-        crate::telemetry::publish_telemetry_event(event);
+        crate::telemetry::publish_with_resource_summary(event, resource_guard);
 
         Ok(InferenceResult::new(output, &self.model_id, latency_ms))
     }
@@ -1890,6 +1897,7 @@ impl XybridModel {
 
         tokio::task::spawn_blocking(move || {
             let start = Instant::now();
+            let resource_guard = crate::telemetry::begin_resource_run();
 
             // Recover from poisoned RwLock to prevent permanent lock errors
             let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
@@ -1927,7 +1935,7 @@ impl XybridModel {
                     .map(|d| d.as_millis() as u64)
                     .unwrap_or(0),
             };
-            crate::telemetry::publish_telemetry_event(event);
+            crate::telemetry::publish_with_resource_summary(event, resource_guard);
 
             Ok(InferenceResult::new(output, &model_id, latency_ms))
         })

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -912,6 +912,7 @@ impl Pipeline {
         };
 
         let start_time = std::time::Instant::now();
+        let resource_guard = crate::telemetry::begin_resource_run();
         let results: Vec<StageExecutionResult> = orchestrator
             .execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn)
             .map_err(|e| {
@@ -983,7 +984,7 @@ impl Pipeline {
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
         };
-        crate::telemetry::publish_telemetry_event(event);
+        crate::telemetry::publish_with_resource_summary(event, resource_guard);
 
         // Clear pipeline context AFTER publish so the event carried
         // correlation IDs visible to the exporter's lazy-read flush.
@@ -1042,6 +1043,7 @@ impl Pipeline {
             };
 
             let start_time = std::time::Instant::now();
+            let resource_guard = crate::telemetry::begin_resource_run();
             let results: Vec<StageExecutionResult> = orchestrator
                 .execute_pipeline(
                     &stage_descriptors,
@@ -1117,7 +1119,7 @@ impl Pipeline {
                     .map(|d| d.as_millis() as u64)
                     .unwrap_or(0),
             };
-            crate::telemetry::publish_telemetry_event(event);
+            crate::telemetry::publish_with_resource_summary(event, resource_guard);
 
             // Clear pipeline context after publish to keep the exporter's
             // lazy-read flush correlated with the just-completed pipeline.

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -909,11 +909,11 @@ fn convert_to_platform_event(
                 // DeepSeek / Anthropic / OpenAI / Gemini.
                 "cache_read_input_tokens",
                 "cache_creation_input_tokens",
-                // Per-inference resource summary (INF-23). Nested JSON
-                // stays under `data.resource_summary`; hoisting the
-                // object to the payload top level lets the analytics
-                // backend column-extract via flat JSON-path selectors
-                // without teaching each consumer the nested shape.
+                // Per-inference resource summary. Nested JSON stays under
+                // `data.resource_summary`; hoisting the object to the payload
+                // top level lets the analytics backend column-extract via
+                // flat JSON-path selectors without teaching each consumer
+                // the nested shape.
                 "resource_summary",
             ]
             .iter()
@@ -1757,7 +1757,7 @@ mod tests {
 
     #[test]
     fn resource_summary_attaches_and_hoists_through_convert() {
-        // End-to-end happy path for INF-23: attach_resource_summary()
+        // End-to-end happy path: attach_resource_summary()
         // edits event.data, then convert_to_platform_event hoists
         // resource_summary to the platform-event payload top level
         // (same hoist mechanism as cache tokens).

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -911,10 +911,9 @@ fn convert_to_platform_event(
                 "cache_creation_input_tokens",
                 // Per-inference resource summary (INF-23). Nested JSON
                 // stays under `data.resource_summary`; hoisting the
-                // object to the payload top level lets the Tinybird
-                // ingest datasource column-extract via
-                // `json:$.resource_summary.*` without teaching each
-                // consumer the nested shape.
+                // object to the payload top level lets the analytics
+                // backend column-extract via flat JSON-path selectors
+                // without teaching each consumer the nested shape.
                 "resource_summary",
             ]
             .iter()

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -26,6 +26,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 pub use xybrid_core::device::DeviceProfile;
+use xybrid_core::device::{ResourceMonitor, ResourceTelemetryMode, ResourceUsageSummary};
 use xybrid_core::event_bus::OrchestratorEvent;
 use xybrid_core::execution::listener::{self as execution_listener, ExecutionEvent};
 use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy};
@@ -115,6 +116,14 @@ pub struct TelemetryConfig {
     /// suppress the latter without dropping the former.
     #[doc(hidden)]
     pub device_id_explicit: bool,
+
+    /// Resource telemetry mode. Defaults to `Off` so existing callers see no
+    /// behavior change. Enable via [`TelemetryConfig::with_resource_telemetry`]
+    /// — authenticated deployments typically use
+    /// `ResourceTelemetryMode::summary()`. Respected by `init_platform_telemetry`
+    /// which pre-warms the process-wide [`xybrid_core::device::ResourceMonitor`]
+    /// so the first inference does not pay a sysinfo cold-read cost.
+    pub resource_telemetry: ResourceTelemetryMode,
 }
 
 impl Default for TelemetryConfig {
@@ -137,6 +146,7 @@ impl Default for TelemetryConfig {
             auto_hardware_detection: true,
             capture_hostname: false,
             device_id_explicit: false,
+            resource_telemetry: ResourceTelemetryMode::Off,
         }
     }
 }
@@ -268,6 +278,45 @@ impl TelemetryConfig {
         self.capture_hostname = enabled;
         self
     }
+
+    /// Enable per-inference resource telemetry (CPU, memory, process RSS,
+    /// pressure, thermal, battery). Sibling to the existing cache-token and
+    /// LLM-metric fields on the wire; fully documented at
+    /// `docs/sdk/resource-telemetry.md`.
+    ///
+    /// Authenticated deployments typically want
+    /// `ResourceTelemetryMode::summary()`. Omitting the call keeps the default
+    /// `Off` so existing callers see no behavior change.
+    pub fn with_resource_telemetry(mut self, mode: ResourceTelemetryMode) -> Self {
+        self.resource_telemetry = mode.normalized();
+        self
+    }
+}
+
+/// Read the `XYBRID_RESOURCE_TELEMETRY` env var, if set. Recognized values:
+/// `off`, `boundary`, `summary`, `summary:<ms>`, `debug_local`,
+/// `debug_local:<ms>`. Unknown values fall back to `None` so the caller can
+/// use their configured default.
+fn resource_mode_from_env() -> Option<ResourceTelemetryMode> {
+    let raw = std::env::var("XYBRID_RESOURCE_TELEMETRY").ok()?;
+    let lower = raw.trim().to_ascii_lowercase();
+    let (head, interval) = match lower.split_once(':') {
+        Some((h, t)) => (h, t.parse::<u32>().ok()),
+        None => (lower.as_str(), None),
+    };
+    let default_interval = ResourceTelemetryMode::DEFAULT_SUMMARY_INTERVAL_MS;
+    let mode = match head {
+        "off" => ResourceTelemetryMode::Off,
+        "boundary" => ResourceTelemetryMode::Boundary,
+        "summary" => ResourceTelemetryMode::Summary {
+            interval_ms: interval.unwrap_or(default_interval),
+        },
+        "debug_local" | "debuglocal" | "debug-local" => ResourceTelemetryMode::DebugLocal {
+            interval_ms: interval.unwrap_or(default_interval),
+        },
+        _ => return None,
+    };
+    Some(mode.normalized())
 }
 
 /// Event payload for platform API (matches IngestTelemetryEvent)
@@ -860,6 +909,13 @@ fn convert_to_platform_event(
                 // DeepSeek / Anthropic / OpenAI / Gemini.
                 "cache_read_input_tokens",
                 "cache_creation_input_tokens",
+                // Per-inference resource summary (INF-23). Nested JSON
+                // stays under `data.resource_summary`; hoisting the
+                // object to the payload top level lets the Tinybird
+                // ingest datasource column-extract via
+                // `json:$.resource_summary.*` without teaching each
+                // consumer the nested shape.
+                "resource_summary",
             ]
             .iter()
             {
@@ -1090,9 +1146,16 @@ static PLATFORM_EXPORTER: RwLock<Option<HttpTelemetryExporter>> = RwLock::new(No
 ///
 /// init_platform_telemetry(config);
 /// ```
-pub fn init_platform_telemetry(config: TelemetryConfig) {
+pub fn init_platform_telemetry(mut config: TelemetryConfig) {
     // Enable span tracing in xybrid-core for execution profiling
     core_tracing::init_tracing(true);
+
+    // Resource-telemetry mode. Env override wins over the config value
+    // so operators can flip `XYBRID_RESOURCE_TELEMETRY=off` during demos
+    // without rebuilding; the env-only init path below uses the same
+    // helper so behavior is identical.
+    config.resource_telemetry = resolve_resource_telemetry_mode(config.resource_telemetry);
+    activate_resource_telemetry(config.resource_telemetry);
 
     // Register automatic execution listener so TemplateExecutor emits
     // ExecutionStarted / ExecutionCompleted / ExecutionFailed events
@@ -1110,6 +1173,104 @@ pub fn init_platform_telemetry(config: TelemetryConfig) {
     }
 }
 
+// -- Process-wide resource-telemetry mode ----------------------------------
+//
+// `XybridModel::run*` / `Pipeline::run*` consult this to decide whether (and
+// how) to instrument a run. Stored independently of `TelemetryConfig` so the
+// SDK doesn't have to carry a config reference into every run path. Writes
+// happen at `init_platform_telemetry`; reads are cheap.
+static RESOURCE_TELEMETRY_MODE: RwLock<ResourceTelemetryMode> =
+    RwLock::new(ResourceTelemetryMode::Off);
+
+fn set_resource_telemetry_mode(mode: ResourceTelemetryMode) {
+    if let Ok(mut guard) = RESOURCE_TELEMETRY_MODE.write() {
+        *guard = mode;
+    }
+}
+
+/// Apply the `XYBRID_RESOURCE_TELEMETRY` env override on top of a configured
+/// mode. The env var wins unconditionally when set (and parses to a known
+/// variant) so operators can disable resource telemetry at runtime without a
+/// rebuild. Both `init_platform_telemetry` and `init_platform_telemetry_from_env`
+/// funnel through here so the two init paths can't drift.
+fn resolve_resource_telemetry_mode(configured: ResourceTelemetryMode) -> ResourceTelemetryMode {
+    match resource_mode_from_env() {
+        Some(env_mode) => env_mode,
+        None => configured,
+    }
+}
+
+/// Pre-warm the global `ResourceMonitor` + publish the active mode to the
+/// process-wide state read by `begin_resource_run`. `Off` still stores the
+/// mode so a later rehydration can read a consistent value; the monitor
+/// just sits idle until something flips it on.
+fn activate_resource_telemetry(mode: ResourceTelemetryMode) {
+    if !mode.is_off() {
+        ResourceMonitor::global().prewarm();
+    }
+    set_resource_telemetry_mode(mode);
+}
+
+/// Current resource-telemetry mode for this process. `Off` until
+/// `init_platform_telemetry` runs with a mode other than `Off`.
+pub fn resource_telemetry_mode() -> ResourceTelemetryMode {
+    match RESOURCE_TELEMETRY_MODE.read() {
+        Ok(g) => *g,
+        Err(poisoned) => *poisoned.into_inner(),
+    }
+}
+
+/// Begin a resource-telemetry scope for one `Model::run*` / `Pipeline::run*`
+/// call. Returns a guard that produces the summary on `finish()`. Callers
+/// who want the summary attached to their outgoing `TelemetryEvent` can use
+/// [`attach_resource_summary`] at emit time.
+pub fn begin_resource_run() -> xybrid_core::device::RunGuard {
+    ResourceMonitor::global().begin_run(resource_telemetry_mode())
+}
+
+/// Mutate a `TelemetryEvent.data` JSON string to add `resource_summary`.
+/// If `data` already parses as an object, the field is inserted alongside
+/// existing keys; otherwise the event is left untouched so we never clobber
+/// a publisher's bespoke payload. Safe to call with `None` summary (no-op).
+pub fn attach_resource_summary(event: &mut TelemetryEvent, summary: Option<ResourceUsageSummary>) {
+    let Some(summary) = summary else {
+        return;
+    };
+    let Ok(summary_json) = serde_json::to_value(&summary) else {
+        return;
+    };
+    let mut parsed: serde_json::Value = match event.data.as_deref() {
+        Some(s) if !s.is_empty() => match serde_json::from_str(s) {
+            Ok(v) => v,
+            Err(_) => return,
+        },
+        _ => serde_json::json!({}),
+    };
+    if let Some(obj) = parsed.as_object_mut() {
+        obj.insert("resource_summary".to_string(), summary_json);
+        event.data = serde_json::to_string(&parsed).ok();
+    }
+}
+
+/// Attach the resource summary from `guard` and publish the event. Run-site
+/// shorthand for callers that always want the two steps bundled:
+///
+/// ```text
+/// let guard = begin_resource_run();
+/// // ... run inference ...
+/// publish_with_resource_summary(event, guard);
+/// ```
+///
+/// Safe to call with a disabled guard; `attach_resource_summary` becomes a
+/// no-op and the publish path is unchanged.
+pub fn publish_with_resource_summary(
+    mut event: TelemetryEvent,
+    guard: xybrid_core::device::RunGuard,
+) {
+    attach_resource_summary(&mut event, guard.finish());
+    publish_telemetry_event(event);
+}
+
 /// Initialize platform telemetry from environment variables
 ///
 /// Returns `true` if initialization succeeded, `false` if XYBRID_API_KEY is not set.
@@ -1118,6 +1279,14 @@ pub fn init_platform_telemetry_from_env() -> bool {
     if let Some(exporter) = HttpTelemetryExporter::from_env() {
         // Enable span tracing in xybrid-core for execution profiling
         core_tracing::init_tracing(true);
+
+        // Resource-telemetry: the env path has no TelemetryConfig, so the
+        // env var is the only way in. Apply the same resolver + activation
+        // pair `init_platform_telemetry` uses so consumers that rely on
+        // `XYBRID_RESOURCE_TELEMETRY=summary` get identical behavior
+        // regardless of which init entry point they chose.
+        let resource_mode = resolve_resource_telemetry_mode(ResourceTelemetryMode::Off);
+        activate_resource_telemetry(resource_mode);
 
         // Register automatic execution listener
         register_execution_listener();
@@ -1585,6 +1754,109 @@ mod tests {
         // this, an empty payload would trivially satisfy the negation
         // above.
         assert!(payload_json.contains("cache_read_input_tokens"));
+    }
+
+    #[test]
+    fn resource_summary_attaches_and_hoists_through_convert() {
+        // End-to-end happy path for INF-23: attach_resource_summary()
+        // edits event.data, then convert_to_platform_event hoists
+        // resource_summary to the platform-event payload top level
+        // (same hoist mechanism as cache tokens).
+        let summary = ResourceUsageSummary {
+            cpu_avg_pct: Some(34.1),
+            cpu_peak_pct: Some(62.5),
+            process_rss_peak_mb: Some(712),
+            available_mem_min_mb: Some(4180),
+            memory_pressure_peak: xybrid_core::device::MemoryPressure::Normal,
+            thermal_state_peak: xybrid_core::device::ThermalState::Normal,
+            battery_pct_end: Some(72),
+            sample_count: 4,
+            sampling_mode: "summary".to_string(),
+            sampling_interval_ms: Some(1000),
+        };
+        let mut event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("qwen2.5-0.5b".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: Some(420),
+            error: None,
+            data: Some(serde_json::json!({ "model_id": "qwen2.5-0.5b" }).to_string()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        attach_resource_summary(&mut event, Some(summary));
+
+        // Sanity: attach mutated event.data.
+        let data_json = event.data.clone().expect("data present");
+        let data: serde_json::Value = serde_json::from_str(&data_json).unwrap();
+        assert!(data.get("resource_summary").is_some());
+        assert_eq!(
+            data["resource_summary"]["cpu_peak_pct"].as_f64(),
+            Some(62.5)
+        );
+
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+        let payload_json = serde_json::to_string(&platform.payload).unwrap();
+
+        // Hoisted to payload top level (sibling of tokens_in / cache_*).
+        assert!(
+            payload_json.contains("\"resource_summary\""),
+            "resource_summary must be hoisted to payload top level, got: {}",
+            payload_json
+        );
+        // And reachable via the object root, not just as a nested string.
+        let parsed: serde_json::Value = serde_json::from_str(&payload_json).unwrap();
+        assert_eq!(
+            parsed["resource_summary"]["cpu_peak_pct"].as_f64(),
+            Some(62.5),
+            "hoisted value should be the same object we attached"
+        );
+    }
+
+    #[test]
+    fn attach_resource_summary_with_none_is_noop() {
+        let original = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: None,
+            target: None,
+            latency_ms: None,
+            error: None,
+            data: Some("{\"model_id\":\"x\"}".to_string()),
+            timestamp_ms: 0,
+        };
+        let mut event = original.clone();
+        attach_resource_summary(&mut event, None);
+        assert_eq!(event.data, original.data);
+    }
+
+    #[test]
+    fn env_resource_mode_parses_all_variants() {
+        // Helper drives the parsed variants without touching the real env.
+        let cases: &[(&str, ResourceTelemetryMode)] = &[
+            ("off", ResourceTelemetryMode::Off),
+            ("boundary", ResourceTelemetryMode::Boundary),
+            (
+                "summary",
+                ResourceTelemetryMode::Summary {
+                    interval_ms: ResourceTelemetryMode::DEFAULT_SUMMARY_INTERVAL_MS,
+                },
+            ),
+            (
+                "summary:500",
+                ResourceTelemetryMode::Summary { interval_ms: 500 },
+            ),
+            (
+                "debug_local:250",
+                ResourceTelemetryMode::DebugLocal { interval_ms: 250 },
+            ),
+        ];
+        for (raw, expected) in cases {
+            std::env::set_var("XYBRID_RESOURCE_TELEMETRY", raw);
+            let parsed = resource_mode_from_env().expect(raw);
+            assert_eq!(&parsed, expected, "parsing `{}`", raw);
+        }
+        std::env::remove_var("XYBRID_RESOURCE_TELEMETRY");
+        assert!(resource_mode_from_env().is_none());
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1813,6 +1813,51 @@ mod tests {
     }
 
     #[test]
+    fn pipeline_complete_publishes_resource_summary_in_payload() {
+        // Parallel coverage to `resource_summary_attaches_and_hoists_through_convert`
+        // but for the PipelineComplete path — the hoist logic has no branch
+        // on event_type, but we assert the shape end-to-end so a future
+        // regression that special-cases Model vs Pipeline won't slip.
+        let summary = ResourceUsageSummary {
+            cpu_avg_pct: Some(12.0),
+            cpu_peak_pct: Some(45.0),
+            process_rss_peak_mb: Some(380),
+            available_mem_min_mb: Some(6000),
+            memory_pressure_peak: xybrid_core::device::MemoryPressure::Normal,
+            thermal_state_peak: xybrid_core::device::ThermalState::Normal,
+            battery_pct_end: None,
+            sample_count: 3,
+            sampling_mode: "summary".to_string(),
+            sampling_interval_ms: Some(1000),
+        };
+        let mut event = TelemetryEvent {
+            event_type: "PipelineComplete".to_string(),
+            stage_name: Some("mirage-document-insights".to_string()),
+            target: None,
+            latency_ms: Some(1_200),
+            error: None,
+            data: Some("{\"stages\":[],\"output_type\":\"Text\"}".to_string()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        attach_resource_summary(&mut event, Some(summary));
+
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+        let payload_json = serde_json::to_string(&platform.payload).unwrap();
+
+        assert!(
+            payload_json.contains("\"resource_summary\""),
+            "PipelineComplete should carry resource_summary on payload top level, got: {payload_json}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&payload_json).unwrap();
+        assert_eq!(parsed["resource_summary"]["sample_count"].as_i64(), Some(3));
+        assert_eq!(
+            parsed["resource_summary"]["memory_pressure_peak"].as_str(),
+            Some("normal")
+        );
+    }
+
+    #[test]
     fn attach_resource_summary_with_none_is_noop() {
         let original = TelemetryEvent {
             event_type: "ModelComplete".to_string(),

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -419,6 +419,23 @@ classes:
         returns: Self
         description: "Enables or disables hostname capture; default is false."
         since: "0.1.0-beta10"
+      with_resource_telemetry:
+        name: with_resource_telemetry
+        parameters:
+          - { name: mode, type: "ResourceTelemetryMode" }
+        returns: Self
+        description: >-
+          Enables per-inference resource telemetry (CPU avg/peak, process
+          RSS peak, min available memory, memory-pressure peak, thermal peak,
+          battery end, sample count). When the mode is not `Off`,
+          `init_platform_telemetry` pre-warms a process-wide
+          `ResourceMonitor` and every subsequent `XybridModel::run*` /
+          `Pipeline::run*` call attaches a `resource_summary` object to its
+          `ModelComplete` / `PipelineComplete` telemetry event. The env var
+          `XYBRID_RESOURCE_TELEMETRY=off|boundary|summary|debug_local` wins
+          over this config value. Full contract at
+          `docs/sdk/resource-telemetry.md`. Default is `Off`.
+        since: "0.1.0-beta12"
 
   XybridConfiguration:
     type: data

--- a/docs/sdk/resource-telemetry.md
+++ b/docs/sdk/resource-telemetry.md
@@ -280,8 +280,22 @@ The Criterion bench suite locks in the SLOs:
 - Cached live-snapshot read: `< 100 µs`.
 - Cache-miss refresh: `< 1 ms`.
 
-If any of these regress in CI, the default flips to `Boundary` until the
-regression is resolved.
+### Measured overhead (Apple Silicon macOS, INF-32 bench)
+
+| Scenario                                       | Observed (median) | SLO                  | Verdict        |
+| ---------------------------------------------- | ----------------- | -------------------- | -------------- |
+| `off` mode, per `begin_run + finish`           | 4.8 ns            | —                    | baseline       |
+| `Boundary` mode, per run                       | 275 µs            | < 1 ms               | pass           |
+| `Summary { interval_ms: 1000 }` per run        | 354 µs            | < 1 ms bookkeeping   | pass           |
+| `Summary { interval_ms: 250 }` (stress) per run | 354 µs            | not a default        | documented only |
+| Cached live-snapshot read (500 ms TTL)         | 25 ns             | < 100 µs             | pass (~4000×)  |
+| Cache-miss refresh                             | 134 µs            | < 1 ms               | pass           |
+
+Reproduce with: `cargo bench -p xybrid-core --bench resource_telemetry`.
+
+Numbers on non-Apple targets will differ; the SLO gates stay the same.
+If any scenario regresses above its gate in CI, the default flips to
+`Boundary` until the regression is resolved.
 
 ## Compatibility
 

--- a/docs/sdk/resource-telemetry.md
+++ b/docs/sdk/resource-telemetry.md
@@ -1,7 +1,6 @@
 # Resource Telemetry
 
-> **Status**: Draft spec, Slice 1 of [INF-23](https://linear.app/xybrid/issue/INF-23).
-> **Owner**: Inference team. **Last updated**: 2026-04-23.
+> **Status**: Draft spec. **Owner**: Inference team. **Last updated**: 2026-04-23.
 
 Resource telemetry attaches CPU, memory, process RSS, memory pressure, thermal,
 and battery context to each Xybrid inference trace so developers can see whether
@@ -82,7 +81,7 @@ Single point-in-time observation.
 | `available_mem_mb` | `u32` | MiB | yes | System-wide available memory. |
 | `total_mem_mb` | `u32` | MiB | yes | Cached after first read; stable for the process lifetime. |
 | `memory_pressure` | `MemoryPressure` | enum | no | Derived from `available_mem_mb / total_mem_mb`. `Unknown` when either field is `None`. |
-| `thermal_state` | `ThermalState` | enum | no | Defaults to `Normal` on platforms without native thermal signals. Enriched by mobile native bridges (INF-26). |
+| `thermal_state` | `ThermalState` | enum | no | Defaults to `Normal` on platforms without native thermal signals. Enriched by mobile native bridges in a later slice. |
 | `battery_pct` | `u8` | % [0 – 100] | yes | Permission-free only. `None` on desktop and on mobile when not available. |
 | `captured_at_ms` | `u64` | ms since epoch | no | For sampler debugging + deterministic tests. |
 
@@ -97,9 +96,9 @@ Derived, not sampled. Purely a function of the available/total ratio.
 | `Critical` | `< 5 %` |
 | `Unknown` | either `available_mem_mb` or `total_mem_mb` is `None` |
 
-Thresholds are a first-cut heuristic. Tuning is tracked against benchmark data
-in INF-32; changes must be rolled with a config version bump and corresponding
-dashboard legend update.
+Thresholds are a first-cut heuristic. Tuning is tracked against benchmark data;
+changes must be rolled with a config version bump and corresponding dashboard
+legend update.
 
 ### `ResourceUsageSummary` (sampler output)
 
@@ -159,7 +158,7 @@ produces partial data, never a missing summary or a failed inference.
 
 ## Live-snapshot surface
 
-Adaptive execution (INF-30) consumes live snapshots synchronously on the hot
+Adaptive execution consumes live snapshots synchronously on the hot
 path. The same primitive backs the sampler, so there is never more than one
 retained `sysinfo::System` in the process.
 
@@ -173,7 +172,7 @@ Semantics:
 - Otherwise refreshes the retained `System`, produces a new snapshot, and
   returns it.
 - **Cached read**: `< 100 µs` target on desktop-class hardware. Validated by
-  benchmark in INF-32.
+  the resource-telemetry Criterion bench.
 - **Cache-miss refresh**: `< 1 ms` target on a warm `System`. First call after
   process start is allowed to exceed this.
 
@@ -220,8 +219,8 @@ shape.
 ### Storage
 
 The analytics backend's `telemetry_events` table adds one typed column per
-summary field (Slice 2 / INF-31). Legacy rows keep `NULL` for every new column;
-the dashboard hides its Resource Usage card when all fields are `NULL`.
+summary field. Legacy rows keep `NULL` for every new column; the dashboard
+hides its Resource Usage card when all fields are `NULL`.
 
 ## Privacy guarantees
 
@@ -273,7 +272,7 @@ the anonymous telemetry PRD, not this one).
   were not validated for overhead.
 - **Live-snapshot TTL**: `500 ms` for internal callers.
 
-Benchmarks in INF-32 lock in the SLOs:
+The Criterion bench suite locks in the SLOs:
 
 - `Boundary` mode: overhead per inference `< 1 ms`.
 - `Summary { interval_ms: 1000 }`: throughput impact `< 1 %` on the
@@ -298,7 +297,7 @@ regression is resolved.
 
 ## Platform availability
 
-Cross-platform availability of each signal is tracked in Slice 4 (INF-26) when
+Cross-platform availability of each signal is tracked in a later slice when
 the native mobile bridges land. Until then, the desktop / server picture is:
 
 | Signal | macOS | Linux | Windows |
@@ -315,13 +314,5 @@ summary.
 
 ## References
 
-- [INF-23 (epic)](https://linear.app/xybrid/issue/INF-23) — goal, acceptance criteria.
-- [INF-24 (spec)](https://linear.app/xybrid/issue/INF-24) — this document.
-- [INF-25 (core sampler)](https://linear.app/xybrid/issue/INF-25) — implementation ticket.
-- [INF-27 (SDK config)](https://linear.app/xybrid/issue/INF-27) — public API surface.
-- [INF-29 (trace attachment)](https://linear.app/xybrid/issue/INF-29) — wire-up in `Model::run*` / `Pipeline::run*`.
-- [INF-30 (adaptive execution)](https://linear.app/xybrid/issue/INF-30) — live-snapshot consumer.
-- [INF-31 (dashboard)](https://linear.app/xybrid/issue/INF-31) — Resource Usage card.
-- [INF-32 (validation)](https://linear.app/xybrid/issue/INF-32) — SLO benchmarks.
 - `crates/xybrid-core/src/device/resource/` — Rust source.
 - `docs/sdk/telemetry.md` — sibling doc for the existing platform-telemetry surface.

--- a/docs/sdk/resource-telemetry.md
+++ b/docs/sdk/resource-telemetry.md
@@ -1,0 +1,287 @@
+# Resource Telemetry
+
+> **Status**: Draft spec, Slice 1 of [INF-23](https://linear.app/xybrid/issue/INF-23).
+> **Owner**: Inference team. **Last updated**: 2026-04-23.
+
+Resource telemetry attaches CPU, memory, process RSS, memory pressure, thermal,
+and battery context to each Xybrid inference trace so developers can see whether
+slow or failed inference was caused by the model or by device pressure.
+
+The same primitive also exposes a synchronous live snapshot consumed internally
+by Xybrid's runtime selector and throttling decisions, so runtime choices adapt
+to current device state instead of frozen init-time values.
+
+## Contents
+
+- [Goals and non-goals](#goals-and-non-goals)
+- [Modes](#modes)
+- [Field reference](#field-reference)
+- [Live-snapshot surface](#live-snapshot-surface)
+- [Trace payload placement](#trace-payload-placement)
+- [Privacy guarantees](#privacy-guarantees)
+- [Defaults and tuning](#defaults-and-tuning)
+- [Compatibility](#compatibility)
+
+## Goals and non-goals
+
+**Goals**
+
+- One shape (`ResourceSnapshot`) consumed by two producers:
+  - a synchronous TTL-cached live-snapshot read, used by Xybrid's own runtime
+    decisions on the inference hot path;
+  - an asynchronous sampler, scoped to one `XybridModel::run*` or
+    `Pipeline::run*` call, that produces a single `ResourceUsageSummary` and
+    attaches it to the `ModelComplete` / `PipelineComplete` telemetry event.
+- Single retained `sysinfo::System` instance, pre-warmed at platform-telemetry
+  init so the first inference does not pay the `~100 ms` cold-refresh cost.
+- Sampling that never fails the inference. A sampler error produces a partial
+  summary rather than propagating up.
+- Wire format additive to existing telemetry: `resource_summary` is an optional
+  field on `event.data`; consumers that don't know about it ignore it.
+
+**Non-goals**
+
+- Raw per-sample time series in uploaded telemetry. Raw samples stay local
+  unless `debug_local` mode is explicitly selected.
+- Per-token resource sampling. Streaming callbacks annotate the existing trace;
+  they do not spawn new monitors.
+- GPU / ANE / NPU utilization (separate PRD).
+- Prompting users for new permissions (mobile in particular — only
+  permission-free signals are collected).
+
+## Modes
+
+`ResourceTelemetryMode` is the caller-facing switch. Set on `TelemetryConfig`
+via `.with_resource_telemetry(...)`.
+
+| Mode | Sampler thread | Collected per inference | Default for |
+|---|---|---|---|
+| `Off` | No | Nothing | Anonymous telemetry |
+| `Boundary` | No | Start + end `ResourceSnapshot` only | — |
+| `Summary { interval_ms }` | Yes (one per process) | Start snapshot + periodic samples + end snapshot, aggregated into `ResourceUsageSummary` | Authenticated telemetry, default `interval_ms: 1000` |
+| `DebugLocal { interval_ms }` | Yes | Same as `Summary`, plus raw samples retained locally (never uploaded) | Manual opt-in for local debugging |
+
+`Boundary` is cheap: no background task, two synchronous `sysinfo::System`
+refreshes around the inference. `Summary` spawns one per-process async task
+that samples on the configured interval; aggregation happens in place and the
+task shuts down when the last in-flight run completes.
+
+Env override, takes precedence over the config value:
+`XYBRID_RESOURCE_TELEMETRY=off|boundary|summary|debug_local`.
+
+## Field reference
+
+### `ResourceSnapshot` (producer output)
+
+Single point-in-time observation.
+
+| Field | Type | Unit | Nullable | Notes |
+|---|---|---|---|---|
+| `cpu_pct` | `f32` | % [0.0 – 100.0] | yes | Global CPU usage (sysinfo `global_cpu_usage`). First-call value may be `None` on some platforms; sampler discards it. |
+| `process_rss_mb` | `u32` | MiB | yes | Resident set size for the current process. Platform-dependent availability. |
+| `available_mem_mb` | `u32` | MiB | yes | System-wide available memory. |
+| `total_mem_mb` | `u32` | MiB | yes | Cached after first read; stable for the process lifetime. |
+| `memory_pressure` | `MemoryPressure` | enum | no | Derived from `available_mem_mb / total_mem_mb`. `Unknown` when either field is `None`. |
+| `thermal_state` | `ThermalState` | enum | no | Defaults to `Normal` on platforms without native thermal signals. Enriched by mobile native bridges (INF-26). |
+| `battery_pct` | `u8` | % [0 – 100] | yes | Permission-free only. `None` on desktop and on mobile when not available. |
+| `captured_at_ms` | `u64` | ms since epoch | no | For sampler debugging + deterministic tests. |
+
+### `MemoryPressure`
+
+Derived, not sampled. Purely a function of the available/total ratio.
+
+| Variant | Threshold (`available / total`) |
+|---|---|
+| `Normal` | `>= 15 %` |
+| `Warn` | `[5 %, 15 %)` |
+| `Critical` | `< 5 %` |
+| `Unknown` | either `available_mem_mb` or `total_mem_mb` is `None` |
+
+Thresholds are a first-cut heuristic. Tuning is tracked against benchmark data
+in INF-32; changes must be rolled with a config version bump and corresponding
+dashboard legend update.
+
+### `ResourceUsageSummary` (sampler output)
+
+One per `ModelComplete` / `PipelineComplete`. All `_peak` / `_min` values are
+taken across samples; `cpu_avg_pct` is a simple mean.
+
+| Field | Type | Unit | Aggregation |
+|---|---|---|---|
+| `cpu_avg_pct` | `f32?` | % | mean across samples, `None` when zero samples had a CPU reading |
+| `cpu_peak_pct` | `f32?` | % | max |
+| `process_rss_peak_mb` | `u32?` | MiB | max |
+| `available_mem_min_mb` | `u32?` | MiB | min |
+| `memory_pressure_peak` | `MemoryPressure` | enum | worst (Critical > Warn > Normal > Unknown) |
+| `thermal_state_peak` | `ThermalState` | enum | worst (Critical > Hot > Warm > Normal) |
+| `battery_pct_end` | `u8?` | % | value from final snapshot |
+| `sample_count` | `u32` | count | number of snapshots aggregated |
+| `sampling_mode` | `string` | label | `"off"` / `"boundary"` / `"summary"` / `"debug_local"` — the label of the mode that produced this summary. Flat string so Tinybird's `LowCardinality(String)` column extracts cleanly. |
+| `sampling_interval_ms` | `u32?` | ms | configured interval for `summary` / `debug_local`; absent on `off` / `boundary` |
+
+## Live-snapshot surface
+
+Adaptive execution (INF-30) consumes live snapshots synchronously on the hot
+path. The same primitive backs the sampler, so there is never more than one
+retained `sysinfo::System` in the process.
+
+```rust
+pub fn current_snapshot(&self, max_age: Duration) -> ResourceSnapshot;
+```
+
+Semantics:
+
+- Returns the cached snapshot if it is younger than `max_age`.
+- Otherwise refreshes the retained `System`, produces a new snapshot, and
+  returns it.
+- **Cached read**: `< 100 µs` target on desktop-class hardware. Validated by
+  benchmark in INF-32.
+- **Cache-miss refresh**: `< 1 ms` target on a warm `System`. First call after
+  process start is allowed to exceed this.
+
+Default TTL for internal callers: `500 ms`. Callers may pass `Duration::ZERO`
+to force a refresh.
+
+The live-snapshot API is **internal Rust surface only**. It is not exposed
+through any FFI binding in the MVP.
+
+## Trace payload placement
+
+### Wire shape
+
+`resource_summary` is a sibling of the existing cache-token fields on the
+publisher's `event.data` JSON. Example `ModelComplete` payload, abbreviated:
+
+```jsonc
+{
+  "model_id": "qwen2.5-0.5b",
+  "tokens_in": 42,
+  "tokens_out": 128,
+  "resource_summary": {
+    "cpu_avg_pct": 34.1,
+    "cpu_peak_pct": 62.5,
+    "process_rss_peak_mb": 712,
+    "available_mem_min_mb": 4180,
+    "memory_pressure_peak": "normal",
+    "thermal_state_peak": "normal",
+    "battery_pct_end": 72,
+    "sample_count": 4,
+    "sampling_mode": "summary"
+  }
+}
+```
+
+### SDK hoist
+
+`xybrid-sdk::telemetry::convert_to_platform_event` hoists `resource_summary` to
+the platform-event payload top level (same mechanism as `tokens_in`,
+`cache_read_input_tokens`). This lets Tinybird `json:$.resource_summary.*`
+column extraction work without teaching the ingest service the nested shape.
+
+### Storage
+
+Tinybird `telemetry_events` datasource adds one typed column per summary field
+(Slice 2 / INF-31). Legacy rows keep `NULL` for every new column; the dashboard
+hides its Resource Usage card when all fields are `NULL`.
+
+## Privacy guarantees
+
+Resource telemetry is **device-level only**. It describes the machine's
+operational state, not the user or their content.
+
+### Collected
+
+Only the fields listed in [`ResourceSnapshot`](#resourcesnapshot-producer-output)
+and [`ResourceUsageSummary`](#resourceusagesummary-sampler-output), plus the
+existing `DeviceProfile` fields that were already on the wire before this spec
+(`chip_family`, `ram_gb`, `os`, `os_version`, `kernel_version`, `arch`).
+
+### Never collected
+
+- Prompts, completions, or any user content.
+- File paths, document names, or the contents of loaded models.
+- Hostnames (they stay behind the existing `with_capture_hostname` opt-in and
+  are independent of this spec).
+- Process lists, other applications' resource use, or anything outside the
+  current process.
+- Per-sample raw observations — **unless** the caller explicitly opts into
+  `DebugLocal` mode, in which case the samples stay on disk locally and are
+  never uploaded.
+- GPS, IP address, or any network-identifying signal.
+
+### Mode table
+
+| Mode | Sends to ingest | Keeps locally |
+|---|---|---|
+| `Off` | nothing | nothing |
+| `Boundary` | summary (2-sample aggregate) | nothing |
+| `Summary` | summary (N-sample aggregate) | nothing |
+| `DebugLocal` | summary (N-sample aggregate) | raw samples in `${XYBRID_CACHE}/resource-debug/` |
+
+### Anonymous telemetry
+
+The anonymous telemetry channel stays `Off` by default. Enabling resource
+telemetry on an anonymous SDK instance requires an explicit opt-in on
+`TelemetryConfig::anonymous(...).with_resource_telemetry(...)` (tracked under
+the anonymous telemetry PRD, not this one).
+
+## Defaults and tuning
+
+- **Authenticated telemetry**: `Summary { interval_ms: 1000 }`.
+- **Anonymous telemetry**: `Off`.
+- **Minimum sample interval**: `250 ms`. Values below this are clamped up by
+  the SDK at config time. The PRD pins this floor; intervals below `250 ms`
+  were not validated for overhead.
+- **Live-snapshot TTL**: `500 ms` for internal callers.
+
+Benchmarks in INF-32 lock in the SLOs:
+
+- `Boundary` mode: overhead per inference `< 1 ms`.
+- `Summary { interval_ms: 1000 }`: throughput impact `< 1 %` on the
+  `llm_streaming_metrics` fixture.
+- Cached live-snapshot read: `< 100 µs`.
+- Cache-miss refresh: `< 1 ms`.
+
+If any of these regress in CI, the default flips to `Boundary` until the
+regression is resolved.
+
+## Compatibility
+
+- **Old SDK clients** (no resource telemetry) produce events without a
+  `resource_summary` field. Ingest accepts them; the dashboard's Resource
+  Usage card hides.
+- **Old backend / old dashboard** sees events that carry `resource_summary`
+  but ignores it — the wire format is additive.
+- **Rollback**: remove the `.with_resource_telemetry(...)` call on
+  `TelemetryConfig`; sampling stops, summaries stop flowing, no schema
+  migration required. Tinybird columns default to `NULL` and stay empty.
+
+## Platform availability
+
+Cross-platform availability of each signal is tracked in Slice 4 (INF-26) when
+the native mobile bridges land. Until then, the desktop / server picture is:
+
+| Signal | macOS | Linux | Windows |
+|---|---|---|---|
+| `cpu_pct` | yes | yes | yes |
+| `process_rss_mb` | yes | yes | yes |
+| `available_mem_mb` / `total_mem_mb` | yes | yes | yes |
+| `memory_pressure` | derived | derived | derived |
+| `thermal_state` | native (Slice 4 extends) | `Normal` (no native) | `Normal` (no native) |
+| `battery_pct` | on portables | on portables | on portables |
+
+Missing signals always degrade to `None` / `Unknown`; they never fail the
+summary.
+
+## References
+
+- [INF-23 (epic)](https://linear.app/xybrid/issue/INF-23) — goal, acceptance criteria.
+- [INF-24 (spec)](https://linear.app/xybrid/issue/INF-24) — this document.
+- [INF-25 (core sampler)](https://linear.app/xybrid/issue/INF-25) — implementation ticket.
+- [INF-27 (SDK config)](https://linear.app/xybrid/issue/INF-27) — public API surface.
+- [INF-29 (trace attachment)](https://linear.app/xybrid/issue/INF-29) — wire-up in `Model::run*` / `Pipeline::run*`.
+- [INF-30 (adaptive execution)](https://linear.app/xybrid/issue/INF-30) — live-snapshot consumer.
+- [INF-31 (dashboard)](https://linear.app/xybrid/issue/INF-31) — Resource Usage card.
+- [INF-32 (validation)](https://linear.app/xybrid/issue/INF-32) — SLO benchmarks.
+- `crates/xybrid-core/src/device/resource/` — Rust source.
+- `docs/sdk/telemetry.md` — sibling doc for the existing platform-telemetry surface.

--- a/docs/sdk/resource-telemetry.md
+++ b/docs/sdk/resource-telemetry.md
@@ -115,9 +115,47 @@ taken across samples; `cpu_avg_pct` is a simple mean.
 | `memory_pressure_peak` | `MemoryPressure` | enum | worst (Critical > Warn > Normal > Unknown) |
 | `thermal_state_peak` | `ThermalState` | enum | worst (Critical > Hot > Warm > Normal) |
 | `battery_pct_end` | `u8?` | % | value from final snapshot |
-| `sample_count` | `u32` | count | number of snapshots aggregated |
-| `sampling_mode` | `string` | label | `"off"` / `"boundary"` / `"summary"` / `"debug_local"` — the label of the mode that produced this summary. Flat string so Tinybird's `LowCardinality(String)` column extracts cleanly. |
+| `sample_count` | `u32` | count | number of snapshots aggregated (see [Interpreting `sample_count`](#interpreting-sample_count) for the composition formula) |
+| `sampling_mode` | `string` | label | `"off"` / `"boundary"` / `"summary"` / `"debug_local"` — the label of the mode that produced this summary. Flat string so the analytics backend's low-cardinality column extracts cleanly. |
 | `sampling_interval_ms` | `u32?` | ms | configured interval for `summary` / `debug_local`; absent on `off` / `boundary` |
+
+### Interpreting `sample_count`
+
+Composition formula:
+
+```
+sample_count = 1 (start bookend) + N (periodic samples) + 1 (end bookend)
+```
+
+- **`N = 0`** when the run finishes before the sampler's first tick. Expected on
+  sub-interval inferences: a 600 ms run with the default `interval_ms: 1000`
+  produces `sample_count = 2`.
+- **`N = floor(run_duration_ms / interval_ms)`** is a good first-order
+  approximation for longer runs — the sampler sleeps between ticks and an
+  off-by-one is normal.
+
+Expected values by mode:
+
+| Mode | `sample_count` | Notes |
+|---|---|---|
+| `off` | no summary emitted | consumer sees `resource_summary: null` |
+| `boundary` | always exactly `2` | bookends, no sampler thread |
+| `summary` | `>= 2` | 2 on sub-interval runs, grows with duration |
+| `debug_local` | `>= 2` | same as `summary`, plus raw samples kept locally |
+
+Debugging signals:
+
+- **`sample_count == 2` on a long run in `summary` mode** is anomalous — either
+  the sampler thread failed to spawn or the guard was dropped before `finish()`
+  (panicking inference path). Either way the aggregation stayed on the bookend
+  fallback.
+- **Identical `cpu_avg_pct` and `cpu_peak_pct`** on a `summary`-mode run
+  usually means `sample_count == 2` — there was no mid-run trajectory to
+  average over.
+
+Graceful-degradation guarantee: `sample_count >= 2` is always true when a
+summary is emitted. A sampler failure (including complete absence of ticks)
+produces partial data, never a missing summary or a failed inference.
 
 ## Live-snapshot surface
 
@@ -175,14 +213,15 @@ publisher's `event.data` JSON. Example `ModelComplete` payload, abbreviated:
 
 `xybrid-sdk::telemetry::convert_to_platform_event` hoists `resource_summary` to
 the platform-event payload top level (same mechanism as `tokens_in`,
-`cache_read_input_tokens`). This lets Tinybird `json:$.resource_summary.*`
-column extraction work without teaching the ingest service the nested shape.
+`cache_read_input_tokens`). This lets the analytics backend extract each field
+via flat JSON-path selectors without teaching the ingest service the nested
+shape.
 
 ### Storage
 
-Tinybird `telemetry_events` datasource adds one typed column per summary field
-(Slice 2 / INF-31). Legacy rows keep `NULL` for every new column; the dashboard
-hides its Resource Usage card when all fields are `NULL`.
+The analytics backend's `telemetry_events` table adds one typed column per
+summary field (Slice 2 / INF-31). Legacy rows keep `NULL` for every new column;
+the dashboard hides its Resource Usage card when all fields are `NULL`.
 
 ## Privacy guarantees
 
@@ -254,7 +293,8 @@ regression is resolved.
   but ignores it — the wire format is additive.
 - **Rollback**: remove the `.with_resource_telemetry(...)` call on
   `TelemetryConfig`; sampling stops, summaries stop flowing, no schema
-  migration required. Tinybird columns default to `NULL` and stay empty.
+  migration required. Analytics-backend columns default to `NULL` and stay
+  empty.
 
 ## Platform availability
 

--- a/docs/sdk/resource-telemetry.md
+++ b/docs/sdk/resource-telemetry.md
@@ -19,7 +19,6 @@ to current device state instead of frozen init-time values.
 - [Trace payload placement](#trace-payload-placement)
 - [Privacy guarantees](#privacy-guarantees)
 - [Defaults and tuning](#defaults-and-tuning)
-- [Compatibility](#compatibility)
 
 ## Goals and non-goals
 
@@ -35,8 +34,6 @@ to current device state instead of frozen init-time values.
   init so the first inference does not pay the `~100 ms` cold-refresh cost.
 - Sampling that never fails the inference. A sampler error produces a partial
   summary rather than propagating up.
-- Wire format additive to existing telemetry: `resource_summary` is an optional
-  field on `event.data`; consumers that don't know about it ignore it.
 
 **Non-goals**
 
@@ -219,8 +216,7 @@ shape.
 ### Storage
 
 The analytics backend's `telemetry_events` table adds one typed column per
-summary field. Legacy rows keep `NULL` for every new column; the dashboard
-hides its Resource Usage card when all fields are `NULL`.
+summary field.
 
 ## Privacy guarantees
 
@@ -296,18 +292,6 @@ Reproduce with: `cargo bench -p xybrid-core --bench resource_telemetry`.
 Numbers on non-Apple targets will differ; the SLO gates stay the same.
 If any scenario regresses above its gate in CI, the default flips to
 `Boundary` until the regression is resolved.
-
-## Compatibility
-
-- **Old SDK clients** (no resource telemetry) produce events without a
-  `resource_summary` field. Ingest accepts them; the dashboard's Resource
-  Usage card hides.
-- **Old backend / old dashboard** sees events that carry `resource_summary`
-  but ignores it — the wire format is additive.
-- **Rollback**: remove the `.with_resource_telemetry(...)` call on
-  `TelemetryConfig`; sampling stops, summaries stop flowing, no schema
-  migration required. Analytics-backend columns default to `NULL` and stay
-  empty.
 
 ## Platform availability
 


### PR DESCRIPTION
## Summary

Adds the `ResourceMonitor` primitive and wires it through the SDK so every `ModelComplete` / `PipelineComplete` event carries a `resource_summary` — CPU, memory, process RSS, memory pressure, thermal, battery — alongside the existing LLM metrics. This is the foundation slice of the resource-telemetry work; benchmarks that defend the SLOs ship on the stacked PR `feat/resource-telemetry-benchmarks`. Mobile native bridges (iOS thermal, Android power) are out of scope and land in a later slice.

## What ships

### `crates/xybrid-core/src/device/resource/`

- `ResourceMonitor` — process-singleton (`Arc<OnceLock<_>>`) wrapping a single retained `sysinfo::System`. Pre-warmed at `init_platform_telemetry` so the first inference doesn't pay the ~100 ms cold-refresh.
- `ResourceMonitor::current_snapshot(max_age)` — synchronous, TTL-cached read for the adaptive-execution hot path. `< 100 µs` cached / `< 1 ms` cache-miss refresh (numbers locked on the benchmarks PR).
- `ResourceMonitor::begin_run(mode) -> RunGuard` — per-inference sampler. Four modes via `ResourceTelemetryMode`: `Off` / `Boundary` / `Summary { interval_ms }` / `DebugLocal { interval_ms }`.
- Sampler is a **`std::thread`** (not a tokio task) with an `AtomicBool` stop flag + 25 ms poll slice. Works identically in sync and async callers — the common path through `XybridModel::run` / `Pipeline::run` is sync, so a tokio-only sampler would have silently never ticked.
- `MemoryPressure::derive(available, total)` — `< 5 %` critical, `< 15 %` warn, else normal. Thresholds are a first-cut heuristic; documented as tunable in the spec. On very high-RAM systems (128 GB+) this over-flags `warn` — a hybrid absolute-floor follow-up is tracked for the next iteration.
- `ResourceUsageSummary` has a flat `sampling_mode: String` label + separate `sampling_interval_ms: Option<u32>` so the analytics backend's low-cardinality string column can extract cleanly.

### `crates/xybrid-sdk/src/telemetry.rs`

- `TelemetryConfig::with_resource_telemetry(mode)` builder.
- `resolve_resource_telemetry_mode()` + `activate_resource_telemetry()` helpers. Both `init_platform_telemetry` and `init_platform_telemetry_from_env` funnel through them so the `XYBRID_RESOURCE_TELEMETRY=off|boundary|summary|debug_local` env override wins uniformly.
- `convert_to_platform_event` hoists `resource_summary` to the payload top level (sibling to `cache_read_input_tokens`, `tokens_in`). Additive — legacy consumers ignore it.
- `attach_resource_summary(&mut event, summary)` attaches the summary on `event.data` JSON.

### `crates/xybrid-core/src/device/types.rs`

`ThermalState` gains `#[serde(rename_all = "lowercase")]` so its wire shape matches `MemoryPressure` and the docs (`"normal"`, `"warm"`, `"hot"`, `"critical"`). No existing consumer asserts PascalCase.

### `crates/xybrid-sdk/src/model.rs` + `pipeline/mod.rs`

`XybridModel::run` and `Pipeline::run` both wrap the call in a `RunGuard`, which aggregates samples and attaches the summary before the outgoing event is published. Drop path cancels the sampler without emitting telemetry (panic-safe).

### `docs/sdk/resource-telemetry.md`

Full spec: modes, field tables, TTL semantics, privacy guarantees, platform availability, and an **"Interpreting `sample_count`"** subsection with the composition formula (`1 start + N periodic + 1 end`) and debugging signals. No platform-vendor names (the SDK docs stay decoupled from any specific analytics backend).

### `docs/sdk/api-surface.yaml`

New public SDK surface recorded for `/sync-api` verification.

## Verification

- `cargo test -p xybrid-core --lib device::resource` — **20 passed, 0 failed** (includes aggregation math, pressure thresholds, cached vs refreshed paths, concurrent access, short-run bookend-only summary, and drop-without-finish cleanup).
- `cargo test -p xybrid-sdk --features platform-macos --lib` — all existing tests + `resource_summary_attaches_and_hoists_through_convert` + `pipeline_complete_publishes_resource_summary_in_payload` pass.
- `cargo check -p xybrid-core -p xybrid-sdk --features platform-macos` — green.
- **End-to-end smoke**: Mirage emits real `resource_summary` blobs → ingest writes through to the analytics backend → the dashboard's Resource Usage card populates with live CPU / RSS / pressure / thermal / samples. Tinybird plumbing + dashboard rendering land in the sibling platform PR (xybrid-ai/xybrid-platform#10).

## Rollback

Remove the `.with_resource_telemetry(...)` call on `TelemetryConfig` or set `XYBRID_RESOURCE_TELEMETRY=off`. Sampling stops, no summary is attached, payload stays the shape old consumers expect. No schema migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)