### PR TITLE
docs: align CLI examples with actual command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Run a model in one line from the CLI, or three lines from any SDK:
 
 **CLI:**
 ```sh
-xybrid run kokoro-82m --input "Hello world" -o output.wav
+xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 ```
 
 **Flutter:**
@@ -216,7 +216,7 @@ stages:
 
 **CLI:**
 ```sh
-xybrid run voice-assistant.yaml --input question.wav -o response.wav
+xybrid run --config voice-assistant.yaml --input-audio question.wav -o response.wav
 ```
 
 **Flutter:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,7 +163,7 @@ irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 
 **CLI:**
 ```sh
-xybrid run kokoro-82m --input "国破山河在，城春草木深" -o output.wav
+xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -o output.wav
 ```
 
 **Flutter:**
@@ -216,7 +216,7 @@ stages:
 
 **CLI:**
 ```sh
-xybrid run voice-assistant.yaml --input question.wav -o response.wav
+xybrid run --config voice-assistant.yaml --input-audio question.wav -o response.wav
 ```
 
 **Flutter:**

--- a/docs/content/docs/concepts/packaging-and-deployment.mdx
+++ b/docs/content/docs/concepts/packaging-and-deployment.mdx
@@ -1,26 +1,24 @@
 ---
 title: Packaging & Deployment
-description: Bundle creation and registry publishing
+description: Bundle creation and distribution
 ---
 
-Package models into distributable `.xyb` bundles and publish them to registries.
+Package models into distributable `.xyb` bundles.
 
 ## Overview
 
-The deployment workflow:
+The packaging workflow:
 
 ```mermaid
 flowchart LR
-    A["Model Files"] --> B["Pack"]
+    A["Model Files"] --> B["xybrid pack"]
     B --> C[".xyb Bundle"]
-    C --> D["Deploy"]
-    D --> E["Registry"]
+    C --> D["Distribute"]
 
     A@{ shape: doc}
     B@{ shape: terminal}
     C@{ shape: docs}
     D@{ shape: terminal}
-    E@{ shape: db}
 ```
 
 ## Phase 4: Package Models
@@ -67,82 +65,57 @@ Every model needs execution configuration:
 ### Pack the Bundle
 
 ```bash
-xybrid pack my-model --version 1.0.0 --target macos-arm64
+xybrid pack my-model --version 1.0.0 --target onnx
 ```
 
-This creates `my-model@1.0.0.xyb` containing:
+This writes `./dist/my-model-1.0.0-onnx.xyb` containing:
 
 ```
-my-model@1.0.0.xyb/
+my-model-1.0.0-onnx.xyb/
 ├── manifest.json          # Bundle metadata + hash
 ├── model_metadata.json    # Execution config
 ├── model.onnx             # Model weights
 └── vocab.json             # Supporting files
 ```
 
-### Platform Variants
+### Runtime Format Variants
 
-Create bundles for each target platform:
-
-```bash
-# Apple Silicon Mac
-xybrid pack whisper-tiny --version 1.0.0 --target macos-arm64
-
-# iOS
-xybrid pack whisper-tiny --version 1.0.0 --target ios-arm64
-
-# Android
-xybrid pack whisper-tiny --version 1.0.0 --target android-arm64
-```
-
-## Phase 5: Deploy to Registry
-
-### Local Registry
-
-Deploy to the local cache:
+The `--target` flag tags the runtime format the bundle is compiled for. Supported values: `onnx`, `coreml`, `tflite`, `generic` (default: `onnx`).
 
 ```bash
-xybrid deploy my-model@1.0.0.xyb --registry local
+# ONNX Runtime (works on macOS, iOS, Android, Linux, Windows)
+xybrid pack whisper-tiny --version 1.0.0 --target onnx
+
+# CoreML (Apple Silicon optimisation)
+xybrid pack whisper-tiny --version 1.0.0 --target coreml
+
+# TensorFlow Lite (mobile)
+xybrid pack whisper-tiny --version 1.0.0 --target tflite
 ```
 
