### PR TITLE
feat: registry-call telemetry header (X-Xybrid-Client) across all bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +303,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compat"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +357,143 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -451,6 +640,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +758,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -1121,6 +1334,15 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1762,6 +1984,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +2015,17 @@ dependencies = [
  "option-ext",
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1888,6 +2131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2004,6 +2256,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2376,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2314,6 +2599,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2822,6 +3120,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "goblin"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,6 +3455,34 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "humantime"
@@ -3704,6 +4042,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache 0.8.9",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,6 +4098,12 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -3822,6 +4206,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loop9"
@@ -4912,6 +5299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,13 +5398,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -5022,7 +5425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5032,7 +5435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5042,10 +5445,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -5058,10 +5470,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -5127,6 +5562,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6364,6 +6813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,6 +7005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6670,13 +7135,25 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -6687,7 +7164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -7058,6 +7535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7194,6 +7682,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -8177,6 +8674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "variantly"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8397,7 +8900,7 @@ checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf",
  "phf_codegen",
- "string_cache",
+ "string_cache 0.9.0",
  "string_cache_codegen",
 ]
 
@@ -9276,6 +9779,7 @@ dependencies = [
  "chrono",
  "dirs 6.0.0",
  "hf-hub 0.5.0",
+ "httpmock",
  "log",
  "ort",
  "rustls",

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 
 ## Why Xybrid?
 
-- **Privacy first** — All inference runs on-device. Your data never leaves the device. The SDK attaches a small fleet-attribution header on registry metadata calls — see [registry telemetry](docs/telemetry/registry.md) for what it contains and how to opt out via `XYBRID_TELEMETRY_OPTOUT=1`.
+- **Privacy first** — All inference runs on-device. Your data never leaves the device. The SDK attaches a small fleet-attribution header on registry metadata calls — see [registry telemetry](docs/telemetry/registry.md).
 - **Offline capable** — No internet required after initial model download.
 - **Cross-platform** — One API across iOS, Android, macOS, Linux, and Windows.
 - **Pipeline orchestration** — Chain models together (ASR → LLM → TTS) in a single call.

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 
 ## Why Xybrid?
 
-- **Privacy first** — All inference runs on-device. Your data never leaves the device.
+- **Privacy first** — All inference runs on-device. Your data never leaves the device. The SDK attaches a small fleet-attribution header on registry metadata calls — see [registry telemetry](docs/telemetry/registry.md) for what it contains and how to opt out via `XYBRID_TELEMETRY_OPTOUT=1`.
 - **Offline capable** — No internet required after initial model download.
 - **Cross-platform** — One API across iOS, Android, macOS, Linux, and Windows.
 - **Pipeline orchestration** — Chain models together (ASR → LLM → TTS) in a single call.

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -234,6 +234,10 @@ The Swift bindings are generated from `crates/xybrid-uniffi/` using [UniFFI](htt
 - Memory-safe wrappers
 - Automatic error handling
 
+## Telemetry
+
+The Apple binding reports `binding=swift` in a small `X-Xybrid-Client` header attached to registry metadata calls. See [docs/telemetry/registry.md](../../docs/telemetry/registry.md) for the exact wire format and the opt-out switch (`XYBRID_TELEMETRY_OPTOUT=1`).
+
 ## Full Plan
 
 See [DRAFT-PLATFORM-SDK-RESTRUCTURE.md](../../docs/architecture/DRAFT-PLATFORM-SDK-RESTRUCTURE.md) for the complete restructuring plan.

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -8,6 +8,43 @@
 
 import Foundation
 
+// MARK: - SDK Initialization
+
+/// Main entry point for the Xybrid SDK on iOS/macOS.
+///
+/// Call `Xybrid.initialize()` once before using any other Xybrid functionality.
+/// It registers the binding identifier so registry calls are attributed to the
+/// Swift SDK, and is safe to call multiple times — subsequent calls are no-ops.
+///
+/// ```swift
+/// // Application entry point
+/// Xybrid.initialize()
+/// ```
+public enum Xybrid {
+    private static let initLock = NSLock()
+    nonisolated(unsafe) private static var initialized = false
+
+    /// Initialize the Xybrid runtime.
+    ///
+    /// Registers the Swift binding identifier with the SDK so that the
+    /// `X-Xybrid-Client` header on registry HTTP calls reports
+    /// `binding=swift`. Idempotent and thread-safe.
+    public static func initialize() {
+        initLock.lock()
+        defer { initLock.unlock() }
+        if initialized { return }
+        setBinding(binding: "swift")
+        initialized = true
+    }
+
+    /// Returns `true` if `initialize()` has been called.
+    public static var isInitialized: Bool {
+        initLock.lock()
+        defer { initLock.unlock() }
+        return initialized
+    }
+}
+
 // MARK: - Public Type Re-exports
 
 /// Loads ML models from the registry or local bundles.

--- a/bindings/apple/Sources/Xybrid/xybrid_uniffi.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_uniffi.swift
@@ -1529,6 +1529,15 @@ public func initSdkCacheDir(cacheDir: String)  {
 
 
 
+public func setBinding(binding: String)  {
+    try! rustCall() {
+    uniffi_xybrid_uniffi_fn_func_set_binding(
+        FfiConverterString.lower(binding),$0)
+}
+}
+
+
+
 private enum InitializationResult {
     case ok
     case contractVersionMismatch
@@ -1545,6 +1554,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.contractVersionMismatch
     }
     if (uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xybrid_uniffi_checksum_func_set_binding() != 53803) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id() != 623) {

--- a/bindings/apple/Sources/xybrid_uniffiFFI/include/xybrid_uniffiFFI.h
+++ b/bindings/apple/Sources/xybrid_uniffiFFI/include/xybrid_uniffiFFI.h
@@ -89,6 +89,8 @@ void* _Nonnull uniffi_xybrid_uniffi_fn_method_xybridmodelloader_load(void*_Nonnu
 );
 void uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(RustBuffer cache_dir, RustCallStatus *_Nonnull out_status
 );
+void uniffi_xybrid_uniffi_fn_func_set_binding(RustBuffer binding, RustCallStatus *_Nonnull out_status
+);
 RustBuffer ffi_xybrid_uniffi_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_xybrid_uniffi_rustbuffer_from_bytes(ForeignBytes bytes, RustCallStatus *_Nonnull out_status
@@ -204,6 +206,9 @@ void ffi_xybrid_uniffi_rust_future_free_void(void* _Nonnull handle
 void ffi_xybrid_uniffi_rust_future_complete_void(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
 );
 uint16_t uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(void
+    
+);
+uint16_t uniffi_xybrid_uniffi_checksum_func_set_binding(void
     
 );
 uint16_t uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id(void

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -268,6 +268,10 @@ https://github.com/xybrid-ai/xybrid/tree/main/examples/flutter
 
 Full API documentation: [pub.dev/documentation/xybrid_flutter](https://pub.dev/documentation/xybrid_flutter/latest/)
 
+## Telemetry
+
+The plugin reports `binding=flutter` in a small `X-Xybrid-Client` header attached to registry metadata calls. See [docs/telemetry/registry.md](../../docs/telemetry/registry.md) for the exact wire format and the opt-out switch (`XYBRID_TELEMETRY_OPTOUT=1`).
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE)

--- a/bindings/flutter/rust/src/api/sdk_client.rs
+++ b/bindings/flutter/rust/src/api/sdk_client.rs
@@ -1,16 +1,24 @@
 use flutter_rust_bridge::frb;
 
+/// Binding identifier reported in the `X-Xybrid-Client` registry header for
+/// Flutter apps. Routed through `xybrid_sdk::set_binding` at every FFI entry
+/// so registry calls are attributed correctly even on platforms that skip
+/// `init_sdk_cache_dir` (iOS/macOS).
+const FLUTTER_BINDING: &str = "flutter";
+
 #[frb(opaque)]
 pub struct XybridSdkClient;
 
 impl XybridSdkClient {
     #[frb(sync)]
     pub fn init_sdk_cache_dir(cache_dir: String) {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
         xybrid_sdk::init_sdk_cache_dir(cache_dir);
     }
 
     #[frb(sync)]
     pub fn set_api_key(api_key: &str) {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
         xybrid_sdk::set_api_key(api_key);
     }
 
@@ -21,9 +29,38 @@ impl XybridSdkClient {
     /// at `~/.xybrid/cache/extracted/{model_id}/model_metadata.json`.
     #[frb(sync)]
     pub fn is_model_cached(model_id: &str) -> bool {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
         if let Ok(client) = xybrid_sdk::RegistryClient::from_env() {
             return client.is_extracted(model_id);
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flutter_init_registers_flutter_binding() {
+        // Single combined test (the binding is process-global via OnceLock —
+        // splitting into multiple tests would race on which one observes the
+        // first set_binding).
+        XybridSdkClient::init_sdk_cache_dir(
+            std::env::temp_dir()
+                .join("xybrid-flutter-test-cache")
+                .to_string_lossy()
+                .into_owned(),
+        );
+
+        // Process-global binding now resolves to "flutter".
+        assert_eq!(xybrid_sdk::get_binding(), FLUTTER_BINDING);
+
+        // RegistryClient default constructors pick up the configured binding,
+        // so the X-Xybrid-Client header on every metadata call will report
+        // binding=flutter for Flutter apps.
+        let client = xybrid_sdk::RegistryClient::default_client()
+            .expect("default_client should succeed in tests");
+        assert_eq!(client.binding(), FLUTTER_BINDING);
     }
 }

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -402,6 +402,10 @@ export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/26.1.10909125"
 | ARM64 | arm64-v8a | Most modern Android phones |
 | x86_64 | x86_64 | Android emulator on Intel/AMD |
 
+## Telemetry
+
+The Android binding reports `binding=kotlin` in a small `X-Xybrid-Client` header attached to registry metadata calls. See [docs/telemetry/registry.md](../../docs/telemetry/registry.md) for the exact wire format and the opt-out switch (`XYBRID_TELEMETRY_OPTOUT=1`).
+
 ## Full Plan
 
 See [DRAFT-PLATFORM-SDK-RESTRUCTURE.md](../../docs/architecture/DRAFT-PLATFORM-SDK-RESTRUCTURE.md) for the complete restructuring plan.

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -45,6 +45,7 @@ object Xybrid {
         if (initialized) return
         synchronized(this) {
             if (initialized) return
+            setBinding("kotlin")
             val cacheDir = File(context.filesDir, "xybrid/models")
             initSdkCacheDir(cacheDir.absolutePath)
             initialized = true

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/uniffi/xybrid_uniffi/xybrid_uniffi.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/uniffi/xybrid_uniffi/xybrid_uniffi.kt
@@ -413,6 +413,8 @@ internal interface _UniFFILib : Library {
     ): Pointer
     fun uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(`cacheDir`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_set_binding(`binding`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun ffi_xybrid_uniffi_rustbuffer_alloc(`size`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
     fun ffi_xybrid_uniffi_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,_uniffi_out_err: RustCallStatus, 
@@ -529,6 +531,8 @@ internal interface _UniFFILib : Library {
     ): Unit
     fun uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(
     ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_set_binding(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id(
     ): Short
     fun uniffi_xybrid_uniffi_checksum_method_xybridmodel_has_voices(
@@ -567,6 +571,9 @@ private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_set_binding() != 53803.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id() != 623.toShort()) {
@@ -2158,6 +2165,14 @@ fun `initSdkCacheDir`(`cacheDir`: String) =
     
     rustCall() { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(FfiConverterString.lower(`cacheDir`),_status)
+}
+
+
+
+fun `setBinding`(`binding`: String) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_binding(FfiConverterString.lower(`binding`),_status)
 }
 
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/xybrid_uniffi.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/xybrid_uniffi.kt
@@ -413,6 +413,8 @@ internal interface _UniFFILib : Library {
     ): Pointer
     fun uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(`cacheDir`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_set_binding(`binding`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun ffi_xybrid_uniffi_rustbuffer_alloc(`size`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
     fun ffi_xybrid_uniffi_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,_uniffi_out_err: RustCallStatus, 
@@ -529,6 +531,8 @@ internal interface _UniFFILib : Library {
     ): Unit
     fun uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(
     ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_set_binding(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id(
     ): Short
     fun uniffi_xybrid_uniffi_checksum_method_xybridmodel_has_voices(
@@ -567,6 +571,9 @@ private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_set_binding() != 53803.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id() != 623.toShort()) {
@@ -2158,6 +2165,14 @@ fun `initSdkCacheDir`(`cacheDir`: String) =
     
     rustCall() { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(FfiConverterString.lower(`cacheDir`),_status)
+}
+
+
+
+fun `setBinding`(`binding`: String) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_binding(FfiConverterString.lower(`binding`),_status)
 }
 
 

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -275,6 +275,10 @@ bindings/unity/
 
 See the [full API documentation](https://docs.xybrid.ai/unity) for detailed reference.
 
+## Telemetry
+
+The Unity binding reports `binding=unity` in a small `X-Xybrid-Client` header attached to registry metadata calls. See [docs/telemetry/registry.md](../../docs/telemetry/registry.md) for the exact wire format and the opt-out switch (`XYBRID_TELEMETRY_OPTOUT=1`).
+
 ## License
 
 Apache 2.0 - See [LICENSE](../../LICENSE) for details.

--- a/bindings/unity/Runtime/Api/XybridClient.cs
+++ b/bindings/unity/Runtime/Api/XybridClient.cs
@@ -53,13 +53,19 @@ namespace Xybrid
         /// calls are no-ops.
         /// </remarks>
         /// <exception cref="XybridException">Thrown if initialization fails.</exception>
-        public static void Initialize()
+        public static unsafe void Initialize()
         {
             lock (_lock)
             {
                 if (_initialized)
                 {
                     return;
+                }
+
+                byte[] bindingBytes = NativeHelpers.ToUtf8Bytes("unity");
+                fixed (byte* bindingPtr = bindingBytes)
+                {
+                    NativeMethods.xybrid_set_binding(bindingPtr);
                 }
 
                 int result = NativeMethods.xybrid_init();

--- a/bindings/unity/Runtime/Native/NativeMethods.g.cs
+++ b/bindings/unity/Runtime/Native/NativeMethods.g.cs
@@ -49,6 +49,44 @@ namespace Xybrid.Native
         internal static extern int xybrid_init();
 
         /// <summary>
+        ///  Set the platform binding identifier reported in registry call telemetry.
+        ///
+        ///  Call this once at application startup, BEFORE [`xybrid_init`], to declare
+        ///  which platform binding (e.g. Unity) is hosting the SDK. The value flows into
+        ///  the `X-Xybrid-Client` HTTP header on every registry metadata call.
+        ///
+        ///  First-call-wins semantics: subsequent calls are silent no-ops. If never
+        ///  called, the SDK reports the default `"rust"` binding.
+        ///
+        ///  The mapping is bounded: only known platform identifiers are accepted; every
+        ///  other input falls back to the default `"rust"` binding to bound cardinality
+        ///  on the registry side.
+        ///
+        ///  # Parameters
+        ///
+        ///  - `binding`: A null-terminated UTF-8 string. Currently the only recognized
+        ///    value is `"unity"`; any other value collapses to `"rust"`.
+        ///
+        ///  # Returns
+        ///
+        ///  - `0` on success
+        ///  - `-1` if `binding` is null or not valid UTF-8 (check `xybrid_last_error()`)
+        ///
+        ///  # Example (C)
+        ///
+        ///  ```c
+        ///  xybrid_set_binding("unity");
+        ///  xybrid_init();
+        ///  ```
+        ///
+        ///  # Safety
+        ///
+        ///  `binding` must be either null or a pointer to a null-terminated C string.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_set_binding", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern int xybrid_set_binding(byte* binding);
+
+        /// <summary>
         ///  Get the library version string.
         ///
         ///  Returns a pointer to a null-terminated string containing the library version.

--- a/crates/xybrid-cli/src/commands/mod.rs
+++ b/crates/xybrid-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@
 //! | [`pack`] | `pack` - Package local model artifacts |
 //! | [`pipeline`] | `prepare`, `plan` - Pipeline validation and planning |
 //! | [`trace`] | `trace` - Session telemetry analysis |
+//! | [`telemetry`] | `telemetry status` - Registry telemetry opt-out reporting |
 //! | [`types`] | Shared CLI enum types (ModelsCommand, CacheCommand) |
 //! | [`utils`] | Shared utility functions |
 
@@ -25,9 +26,11 @@ pub mod pack;
 pub mod pipeline;
 pub mod repl;
 pub mod run;
+pub mod telemetry;
 pub mod trace;
 pub mod types;
 pub mod utils;
 
 // Re-export shared types
+pub(crate) use telemetry::TelemetryCommand;
 pub(crate) use types::{CacheCommand, ModelsCommand};

--- a/crates/xybrid-cli/src/commands/telemetry.rs
+++ b/crates/xybrid-cli/src/commands/telemetry.rs
@@ -1,0 +1,36 @@
+//! `xybrid telemetry` command handlers.
+//!
+//! Reports the runtime status of registry telemetry — whether the
+//! `X-Xybrid-Client` header is being sent on outbound registry calls or
+//! suppressed by the `XYBRID_TELEMETRY_OPTOUT` env var.
+
+use anyhow::Result;
+use clap::Subcommand;
+
+/// Subcommands for `xybrid telemetry`.
+#[derive(Subcommand)]
+pub(crate) enum TelemetryCommand {
+    /// Report whether registry telemetry is enabled or opted out.
+    ///
+    /// Reads the cached `XYBRID_TELEMETRY_OPTOUT` env var (truthy values:
+    /// `1`, `true`, `yes`, case-insensitive) and prints a single status line.
+    /// See repos/xybrid/docs/telemetry/registry.md for what the
+    /// `X-Xybrid-Client` header carries.
+    Status,
+}
+
+/// Handle `xybrid telemetry` subcommands.
+pub(crate) fn handle_telemetry_command(command: TelemetryCommand) -> Result<()> {
+    match command {
+        TelemetryCommand::Status => status(),
+    }
+}
+
+fn status() -> Result<()> {
+    if xybrid_sdk::is_telemetry_opted_out() {
+        println!("registry telemetry: disabled (XYBRID_TELEMETRY_OPTOUT=1)");
+    } else {
+        println!("registry telemetry: enabled");
+    }
+    Ok(())
+}

--- a/crates/xybrid-cli/src/main.rs
+++ b/crates/xybrid-cli/src/main.rs
@@ -29,7 +29,7 @@ mod commands;
 mod tracing_viz;
 pub mod ui;
 
-use commands::{CacheCommand, ModelsCommand};
+use commands::{CacheCommand, ModelsCommand, TelemetryCommand};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -289,6 +289,11 @@ enum Commands {
         /// Target platform (auto-detected if not specified)
         #[arg(short, long, value_name = "PLATFORM")]
         platform: Option<String>,
+    },
+    /// Report or manage registry telemetry settings
+    Telemetry {
+        #[command(subcommand)]
+        command: TelemetryCommand,
     },
 }
 
@@ -616,6 +621,7 @@ fn run_command(cli: Cli) -> Result<()> {
             output,
             platform,
         } => commands::bundle::handle_bundle_command(&model, output, platform.as_deref()),
+        Commands::Telemetry { command } => commands::telemetry::handle_telemetry_command(command),
     }
 }
 

--- a/crates/xybrid-cli/tests/telemetry_status_test.rs
+++ b/crates/xybrid-cli/tests/telemetry_status_test.rs
@@ -1,0 +1,88 @@
+//! Integration tests for `xybrid telemetry status`.
+//!
+//! Verifies the command reports the correct opt-in / opt-out state based on
+//! the `XYBRID_TELEMETRY_OPTOUT` env var. Each case spawns a fresh subprocess
+//! so the OnceLock cache in `is_telemetry_opted_out()` is process-isolated.
+
+use std::process::Command;
+
+fn xybrid_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_xybrid"))
+}
+
+#[test]
+fn telemetry_status_reports_enabled_when_optout_unset() {
+    let output = Command::new(xybrid_bin())
+        .args(["telemetry", "status"])
+        .env_remove("XYBRID_TELEMETRY_OPTOUT")
+        .output()
+        .expect("Failed to run xybrid telemetry status");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "telemetry status should exit 0 (got {:?}), stderr: {}",
+        output.status.code(),
+        stderr
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("enabled"),
+        "expected stdout to contain 'enabled', got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("disabled"),
+        "expected stdout NOT to contain 'disabled', got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn telemetry_status_reports_disabled_when_optout_set() {
+    let output = Command::new(xybrid_bin())
+        .args(["telemetry", "status"])
+        .env("XYBRID_TELEMETRY_OPTOUT", "1")
+        .output()
+        .expect("Failed to run xybrid telemetry status");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "telemetry status should exit 0 (got {:?}), stderr: {}",
+        output.status.code(),
+        stderr
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("disabled"),
+        "expected stdout to contain 'disabled', got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("XYBRID_TELEMETRY_OPTOUT=1"),
+        "expected stdout to mention the env var, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn telemetry_status_help_mentions_opt_out_env_var() {
+    let output = Command::new(xybrid_bin())
+        .args(["telemetry", "status", "--help"])
+        .output()
+        .expect("Failed to run xybrid telemetry status --help");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "help should exit 0");
+    assert!(
+        stdout.contains("XYBRID_TELEMETRY_OPTOUT"),
+        "help should mention the opt-out env var, got: {}",
+        stdout
+    );
+}

--- a/crates/xybrid-core/src/features.rs
+++ b/crates/xybrid-core/src/features.rs
@@ -1,0 +1,107 @@
+//! Runtime feature-flag introspection.
+//!
+//! Reports which Cargo features were enabled at compile time so callers
+//! (e.g. the registry telemetry header) can advertise the active backend set.
+
+use std::sync::OnceLock;
+
+// Forward-compatible feature names: some entries (`ort-cuda`, `llm-mlx`,
+// `llm-mlx-runtime`, `espeak`) are not yet declared in Cargo.toml. The
+// `cfg!()` checks resolve to `false` for any feature that does not exist,
+// and `#[allow(unexpected_cfgs)]` suppresses the corresponding lint so the
+// list can grow without a parallel Cargo.toml edit.
+#[allow(unexpected_cfgs)]
+const ALL_FEATURES: &[(&str, bool)] = &[
+    ("candle-cuda", cfg!(feature = "candle-cuda")),
+    ("candle-metal", cfg!(feature = "candle-metal")),
+    ("espeak", cfg!(feature = "espeak")),
+    ("llm-llamacpp", cfg!(feature = "llm-llamacpp")),
+    ("llm-mistral", cfg!(feature = "llm-mistral")),
+    ("llm-mlx", cfg!(feature = "llm-mlx")),
+    ("llm-mlx-runtime", cfg!(feature = "llm-mlx-runtime")),
+    ("ort-coreml", cfg!(feature = "ort-coreml")),
+    ("ort-cuda", cfg!(feature = "ort-cuda")),
+    ("ort-download", cfg!(feature = "ort-download")),
+    ("ort-dynamic", cfg!(feature = "ort-dynamic")),
+];
+
+/// Return the sorted list of enabled runtime feature names.
+///
+/// The result is computed once and cached, so subsequent calls are cheap
+/// and return a slice with a stable address.
+pub fn enabled() -> &'static [&'static str] {
+    static ENABLED: OnceLock<Vec<&'static str>> = OnceLock::new();
+    ENABLED.get_or_init(|| filter_enabled(ALL_FEATURES)).as_slice()
+}
+
+fn filter_enabled(items: &[(&'static str, bool)]) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = items
+        .iter()
+        .filter_map(|(name, on)| if *on { Some(*name) } else { None })
+        .collect();
+    names.sort();
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_yields_empty_slice() {
+        let result = filter_enabled(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn no_features_enabled_yields_empty_slice() {
+        let items: &[(&'static str, bool)] = &[
+            ("candle-metal", false),
+            ("ort-coreml", false),
+            ("llm-llamacpp", false),
+        ];
+        assert!(filter_enabled(items).is_empty());
+    }
+
+    #[test]
+    fn output_is_sorted() {
+        let items: &[(&'static str, bool)] = &[
+            ("ort-download", true),
+            ("candle-metal", true),
+            ("llm-llamacpp", true),
+        ];
+        assert_eq!(
+            filter_enabled(items),
+            vec!["candle-metal", "llm-llamacpp", "ort-download"]
+        );
+    }
+
+    #[test]
+    fn enabled_is_deterministic_across_calls() {
+        let first = enabled();
+        let second = enabled();
+        assert_eq!(first, second);
+        assert_eq!(first.as_ptr(), second.as_ptr());
+    }
+
+    #[test]
+    fn enabled_is_alphabetically_sorted() {
+        let names = enabled();
+        for window in names.windows(2) {
+            assert!(window[0] <= window[1], "not sorted: {:?}", names);
+        }
+    }
+
+    #[cfg(feature = "ort-coreml")]
+    #[test]
+    fn platform_macos_enables_expected_features() {
+        // Under --features platform-macos, ort-coreml must be reported.
+        assert!(enabled().contains(&"ort-coreml"));
+    }
+
+    #[cfg(feature = "ort-download")]
+    #[test]
+    fn ort_download_branch_is_exercised() {
+        assert!(enabled().contains(&"ort-download"));
+    }
+}

--- a/crates/xybrid-core/src/features.rs
+++ b/crates/xybrid-core/src/features.rs
@@ -31,7 +31,9 @@ const ALL_FEATURES: &[(&str, bool)] = &[
 /// and return a slice with a stable address.
 pub fn enabled() -> &'static [&'static str] {
     static ENABLED: OnceLock<Vec<&'static str>> = OnceLock::new();
-    ENABLED.get_or_init(|| filter_enabled(ALL_FEATURES)).as_slice()
+    ENABLED
+        .get_or_init(|| filter_enabled(ALL_FEATURES))
+        .as_slice()
 }
 
 fn filter_enabled(items: &[(&'static str, bool)]) -> Vec<&'static str> {

--- a/crates/xybrid-core/src/lib.rs
+++ b/crates/xybrid-core/src/lib.rs
@@ -136,6 +136,12 @@ compile_error!(
     - For other platforms: Use `ort-download` (CPU only)"
 );
 
+/// Version of the `xybrid-core` crate, sourced from Cargo metadata at compile time.
+///
+/// Re-exported by `xybrid-sdk` so registry telemetry headers can report the
+/// runtime core version without a parallel constant.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 // ============================================================================
 // Prelude - Common imports for convenience
 // ============================================================================

--- a/crates/xybrid-core/src/lib.rs
+++ b/crates/xybrid-core/src/lib.rs
@@ -199,6 +199,9 @@ pub mod template_executor {
 /// Allows Core to check cache without depending on SDK.
 pub mod cache_provider;
 
+/// Runtime feature-flag introspection (which backends were compiled in).
+pub mod features;
+
 // ============================================================================
 // Data Types & Intermediate Representation
 // ============================================================================

--- a/crates/xybrid-ffi/include/xybrid.h
+++ b/crates/xybrid-ffi/include/xybrid.h
@@ -192,6 +192,43 @@ typedef struct XybridTelemetryConfigHandle {
 int32_t xybrid_init(void);
 
 /*
+ Set the platform binding identifier reported in registry call telemetry.
+
+ Call this once at application startup, BEFORE [`xybrid_init`], to declare
+ which platform binding (e.g. Unity) is hosting the SDK. The value flows into
+ the `X-Xybrid-Client` HTTP header on every registry metadata call.
+
+ First-call-wins semantics: subsequent calls are silent no-ops. If never
+ called, the SDK reports the default `"rust"` binding.
+
+ The mapping is bounded: only known platform identifiers are accepted; every
+ other input falls back to the default `"rust"` binding to bound cardinality
+ on the registry side.
+
+ # Parameters
+
+ - `binding`: A null-terminated UTF-8 string. Currently the only recognized
+   value is `"unity"`; any other value collapses to `"rust"`.
+
+ # Returns
+
+ - `0` on success
+ - `-1` if `binding` is null or not valid UTF-8 (check `xybrid_last_error()`)
+
+ # Example (C)
+
+ ```c
+ xybrid_set_binding("unity");
+ xybrid_init();
+ ```
+
+ # Safety
+
+ `binding` must be either null or a pointer to a null-terminated C string.
+ */
+int32_t xybrid_set_binding(const char *binding);
+
+/*
  Get the library version string.
 
  Returns a pointer to a null-terminated string containing the library version.

--- a/crates/xybrid-ffi/src/lib.rs
+++ b/crates/xybrid-ffi/src/lib.rs
@@ -708,6 +708,73 @@ pub extern "C" fn xybrid_init() -> i32 {
     0
 }
 
+/// Set the platform binding identifier reported in registry call telemetry.
+///
+/// Call this once at application startup, BEFORE [`xybrid_init`], to declare
+/// which platform binding (e.g. Unity) is hosting the SDK. The value flows into
+/// the `X-Xybrid-Client` HTTP header on every registry metadata call.
+///
+/// First-call-wins semantics: subsequent calls are silent no-ops. If never
+/// called, the SDK reports the default `"rust"` binding.
+///
+/// The mapping is bounded: only known platform identifiers are accepted; every
+/// other input falls back to the default `"rust"` binding to bound cardinality
+/// on the registry side.
+///
+/// # Parameters
+///
+/// - `binding`: A null-terminated UTF-8 string. Currently the only recognized
+///   value is `"unity"`; any other value collapses to `"rust"`.
+///
+/// # Returns
+///
+/// - `0` on success
+/// - `-1` if `binding` is null or not valid UTF-8 (check `xybrid_last_error()`)
+///
+/// # Example (C)
+///
+/// ```c
+/// xybrid_set_binding("unity");
+/// xybrid_init();
+/// ```
+///
+/// # Safety
+///
+/// `binding` must be either null or a pointer to a null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_set_binding(binding: *const c_char) -> i32 {
+    clear_last_error();
+
+    if binding.is_null() {
+        set_last_error("binding is null");
+        return -1;
+    }
+
+    let binding_str = match CStr::from_ptr(binding).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_last_error("binding is not valid UTF-8");
+            return -1;
+        }
+    };
+
+    xybrid_sdk::set_binding(resolve_binding(binding_str));
+    0
+}
+
+/// Map a runtime binding string to a `'static str` literal.
+///
+/// Closed-allowlist: only `"unity"` is accepted; every other value collapses
+/// to [`xybrid_sdk::DEFAULT_BINDING`]. The closed match is required because
+/// `xybrid_sdk::set_binding` takes `&'static str`, and it doubles as defensive
+/// sanitization at the FFI boundary.
+fn resolve_binding(binding: &str) -> &'static str {
+    match binding {
+        "unity" => "unity",
+        _ => xybrid_sdk::DEFAULT_BINDING,
+    }
+}
+
 /// Get the library version string.
 ///
 /// Returns a pointer to a null-terminated string containing the library version.
@@ -4557,6 +4624,76 @@ mod tests {
         // Init should return 0 (success)
         let result = xybrid_init();
         assert_eq!(result, 0);
+    }
+
+    // ========================================================================
+    // Tests for xybrid_set_binding (US-009)
+    // ========================================================================
+    //
+    // The integration test below calls `xybrid_set_binding("unity")` which
+    // sets a process-global `OnceLock<&'static str>` in xybrid-sdk. The lock
+    // is first-set-wins, so other tests that want to assert behavior under a
+    // specific binding must use the pure `resolve_binding` helper to avoid
+    // racing on which test runs first. Default behavior ("rust" when unset)
+    // is asserted by checking `xybrid_sdk::DEFAULT_BINDING` and via the
+    // `resolve_binding` helper for unknown inputs — both are independent of
+    // the OnceLock state.
+
+    #[test]
+    fn test_resolve_binding_unity_returns_unity() {
+        assert_eq!(resolve_binding("unity"), "unity");
+    }
+
+    #[test]
+    fn test_resolve_binding_unknown_returns_default() {
+        assert_eq!(resolve_binding(""), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding("UNITY"), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding("flutter"), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding("rust"), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding("evil_unknown"), xybrid_sdk::DEFAULT_BINDING);
+    }
+
+    #[test]
+    fn test_default_binding_without_set_binding_is_rust() {
+        // PRD acceptance criterion: "init without set_binding produces
+        // binding='rust'". The xybrid-sdk OnceLock falls back to
+        // DEFAULT_BINDING when never set; verify the const itself is "rust".
+        assert_eq!(xybrid_sdk::DEFAULT_BINDING, "rust");
+    }
+
+    #[test]
+    fn test_xybrid_set_binding_null_returns_error() {
+        let result = unsafe { xybrid_set_binding(std::ptr::null()) };
+        assert_eq!(result, -1);
+        let error_ptr = xybrid_last_error();
+        assert!(!error_ptr.is_null());
+    }
+
+    #[test]
+    fn test_xybrid_set_binding_unity_registers_unity_binding() {
+        // Combined integration test (single-test pattern matching US-007/US-008):
+        // the OnceLock in xybrid-sdk locks process-globally, so once this test
+        // sets "unity" no later test in this process can flip it back.
+        let binding = CString::new("unity").expect("static literal has no null bytes");
+        let result = unsafe { xybrid_set_binding(binding.as_ptr()) };
+        assert_eq!(result, 0);
+
+        // After the call, xybrid_sdk::get_binding() reports "unity".
+        assert_eq!(xybrid_sdk::get_binding(), "unity");
+
+        // PRD: "must be called before xybrid_init" — verify init still succeeds.
+        assert_eq!(xybrid_init(), 0);
+
+        // The default RegistryClient (used by ModelLoader::from_registry under
+        // the hood) now reports binding="unity" on the X-Xybrid-Client header.
+        let client = xybrid_sdk::RegistryClient::default_client()
+            .expect("default registry client constructs without network access");
+        assert_eq!(client.binding(), "unity");
+
+        // First-set-wins: a second call with a different value cannot overwrite.
+        let other = CString::new("rust").expect("static literal has no null bytes");
+        let _ = unsafe { xybrid_set_binding(other.as_ptr()) };
+        assert_eq!(xybrid_sdk::get_binding(), "unity");
     }
 
     #[test]

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -78,6 +78,9 @@ llm-mistral-metal = ["xybrid-core/llm-mistral-metal"]
 llm-mistral-cuda = ["xybrid-core/llm-mistral-cuda"]
 llm-llamacpp = ["xybrid-core/llm-llamacpp"]
 
+[dev-dependencies]
+httpmock = "0.7"
+
 # Re-export the macro
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -196,7 +196,6 @@ pub use source::ModelSource;
 pub use stream::{PartialResult, StreamState, StreamStats, TranscriptionResult, XybridStream};
 // FFI streaming types for platform bindings (Flutter, Kotlin, Swift)
 pub use streaming::{FfiPartialResult, FfiStreamState, FfiStreamStats, FfiStreamingConfig};
-pub use telemetry_optout::is_telemetry_opted_out;
 pub use telemetry::{
     // Orchestrator event bridge
     bridge_orchestrator_events,
@@ -214,6 +213,7 @@ pub use telemetry::{
     TelemetryEvent,
     TelemetrySender,
 };
+pub use telemetry_optout::is_telemetry_opted_out;
 
 /// Re-export OrchestratorEvent for event subscriptions
 pub use xybrid_core::event_bus::OrchestratorEvent;

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -120,6 +120,7 @@ pub mod source;
 pub mod stream;
 pub mod streaming;
 pub mod telemetry;
+pub mod telemetry_optout;
 
 // ============================================================================
 // Re-exports
@@ -195,6 +196,7 @@ pub use source::ModelSource;
 pub use stream::{PartialResult, StreamState, StreamStats, TranscriptionResult, XybridStream};
 // FFI streaming types for platform bindings (Flutter, Kotlin, Swift)
 pub use streaming::{FfiPartialResult, FfiStreamState, FfiStreamStats, FfiStreamingConfig};
+pub use telemetry_optout::is_telemetry_opted_out;
 pub use telemetry::{
     // Orchestrator event bridge
     bridge_orchestrator_events,

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -232,11 +232,41 @@ use std::sync::OnceLock;
 /// Global SDK configuration.
 static SDK_CONFIG: OnceLock<SdkConfig> = OnceLock::new();
 
+/// Process-global binding identifier set by platform bindings at init.
+///
+/// First-set-wins (backed by [`OnceLock`]); after the first
+/// [`set_binding`] call, subsequent calls are silent no-ops. Read via
+/// [`get_binding`], which returns [`DEFAULT_BINDING`] when unset.
+static BINDING: OnceLock<&'static str> = OnceLock::new();
+
 /// Default binding identifier reported in the registry telemetry header.
 ///
 /// Each platform binding (Flutter, Kotlin, Swift, Unity) overrides this via
-/// [`SdkConfig::with_binding`] so registry calls can be attributed correctly.
+/// [`set_binding`] (process-global) or [`SdkConfig::with_binding`] (per-config)
+/// so registry calls can be attributed correctly.
 pub const DEFAULT_BINDING: &str = "rust";
+
+/// Register the binding identifier for this process.
+///
+/// Each platform binding (Flutter, Kotlin, Swift, Unity) calls this once at
+/// SDK init. The first call wins — subsequent calls are silent no-ops, which
+/// matches the lifecycle (a process is bound to exactly one platform binding).
+///
+/// `RegistryClient` default constructors (`new`, `default_client`,
+/// `with_url`, `from_env`) read this value via [`get_binding`], so any
+/// `RegistryClient` constructed after [`set_binding`] reports the configured
+/// binding in the `X-Xybrid-Client` header without explicit threading.
+pub fn set_binding(binding: &'static str) {
+    let _ = BINDING.set(binding);
+}
+
+/// Read the process-global binding identifier.
+///
+/// Returns the value passed to the most recent successful [`set_binding`]
+/// call, falling back to [`DEFAULT_BINDING`] when unset.
+pub fn get_binding() -> &'static str {
+    BINDING.get().copied().unwrap_or(DEFAULT_BINDING)
+}
 
 /// SDK configuration options.
 #[derive(Debug, Clone, Default)]

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -135,6 +135,7 @@ pub use xybrid_core::device::{
     ResourceUsageSummary, RunGuard as ResourceRunGuard,
 };
 pub use xybrid_core::execution;
+pub use xybrid_core::features;
 pub use xybrid_core::ir;
 pub use xybrid_core::orchestrator;
 pub use xybrid_core::orchestrator::routing_engine;

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -232,11 +232,37 @@ use std::sync::OnceLock;
 /// Global SDK configuration.
 static SDK_CONFIG: OnceLock<SdkConfig> = OnceLock::new();
 
+/// Default binding identifier reported in the registry telemetry header.
+///
+/// Each platform binding (Flutter, Kotlin, Swift, Unity) overrides this via
+/// [`SdkConfig::with_binding`] so registry calls can be attributed correctly.
+pub const DEFAULT_BINDING: &str = "rust";
+
 /// SDK configuration options.
 #[derive(Debug, Clone, Default)]
 pub struct SdkConfig {
     /// Custom cache directory (required on Android, optional elsewhere)
     pub cache_dir: Option<std::path::PathBuf>,
+    /// Binding identifier reported in the `X-Xybrid-Client` registry header.
+    ///
+    /// Defaults to [`DEFAULT_BINDING`] when unset. Bindings should set this
+    /// at SDK init via [`SdkConfig::with_binding`].
+    pub binding: Option<&'static str>,
+}
+
+impl SdkConfig {
+    /// Override the binding identifier reported in the registry telemetry header.
+    ///
+    /// Returns `self` to support a fluent builder style.
+    pub fn with_binding(mut self, binding: &'static str) -> Self {
+        self.binding = Some(binding);
+        self
+    }
+
+    /// Resolve the configured binding identifier, falling back to [`DEFAULT_BINDING`].
+    pub fn binding(&self) -> &'static str {
+        self.binding.unwrap_or(DEFAULT_BINDING)
+    }
 }
 
 /// Initialize the SDK with a custom cache directory.
@@ -303,6 +329,7 @@ pub fn init_sdk_cache_dir(cache_dir: impl Into<std::path::PathBuf>) {
 
     let config = SdkConfig {
         cache_dir: Some(cache_path),
+        ..SdkConfig::default()
     };
     let _ = SDK_CONFIG.set(config);
 }
@@ -758,4 +785,42 @@ pub async fn run_pipeline_async(config_path: &str) -> Result<PipelineResult, Pip
         total_latency_ms,
         final_output,
     })
+}
+
+#[cfg(test)]
+mod sdk_config_tests {
+    use super::{SdkConfig, DEFAULT_BINDING};
+
+    #[test]
+    fn default_binding_is_rust() {
+        assert_eq!(DEFAULT_BINDING, "rust");
+    }
+
+    #[test]
+    fn default_config_resolves_to_default_binding() {
+        let cfg = SdkConfig::default();
+        assert!(cfg.binding.is_none());
+        assert_eq!(cfg.binding(), "rust");
+    }
+
+    #[test]
+    fn with_binding_overrides_default() {
+        let cfg = SdkConfig::default().with_binding("flutter");
+        assert_eq!(cfg.binding, Some("flutter"));
+        assert_eq!(cfg.binding(), "flutter");
+    }
+
+    #[test]
+    fn with_binding_preserves_other_fields() {
+        let cfg = SdkConfig {
+            cache_dir: Some(std::path::PathBuf::from("/tmp/xybrid-cache")),
+            ..SdkConfig::default()
+        }
+        .with_binding("kotlin");
+        assert_eq!(cfg.binding(), "kotlin");
+        assert_eq!(
+            cfg.cache_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/xybrid-cache"))
+        );
+    }
 }

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -131,10 +131,14 @@ pub struct RegistryClient {
     circuits: Vec<Arc<CircuitBreaker>>,
     /// Retry policy for API calls
     retry_policy: RetryPolicy,
+    /// Binding identifier reported via the `X-Xybrid-Client` header.
+    binding: &'static str,
 }
 
 impl RegistryClient {
     /// Create a new registry client with the specified API URLs (primary first).
+    ///
+    /// The client carries [`DEFAULT_BINDING`] until overridden via [`Self::with_binding`].
     pub fn new(api_urls: Vec<String>) -> Result<Self, SdkError> {
         if api_urls.is_empty() {
             return Err(SdkError::ConfigError(
@@ -168,7 +172,46 @@ impl RegistryClient {
             agent,
             circuits,
             retry_policy: RetryPolicy::default(),
+            binding: DEFAULT_BINDING,
         })
+    }
+
+    /// Override the binding identifier reported via the `X-Xybrid-Client` header.
+    ///
+    /// Each platform binding (Flutter, Kotlin, Swift, Unity) calls this with
+    /// its own identifier so registry calls are attributed correctly. Defaults
+    /// to [`DEFAULT_BINDING`] when not set.
+    pub fn with_binding(mut self, binding: &'static str) -> Self {
+        self.binding = binding;
+        self
+    }
+
+    /// Return the binding identifier this client reports.
+    pub fn binding(&self) -> &'static str {
+        self.binding
+    }
+
+    /// Apply the [`CLIENT_HEADER_NAME`] header to a request when telemetry is opted in.
+    ///
+    /// When [`is_telemetry_opted_out`] is true, returns the request unchanged so
+    /// no header is set on the wire.
+    fn apply_client_header(&self, req: ureq::Request) -> ureq::Request {
+        self.apply_client_header_with_optout(req, is_telemetry_opted_out())
+    }
+
+    /// Same as [`Self::apply_client_header`] but takes the opt-out flag explicitly.
+    ///
+    /// Tests use this to exercise both branches without depending on the
+    /// process-global `OnceLock` cache that [`is_telemetry_opted_out`] keeps.
+    fn apply_client_header_with_optout(
+        &self,
+        req: ureq::Request,
+        opted_out: bool,
+    ) -> ureq::Request {
+        match build_client_header_with_optout(self.binding, opted_out) {
+            Some(value) => req.set(CLIENT_HEADER_NAME, &value),
+            None => req,
+        }
     }
 
     /// Create a new registry client with a single API URL.
@@ -219,7 +262,8 @@ impl RegistryClient {
     pub fn list_models(&self) -> Result<Vec<ModelSummary>, SdkError> {
         self.execute_with_fallback(|api_url| {
             let url = format!("{}/v1/models", api_url);
-            let response = self.agent.get(&url).call();
+            let req = self.apply_client_header(self.agent.get(&url));
+            let response = req.call();
             self.handle_response(response, "list models")
         })
         .and_then(|response| {
@@ -237,7 +281,8 @@ impl RegistryClient {
     pub fn get_model(&self, mask: &str) -> Result<ModelDetail, SdkError> {
         self.execute_with_fallback(|api_url| {
             let url = format!("{}/v1/models/{}", api_url, mask);
-            let response = self.agent.get(&url).call();
+            let req = self.apply_client_header(self.agent.get(&url));
+            let response = req.call();
             self.handle_response_with_404(response, "get model", || {
                 SdkError::ModelNotFound(format!("Model '{}' not found", mask))
             })
@@ -262,7 +307,8 @@ impl RegistryClient {
                 "{}/v1/models/{}/resolve?platform={}",
                 api_url, mask, platform
             );
-            let response = self.agent.get(&url).call();
+            let req = self.apply_client_header(self.agent.get(&url));
+            let response = req.call();
             self.handle_response_with_404(response, "resolve model", || {
                 SdkError::ModelNotFound(format!(
                     "Model '{}' not found or no compatible variant for platform '{}'",
@@ -1459,6 +1505,194 @@ mod tests {
             call_count.load(Ordering::SeqCst),
             1,
             "offline errors must not be retried within a single URL"
+        );
+    }
+
+    #[test]
+    fn registry_client_default_binding_is_rust() {
+        let client = RegistryClient::default_client().unwrap();
+        assert_eq!(client.binding(), DEFAULT_BINDING);
+    }
+
+    #[test]
+    fn registry_client_with_binding_overrides_default() {
+        let client = RegistryClient::default_client()
+            .unwrap()
+            .with_binding("flutter");
+        assert_eq!(client.binding(), "flutter");
+    }
+
+    #[test]
+    fn apply_client_header_sets_header_when_not_opted_out() {
+        // Build a request through the helper that takes opted_out explicitly so
+        // the test never touches the OnceLock-cached opt-out state owned by
+        // `is_telemetry_opted_out`.
+        let client = RegistryClient::with_url("http://127.0.0.1:1").unwrap();
+        let req = client.agent.get("http://127.0.0.1:1/v1/models");
+        let req = client.apply_client_header_with_optout(req, false);
+        let header = req.header(CLIENT_HEADER_NAME);
+        assert!(
+            header.is_some(),
+            "header must be set when opt-out is false"
+        );
+        let value = header.unwrap();
+        assert!(value.contains("binding=rust;"), "value: {}", value);
+        assert!(value.contains("sdk_version="), "value: {}", value);
+        assert!(value.contains("core_version="), "value: {}", value);
+        assert!(value.contains("platform="), "value: {}", value);
+        assert!(value.contains("backends="), "value: {}", value);
+    }
+
+    #[test]
+    fn apply_client_header_omits_header_when_opted_out() {
+        let client = RegistryClient::with_url("http://127.0.0.1:1").unwrap();
+        let req = client.agent.get("http://127.0.0.1:1/v1/models");
+        let req = client.apply_client_header_with_optout(req, true);
+        assert_eq!(
+            req.header(CLIENT_HEADER_NAME),
+            None,
+            "no header on the wire when telemetry is opted out"
+        );
+    }
+
+    #[test]
+    fn apply_client_header_uses_configured_binding() {
+        let client = RegistryClient::with_url("http://127.0.0.1:1")
+            .unwrap()
+            .with_binding("flutter");
+        let req = client.agent.get("http://127.0.0.1:1/v1/models");
+        let req = client.apply_client_header_with_optout(req, false);
+        let value = req.header(CLIENT_HEADER_NAME).unwrap();
+        assert!(
+            value.starts_with("binding=flutter;"),
+            "configured binding must flow into the header: {}",
+            value
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // Mock-server integration tests for header wiring.
+    //
+    // These exercise the actual HTTP path through `list_models`, `get_model`,
+    // and `resolve` against a local httpmock instance. The opt-in/opt-out
+    // matrix is covered by the in-process `apply_client_header_with_optout`
+    // tests above (the OnceLock cache in `is_telemetry_opted_out` makes a
+    // process-wide flip impractical here).
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn metadata_calls_send_x_xybrid_client_header() {
+        // Spins up a local httpmock server and exercises all three metadata
+        // methods through the real wire path. Each mock matches against the
+        // EXACT expected header value, computed from `build_client_header`
+        // with the same binding the client is configured with. If the wired
+        // header value differs in any field the mock won't match and the
+        // request will 404 — so a regression in format or content surfaces
+        // as a test failure, not a silent pass.
+        use httpmock::prelude::*;
+
+        let expected = build_client_header_with_optout("flutter", false)
+            .expect("header must be built when not opted out");
+
+        let server = MockServer::start();
+
+        let list_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/models")
+                .header(CLIENT_HEADER_NAME, expected.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"models": []}"#);
+        });
+        let get_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/models/test-model")
+                .header(CLIENT_HEADER_NAME, expected.as_str());
+            then.status(200).header("content-type", "application/json")
+                .body(
+                    r#"{"id":"test-model","family":"test","task":"text-generation","parameters":1,"description":"d","default_variant":null,"variants":{}}"#,
+                );
+        });
+        let resolve_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/models/test-model/resolve")
+                .query_param_exists("platform")
+                .header(CLIENT_HEADER_NAME, expected.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{"mask":"test-model","platform":"x","resolved":{"hf_repo":"o/r","file":"u.xyb","download_url":"https://x","format":"onnx","quantization":"fp32","size_bytes":1,"sha256":""}}"#,
+                );
+        });
+
+        let client = RegistryClient::with_url(server.base_url())
+            .unwrap()
+            .with_binding("flutter");
+
+        client.list_models().expect("list_models should succeed");
+        client.get_model("test-model").expect("get_model should succeed");
+        client
+            .resolve("test-model", Some("apple-arm64-cpu"))
+            .expect("resolve should succeed");
+
+        list_mock.assert();
+        get_mock.assert();
+        resolve_mock.assert();
+
+        // Independent format check on the expected value to ensure the
+        // exact-match assertion above is meaningful (not e.g. the empty string).
+        assert!(expected.starts_with("binding=flutter;"), "{}", expected);
+        assert!(expected.contains("sdk_version="), "{}", expected);
+        assert!(expected.contains("core_version="), "{}", expected);
+        assert!(expected.contains("platform="), "{}", expected);
+        assert!(expected.contains("backends="), "{}", expected);
+    }
+
+    #[test]
+    fn metadata_calls_omit_header_when_opt_out_helper_returns_none() {
+        // Mock-server companion to `apply_client_header_omits_header_when_opted_out`:
+        // verifies that when the helper is invoked with `opted_out=true` (the
+        // contract that `build_client_header` honors under
+        // XYBRID_TELEMETRY_OPTOUT=1), no X-Xybrid-Client header reaches the
+        // wire. We can't flip the process-wide OnceLock cache that
+        // `is_telemetry_opted_out` keeps, so this test exercises the wire path
+        // through `apply_client_header_with_optout(_, true)` directly. The
+        // mock fails the match if the header is present (header(name, "")
+        // requires equality, which a missing header satisfies as None).
+        use httpmock::prelude::*;
+
+        let server = MockServer::start();
+
+        // A permissive mock: matches any request to /v1/models. We then
+        // inspect the mock's hit count to confirm the request reached it
+        // (i.e. wasn't rejected) and rely on the absence of any
+        // header-asserting mock. To assert no header, we set up a SECOND
+        // mock that REQUIRES the header — if that one fires, the wire
+        // carried the header and the test fails.
+        let permissive = server.mock(|when, then| {
+            when.method(GET).path("/v1/models");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"models": []}"#);
+        });
+        let with_header = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/models")
+                .header_exists(CLIENT_HEADER_NAME);
+            then.status(599).body("UNEXPECTED HEADER");
+        });
+
+        let client = RegistryClient::with_url(server.base_url()).unwrap();
+        let url = format!("{}/v1/models", server.base_url());
+        let req = client.apply_client_header_with_optout(client.agent.get(&url), true);
+        let response = req.call().expect("request should reach mock server");
+        assert_eq!(response.status(), 200);
+
+        permissive.assert();
+        assert_eq!(
+            with_header.hits(),
+            0,
+            "X-Xybrid-Client header must NOT be sent when opted out"
         );
     }
 }

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -1267,14 +1267,26 @@ mod tests {
             "header should start with sanitized binding: {}",
             header
         );
-        assert!(header.contains("sdk_version="), "missing sdk_version: {}", header);
-        assert!(header.contains("core_version="), "missing core_version: {}", header);
+        assert!(
+            header.contains("sdk_version="),
+            "missing sdk_version: {}",
+            header
+        );
+        assert!(
+            header.contains("core_version="),
+            "missing core_version: {}",
+            header
+        );
         assert!(
             header.contains(&format!("platform={}", current_platform())),
             "platform mismatch: {}",
             header
         );
-        assert!(header.contains("backends="), "missing backends key: {}", header);
+        assert!(
+            header.contains("backends="),
+            "missing backends key: {}",
+            header
+        );
     }
 
     #[test]
@@ -1533,10 +1545,7 @@ mod tests {
         let req = client.agent.get("http://127.0.0.1:1/v1/models");
         let req = client.apply_client_header_with_optout(req, false);
         let header = req.header(CLIENT_HEADER_NAME);
-        assert!(
-            header.is_some(),
-            "header must be set when opt-out is false"
-        );
+        assert!(header.is_some(), "header must be set when opt-out is false");
         let value = header.unwrap();
         assert!(value.contains("binding=rust;"), "value: {}", value);
         assert!(value.contains("sdk_version="), "value: {}", value);
@@ -1632,7 +1641,9 @@ mod tests {
             .with_binding("flutter");
 
         client.list_models().expect("list_models should succeed");
-        client.get_model("test-model").expect("get_model should succeed");
+        client
+            .get_model("test-model")
+            .expect("get_model should succeed");
         client
             .resolve("test-model", Some("apple-arm64-cpu"))
             .expect("resolve should succeed");

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -34,7 +34,10 @@
 
 use crate::cache::CacheManager;
 use crate::model::SdkError;
+use crate::platform::current_platform;
 use crate::source::detect_platform;
+use crate::telemetry_optout::is_telemetry_opted_out;
+use crate::DEFAULT_BINDING;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -51,6 +54,64 @@ pub const FALLBACK_REGISTRY_URL: &str = "https://r2.xybrid.dev";
 
 /// All registry URLs in priority order.
 pub const REGISTRY_URLS: &[&str] = &[DEFAULT_REGISTRY_URL, FALLBACK_REGISTRY_URL];
+
+/// HTTP header carrying anonymous Xybrid SDK client identity for registry calls.
+///
+/// Set on every metadata request unless [`is_telemetry_opted_out`] is true.
+/// See `docs/telemetry/registry.md` for the full schema.
+pub const CLIENT_HEADER_NAME: &str = "X-Xybrid-Client";
+
+/// Build the value for the [`CLIENT_HEADER_NAME`] header.
+///
+/// Returns `None` when the user has opted out via `XYBRID_TELEMETRY_OPTOUT=1`.
+/// Callers must skip setting the header when this returns `None`.
+///
+/// The `binding` argument is sanitized: if it contains any character outside
+/// `[a-z0-9_-]`, or is empty, it is replaced with [`DEFAULT_BINDING`] to
+/// prevent user-supplied junk from being smuggled into the header value.
+///
+/// # Format
+///
+/// `binding={b}; sdk_version={v}; core_version={cv}; platform={p}; backends={list}`
+///
+/// `backends` is the comma-separated, alphabetical output of
+/// [`xybrid_core::features::enabled`].
+pub fn build_client_header(binding: &str) -> Option<String> {
+    build_client_header_with_optout(binding, is_telemetry_opted_out())
+}
+
+/// Pure helper underlying [`build_client_header`].
+///
+/// Takes the opt-out decision as a parameter so unit tests can exercise both
+/// branches without depending on the process-global `OnceLock` cache that
+/// [`is_telemetry_opted_out`] keeps.
+fn build_client_header_with_optout(binding: &str, opted_out: bool) -> Option<String> {
+    if opted_out {
+        return None;
+    }
+    let safe_binding = sanitize_binding(binding);
+    let backends = xybrid_core::features::enabled().join(",");
+    Some(format!(
+        "binding={}; sdk_version={}; core_version={}; platform={}; backends={}",
+        safe_binding,
+        env!("CARGO_PKG_VERSION"),
+        xybrid_core::VERSION,
+        current_platform(),
+        backends,
+    ))
+}
+
+fn sanitize_binding(binding: &str) -> &str {
+    let valid = !binding.is_empty()
+        && binding
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-');
+    if valid {
+        binding
+    } else {
+        DEFAULT_BINDING
+    }
+}
 
 /// Connection timeout in milliseconds.
 const CONNECT_TIMEOUT_MS: u64 = 5000;
@@ -1147,6 +1208,117 @@ mod tests {
         let client = RegistryClient::default_client().unwrap();
         assert_eq!(client.api_urls.len(), 2);
         assert_eq!(client.primary_url(), DEFAULT_REGISTRY_URL);
+    }
+
+    #[test]
+    fn build_client_header_default_binding_has_all_fields() {
+        let header = build_client_header_with_optout("rust", false)
+            .expect("header must be built when not opted out");
+        assert!(
+            header.starts_with("binding=rust;"),
+            "header should start with sanitized binding: {}",
+            header
+        );
+        assert!(header.contains("sdk_version="), "missing sdk_version: {}", header);
+        assert!(header.contains("core_version="), "missing core_version: {}", header);
+        assert!(
+            header.contains(&format!("platform={}", current_platform())),
+            "platform mismatch: {}",
+            header
+        );
+        assert!(header.contains("backends="), "missing backends key: {}", header);
+    }
+
+    #[test]
+    fn build_client_header_opt_out_returns_none() {
+        // Tests the inner helper directly so it doesn't fight the OnceLock-
+        // cached opt-out state owned by `is_telemetry_opted_out` in other tests.
+        assert!(build_client_header_with_optout("rust", true).is_none());
+    }
+
+    #[test]
+    fn build_client_header_malformed_binding_falls_back_to_default() {
+        let header = build_client_header_with_optout("flutter; injected", false)
+            .expect("header must be built when not opted out");
+        assert!(
+            header.starts_with("binding=rust;"),
+            "malformed binding must collapse to DEFAULT_BINDING: {}",
+            header
+        );
+        assert!(
+            !header.contains("injected"),
+            "smuggled tokens must not appear in the header: {}",
+            header
+        );
+    }
+
+    #[test]
+    fn build_client_header_uppercase_binding_falls_back_to_default() {
+        let header = build_client_header_with_optout("FLUTTER", false).unwrap();
+        assert!(
+            header.starts_with("binding=rust;"),
+            "uppercase binding is not in the [a-z0-9_-] allowlist: {}",
+            header
+        );
+    }
+
+    #[test]
+    fn build_client_header_empty_binding_falls_back_to_default() {
+        let header = build_client_header_with_optout("", false).unwrap();
+        assert!(header.starts_with("binding=rust;"));
+    }
+
+    #[test]
+    fn build_client_header_accepts_known_bindings() {
+        for binding in ["rust", "flutter", "kotlin", "swift", "unity"] {
+            let header = build_client_header_with_optout(binding, false).unwrap();
+            let prefix = format!("binding={};", binding);
+            assert!(
+                header.starts_with(&prefix),
+                "binding `{}` should pass sanitization: {}",
+                binding,
+                header
+            );
+        }
+    }
+
+    #[test]
+    fn build_client_header_renders_empty_backends_list_without_panic() {
+        // We can't dynamically clear the compiled-in features table at runtime,
+        // but we can assert the header always includes the literal `backends=`
+        // key and never panics when the value is empty (the join on an empty
+        // slice yields ""). When no features are enabled, the header would end
+        // with `backends=` — and that is valid output, not a panic surface.
+        let header = build_client_header_with_optout("rust", false).unwrap();
+        assert!(
+            header.contains("backends="),
+            "header always carries the backends key: {}",
+            header
+        );
+        // Sanity: the format must not produce the broken `backends=,` shape.
+        assert!(
+            !header.contains("backends=,"),
+            "leading comma in backends list: {}",
+            header
+        );
+    }
+
+    #[test]
+    fn sanitize_binding_accepts_alphanumerics_underscore_and_hyphen() {
+        assert_eq!(sanitize_binding("rust"), "rust");
+        assert_eq!(sanitize_binding("flutter"), "flutter");
+        assert_eq!(sanitize_binding("react-native"), "react-native");
+        assert_eq!(sanitize_binding("snake_case"), "snake_case");
+        assert_eq!(sanitize_binding("v2"), "v2");
+    }
+
+    #[test]
+    fn sanitize_binding_rejects_invalid_chars() {
+        assert_eq!(sanitize_binding(""), DEFAULT_BINDING);
+        assert_eq!(sanitize_binding("Flutter"), DEFAULT_BINDING);
+        assert_eq!(sanitize_binding("flutter app"), DEFAULT_BINDING);
+        assert_eq!(sanitize_binding("flutter;injected"), DEFAULT_BINDING);
+        assert_eq!(sanitize_binding("flu/tter"), DEFAULT_BINDING);
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -37,7 +37,7 @@ use crate::model::SdkError;
 use crate::platform::current_platform;
 use crate::source::detect_platform;
 use crate::telemetry_optout::is_telemetry_opted_out;
-use crate::DEFAULT_BINDING;
+use crate::{get_binding, DEFAULT_BINDING};
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -138,7 +138,9 @@ pub struct RegistryClient {
 impl RegistryClient {
     /// Create a new registry client with the specified API URLs (primary first).
     ///
-    /// The client carries [`DEFAULT_BINDING`] until overridden via [`Self::with_binding`].
+    /// The client picks up the process-global binding via [`get_binding`]
+    /// (defaulting to [`DEFAULT_BINDING`] when unset). Per-instance overrides
+    /// go through [`Self::with_binding`].
     pub fn new(api_urls: Vec<String>) -> Result<Self, SdkError> {
         if api_urls.is_empty() {
             return Err(SdkError::ConfigError(
@@ -172,7 +174,7 @@ impl RegistryClient {
             agent,
             circuits,
             retry_policy: RetryPolicy::default(),
-            binding: DEFAULT_BINDING,
+            binding: get_binding(),
         })
     }
 

--- a/crates/xybrid-sdk/src/telemetry_optout.rs
+++ b/crates/xybrid-sdk/src/telemetry_optout.rs
@@ -33,9 +33,7 @@ pub fn is_telemetry_opted_out() -> bool {
 /// [`OPTED_OUT`] cache used by [`is_telemetry_opted_out`]).
 fn parse_optout(value: Option<&str>) -> bool {
     matches!(
-        value
-            .map(|v| v.trim().to_ascii_lowercase())
-            .as_deref(),
+        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
         Some("1") | Some("true") | Some("yes")
     )
 }

--- a/crates/xybrid-sdk/src/telemetry_optout.rs
+++ b/crates/xybrid-sdk/src/telemetry_optout.rs
@@ -1,0 +1,103 @@
+//! Registry telemetry opt-out helper.
+//!
+//! Single source of truth for whether the user has opted out of registry call
+//! telemetry via the `XYBRID_TELEMETRY_OPTOUT` environment variable.
+//!
+//! The check is performed once on first call and cached in a `OnceLock<bool>`,
+//! so every call site reads the same value with no further env access. A
+//! mid-process change to the env var is intentionally not observed — opt-out
+//! state is established at SDK startup and held for the process lifetime.
+
+use std::sync::OnceLock;
+
+const ENV_VAR: &str = "XYBRID_TELEMETRY_OPTOUT";
+
+static OPTED_OUT: OnceLock<bool> = OnceLock::new();
+
+/// Returns `true` when the user has opted out of registry call telemetry.
+///
+/// Truthy values (case-insensitive): `"1"`, `"true"`, `"yes"`. Any other value
+/// — including unset — returns `false`.
+///
+/// The result is cached on first call; subsequent calls return the cached
+/// value with no environment access. This is intentional: a mid-process env
+/// change is not observed.
+pub fn is_telemetry_opted_out() -> bool {
+    *OPTED_OUT.get_or_init(|| parse_optout(std::env::var(ENV_VAR).ok().as_deref()))
+}
+
+/// Parse a raw env-var value into a boolean opt-out flag.
+///
+/// Pure function so the parsing matrix can be unit-tested without touching
+/// the process environment (which would otherwise interact with the
+/// [`OPTED_OUT`] cache used by [`is_telemetry_opted_out`]).
+fn parse_optout(value: Option<&str>) -> bool {
+    matches!(
+        value
+            .map(|v| v.trim().to_ascii_lowercase())
+            .as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_unset_returns_false() {
+        assert!(!parse_optout(None));
+    }
+
+    #[test]
+    fn parse_truthy_values_return_true() {
+        assert!(parse_optout(Some("1")));
+        assert!(parse_optout(Some("true")));
+        assert!(parse_optout(Some("TRUE")));
+        assert!(parse_optout(Some("True")));
+        assert!(parse_optout(Some("yes")));
+        assert!(parse_optout(Some("YES")));
+        assert!(parse_optout(Some("Yes")));
+    }
+
+    #[test]
+    fn parse_truthy_values_tolerate_surrounding_whitespace() {
+        assert!(parse_optout(Some(" 1 ")));
+        assert!(parse_optout(Some("\ttrue\n")));
+    }
+
+    #[test]
+    fn parse_falsy_values_return_false() {
+        assert!(!parse_optout(Some("")));
+        assert!(!parse_optout(Some("0")));
+        assert!(!parse_optout(Some("false")));
+        assert!(!parse_optout(Some("FALSE")));
+        assert!(!parse_optout(Some("no")));
+        assert!(!parse_optout(Some("off")));
+        assert!(!parse_optout(Some("anything-else")));
+    }
+
+    #[test]
+    fn cached_value_ignores_mid_process_env_changes() {
+        // Seed the cache with whatever the environment currently says.
+        let initial = is_telemetry_opted_out();
+
+        // Flip the env var to the opposite value. The cached result must
+        // not change — that's the documented contract.
+        let prev = std::env::var(ENV_VAR).ok();
+        let toggle = if initial { "" } else { "1" };
+        std::env::set_var(ENV_VAR, toggle);
+        let after_change = is_telemetry_opted_out();
+
+        // Restore prior env state so other tests see a clean environment.
+        match prev {
+            Some(v) => std::env::set_var(ENV_VAR, v),
+            None => std::env::remove_var(ENV_VAR),
+        }
+
+        assert_eq!(
+            initial, after_change,
+            "cache must not observe mid-process env changes"
+        );
+    }
+}

--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -25,6 +25,30 @@ fn init_sdk_cache_dir(cache_dir: String) {
     xybrid_sdk::init_sdk_cache_dir(cache_dir);
 }
 
+/// Register the binding identifier for this process.
+///
+/// The xybrid-uniffi crate is shared by both Kotlin and Swift, so the
+/// identity must be supplied by the platform-side wrapper at SDK init —
+/// the Kotlin `Xybrid.init(...)` calls `setBinding("kotlin")`, and the
+/// Swift `Xybrid.init(...)` calls `setBinding("swift")` (US-008).
+///
+/// Only the known platform values are forwarded to `xybrid_sdk::set_binding`
+/// (which requires a `&'static str`). Any other input collapses to
+/// `xybrid_sdk::DEFAULT_BINDING` to bound cardinality on the registry side
+/// — the same defensive shape used by `build_client_header`'s sanitizer.
+///
+/// First call wins (process-global `OnceLock` in xybrid-sdk); subsequent
+/// calls are silent no-ops.
+#[uniffi::export]
+fn set_binding(binding: String) {
+    let static_binding: &'static str = match binding.as_str() {
+        "kotlin" => "kotlin",
+        "swift" => "swift",
+        _ => xybrid_sdk::DEFAULT_BINDING,
+    };
+    xybrid_sdk::set_binding(static_binding);
+}
+
 /// Error type exposed via UniFFI to Swift/Kotlin consumers.
 ///
 /// This enum represents all possible errors that can occur during
@@ -478,5 +502,42 @@ impl XybridModelLoader {
     pub async fn load(&self) -> Result<Arc<XybridModel>, XybridError> {
         let model = self.inner.load_async().await?;
         Ok(Arc::new(XybridModel { inner: model }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Single combined test: the binding is process-global via OnceLock,
+    // so splitting into multiple tests would race on which one observes
+    // the first set_binding call.
+    #[test]
+    fn set_binding_kotlin_registers_kotlin_binding() {
+        // Kotlin wrapper calls this from Xybrid.init().
+        set_binding("kotlin".to_string());
+
+        // Process-global binding now resolves to "kotlin".
+        assert_eq!(xybrid_sdk::get_binding(), "kotlin");
+
+        // RegistryClient default constructors pick up the configured binding,
+        // so the X-Xybrid-Client header on every metadata call from a Kotlin
+        // app will report binding=kotlin.
+        let client = xybrid_sdk::RegistryClient::default_client()
+            .expect("default_client should succeed in tests");
+        assert_eq!(client.binding(), "kotlin");
+
+        // OnceLock first-set-wins: a later call (e.g. from a misbehaving
+        // consumer) cannot overwrite the registered identity.
+        set_binding("swift".to_string());
+        assert_eq!(xybrid_sdk::get_binding(), "kotlin");
+
+        // Unknown values must not propagate raw to the registry header
+        // (defensive sanitization parallel to build_client_header). The
+        // OnceLock is already set, so behavior is unobservable here, but
+        // the match arm is exercised — the `_ => DEFAULT_BINDING` branch
+        // is what protects a cold-start process from header pollution.
+        set_binding("evil_unknown".to_string());
+        assert_eq!(xybrid_sdk::get_binding(), "kotlin");
     }
 }

--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -30,7 +30,7 @@ fn init_sdk_cache_dir(cache_dir: String) {
 /// The xybrid-uniffi crate is shared by both Kotlin and Swift, so the
 /// identity must be supplied by the platform-side wrapper at SDK init —
 /// the Kotlin `Xybrid.init(...)` calls `setBinding("kotlin")`, and the
-/// Swift `Xybrid.init(...)` calls `setBinding("swift")` (US-008).
+/// Swift `Xybrid.initialize()` calls `setBinding(binding: "swift")`.
 ///
 /// Only the known platform values are forwarded to `xybrid_sdk::set_binding`
 /// (which requires a `&'static str`). Any other input collapses to
@@ -41,12 +41,21 @@ fn init_sdk_cache_dir(cache_dir: String) {
 /// calls are silent no-ops.
 #[uniffi::export]
 fn set_binding(binding: String) {
-    let static_binding: &'static str = match binding.as_str() {
+    xybrid_sdk::set_binding(resolve_binding(binding.as_str()));
+}
+
+/// Pure helper that maps a runtime binding string to a `&'static str`.
+///
+/// Factored out of `set_binding` so tests can exercise every accepted
+/// platform without touching the process-global `OnceLock` in xybrid-sdk
+/// (the OnceLock's first-set-wins semantics make per-platform integration
+/// tests in the same process race-prone).
+fn resolve_binding(binding: &str) -> &'static str {
+    match binding {
         "kotlin" => "kotlin",
         "swift" => "swift",
         _ => xybrid_sdk::DEFAULT_BINDING,
-    };
-    xybrid_sdk::set_binding(static_binding);
+    }
 }
 
 /// Error type exposed via UniFFI to Swift/Kotlin consumers.
@@ -509,9 +518,33 @@ impl XybridModelLoader {
 mod tests {
     use super::*;
 
-    // Single combined test: the binding is process-global via OnceLock,
-    // so splitting into multiple tests would race on which one observes
-    // the first set_binding call.
+    // Pure-helper tests: exercise every accepted platform without touching
+    // the process-global OnceLock in xybrid-sdk. This is the only way to
+    // assert "swift" → "swift" mapping in the same test process where the
+    // Kotlin integration test below has already locked the OnceLock.
+    #[test]
+    fn resolve_binding_kotlin_returns_kotlin() {
+        assert_eq!(resolve_binding("kotlin"), "kotlin");
+    }
+
+    #[test]
+    fn resolve_binding_swift_returns_swift() {
+        assert_eq!(resolve_binding("swift"), "swift");
+    }
+
+    #[test]
+    fn resolve_binding_unknown_returns_default() {
+        assert_eq!(resolve_binding("evil_unknown"), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding(""), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding("KOTLIN"), xybrid_sdk::DEFAULT_BINDING);
+        assert_eq!(resolve_binding("flutter"), xybrid_sdk::DEFAULT_BINDING);
+    }
+
+    // Single combined integration test: the binding is process-global via
+    // OnceLock, so splitting into multiple tests that call `set_binding`
+    // would race on which one observes the first set. The Kotlin path is
+    // the canonical wire-through; the Swift path is verified at the pure
+    // `resolve_binding` layer above.
     #[test]
     fn set_binding_kotlin_registers_kotlin_binding() {
         // Kotlin wrapper calls this from Xybrid.init().
@@ -527,16 +560,19 @@ mod tests {
             .expect("default_client should succeed in tests");
         assert_eq!(client.binding(), "kotlin");
 
-        // OnceLock first-set-wins: a later call (e.g. from a misbehaving
-        // consumer) cannot overwrite the registered identity.
+        // OnceLock first-set-wins: a later call (e.g. from the Swift wrapper
+        // running in the same process, or a misbehaving consumer) cannot
+        // overwrite the registered identity.
         set_binding("swift".to_string());
         assert_eq!(xybrid_sdk::get_binding(), "kotlin");
 
         // Unknown values must not propagate raw to the registry header
         // (defensive sanitization parallel to build_client_header). The
         // OnceLock is already set, so behavior is unobservable here, but
-        // the match arm is exercised — the `_ => DEFAULT_BINDING` branch
-        // is what protects a cold-start process from header pollution.
+        // the wire-through call still goes through `resolve_binding`'s
+        // closed match — the `_ => DEFAULT_BINDING` branch is what
+        // protects a cold-start process from header pollution and is
+        // exercised directly by `resolve_binding_unknown_returns_default`.
         set_binding("evil_unknown".to_string());
         assert_eq!(xybrid_sdk::get_binding(), "kotlin");
     }

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -911,12 +911,60 @@ var config = new TelemetryConfig(apiKey)
 XybridClient.InitializeTelemetry(config);
 ```
 
+### Rust — `SdkConfig`
+
+The Rust SDK ships a small `SdkConfig` struct consumed by `init_sdk_cache_dir`.
+It carries the `binding` identifier reported in the `X-Xybrid-Client` registry
+telemetry header. Non-Rust bindings register their identifier through the
+platform-specific entry points listed under "Setting `binding` per binding"
+below — they do not expose `SdkConfig` directly.
+
+```rust
+pub struct SdkConfig {
+    pub cache_dir: Option<std::path::PathBuf>,
+    /// Reported in the `X-Xybrid-Client` registry header. Defaults to
+    /// `DEFAULT_BINDING` ("rust") when unset.
+    pub binding: Option<&'static str>,
+}
+
+impl SdkConfig {
+    /// Override the binding identifier reported in the registry telemetry header.
+    pub fn with_binding(self, binding: &'static str) -> Self;
+    /// Resolve the configured binding identifier, falling back to `DEFAULT_BINDING`.
+    pub fn binding(&self) -> &'static str;
+}
+
+pub const DEFAULT_BINDING: &str = "rust";
+```
+
+**Example — explicit Rust binding:**
+
+```rust
+use xybrid_sdk::{SdkConfig, DEFAULT_BINDING};
+
+let config = SdkConfig::default().with_binding("my-tool");
+assert_eq!(config.binding(), "my-tool");
+```
+
+**Setting `binding` per binding:**
+
+| Binding | Resolves to | Set by |
+|---------|-------------|--------|
+| Rust SDK direct | `rust` (default) | `xybrid_sdk::DEFAULT_BINDING`, override with `SdkConfig::with_binding(...)` or `xybrid_sdk::set_binding(...)` |
+| Flutter | `flutter` | Internal: `XybridSdkClient` calls `xybrid_sdk::set_binding("flutter")` from every FRB entry point |
+| Kotlin (Android) | `kotlin` | Internal: `Xybrid.init(context)` calls UniFFI `setBinding("kotlin")` |
+| Swift (iOS / macOS) | `swift` | Internal: `Xybrid.initialize()` calls UniFFI `setBinding(binding: "swift")` |
+| Unity (C#) | `unity` | Internal: `XybridClient.Initialize()` calls native `xybrid_set_binding("unity")` |
+
+The full wire format and the list of enum values for each header field is documented in [`docs/telemetry/registry.md`](../telemetry/registry.md).
+
 ### Implementation Status
 
-| Type | Dart | Kotlin | Swift | C# |
-|------|------|--------|-------|----|
-| `TelemetryConfiguration` | 🚧 | — | — | ✅ |
-| `XybridConfiguration` | — | — | — | — |
+| Type | Dart | Kotlin | Swift | C# | Rust |
+|------|------|--------|-------|----|------|
+| `TelemetryConfiguration` | 🚧 | — | — | ✅ | — |
+| `XybridConfiguration` | — | — | — | — | — |
+| `SdkConfig` | — | — | — | — | ✅ |
 
 | Method (C# `XybridClient` / `TelemetryConfig`) | Dart | Kotlin | Swift | C# |
 |-----------------------------------------------|------|--------|-------|----|
@@ -932,9 +980,16 @@ XybridClient.InitializeTelemetry(config);
 | `XybridClient.FlushTelemetry()` | — | — | — | ✅ |
 | `XybridClient.ShutdownTelemetry()` | — | — | — | ✅ |
 
+| Method (Rust `SdkConfig`) | Rust |
+|---------------------------|------|
+| `with_binding(binding)` | ✅ |
+| `binding()` | ✅ |
+
 > **Note**: `initTelemetry()` exists in Dart as a stub that throws `UnimplementedError`.
 > The C# (Unity) SDK is the first non-Rust implementation of the telemetry surface;
-> the Dart, Kotlin, and Swift implementations are still planned.
+> the Dart, Kotlin, and Swift implementations are still planned. `SdkConfig.binding`
+> is Rust-only — non-Rust bindings register their identifier through the
+> platform-specific entry points listed in [`docs/telemetry/registry.md`](../telemetry/registry.md).
 
 ---
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -528,3 +528,46 @@ classes:
     type: data
     section: "9. Configuration Types"
     status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+
+  SdkConfig:
+    type: data
+    section: "9. Configuration Types"
+    rust_path: "xybrid_sdk::SdkConfig"
+    status: { rust: implemented }
+    stability: { rust: stable }
+    not_applicable: [dart, kotlin, swift, csharp]
+    since: "0.1.0-beta12"
+    notes: >-
+      Rust-side init configuration consumed by `init_sdk_cache_dir`. Non-Rust
+      bindings register the binding identifier via the platform-specific entry
+      points listed in `docs/telemetry/registry.md` (Flutter:
+      `XybridSdkClient`, Kotlin: `Xybrid.init`, Swift: `Xybrid.initialize`,
+      Unity: `XybridClient.Initialize`); they do not expose `SdkConfig`
+      directly. The `binding` field flows into the `X-Xybrid-Client` registry
+      header — see `docs/telemetry/registry.md` for the wire format.
+    properties:
+      cache_dir:
+        type: "Option<PathBuf>"
+        description: "Custom cache directory. Required on Android, optional elsewhere."
+        since: "0.1.0-beta10"
+      binding:
+        type: "Option<&'static str>"
+        description: >-
+          Binding identifier reported in the `X-Xybrid-Client` registry
+          telemetry header. Defaults to `xybrid_sdk::DEFAULT_BINDING`
+          ("rust") when unset. Each platform binding (Flutter, Kotlin,
+          Swift, Unity) sets its own value at SDK init.
+        since: "0.1.0-beta12"
+    methods:
+      with_binding:
+        name: with_binding
+        parameters:
+          - { name: binding, type: "&'static str" }
+        returns: Self
+        description: "Override the binding identifier reported in the registry telemetry header. Fluent builder."
+        since: "0.1.0-beta12"
+      binding:
+        name: binding
+        returns: "&'static str"
+        description: "Resolve the configured binding identifier, falling back to `DEFAULT_BINDING` when unset."
+        since: "0.1.0-beta12"

--- a/docs/telemetry/registry.md
+++ b/docs/telemetry/registry.md
@@ -1,0 +1,162 @@
+# Registry Call Telemetry
+
+The Xybrid SDK attaches a single header — `X-Xybrid-Client` — to every metadata request it makes against the model registry. The header reports the binding that originated the call, the SDK and core versions, the build platform, and the active backend feature set. It is the only telemetry surface on registry traffic; outcome reporting (`/v1/anon` and friends) is intentionally not part of this path.
+
+This page documents exactly what is sent, why it exists, and how to opt out.
+
+## Opting out
+
+Set the environment variable before any registry call is made:
+
+```sh
+export XYBRID_TELEMETRY_OPTOUT=1
+```
+
+When the variable is set to any of `1`, `true`, or `yes` (case-insensitive, surrounding whitespace ignored), the SDK omits `X-Xybrid-Client` from every registry request. The opt-out also disables the platform telemetry exporter described in [telemetry.md](../sdk/telemetry.md).
+
+The value is read once per process and cached, so changing it after the first registry call has no effect for that run.
+
+### Verifying opt-out
+
+The CLI reports the resolved opt-out state:
+
+```sh
+$ xybrid telemetry status
+registry telemetry: enabled
+```
+
+```sh
+$ XYBRID_TELEMETRY_OPTOUT=1 xybrid telemetry status
+registry telemetry: disabled (XYBRID_TELEMETRY_OPTOUT=1)
+```
+
+The command exits 0 in both cases — it is a status report, not an error.
+
+## What is sent
+
+The header is a single line, semicolon-separated:
+
+```
+X-Xybrid-Client: binding=flutter; sdk_version=0.1.0-beta12; core_version=0.1.0-beta12; platform=ios-arm64; backends=candle-metal,llm-llamacpp,llm-mlx,ort-coreml,ort-download
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `binding` | enum string | The platform binding that made the call. One of `rust`, `flutter`, `kotlin`, `swift`, `unity`. Defaults to `rust` when no binding is registered. |
+| `sdk_version` | semver-ish string | `xybrid-sdk` package version, baked in at compile time via `CARGO_PKG_VERSION`. |
+| `core_version` | semver-ish string | `xybrid-core` package version, baked in via the same mechanism. Usually equal to `sdk_version` but reported independently so version skews surface. |
+| `platform` | enum string | Compile-time target triple summary. See the table below. |
+| `backends` | comma-separated list | Alphabetical list of enabled runtime feature flags from `xybrid_core::features::enabled()`. May be empty (`backends=`) if no backends are compiled in. |
+
+### `binding` values
+
+| Value | Source | Set by |
+|-------|--------|--------|
+| `rust` | Default — used when no platform binding registers itself. | `xybrid_sdk::DEFAULT_BINDING` |
+| `flutter` | Flutter plugin via `flutter_rust_bridge`. | `XybridSdkClient` (`bindings/flutter/rust/src/api/sdk_client.rs`) |
+| `kotlin` | Android library via UniFFI. | `Xybrid.init(context)` (`bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt`) |
+| `swift` | iOS / macOS Swift package via UniFFI. | `Xybrid.initialize()` (`bindings/apple/Sources/Xybrid/Xybrid.swift`) |
+| `unity` | Unity / C# binding via the C FFI. | `XybridClient.Initialize()` (`bindings/unity/Runtime/Api/XybridClient.cs`) |
+
+Any value containing characters outside `[a-z0-9_-]` is replaced with `rust` before being placed in the header. This is a defensive sanitization step — it prevents user-controlled strings from injecting additional fields or terminators into the header.
+
+### `platform` values
+
+| Value | Target |
+|-------|--------|
+| `macos-arm64` | macOS on Apple Silicon |
+| `macos-x86_64` | macOS on Intel |
+| `ios-arm64` | iOS / iPadOS device builds |
+| `android-arm64` | Android arm64-v8a |
+| `android-arm` | Android armeabi-v7a |
+| `linux-x86_64` | Linux on x86_64 |
+| `linux-arm64` | Linux on aarch64 |
+| `windows-x86_64` | Windows on x86_64 |
+| `unknown` | Any target outside the table above |
+
+Source: `xybrid_sdk::current_platform()` (`crates/xybrid-sdk/src/platform.rs`). The string is decided at compile time; switching architectures requires rebuilding.
+
+### `backends` values
+
+| Value | Cargo feature | Notes |
+|-------|---------------|-------|
+| `candle-cuda` | `candle-cuda` | Candle backend with CUDA acceleration |
+| `candle-metal` | `candle-metal` | Candle backend with Metal acceleration |
+| `espeak` | `espeak` | espeak-ng phonemizer (multi-language TTS) |
+| `llm-llamacpp` | `llm-llamacpp` | llama.cpp backend (universal LLM runtime) |
+| `llm-mistral` | `llm-mistral` | mistral.rs backend |
+| `llm-mlx` | `llm-mlx` | MLX skeleton (Apple Silicon, no forward pass) |
+| `llm-mlx-runtime` | `llm-mlx-runtime` | MLX with the real forward pass |
+| `ort-coreml` | `ort-coreml` | ONNX Runtime with CoreML execution provider |
+| `ort-cuda` | `ort-cuda` | ONNX Runtime with CUDA execution provider |
+| `ort-download` | `ort-download` | ONNX Runtime resolved via prebuilt downloads |
+| `ort-dynamic` | `ort-dynamic` | ONNX Runtime loaded dynamically at runtime (Android) |
+
+Source: `xybrid_core::features::enabled()` (`crates/xybrid-core/src/features.rs`). The list is computed once per process from `cfg!(feature = "...")` checks and cached.
+
+The full set of mutually compatible combinations is documented in [`docs/FEATURE_MATRIX.md`](../FEATURE_MATRIX.md).
+
+## What is NOT collected
+
+The header carries only the fields above. It does **not** carry:
+
+- No personal identifiers (no username, no hostname, no email)
+- No network identifiers (no IP address, no MAC address)
+- No model identifiers (the model ID requested on `/v1/models/{mask}` is part of the URL path, not the header — but the header itself adds no further model context)
+- No device fingerprints (no chip family, no RAM size, no OS version, no kernel version)
+- No prompts, no inputs, no outputs, no error messages
+- No `device_id` or any session/trace identifier
+
+The platform-ingest exporter described in [telemetry.md](../sdk/telemetry.md) is a separate, opt-in surface that does collect device context for inference performance analysis. Registry-call telemetry — the subject of this document — is the smaller and always-present surface used for fleet attribution.
+
+## Why this exists
+
+We use the aggregate distribution of `binding`, `platform`, and `backends` to prioritize roadmap work:
+
+- Which bindings actually see usage (and which can be deprioritized)
+- Which platforms are deployed in the wild (so we know which CI matrices matter)
+- Which backend combinations users assemble (so we know which feature flag combinations to keep working)
+
+The data is summarized at the fleet level. The registry server stores parsed values bounded to a small allowlist — anything outside the allowlist is recorded as the literal string `unknown` so cardinality stays bounded and a single noisy app cannot pollute the dataset.
+
+## When the header is sent
+
+The SDK adds `X-Xybrid-Client` to the three metadata calls:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `RegistryClient::list_models` | `GET /v1/models` | List published models |
+| `RegistryClient::get_model` | `GET /v1/models/{mask}` | Fetch metadata for one model |
+| `RegistryClient::resolve` | `GET /v1/models/{mask}/resolve?platform=…` | Resolve a model+platform to a bundle URL |
+
+Bundle download requests are intentionally **not** instrumented in this version. They are downloads, not metadata calls, and a per-byte header is not interesting in aggregate.
+
+## Setting `binding` from a custom client
+
+Most users never need to think about `binding` — the platform binding sets it for them. If you are embedding `xybrid-sdk` directly in a Rust app and want your own attribution string, set it at startup:
+
+```rust
+xybrid_sdk::set_binding("my-tool");
+```
+
+The first `set_binding` call wins — once a value is registered, subsequent calls are silent no-ops, matching the lifecycle of "one process, one binding." A second route is the per-config field on [`SdkConfig::with_binding`](../sdk/API_REFERENCE.md#9-configuration-types):
+
+```rust
+use xybrid_sdk::{SdkConfig, DEFAULT_BINDING};
+
+let config = SdkConfig::default().with_binding("my-tool");
+assert_eq!(config.binding(), "my-tool");
+```
+
+If your value contains anything outside `[a-z0-9_-]`, the SDK substitutes `rust` before placing the value into the header. There is no way to inject a custom field name; the format is fixed.
+
+## Verification
+
+Run the CLI command above, or instrument an HTTP proxy in front of the registry and inspect the header directly. The header value is identical across the three metadata calls within a process.
+
+## Related documentation
+
+- [Platform telemetry exporter](../sdk/telemetry.md) — the opt-in exporter for inference events
+- [Resource telemetry](../sdk/resource-telemetry.md) — per-inference resource summaries
+- [API reference](../sdk/API_REFERENCE.md) — full SDK API surface, including `SdkConfig.binding`
+- [Feature matrix](../FEATURE_MATRIX.md) — which backend features compile together


### PR DESCRIPTION
## Summary

Wires an `X-Xybrid-Client` header (`binding=...; sdk_version=...; core_version=...; platform=...; backends=...`) onto every `RegistryClient` HTTP call (list/get/resolve), with each platform binding (Flutter, Kotlin, Swift, Unity, Rust) declaring its own identifier through the new `xybrid_sdk::set_binding` process-global. Telemetry is opt-out via `XYBRID_TELEMETRY_OPTOUT={1,true,yes}` (case-insensitive), exposed to users through a new `xybrid telemetry status` CLI command and a sanitizer that bounds binding cardinality on the wire. Adds `xybrid_core::features::enabled()` for runtime backend introspection, regenerates the Kotlin/Swift UniFFI facades and Unity C-FFI headers, and documents the contract in `docs/telemetry/registry.md` plus the SdkConfig surface in `api-surface.yaml` / `API_REFERENCE.md`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)