### PR TITLE
chore(release): track Package.swift sdkVersion in version-sync + CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,14 @@ jobs:
           KOTLIN_VERSION=$(grep '^version = ' bindings/kotlin/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
           echo "Kotlin gradle:    $KOTLIN_VERSION"
 
+          # Check Swift (root Package.swift sdkVersion drives the SPM
+          # release-asset URL and must match the tag).
+          SWIFT_VERSION=$(grep '^let sdkVersion = ' Package.swift | sed 's/let sdkVersion = "\(.*\)"/\1/')
+          echo "Swift Package:    $SWIFT_VERSION"
+
           # Verify all match
           FAILED=0
-          for V in "$CARGO_VERSION" "$FLUTTER_VERSION_PKG" "$UNITY_VERSION" "$KOTLIN_VERSION"; do
+          for V in "$CARGO_VERSION" "$FLUTTER_VERSION_PKG" "$UNITY_VERSION" "$KOTLIN_VERSION" "$SWIFT_VERSION"; do
             if [ "$V" != "$TAG_VERSION" ]; then
               echo ""
               echo "ERROR: Version mismatch! Tag is v$TAG_VERSION but found $V"

--- a/tools/scripts/version-sync.sh
+++ b/tools/scripts/version-sync.sh
@@ -15,6 +15,10 @@ CARGO_WORKSPACE="$REPO_ROOT/Cargo.toml"
 FLUTTER_PUBSPEC="$REPO_ROOT/bindings/flutter/pubspec.yaml"
 UNITY_PACKAGE="$REPO_ROOT/bindings/unity/package.json"
 KOTLIN_GRADLE="$REPO_ROOT/bindings/kotlin/build.gradle.kts"
+# Root SPM manifest. `let sdkVersion = "..."` drives the GitHub release-asset
+# URL for SPM consumers in remote mode and MUST match the cargo workspace
+# version.
+SWIFT_PACKAGE="$REPO_ROOT/Package.swift"
 
 # Extract current workspace version from Cargo.toml
 get_cargo_version() {
@@ -37,6 +41,11 @@ get_unity_version() {
 # Extract version from Kotlin build.gradle.kts
 get_kotlin_version() {
     grep '^version = ' "$KOTLIN_GRADLE" | sed 's/version = "\(.*\)"/\1/'
+}
+
+# Extract sdkVersion from root Package.swift
+get_swift_version() {
+    grep '^let sdkVersion = ' "$SWIFT_PACKAGE" | sed 's/let sdkVersion = "\(.*\)"/\1/'
 }
 
 # Set version in Cargo workspace (all Rust crates inherit via version.workspace = true)
@@ -74,6 +83,15 @@ set_kotlin_version() {
     rm -f "$KOTLIN_GRADLE.bak"
 }
 
+# Set sdkVersion in root Package.swift. Leaves useLocalNatives and
+# xybridFFIChecksum untouched — those are managed independently
+# (set-natives-mode.sh / sync-spm-checksum.sh).
+set_swift_version() {
+    local version="$1"
+    sed -i.bak "s/^let sdkVersion = \".*\"/let sdkVersion = \"$version\"/" "$SWIFT_PACKAGE"
+    rm -f "$SWIFT_PACKAGE.bak"
+}
+
 # Check mode: verify all versions match
 check_versions() {
     local cargo_version
@@ -83,7 +101,7 @@ check_versions() {
     echo "Cargo workspace version: $cargo_version"
     echo ""
 
-    for name_func in "Flutter:get_flutter_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version"; do
+    for name_func in "Flutter:get_flutter_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version"; do
         local name="${name_func%%:*}"
         local func="${name_func##*:}"
         local version
@@ -118,6 +136,7 @@ case "${1:-}" in
         set_flutter_version "$VERSION"
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
+        set_swift_version "$VERSION"
         echo "Done. Run '$0 --check' to verify."
         ;;
     --help|-h)
@@ -136,6 +155,7 @@ case "${1:-}" in
         set_flutter_version "$VERSION"
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
+        set_swift_version "$VERSION"
         echo ""
         echo "Rust crates inherit via version.workspace = true."
 


### PR DESCRIPTION
## Summary

Follow-up to #62. Extend `tools/scripts/version-sync.sh` and the release workflow's `check-version` job to track the new root `Package.swift`'s `let sdkVersion = "..."` literal alongside Cargo / Flutter / Unity / Kotlin.

Without this, `just bump-version <V>` would leave the SPM manifest's `sdkVersion` behind. The next release would build and upload assets at `v<V>`, but `Package.swift`'s URL still pointed at the previous release's zip — the "Verify root Package.swift checksum" step from #62 would catch it as a checksum mismatch, but the failure surfaced as "stale checksum" rather than "sdkVersion doesn't match tag," which is harder to debug.

## Changes

- **`tools/scripts/version-sync.sh`**: add `get_swift_version` / `set_swift_version`, wire into the no-arg sync path, the explicit-version set path, and the `--check` matrix. Leaves `useLocalNatives` and `xybridFFIChecksum` alone — those are managed by `bindings/apple/scripts/{set-natives-mode,sync-spm-checksum}.sh`.
- **`.github/workflows/release.yml`** check-version job: extract Swift version from `Package.swift` and add it to the tag-equality loop, with the same "run just bump-version" hint on mismatch.

## Verified locally

```
$ ./tools/scripts/version-sync.sh --check
Cargo workspace version: 0.1.0-beta12
  Flutter: 0.1.0-beta12 ✓
  Unity:   0.1.0-beta12 ✓
  Kotlin:  0.1.0-beta12 ✓
  Swift:   0.1.0-beta13 ✗ (expected 0.1.0-beta12)
Version mismatch detected!
```

(`sdkVersion = "0.1.0-beta13"` is the pre-baked next-release pin shipped in #62; Cargo is still on beta12 because we haven't bumped yet. After `just bump-version 0.1.0-beta13`, all five line up.)

## Test plan

- [ ] CI passes on this PR.
- [ ] Maintainer runs `just bump-version 0.1.0-beta13` locally and confirms `version-sync.sh --check` shows all five at beta13.
- [ ] When tag `v0.1.0-beta13` is pushed, `release.yml`'s check-version job verifies Swift alongside the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)