-Bundles are stored at:
+## Phase 5: Distribute the Bundle
 
-```
-~/.xybrid/registry/
-├── index.json                    # Bundle index
-└── my-model/
-    └── 1.0.0/
-        └── macos-arm64/
-            └── my-model.xyb
-```
+The `.xyb` file written to `./dist/` is self-contained. Distribute it however suits your project:
 
-### Remote Registry
+- Attach to a GitHub release
+- Host on HuggingFace, S3, or any HTTP server
+- Ship inside an app bundle
 
-Deploy to an HTTP registry:
+Consumers load the bundle directly without going through a registry:
 
 ```bash
-xybrid deploy my-model@1.0.0.xyb --registry remote -p https://registry.xybrid.dev
+xybrid run --bundle ./dist/my-model-1.0.0-onnx.xyb --input-text "Hello"
 ```
 
-### Verify Deployment
-
-Check the registry index:
-
-```bash
-cat ~/.xybrid/registry/index.json
+```rust
+let model = ModelLoader::from_bundle("./dist/my-model-1.0.0-onnx.xyb")?.load()?;
 ```
 
-```json
-{
-  "my-model/1.0.0/macos-arm64": {
-    "model_id": "my-model",
-    "version": "1.0.0",
-    "target": "macos-arm64",
-    "size_bytes": 12345678,
-    "path": "~/.xybrid/registry/my-model/1.0.0/macos-arm64/my-model.xyb"
-  }
-}
+```dart
+final model = await XybridModelLoader.fromBundle('my-model-1.0.0-onnx.xyb').load();
 ```
+
+If you want to publish to the public xybrid registry, see the `xybrid bundle` command, which fetches a published model and produces a `.xyb`.
 
 ## Bundle Types
 
@@ -207,41 +180,6 @@ cat ~/.xybrid/registry/index.json
     }
   ]
 }
-```
-
-## Using justfile Commands
-
-The project includes convenient commands:
-
-```bash
-# Create all bundles
-just registry::create
-
-# Create specific bundle
-just registry::create-bundle whisper-tiny
-
-# Check cache status
-just registry::cache-status
-
-# Start local registry server
-just registry::serve-local
-
-# Clean registry
-just registry::clean
-```
-
-## Registry Server
-
-Serve bundles over HTTP for distributed access:
-
-```bash
-just registry::serve-local
-```
-
-This serves `~/.xybrid/registry/` on port 8080. Clients can fetch bundles:
-
-```bash
-curl http://localhost:8080/bundles/whisper-tiny/1.0/macos-arm64/whisper-tiny.xyb
 ```
 
 ## Next Steps

--- a/docs/content/docs/concepts/packaging-and-deployment.zh.mdx
+++ b/docs/content/docs/concepts/packaging-and-deployment.zh.mdx
@@ -1,26 +1,24 @@
 ---
 title: 打包与部署
-description: Bundle 创建与注册表发布
+description: Bundle 创建与分发
 ---
 
-将模型打包为可分发的 `.xyb` Bundle 并发布到注册表。
+将模型打包为可分发的 `.xyb` Bundle。
 
 ## 概览
 
-部署工作流：
+打包工作流：
 
 ```mermaid
 flowchart LR
-    A["模型文件"] --> B["打包"]
+    A["模型文件"] --> B["xybrid pack"]
     B --> C[".xyb Bundle"]
-    C --> D["部署"]
-    D --> E["注册表"]
+    C --> D["分发"]
 
     A@{ shape: doc}
     B@{ shape: terminal}
     C@{ shape: docs}
     D@{ shape: terminal}
-    E@{ shape: db}
 ```
 
 ## 第四阶段：打包模型
@@ -67,82 +65,57 @@ models/my-model/
 ### 打包 Bundle
 
 ```bash
