### PR TITLE
docs: added Chinese localization for newly added docs

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,12 +33,14 @@
 <br>
 [![License][license-shield]][license-url]
 [![Build][build-shield]][build-url]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
 [![Stars][stars-shield]][stars-url]
 [![Release][release-shield]][release-url]
 [![Release Date][release-date-shield]][release-url]
 <br>
 [![pub.dev][pubdev-shield]][pubdev-url]
 [![Maven Central][maven-shield]][maven-url]
+[![Visitors](https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid)](https://github.com/xybrid-ai/xybrid)
 
 </p>
 
@@ -52,6 +54,8 @@
 [license-url]: https://opensource.org/licenses/Apache-2.0
 [build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat
 [build-url]: https://github.com/xybrid-ai/xybrid/actions
+[scorecard-shield]: https://api.scorecard.dev/projects/github.com/xybrid-ai/xybrid/badge
+[scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/xybrid-ai/xybrid
 [stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat
 [stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
 [release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat&sort=semver
@@ -68,9 +72,7 @@
   <img src="docs/demo-android.gif" alt="Android demo" width="150">
 </p>
 
-<p align="center">
-  <img src="docs/game-demo.gif" alt="游戏演示" width="540">
-</p>
+
 
 ## 从这里开始
 
@@ -81,8 +83,11 @@
 | 为游戏添加 AI NPC | [Unity SDK →](bindings/unity/)，体验 [3D 酒馆示例](https://github.com/xybrid-ai/xybrid-unity-tavern) |
 | Android 原生开发 | [Kotlin SDK →](bindings/kotlin/) |
 | Rust / 嵌入式 | [核心 crate →](crates/) |
-
 ---
+
+<p align="center">
+  <img src="docs/game-demo.gif" alt="游戏演示" width="540">
+</p>
 
 ## SDK
 
@@ -101,7 +106,38 @@ Xybrid 是一个 **Rust 驱动的运行时**，为所有主流平台提供原生
 
 ### 安装
 
-**CLI** — 一键安装（无需 Rust）：
+**Unity** → Package Manager：
+
+```sh
+https://github.com/xybrid-ai/xybrid.git#upm
+```
+
+**Flutter** → `pubspec.yaml`：
+
+```yaml
+dependencies:
+  xybrid_flutter: ^0.1.0
+```
+
+**Swift (iOS / macOS)**：
+
+```swift
+// Package.swift
+dependencies: [
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.1.0")
+]
+```
+
+**Kotlin (Android)**：
+
+```gradle
+// build.gradle.kts
+dependencies {
+    implementation("ai.xybrid:xybrid-kotlin:0.1.0-beta12")
+}
+```
+
+**CLI**
 
 ```bash
 # macOS / Linux
@@ -113,39 +149,7 @@ curl -sSL https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.sh |
 irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 ```
 
-或使用 Rust：
-
-```bash
-cargo install --git https://github.com/xybrid-ai/xybrid xybrid-cli
-```
-
-也可以直接从 [Releases](https://github.com/xybrid-ai/xybrid/releases) 下载二进制文件。
-
-完整的安装指南请参阅 [Installation Guide](docs/INSTALLATION.md)（英文）。
-
-**Unity** — Package Manager → 通过 git URL 添加：
-
-```bash
-https://github.com/xybrid-ai/xybrid.git#upm
-```
-
-> `upm` 分支包含所有平台的预编译原生库。
-> 固定版本：`https://github.com/xybrid-ai/xybrid.git#upm/v0.1.0-beta8`
-
-**Flutter** — 添加到你的 `pubspec.yaml`：
-
-```yaml
-dependencies:
-  xybrid_flutter: ^0.1.0
-```
-
-**Kotlin (Android)** — 添加到你的 `build.gradle.kts`：
-
-```gradle
-dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.1.0-beta9")
-}
-```
+完整安装选项、硬件加速与 CLI 参考请参阅 [Installation Guide](docs/INSTALLATION.md)。
 
 ---
 
@@ -164,29 +168,29 @@ xybrid run kokoro-82m --input "国破山河在，城春草木深" -o output.wav
 
 **Flutter:**
 ```dart
-final model = await Xybrid.model(modelId: 'kokoro-82m').load();
-final result = await model.run(envelope: Envelope.text(text: '国破山河在，城春草木深'));
+final model = await Xybrid.model('kokoro-82m').load();
+final result = await model.run(XybridEnvelope.text('国破山河在，城春草木深'));
 // 输出 → 24kHz WAV 音频
 ```
 
 **Kotlin:**
 ```kotlin
-val model = Xybrid.model(modelId = "kokoro-82m").load()
-val result = model.run(envelope = XybridEnvelope.Text("国破山河在，城春草木深"))
+val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
+val result = model.run(Envelope.text("国破山河在，城春草木深"))
 // 输出 → 24kHz WAV 音频
 ```
 
 **Swift:**
 ```swift
-let model = try Xybrid.model(modelId: "kokoro-82m").load()
-let result = try model.run(envelope: .text("国破山河在，城春草木深"))
+let model = try ModelLoader.fromRegistry(modelId: "kokoro-82m").load()
+let result = try model.run(envelope: Envelope.text("国破山河在，城春草木深"))
 // 输出 → 24kHz WAV 音频
 ```
 
 **Unity (C#):**
 ```csharp
-var model = Xybrid.Model(modelId: "kokoro-82m").Load();
-var result = model.Run(envelope: Envelope.Text("国破山河在，城春草木深"));
+var model = XybridClient.LoadModel("kokoro-82m");
+var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 // 输出 → 24kHz WAV 音频
 ```
 
@@ -217,9 +221,8 @@ xybrid run voice-assistant.yaml --input question.wav -o response.wav
 
 **Flutter:**
 ```dart
-final pipeline = await Xybrid.pipeline(yamlContent: yamlString).load();
-await pipeline.loadModels();
-final result = await pipeline.run(envelope: Envelope.audio(bytes: audioBytes));
+final pipeline = Xybrid.pipeline(yaml: yamlString);
+final result = await pipeline.run(XybridEnvelope.audio(bytes: audioBytes, sampleRate: 16000));
 ```
 
 **Kotlin:**
@@ -290,12 +293,49 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | Phi-4 Mini | LLM | 3.8B | P2 | 规格就绪（首个多量化：Q4, Q8, FP16） |
 | Qwen3 0.6B | LLM | 600M | P2 | 计划中 |
 | Trinity Nano | LLM (MoE) | 6B（1B 活跃） | P2 | 计划中 |
-| LFM2 700M | LLM | 700M | P2 | 计划中 |
+| LFM2-VL 700M | Vision+LLM | 700M | P2 | 计划中 |
 | Nomic Embed Text v1.5 | 嵌入 | 137M | P1 | 受阻（需要 Tokenize/MeanPool 步骤） |
 | LFM2-VL 450M | 视觉 | 450M | P2 | 计划中 |
 | Whisper Tiny CoreML | ASR | 39M | P2 | 计划中 |
 | Qwen3-TTS 0.6B | TTS | 600M | P2 | 受阻（需要自定义 SafeTensors 运行时） |
 | Chatterbox Turbo | TTS | 350M | P3 | 受阻（需要 ModelGraph 模板） |
+
+<details>
+<summary><h3>自定义模型（实验性）</h3></summary>
+
+> **注意**：自定义模型支持为实验性功能。`model_metadata.json` schema 已稳定，但 AI 辅助工具（`/xybrid-init`）仍在积极开发中，可能尚不支持所有模型类型。
+
+Xybrid 支持**任意** ONNX、GGUF 或 SafeTensors 模型，只需提供一个 `model_metadata.json` 告诉 xybrid 如何运行它。
+
+**使用 AI 助手**（Claude Code、Codex 等）：
+
+```sh
+# 将 xybrid skills 安装到你的项目中
+curl -sSL https://raw.githubusercontent.com/xybrid-ai/xybrid/master/tools/scripts/install-skills.sh | sh
+
+# 从 HuggingFace 模型生成 model_metadata.json
+claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
+```
+
+Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚本会为 Claude Code（`.claude/skills`）和 Codex（`.codex/skills`）创建符号链接。
+
+**手动创建** — 在模型目录中新建 `model_metadata.json`：
+
+```json
+{
+  "model_id": "my-model",
+  "version": "1.0",
+  "execution_template": { "type": "Onnx", "model_file": "model.onnx" },
+  "preprocessing": [],
+  "postprocessing": [],
+  "files": ["model.onnx"],
+  "metadata": { "task": "text-generation" }
+}
+```
+
+完整 schema 见 [model metadata 文档](docs/sdk/API_REFERENCE.md)，或参考 [`integration-tests/fixtures/models/`](integration-tests/fixtures/models/) 中的现有示例。
+
+</details>
 
 ---
 

--- a/docs/content/docs/cli/reference/run.mdx
+++ b/docs/content/docs/cli/reference/run.mdx
@@ -106,7 +106,7 @@ stages:
   - kokoro-82m@0.1
 ```
 
-See [Pipelines](/docs/internals/pipelines) for full DSL reference.
+See [Pipelines](/docs/concepts/pipelines) for full DSL reference.
 
 ## Tracing LLM Inference
 

--- a/docs/content/docs/cli/reference/run.zh.mdx
+++ b/docs/content/docs/cli/reference/run.zh.mdx
@@ -1,0 +1,133 @@
+---
+title: xybrid run
+description: 执行混合流水线
+---
+
+在当前设备上执行混合流水线。
+
+## 用法
+
+```bash
+xybrid run --config <path>
+xybrid run --pipeline <name>
+xybrid run --pipeline <name> --dry-run
+```
+
+## 选项
+
+| 选项 | 简写 | 说明 |
+|--------|-------|-------------|
+| `--config` | `-c` | 直接加载流水线 YAML 文件 |
+| `--pipeline` | `-p` | 在 `examples/` 目录下查找 `<name>.yml` |
+| `--bundle` | `-b` | 直接运行 `.xyb` Bundle 文件 |
+| `--input-text` | | 文本模型（LLM、TTS）的文本输入 |
+| `--input-audio` | | 音频模型（ASR）的 WAV 文件路径 |
+| `--target` | | 强制指定模型格式（`onnx`、`coreml`、`tflite`）；省略时自动检测 |
+| `--dry-run` | | 模拟路由决策但不执行推理 |
+| `--policy` | | 加载附加策略 Bundle |
+| `--trace` | | 启用执行追踪，输出火焰图与 LLM 指标 |
+| `--trace-export` | | 将追踪导出为 JSON 文件（Chrome trace 格式） |
+
+## 执行流程
+
+1. 将 YAML 解析为 `PipelineConfig`
+2. 执行策略 → 路由 → 推理的循环
+3. 打印各阶段延迟与路由摘要
+
+在 dry-run 模式下，CLI 仅打印路由决策与模拟输出，不会调用适配器。
+
+## 示例
+
+### 从配置文件运行
+
+```bash
+xybrid run --config ./pipelines/voice-assistant.yaml
+```
+
+### 运行命名流水线
+
+```bash
+xybrid run --pipeline hiiipe
+```
+
+按以下顺序查找 `hiiipe.yml` 或 `hiiipe.yaml`：
+- `xybrid-cli/examples/`
+- `./examples/`
+
+### Dry Run（仅模拟）
+
+```bash
+xybrid run --pipeline hiiipe --dry-run
+```
+
+输出显示路由决策，不执行实际推理：
+
+```
+▶️ Stage: whisper-tiny@1.2 → would route to: local
+▶️ Stage: gpt-4o-mini → would route to: integration
+▶️ Stage: kokoro-82m@0.1 → would route to: local
+```
+
+### 使用自定义策略
+
+```bash
+xybrid run --pipeline hiiipe --policy ./policies/strict-privacy.yaml
+```
+
+## 示例输出
+
+```
+▶️ Stage: whisper-tiny@1.2 → local
+🎯 Routing: local (fast path)
+⚙️ Execution complete (52ms)
+
+▶️ Stage: gpt-4o-mini → integration
+🎯 Routing: integration (OpenAI)
+⚙️ Execution complete (340ms)
+
+▶️ Stage: kokoro-82m@0.1 → local
+🎯 Routing: local (fast path)
+⚙️ Execution complete (89ms)
+
+🎉 Pipeline complete (total 481ms)
+```
+
+## 流水线格式
+
+`run` 命令接受 YAML 格式的流水线定义：
+
+```yaml
+name: "voice-assistant"
+stages:
+  - whisper-tiny@1.0
+  - target: integration
+    provider: openai
+    model: gpt-4o-mini
+  - kokoro-82m@0.1
+```
+
+完整 DSL 参考见 [流水线](/zh/docs/concepts/pipelines)。
+
+## LLM 推理追踪
+
+当传入 `--trace` 且流水线包含 LLM 阶段时，CLI 会在输出后额外打印一个指标块：
+
+```
+📊 LLM Trace:
+------------------------------------------------------------
+  TTFT                  : 412 ms
+  Decode TPS            : 42.80 tok/s
+  Prefill TPS           : 184.20 tok/s
+  Wallclock TPS         : 38.10 tok/s
+  Mean ITL              : 14.30 ms
+  p95 ITL               : 28 ms
+  Emitted chunks        : 64
+  Tokens generated      : 64
+  Finish reason         : stop
+------------------------------------------------------------
+```
+
+这些值从输出 Envelope 的 metadata 中读取，由 LLM 适配器的流式路径填充。
+非 LLM 阶段（ASR、TTS、Embedding）不会输出这些字段，相应块将被跳过。
+
+字段定义与端到端发射路径见 [LLM 指标](/zh/docs/internals/llm-metrics)。

--- a/docs/content/docs/cli/reference/trace.zh.mdx
+++ b/docs/content/docs/cli/reference/trace.zh.mdx
@@ -1,0 +1,167 @@
+---
+title: xybrid trace
+description: 查看历史运行的遥测数据
+---
+
+查看历史流水线运行的遥测日志与追踪记录。
+
+## 用法
+
+```bash
+xybrid trace --session <id>
+xybrid trace --latest
+xybrid trace --latest --export <path>
+```
+
+## 选项
+
+| 选项 | 简写 | 说明 |
+|--------|-------|-------------|
+| `--session` | `-s` | 指定会话标识符 |
+| `--latest` | | 加载最近一次会话 |
+| `--export` | | 将 JSON 摘要写入文件 |
+| `--output` | | 输出格式：`pretty` 或 `json` |
+
+## 执行流程
+
+1. 从 `~/.xybrid/traces/<session>.log` 读取结构化 JSON 追踪
+2. 解析阶段延迟、路由决策与决策结果
+3. 显示彩色摘要表格
+
+## 示例
+
+### 查看最新追踪
+
+```bash
+xybrid trace --latest
+```
+
+### 查看指定会话
+
+```bash
+xybrid trace --session abc123
+```
+
+### 导出为 JSON
+
+```bash
+xybrid trace --latest --export trace.json
+```
+
+### 格式化输出
+
+```bash
+xybrid trace --latest --output pretty
+```
+
+## 示例输出
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Session: abc123                                             │
+│ Pipeline: voice-assistant                                   │
+│ Started: 2024-12-12T10:30:00Z                               │
+├─────────────────────────────────────────────────────────────┤
+│ Stage              │ Target      │ Latency │ Status         │
+├────────────────────┼─────────────┼─────────┼────────────────┤
+│ whisper-tiny@1.2   │ local       │ 52ms    │ ✓ success      │
+│ gpt-4o-mini        │ integration │ 340ms   │ ✓ success      │
+│ kokoro-82m@0.1     │ local       │ 89ms    │ ✓ success      │
+├─────────────────────────────────────────────────────────────┤
+│ Total: 481ms                                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 追踪数据
+
+每条追踪记录包含：
+
+| 字段 | 说明 |
+|-------|-------------|
+| `session_id` | 唯一标识符 |
+| `pipeline_name` | 已执行的流水线名称 |
+| `started_at` | 执行开始时间 |
+| `stages` | 各阶段结果数组 |
+| `total_latency_ms` | 端到端总耗时 |
+
+### 阶段数据
+
+| 字段 | 说明 |
+|-------|-------------|
+| `name` | 阶段标识符 |
+| `target` | 执行位置（local、integration） |
+| `latency_ms` | 执行耗时 |
+| `status` | 成功或失败 |
+| `routing_reason` | 选择该目标的原因 |
+| `policy_result` | 策略评估结果 |
+
+### LLM 阶段元数据
+
+LLM 阶段的 span metadata 中携带额外字段。当 `xybrid run` 使用 `--trace` 时，
+这些字段会出现在 CLI 输出和导出的 Chrome trace 中：
+
+| 字段 | 说明 |
+|-------|-------------|
+| `ttft_ms` | 首个 token 的时间（ms） |
+| `decode_tps` | 仅解码阶段的 tokens/秒 |
+| `prefill_tps` | 预填充阶段的 tokens/秒 |
+| `tokens_per_second` | 挂钟吞吐量（含预填充） |
+| `mean_itl_ms` | 平均块间延迟（ms） |
+| `p95_itl_ms` | 第 95 百分位块间延迟（ms） |
+| `emitted_chunks` | 流式块数量 |
+| `tokens_generated` | 总生成 token 数 |
+| `finish_reason` | `"stop"`、`"length"` 或 `"unknown"` |
+
+非 LLM 阶段不输出这些字段。完整协议见 [LLM 指标](/zh/docs/internals/llm-metrics)。
+
+## 追踪存储
+
+追踪文件存储于：
+
+```
+~/.xybrid/traces/
+├── abc123.log
+├── def456.log
+└── ...
+```
+
+每个文件包含换行分隔的 JSON 事件。
+
+## 导出格式
+
+导出的 JSON 包含完整追踪数据：
+
+```json
+{
+  "session_id": "abc123",
+  "pipeline_name": "voice-assistant",
+  "started_at": "2024-12-12T10:30:00Z",
+  "stages": [
+    {
+      "name": "whisper-tiny@1.2",
+      "target": "local",
+      "latency_ms": 52,
+      "status": "success",
+      "routing_reason": "model_available_locally"
+    }
+  ],
+  "total_latency_ms": 481
+}
+```
+
+## 示例工作流
+
+调试流水线性能：
+
+```bash
+# 运行流水线
+xybrid run --pipeline voice-assistant
+
+# 查看执行详情
+xybrid trace --latest
+
+# 导出以供分析
+xybrid trace --latest --export debug.json
+```
+
+遥测配置见 [可观测性](/zh/docs/internals/observability)。

--- a/docs/content/docs/internals/index.mdx
+++ b/docs/content/docs/internals/index.mdx
@@ -34,9 +34,9 @@ See [Data Flow & Execution](/docs/internals/data-flow-and-execution) for details
 
 | Component | Purpose |
 |-----------|---------|
-| [Registry](/docs/internals/registry) | Bundle distribution server |
-| [Bundles](/docs/internals/bundles) | Packaged models (`.xyb` format) |
-| [Pipeline DSL](/docs/internals/pipelines) | YAML pipeline definitions |
-| [Streaming](/docs/internals/streaming) | Real-time inference |
+| [Registry](/docs/concepts/registry) | Bundle distribution server |
+| [Bundles](/docs/concepts/bundles) | Packaged models (`.xyb` format) |
+| [Pipeline DSL](/docs/concepts/pipelines) | YAML pipeline definitions |
+| [Streaming](/docs/concepts/streaming) | Real-time inference |
 | [Observability](/docs/internals/observability) | Telemetry, tracing, and device intelligence |
 | [LLM Metrics](/docs/internals/llm-metrics) | TTFT, decode/prefill TPS, inter-chunk latency |

--- a/docs/content/docs/internals/index.zh.mdx
+++ b/docs/content/docs/internals/index.zh.mdx
@@ -1,0 +1,42 @@
+---
+title: 内部机制
+description: Xybrid 底层工作原理
+---
+
+本节面向研究人员、贡献者和希望深入了解系统运作方式的开发者，介绍 Xybrid 的内部架构。
+
+## 概述
+
+Xybrid 是一个混合云/本地 ML 推理编排器。它根据模型可用性、设备能力和用户策略，在本地执行与云端 API 之间动态路由 ML 工作负载。
+
+## 核心架构
+
+系统围绕以下关键组件构建：
+
+| 组件 | 用途 |
+|-----------|---------|
+| [Envelope](/zh/docs/internals/envelope) | 音频、文本、Embedding 的通用数据容器 |
+| [Orchestrator](/zh/docs/internals/orchestrator) | 将请求路由到合适的执行目标 |
+| [Pipeline](/zh/docs/internals/pipeline) | 串联多个阶段（ASR → LLM → TTS） |
+| [Executor](/zh/docs/internals/executor) | 通过 ONNX 或 Candle 运行时执行模型 |
+| [StreamSession](/zh/docs/internals/stream-session) | 实时流式推理 |
+
+## 数据流
+
+1. **输入**以 `Envelope` 形式到达（音频字节、文本或 Embedding）
+2. **Orchestrator** 决定执行目标（设备端、云端或回退）
+3. **Executor** 运行模型并产生输出
+4. **输出**被封装到新的 `Envelope` 中，传递给下一阶段
+
+详情见 [数据流与执行](/zh/docs/internals/data-flow-and-execution)。
+
+## 基础设施
+
+| 组件 | 用途 |
+|-----------|---------|
+| [Registry](/zh/docs/concepts/registry) | Bundle 分发服务器 |
+| [Bundles](/zh/docs/concepts/bundles) | 打包的模型（`.xyb` 格式） |
+| [Pipeline DSL](/zh/docs/concepts/pipelines) | YAML 流水线定义 |
+| [Streaming](/zh/docs/concepts/streaming) | 实时推理 |
+| [Observability](/zh/docs/internals/observability) | 遥测、追踪与设备智能 |
+| [LLM Metrics](/zh/docs/internals/llm-metrics) | TTFT、解码/预填充 TPS、块间延迟 |

--- a/docs/content/docs/internals/llm-metrics.zh.mdx
+++ b/docs/content/docs/internals/llm-metrics.zh.mdx
@@ -1,0 +1,79 @@
+---
+title: LLM 遥测指标
+description: TTFT、解码/预填充 TPS、块间延迟 — SDK 每次 LLM 推理输出的指标
+---
+
+xybrid SDK 将每次推理的 LLM 遥测数据以字符串键值对的形式写入活跃 tracing span 和输出 Envelope 的 metadata。这些指标由 LLM 适配器的流式路径自动生成，调用方无需额外配置。
+
+本页记录 **生产协议** — SDK 提供的字段、单位与保证。
+
+## 字段参考
+
+| 字段 | 单位 | 类型 | 来源 |
+| --- | --- | --- | --- |
+| `ttft_ms` | ms | `u64` | 首个 `Response::Chunk` 发出时的 `Instant` 减去 `generate()` 开始时间。 |
+| `tokens_generated` | 数量 | `usize` | mistralrs `Usage.completion_tokens`（终止块）。 |
+| `tokens_per_second` | tok/s | `f32` | 挂钟吞吐量：`tokens_generated / elapsed`，含预填充时间。 |
+| `decode_tps` | tok/s | `f32` | mistralrs `Usage.avg_compl_tok_per_sec` — 仅稳态解码。值为 0.0 时（计时精度不足）返回 `None`。 |
+| `prefill_tps` | tok/s | `f32` | mistralrs `Usage.avg_prompt_tok_per_sec`，同样的零值过滤语义。 |
+| `mean_itl_ms` | ms | `f32` | 块间 `Instant` 差值的算术平均。仅发出一个块时返回 `None`。 |
+| `p95_itl_ms` | ms | `u32` | 块间差值的第 95 百分位。同样的单块保护。 |
+| `emitted_chunks` | 数量 | `u32` | 流中观察到的 `Response::Chunk` 数量。 |
+| `finish_reason` | — | `String` | 终止块的 `ChunkChoice.finish_reason`，取值见下表。 |
+
+### `finish_reason` 取值
+
+| 值 | 含义 |
+|-------|---------|
+| `stop` | 模型生成了自然的序列结束 token，响应完整。 |
+| `length` | 生成因达到 `max_tokens` 上限而截断，模型本可继续生成。若响应不完整，可考虑增大 `GenerationConfig.max_tokens`。 |
+| `unknown` | SDK 无法从终止块中提取 `finish_reason`。正常情况下在终止块检测修复后不应出现；若出现，则表明流协议异常。 |
+
+## 指标的输出位置
+
+### 输出 Envelope metadata
+
+`TemplateExecutor::execute()` 返回后，输出 `Envelope.metadata`（`HashMap<String, String>`）中携带全部九个字段的字符串键值对，调用方可直接读取：
+
+```rust
+let output = executor.execute(&metadata, &input)?;
+if let Some(ttft) = output.metadata.get("ttft_ms") {
+    println!("Time to first token: {} ms", ttft);
+}
+```
+
+### Tracing span metadata
+
+相同字段通过 `xybrid_core::tracing::add_metadata(key, value)` 写入活跃 tracing span，可在以下位置获取：
+
+- `xybrid trace --latest`（CLI 查看）
+- `xybrid run --trace`（为 LLM 阶段打印 LLM Trace 块）
+- 任何从导出 trace 中读取 span metadata 的遥测后端
+
+此外，`generation_time_ms`（`generate()` 调用的总挂钟时间）也会写入 span metadata，但未列入上表，因为它与阶段级别的 `latency_ms` 重复，且并非 LLM 特有。
+
+## 发射路径
+
+1. `MistralBackend::generate`（`core/src/runtime_adapter/llm/mistral.rs`）通过 `stream_chat_request` 流式输出 token。当 `is_streaming=true` 时，mistralrs 通过**最后一个 `Response::Chunk`** 而非 `Response::Done` 信号表示完成。`ChunkChoice.finish_reason` 和 `ChatCompletionChunkResponse.usage` 仅在该终止块上为 `Some(..)`。流在没有终止信号的情况下关闭时返回 `AdapterError::InferenceFailed`；部分文本不会作为成功结果发布。
+2. `LlmRuntimeAdapter::execute`（`core/src/runtime_adapter/llm/adapter.rs`）将每个标量写入响应 Envelope 的 metadata **并**通过 `add_metadata` 写入活跃 tracing span。两个目标是有意为之：Envelope 服务于进程内的 Rust 消费者，tracing span 流向遥测管道。
+
+## 默认确定性
+
+`GenerationConfig::default()` 使用 `temperature = 0.0`，选择 mistralrs 的确定性采样器。需要采样的调用方必须显式设置 `temperature > 0.0`。这保证了测试、缓存以及依赖稳定本地推理的阶段的输出可复现。
+
+## 保证与非保证
+
+- **每次成功 LLM 生成均保证输出**：`ttft_ms`、`tokens_generated`、`tokens_per_second`、`emitted_chunks`、`finish_reason`。
+- **尽力输出**：`decode_tps`、`prefill_tps`、`mean_itl_ms`、`p95_itl_ms`。在快速硬件上短提示偶尔会使 mistralrs 产生 `avg_*_tok_per_sec = 0.0`，这些值会被过滤为 `None`。ITL 汇总需要至少两个发出的块。
+- **不输出**：原始的每块间隔（`inter_chunk_ms`）。在进程内保留于 `GenerationOutput` 供 Rust 调试使用，不序列化到 Envelope metadata 或 tracing span。
+
+## 非 LLM 阶段
+
+预处理、后处理、ASR、TTS 和 Embedding 阶段不输出上述九个字段中的任何一个。其 tracing span 仅携带通用 metadata（阶段名称、耗时、模型 ID）。
+
+## 相关资源
+
+- `core/src/runtime_adapter/llm/mistral.rs` — 流式状态机（`StreamState` + `handle_response`）
+- `core/src/runtime_adapter/llm/adapter.rs` — Envelope 与 tracing 发射
+- `core/src/runtime_adapter/llm/config.rs` — `GenerationConfig` 默认值
+- `core/examples/llm_streaming_metrics.rs` — 含软断言的参考示例

--- a/docs/content/docs/internals/observability.zh.mdx
+++ b/docs/content/docs/internals/observability.zh.mdx
@@ -1,0 +1,361 @@
+---
+title: 可观测性
+description: 遥测、追踪与设备智能
+---
+
+通过遥测、设备指标和追踪来监控和调试 Xybrid 流水线。
+
+## 概述
+
+Xybrid 出于两个目的收集遥测数据：
+
+1. **运行时优化** — 设备能力信息用于指导路由决策
+2. **用量分析** — 用于调试和可视化的指标数据
+
+## 设备智能
+
+### 硬件能力
+
+系统检测硬件能力以优化路由：
+
+```rust
+pub struct HardwareCapabilities {
+    // 加速器可用性
+    pub has_gpu: bool,
+    pub has_metal: bool,      // iOS/macOS
+    pub has_nnapi: bool,      // Android
+    pub has_coreml: bool,     // iOS/macOS Neural Engine
+
+    // 资源指标
+    pub memory_available_mb: u64,
+    pub memory_total_mb: u64,
+    pub battery_level: u8,    // 0-100
+    pub thermal_state: ThermalState,
+
+    // 平台信息
+    pub platform: Platform,
+    pub gpu_type: Option<GpuType>,
+    pub npu_type: Option<NpuType>,
+}
+```
+
+### 温控状态
+
+| 状态 | 温度 | 动作 |
+|-------|-------------|--------|
+| `Normal` | < 60°C | 全性能运行 |
+| `Warm` | 60-70°C | 可能降频 |
+| `Hot` | 70-80°C | 降低工作负载 |
+| `Critical` | > 80°C | 暂停高负载操作 |
+
+### 决策方法
+
+```rust
+// 是否应降低工作负载？
+capabilities.should_throttle()
+// → 电量 < 20% 或热状态为 Hot/Critical 时返回 true
+
+// 优先使用哪种加速器？
+capabilities.should_prefer_metal()   // macOS/iOS
+capabilities.should_prefer_nnapi()   // Android
+capabilities.should_prefer_gpu()     // 通用 GPU 计算
+```
+
+### Flutter 用法
+
+```dart
+final caps = await xybrid.getDeviceCapabilities();
+print('GPU: ${caps.hasGpu}, Metal: ${caps.hasMetal}');
+print('Battery: ${caps.batteryLevel}%, Thermal: ${caps.thermalState}');
+
+if (caps.shouldThrottle) {
+  // 使用云端推理或低性能模型
+}
+```
+
+## 遥测事件
+
+### 事件类型
+
+事件从编排器经由事件总线流出：
+
+| 事件 | 说明 |
+|-------|-------------|
+| `PipelineStart` | 流水线开始执行 |
+| `PipelineComplete` | 流水线执行完成 |
+| `StageStart` | 阶段开始处理 |
+| `StageComplete` | 阶段处理完成 |
+| `StageError` | 阶段执行失败 |
+| `RoutingDecided` | 路由目标已选定 |
+| `ExecutionStarted` | 推理开始 |
+| `ExecutionCompleted` | 推理完成 |
+| `PolicyEvaluated` | 策略检查结果 |
+
+### 事件结构
+
+```rust
+pub struct TelemetryEvent {
+    pub event_type: String,
+    pub stage_name: Option<String>,
+    pub target: Option<String>,       // "local"、"cloud"、"fallback"
+    pub latency_ms: Option<u32>,
+    pub error: Option<String>,
+    pub data: Option<String>,         // 附加 JSON
+    pub timestamp_ms: u64,
+}
+```
+
+### 订阅事件
+
+```dart
+final stream = subscribeTelemetryEvents();
+stream.listen((event) {
+  print('[${event.eventType}] ${event.stageName ?? ""} '
+        '${event.target ?? ""} ${event.latencyMs ?? ""}ms');
+});
+```
+
+## LLM 遥测指标
+
+LLM 阶段通过 `xybrid_core::tracing::add_metadata` 将每次推理的额外指标以字符串键值对形式写入活跃 tracing span。这些指标随阶段 span 流经遥测管道，可在 Xybrid 控制台和分析 API 上获取。
+
+| 字段 | 说明 |
+|-------|-------------|
+| `ttft_ms` | 首个流式块发出的时间（ms） |
+| `tokens_generated` | 来自 mistralrs `Usage` 的 token 数 |
+| `tokens_per_second` | 挂钟吞吐量（含预填充） |
+| `decode_tps` | 来自 `Usage.avg_compl_tok_per_sec` 的仅解码吞吐量 |
+| `prefill_tps` | 来自 `Usage.avg_prompt_tok_per_sec` 的预填充吞吐量 |
+| `mean_itl_ms` | 平均块间延迟 |
+| `p95_itl_ms` | 第 95 百分位块间延迟 |
+| `emitted_chunks` | 观察到的流式块数量 |
+| `finish_reason` | `"stop"`、`"length"` 或 `"unknown"` |
+
+非 LLM 阶段（ASR、TTS、Embedding）不输出这些字段。
+
+完整字段参考、发射路径与保证见 [LLM 指标](/zh/docs/internals/llm-metrics)。
+
+## 会话指标
+
+用于分析的基于会话的聚合数据：
+
+```rust
+pub struct SessionMetrics {
+    pub session_id: String,
+    pub device_id: String,
+    pub started_at: u64,
+    pub ended_at: Option<u64>,
+
+    // 聚合数据
+    pub total_inferences: u64,
+    pub total_latency_ms: u64,
+    pub models_used: Vec<String>,
+    pub error_count: u64,
+
+    // 设备快照
+    pub hardware_capabilities: HardwareCapabilities,
+}
+```
+
+### 单模型指标
+
+```rust
+pub struct ApiCallMetric {
+    pub model_id: String,
+    pub version: String,
+    pub call_count: u64,
+    pub total_latency_ms: u64,
+    pub avg_latency_ms: u64,
+    pub error_count: u64,
+    pub last_called: u64,
+}
+```
+
+## CLI 追踪
+
+### 查看追踪
+
+```bash
+# 最新会话
+xybrid trace --latest
+
+# 指定会话
+xybrid trace --session abc123
+
+# 导出到文件
+xybrid trace --latest --export trace.json
+```
+
+### 追踪存储
+
+追踪文件存储于 `~/.xybrid/traces/`：
+
+```
+~/.xybrid/traces/
+├── abc123.log
+├── def456.log
+└── ...
+```
+
+## 导出格式
+
+会话数据以 JSON 格式导出：
+
+```json
+{
+  "version": "2.0",
+  "session": {
+    "session_id": "550e8400-e29b-41d4-a716-446655440000",
+    "device_id": "device-abc123",
+    "platform": "macos",
+    "started_at": "2024-12-12T12:00:00Z"
+  },
+  "hardware": {
+    "has_gpu": true,
+    "gpu_type": "metal",
+    "has_npu": true,
+    "memory_total_mb": 16384,
+    "battery_level": 85,
+    "thermal_state": "normal"
+  },
+  "metrics": {
+    "total_inferences": 42,
+    "total_latency_ms": 12500,
+    "avg_latency_ms": 297,
+    "error_count": 0,
+    "by_model": [
+      {
+        "model_id": "wav2vec2-base-960h",
+        "call_count": 42,
+        "avg_latency_ms": 297
+      }
+    ]
+  }
+}
+```
+
+## Flutter SDK API
+
+### 设备能力
+
+```dart
+// 获取当前设备能力
+HardwareCapabilities getDeviceCapabilities();
+
+// 检查模型是否可在本地运行
+bool canRunModelLocally({required String modelId, String? version});
+```
+
+### 会话指标
+
+```dart
+// 获取当前会话指标
+SessionMetrics getSessionMetrics();
+
+// 将遥测数据导出为 JSON
+String exportTelemetryJson();
+
+// 重置会话
+void resetSession();
+```
+
+### 遥测流
+
+```dart
+// 订阅实时事件
+Stream<TelemetryEvent> subscribeTelemetryEvents();
+```
+
+## 配置
+
+### CLI 配置
+
+在 `~/.config/xybrid/config.yml` 中：
+
+```yaml
+telemetry:
+  enabled: true
+  endpoint: "http://localhost:4318"
+  sampling_rate: 0.05
+  privacy_mode: "summary_only"
+```
+
+### Rust 配置
+
+```rust
+let mut telemetry = Telemetry::new();
+telemetry.set_enabled(false); // 禁用
+
+// 或创建时即禁用
+let telemetry = Telemetry::with_enabled(false);
+```
+
+## 最佳使用方法
+
+### 尽早初始化
+
+```dart
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await RustLib.init();
+  initTelemetryStream();
+  runApp(MyApp());
+}
+```
+
+### 只订阅一次
+
+```dart
+late StreamSubscription<TelemetryEvent> _subscription;
+
+@override
+void initState() {
+  super.initState();
+  _subscription = subscribeTelemetryEvents().listen(_onEvent);
+}
+
+@override
+void dispose() {
+  _subscription.cancel();
+  super.dispose();
+}
+```
+
+### 会话结束前导出文件
+
+```dart
+final json = xybrid.exportTelemetryJson();
+await uploadToBackend(json);
+```
+
+### 推理前检查设备能力
+
+```dart
+final caps = xybrid.getDeviceCapabilities();
+if (caps.shouldThrottle) {
+  return useCloudFallback();
+}
+```
+
+## 错误分类
+
+错误按类别分类以便调试：
+
+| 类别 | 说明 |
+|----------|-------------|
+| `ModelLoading` | Bundle/模型文件问题 |
+| `Preprocessing` | 输入格式/转换 |
+| `Inference` | 运行时执行 |
+| `Postprocessing` | 输出格式 |
+| `Network` | Registry/云端连接 |
+| `Hardware` | GPU/NPU 初始化 |
+| `Memory` | 内存不足（OOM） |
+
+## 平台支持
+
+| 平台 | GPU | NPU | 电量 | 温控 |
+|----------|-----|-----|---------|---------|
+| macOS | Metal | CoreML | pmset | - |
+| iOS | Metal | CoreML | UIDevice | ProcessInfo |
+| Android | Vulkan | NNAPI | BatteryManager | JNI |
+| Linux | Vulkan | - | /sys/class | /sys/class |


### PR DESCRIPTION
## Summary

1. added Chinese localization files for `docs/content/docs/cli/reference` and `docs/content/docs/internals`
2. Fixed broken link to pipelines documentation in `docs/content/docs/cli/reference/run.mdx`
3. updated the CN README (`README.zh-CN.md`) to match with the English version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [ ] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)