-xybrid pack my-model --version 1.0.0 --target macos-arm64
+xybrid pack my-model --version 1.0.0 --target onnx
 ```
 
-此命令创建 `my-model@1.0.0.xyb`，包含：
+此命令写入 `./dist/my-model-1.0.0-onnx.xyb`，包含：
 
 ```
-my-model@1.0.0.xyb/
+my-model-1.0.0-onnx.xyb/
 ├── manifest.json          # Bundle 元数据 + 哈希值
 ├── model_metadata.json    # 执行配置
 ├── model.onnx             # 模型权重
 └── vocab.json             # 其他所需文件
 ```
 
-### 平台变体
+### 运行时格式变体
 
-为每个目标平台创建 Bundle：
-
-```bash
-# Apple Silicon Mac
-xybrid pack whisper-tiny --version 1.0.0 --target macos-arm64
-
-# iOS
-xybrid pack whisper-tiny --version 1.0.0 --target ios-arm64
-
-# Android
-xybrid pack whisper-tiny --version 1.0.0 --target android-arm64
-```
-
-## 第五阶段：部署到注册表
-
-### 本地注册表
-
-部署到本地缓存：
+`--target` 参数标识 Bundle 编译的运行时格式。支持的值：`onnx`、`coreml`、`tflite`、`generic`（默认：`onnx`）。
 
 ```bash
-xybrid deploy my-model@1.0.0.xyb --registry local
+# ONNX Runtime（适用于 macOS、iOS、Android、Linux、Windows）
+xybrid pack whisper-tiny --version 1.0.0 --target onnx
+
+# CoreML（Apple Silicon 优化）
+xybrid pack whisper-tiny --version 1.0.0 --target coreml
+
+# TensorFlow Lite（移动端）
+xybrid pack whisper-tiny --version 1.0.0 --target tflite
 ```
 
-Bundle 存储路径：
+## 第五阶段：分发 Bundle
 
-```
-~/.xybrid/registry/
-├── index.json                    # Bundle 索引
-└── my-model/
-    └── 1.0.0/
-        └── macos-arm64/
-            └── my-model.xyb
-```
+写入 `./dist/` 的 `.xyb` 文件是自包含的。可以按项目需要任意分发：
 
-### 远程注册表
+- 附加到 GitHub Release
+- 托管在 HuggingFace、S3 或任意 HTTP 服务器
+- 打包进应用本身
 
-部署到 HTTP 注册表：
+消费方无需经过注册表，直接加载 Bundle：
 
 ```bash
-xybrid deploy my-model@1.0.0.xyb --registry remote -p https://registry.xybrid.dev
+xybrid run --bundle ./dist/my-model-1.0.0-onnx.xyb --input-text "Hello"
 ```
 
-### 验证部署
-
-检查注册表索引：
-
-```bash
-cat ~/.xybrid/registry/index.json
+```rust
+let model = ModelLoader::from_bundle("./dist/my-model-1.0.0-onnx.xyb")?.load()?;
 ```
 
-```json
-{
-  "my-model/1.0.0/macos-arm64": {
-    "model_id": "my-model",
-    "version": "1.0.0",
-    "target": "macos-arm64",
-    "size_bytes": 12345678,
-    "path": "~/.xybrid/registry/my-model/1.0.0/macos-arm64/my-model.xyb"
-  }
-}
+```dart
+final model = await XybridModelLoader.fromBundle('my-model-1.0.0-onnx.xyb').load();
 ```
+
+如需发布到 xybrid 公共注册表，请参阅 `xybrid bundle` 命令——它会从已发布的模型构建 `.xyb`。
 
 ## Bundle 类型
 
@@ -207,41 +180,6 @@ cat ~/.xybrid/registry/index.json
     }
   ]
 }
-```
-
-## 使用 justfile 命令
-
-项目内置了便捷命令：
-
-```bash
-# 创建所有 Bundle
-just registry::create
-
-# 创建指定 Bundle
-just registry::create-bundle whisper-tiny
-
-# 检查缓存状态
-just registry::cache-status
-
-# 启动本地注册表服务器
-just registry::serve-local
-
-# 清理注册表
-just registry::clean
-```
-
-## 注册表服务器
-
-通过 HTTP 提供 Bundle 以供分布式访问：
-
-```bash
-just registry::serve-local
-```
-
-此命令在 8080 端口提供 `~/.xybrid/registry/` 服务。客户端可获取 Bundle：
-
-```bash
-curl http://localhost:8080/bundles/whisper-tiny/1.0/macos-arm64/whisper-tiny.xyb
 ```
 
 ## 下一步

--- a/docs/content/docs/concepts/registry.mdx
+++ b/docs/content/docs/concepts/registry.mdx
@@ -71,24 +71,6 @@ The registry automatically detects the current platform:
 | Linux | `linux-x86_64` |
 | Windows | `windows-x86_64` |
 
-## Registry Server
-
-### Start Server
-
-```bash
-just registry::serve-local
-```
-
-Serves from `~/.xybrid/registry/` on `http://localhost:8080`.
-
-### Endpoints
-
-| Endpoint | Description |
-|----------|-------------|
-| `GET /index` | List all bundles |
-| `GET /bundles/{id}/{version}/{platform}/{id}.xyb` | Download bundle |
-| `GET /health` | Health check |
-
 ## Using in Pipelines
 
 Reference the registry URL in pipeline YAML:

--- a/docs/content/docs/concepts/registry.zh.mdx
+++ b/docs/content/docs/concepts/registry.zh.mdx
@@ -71,24 +71,6 @@ Bundle 包含模型 ID、版本和平台：
 | Linux | `linux-x86_64` |
 | Windows | `windows-x86_64` |
 
-## 注册表服务器
-
-### 启动服务器
-
-```bash
-just registry::serve-local
-```
-
-从 `~/.xybrid/registry/` 在 `http://localhost:8080` 提供服务。
-
-### 接口
-
-| 接口 | 说明 |
-|----------|-------------|
-| `GET /index` | 列出所有 Bundle |
-| `GET /bundles/{id}/{version}/{platform}/{id}.xyb` | 下载 Bundle |
-| `GET /health` | 健康检查 |
-
 ## 在流水线中使用
 
 在流水线 YAML 中引用注册表 URL：

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -151,10 +151,10 @@ cargo install xybrid-cli
 xybrid models list
 
 # Run text-to-speech
-xybrid run kokoro-82m --input "Hello from Xybrid!" --output hello.wav
+xybrid run --model kokoro-82m --input-text "Hello from Xybrid!" --output hello.wav
 
 # Run speech-to-text
-xybrid run whisper-tiny --input recording.wav
+xybrid run --model whisper-tiny --input-audio recording.wav
 ```
 
 **Expected output:**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -152,10 +152,10 @@ cargo install xybrid-cli
 xybrid models list
 
 # 运行文本转语音
-xybrid run kokoro-82m --input "Hello from Xybrid!" --output hello.wav
+xybrid run --model kokoro-82m --input-text "Hello from Xybrid!" --output hello.wav
 
 # 运行语音转文字
-xybrid run whisper-tiny --input recording.wav
+xybrid run --model whisper-tiny --input-audio recording.wav
 ```
 
 **预期输出：**

--- a/examples/README.md
+++ b/examples/README.md
@@ -201,7 +201,7 @@ Native libraries need to be built from Rust before the SDK works:
 
 1. Check internet connectivity
 2. Verify the model ID exists in the registry: `xybrid models list`
-3. For offline usage, download models first: `xybrid models pull <model-id>`
+3. For offline usage, download models first: `xybrid fetch --model <model-id>`
 
 ### Build failures
 

--- a/examples/flutter/README.md
+++ b/examples/flutter/README.md
@@ -276,7 +276,7 @@ flutter analyze
 
 1. Check internet connectivity
 2. Verify model ID: `xybrid models list`
-3. Try downloading manually: `xybrid models pull <model-id>`
+3. Try downloading manually: `xybrid fetch --model <model-id>`
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary

The README, quickstart, packaging-and-deployment, and registry pages had CLI invocations that don't match `xybrid-cli`. New users following the docs would hit clap parse errors or nonexistent subcommands.

**Specific drift fixed:**

- `xybrid run <model-id>` and `xybrid run <pipeline.yaml>` shown as positional forms — both must be flags (`--model`, `--config`).
- Generic `--input` shown instead of the real `--input-text` / `--input-audio`.
- References to `xybrid models pull`, `xybrid deploy`, and `just registry::*` recipes that don't exist in the binary or justfile.
- `xybrid pack --target macos-arm64 / ios-arm64 / android-arm64`, conflicting with the `(onnx, coreml, tflite, generic)` set documented in the clap help text (`crates/xybrid-cli/src/main.rs:271`).

**What changed:**

- `xybrid run` examples in `README.md`, `README.zh-CN.md`, `docs/content/docs/quickstart.{mdx,zh.mdx}` rewritten to use `--model`/`--config` and `--input-text`/`--input-audio`.
- `examples/README.md` and `examples/flutter/README.md`: `models pull` → `fetch --model`.
- `docs/content/docs/concepts/packaging-and-deployment.{mdx,zh.mdx}`: Phase 5 ("Deploy to Registry") rewritten as "Distribute the Bundle" describing the actual `./dist/<name>-<version>-<target>.xyb` output. Removed fictional `just registry::*` and "Registry Server" sections. `--target` examples switched to `onnx` / `coreml` / `tflite`.
- `docs/content/docs/concepts/registry.{mdx,zh.mdx}`: dropped the "Registry Server" subsection (`just registry::serve-local` plus three HTTP endpoints, all fictional).

10 files, +68 / −228 lines.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — N/A, docs-only
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## Test plan

- [ ] Sanity greps return zero hits:
  ```sh
  grep -rnE 'xybrid run [a-z][a-z0-9_-]+( |$)' README.md README.zh-CN.md docs examples/README.md
  grep -rnE 'xybrid (deploy|policy|profile|session|config) ' README.md README.zh-CN.md docs examples
  grep -rnE 'xybrid models pull' README.md README.zh-CN.md docs examples
  grep -rnE -- 'xybrid pack.*--target (macos|ios|android)-' docs
  grep -rnE 'xybrid run.*--input ' README.md README.zh-CN.md docs examples
  grep -rnE 'just registry::' docs README.md README.zh-CN.md examples
  ```
- [ ] Spot-check the corrected examples actually run:
  ```sh
  cargo build -p xybrid-cli --release
  ./target/release/xybrid run --model kokoro-82m --input-text "Hello world" -o /tmp/out.wav
  ./target/release/xybrid run --model whisper-tiny --input-audio integration-tests/fixtures/input/jfk.wav
  ```
- [ ] Render the docs site locally and skim the changed pages (`docs/content/docs/quickstart.{mdx,zh.mdx}`, `docs/content/docs/concepts/packaging-and-deployment.{mdx,zh.mdx}`, `docs/content/docs/concepts/registry.{mdx,zh.mdx}`).

## Out of scope

Flagged but not touched here (separate audit):

- `registry.{mdx,zh.mdx}` still describes a `~/.xybrid/registry/<model>/<version>/<platform>/` layout; the actual cache lives at `~/.xybrid/cache/<model-id>/universal.xyb`.
- `docs/content/docs/cli/reference/run.mdx` only documents `--config` / `--pipeline`; enriching it with `--model`, `--huggingface`, `--input-text`, `--input-audio`, `--voice`, `-o` would help.