### PR TITLE
feat(telemetry): add backend, provider, ModelDownload for billing (IN…

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -21,8 +21,9 @@
 use log::{debug, info, warn};
 
 use super::template::{
-    span_kind_from_template, stage_kind_from_task, ExecutionMode, ExecutionTemplate, ModelMetadata,
-    PipelineStage, PostprocessingStep,
+    backend_label_from_template, normalize_llm_backend_hint, span_kind_from_template,
+    stage_kind_from_task, ExecutionMode, ExecutionTemplate, ModelMetadata, PipelineStage,
+    PostprocessingStep,
 };
 use crate::conversation::ConversationContext;
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
@@ -243,6 +244,18 @@ impl TemplateExecutor {
             "span_kind",
             span_kind_from_template(&metadata.execution_template),
         );
+
+        // Cost-accounting backend label (per `PlatformEvent.backend`).
+        // The bundle's `metadata.backend` hint disambiguates GGUF runtimes
+        // (llama.cpp vs mistral.rs); for ONNX/SafeTensors the template
+        // itself fixes the label. Omitted when the runtime isn't part of
+        // the closed set yet (CoreML / TFLite / ModelGraph) so analytics
+        // sees "absent" not "guessed".
+        let backend_hint = metadata.metadata.get("backend").and_then(|v| v.as_str());
+        if let Some(label) = backend_label_from_template(&metadata.execution_template, backend_hint)
+        {
+            xybrid_trace::add_metadata("backend", label);
+        }
 
         // Step 1: Handling ModelGraph (multi-model DAG)
         if let ExecutionTemplate::ModelGraph { stages, config } = &metadata.execution_template {
@@ -1173,7 +1186,11 @@ impl TemplateExecutor {
 
         let _llm_span = xybrid_trace::SpanGuard::new("llm_inference");
         xybrid_trace::add_metadata("model", model_file);
-        if let Some(hint) = backend_hint {
+        // Normalise the legacy `mistral` alias to the canonical wire label
+        // before annotating the span: the SDK telemetry hoist reads this
+        // span for the `backend` field on `PlatformEvent`, which must be
+        // in the closed set `{llamacpp, mistralrs, ...}`.
+        if let Some(hint) = backend_hint.and_then(normalize_llm_backend_hint) {
             xybrid_trace::add_metadata("backend", hint);
         }
 

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -21,10 +21,11 @@
 use log::{debug, info, warn};
 
 use super::template::{
-    backend_label_from_template, normalize_llm_backend_hint, span_kind_from_template,
-    stage_kind_from_task, ExecutionMode, ExecutionTemplate, ModelMetadata, PipelineStage,
-    PostprocessingStep,
+    backend_label_from_template, span_kind_from_template, stage_kind_from_task, ExecutionMode,
+    ExecutionTemplate, ModelMetadata, PipelineStage,
 };
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+use super::template::{normalize_llm_backend_hint, PostprocessingStep};
 use crate::conversation::ConversationContext;
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 use crate::ir::EnvelopeKind;

--- a/crates/xybrid-core/src/execution/strategies/llm.rs
+++ b/crates/xybrid-core/src/execution/strategies/llm.rs
@@ -11,7 +11,7 @@ use log::{debug, info};
 use std::path::Path;
 
 use super::{ExecutionContext, ExecutionStrategy};
-use crate::execution::template::{ExecutionTemplate, ModelMetadata};
+use crate::execution::template::{normalize_llm_backend_hint, ExecutionTemplate, ModelMetadata};
 use crate::execution::types::ExecutorResult;
 use crate::ir::{Envelope, EnvelopeKind};
 use crate::runtime_adapter::AdapterError;
@@ -548,7 +548,15 @@ impl<I: LlmInference + 'static> ExecutionStrategy for LlmStrategy<I> {
         );
 
         xybrid_trace::add_metadata("model", &config.model_path);
-        if let Some(hint) = &config.backend_hint {
+        // Emit the canonical wire label (`mistralrs` / `llamacpp`) onto the
+        // inner LLM span so the SDK telemetry hoist surfaces a closed-set
+        // value on `PlatformEvent.backend`. The raw `metadata.backend`
+        // string can still be the legacy `mistral` alias on older bundles.
+        if let Some(hint) = config
+            .backend_hint
+            .as_deref()
+            .and_then(normalize_llm_backend_hint)
+        {
             xybrid_trace::add_metadata("backend", hint);
         }
 

--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -432,6 +432,7 @@ pub fn normalize_llm_backend_hint(hint: &str) -> Option<&'static str> {
     match hint {
         "llamacpp" => Some("llamacpp"),
         "mistral" | "mistralrs" => Some("mistralrs"),
+        "mlx" => Some("mlx"),
         _ => None,
     }
 }
@@ -456,7 +457,12 @@ pub fn backend_label_from_template(
 ) -> Option<&'static str> {
     match template {
         ExecutionTemplate::Onnx { .. } => Some("ort"),
-        ExecutionTemplate::SafeTensors { .. } => Some("candle"),
+        // SafeTensors is Candle's native format; an `mlx` hint on an
+        // Apple Silicon bundle overrides the default so the wire label
+        // reflects the actual runtime that will execute the model.
+        ExecutionTemplate::SafeTensors { .. } => {
+            hint.and_then(normalize_llm_backend_hint).or(Some("candle"))
+        }
         ExecutionTemplate::Gguf { .. } => hint.and_then(normalize_llm_backend_hint),
         ExecutionTemplate::CoreMl { .. }
         | ExecutionTemplate::TfLite { .. }
@@ -558,7 +564,9 @@ mod tests {
         };
         assert_eq!(backend_label_from_template(&onnx, None), Some("ort"));
 
-        // SafeTensors always rides the Candle runtime in this workspace.
+        // SafeTensors defaults to Candle when no hint is set; an
+        // `mlx` hint overrides for Apple-Silicon-targeted bundles
+        // where the runtime selector picks MLX over Candle.
         let safe = ExecutionTemplate::SafeTensors {
             model_file: "m.safetensors".into(),
             architecture: None,
@@ -566,6 +574,11 @@ mod tests {
             tokenizer_file: None,
         };
         assert_eq!(backend_label_from_template(&safe, None), Some("candle"));
+        assert_eq!(
+            backend_label_from_template(&safe, Some("mlx")),
+            Some("mlx"),
+            "mlx hint must override the candle default for SafeTensors bundles"
+        );
 
         // GGUF: hint required to disambiguate llama.cpp vs mistral.rs;
         // omit when the bundle didn't pin a backend so downstream can
@@ -590,6 +603,9 @@ mod tests {
             backend_label_from_template(&gguf, Some("mistralrs")),
             Some("mistralrs")
         );
+        // GGUF + mlx hint: the MLX runtime can also consume converted
+        // GGUFs, so the hint path must accept `"mlx"` here too.
+        assert_eq!(backend_label_from_template(&gguf, Some("mlx")), Some("mlx"));
     }
 
     #[test]
@@ -601,6 +617,9 @@ mod tests {
         assert_eq!(normalize_llm_backend_hint("mistral"), Some("mistralrs"));
         assert_eq!(normalize_llm_backend_hint("mistralrs"), Some("mistralrs"));
         assert_eq!(normalize_llm_backend_hint("llamacpp"), Some("llamacpp"));
+        // MLX is the Apple-Silicon-only LLM runtime; the wire label is
+        // already canonical so the mapping is identity.
+        assert_eq!(normalize_llm_backend_hint("mlx"), Some("mlx"));
         // Unknown hints must return None so callers omit the field
         // rather than emit a guessed value.
         assert_eq!(normalize_llm_backend_hint("unknown"), None);

--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -418,6 +418,52 @@ pub fn stage_kind_from_task(task: &str) -> Option<&'static str> {
     }
 }
 
+/// Normalise a GGUF `metadata.backend` hint to the canonical wire label.
+///
+/// Accepts both the canonical name and the historical `mistral` alias that
+/// flows through older bundle files; returns `None` for unrecognised hints
+/// so the caller can omit the field rather than emit a guessed value.
+///
+/// Used both by [`backend_label_from_template`] (outer `execute:` span)
+/// and by the inner `llm_inference` span sites so the wire payload's
+/// `backend` field is the same canonical string regardless of which span
+/// the SDK telemetry hoist reads.
+pub fn normalize_llm_backend_hint(hint: &str) -> Option<&'static str> {
+    match hint {
+        "llamacpp" => Some("llamacpp"),
+        "mistral" | "mistralrs" => Some("mistralrs"),
+        _ => None,
+    }
+}
+
+/// Map a model's execution template (and optional `backend` hint from
+/// `ModelMetadata.metadata`) to the canonical backend label used by cost
+/// telemetry and the analytics ingest path. Values are aligned with the
+/// closed set documented for the `backend` field on `PlatformEvent`:
+/// `llamacpp` | `mlx` | `mistralrs` | `ort` | `candle` | `cloud`.
+///
+/// Returns `None` when the runtime is not yet covered by that closed set
+/// (e.g. CoreML, TFLite, ModelGraph) — the contract is "additive, omit
+/// when unknown" so unrecognised templates simply leave the field absent.
+///
+/// `cloud` is intentionally not represented here: the cloud adapter
+/// emits the label from its own span site (see
+/// `runtime_adapter::cloud::CloudRuntimeAdapter::execute`) where the
+/// provider identity is also in scope.
+pub fn backend_label_from_template(
+    template: &ExecutionTemplate,
+    hint: Option<&str>,
+) -> Option<&'static str> {
+    match template {
+        ExecutionTemplate::Onnx { .. } => Some("ort"),
+        ExecutionTemplate::SafeTensors { .. } => Some("candle"),
+        ExecutionTemplate::Gguf { .. } => hint.and_then(normalize_llm_backend_hint),
+        ExecutionTemplate::CoreMl { .. }
+        | ExecutionTemplate::TfLite { .. }
+        | ExecutionTemplate::ModelGraph { .. } => None,
+    }
+}
+
 /// Map a model's execution template to the `span_kind` colour hint used by
 /// the swim-lane bar renderer (`gpu` / `cpu` / `io` / `tool`).
 ///
@@ -502,6 +548,85 @@ mod tests {
             ExecutionMode::Autoregressive { max_tokens, .. } => assert_eq!(max_tokens, 100),
             _ => panic!("Expected autoregressive mode"),
         }
+    }
+
+    #[test]
+    fn backend_label_covers_canonical_runtimes() {
+        // ONNX → "ort" (analytics-canonical name for the ONNX Runtime path).
+        let onnx = ExecutionTemplate::Onnx {
+            model_file: "m.onnx".into(),
+        };
+        assert_eq!(backend_label_from_template(&onnx, None), Some("ort"));
+
+        // SafeTensors always rides the Candle runtime in this workspace.
+        let safe = ExecutionTemplate::SafeTensors {
+            model_file: "m.safetensors".into(),
+            architecture: None,
+            config_file: None,
+            tokenizer_file: None,
+        };
+        assert_eq!(backend_label_from_template(&safe, None), Some("candle"));
+
+        // GGUF: hint required to disambiguate llama.cpp vs mistral.rs;
+        // omit when the bundle didn't pin a backend so downstream can
+        // tell "we don't know" from "we know it's X".
+        let gguf = ExecutionTemplate::Gguf {
+            model_file: "m.gguf".into(),
+            chat_template: None,
+            context_length: 2048,
+            generation_params: None,
+        };
+        assert_eq!(backend_label_from_template(&gguf, None), None);
+        assert_eq!(
+            backend_label_from_template(&gguf, Some("llamacpp")),
+            Some("llamacpp")
+        );
+        // Accept both the bundle-file alias and the canonical name.
+        assert_eq!(
+            backend_label_from_template(&gguf, Some("mistral")),
+            Some("mistralrs")
+        );
+        assert_eq!(
+            backend_label_from_template(&gguf, Some("mistralrs")),
+            Some("mistralrs")
+        );
+    }
+
+    #[test]
+    fn normalize_llm_backend_hint_canonicalises_aliases() {
+        // The legacy `mistral` alias must normalise to the canonical
+        // `mistralrs` so the inner `llm_inference` span (read by the SDK
+        // hoist for `PlatformEvent.backend`) and the outer `execute:`
+        // span agree on the closed-set wire value.
+        assert_eq!(normalize_llm_backend_hint("mistral"), Some("mistralrs"));
+        assert_eq!(normalize_llm_backend_hint("mistralrs"), Some("mistralrs"));
+        assert_eq!(normalize_llm_backend_hint("llamacpp"), Some("llamacpp"));
+        // Unknown hints must return None so callers omit the field
+        // rather than emit a guessed value.
+        assert_eq!(normalize_llm_backend_hint("unknown"), None);
+        assert_eq!(normalize_llm_backend_hint(""), None);
+    }
+
+    #[test]
+    fn backend_label_omits_unknown_runtimes() {
+        // Templates not yet covered by the closed-set contract must
+        // return None so the wire field stays absent rather than
+        // emitting a guessed value.
+        let coreml = ExecutionTemplate::CoreMl {
+            model_file: "m.mlmodel".into(),
+        };
+        assert!(backend_label_from_template(&coreml, None).is_none());
+
+        let tflite = ExecutionTemplate::TfLite {
+            model_file: "m.tflite".into(),
+        };
+        assert!(backend_label_from_template(&tflite, None).is_none());
+
+        let graph = ExecutionTemplate::ModelGraph {
+            stages: Vec::new(),
+            config: HashMap::new(),
+        };
+        assert!(backend_label_from_template(&graph, None).is_none());
     }
 
     #[test]

--- a/crates/xybrid-core/src/execution/template/mod.rs
+++ b/crates/xybrid-core/src/execution/template/mod.rs
@@ -14,8 +14,9 @@ mod voice;
 
 // Re-export metadata types + swim-lane grouping helpers
 pub use metadata::{
-    span_kind_from_template, stage_kind_from_task, ExecutionMode, ExecutionTemplate,
-    GenerationParams, ModelMetadata, PipelineStage, RefinementSchedule,
+    backend_label_from_template, normalize_llm_backend_hint, span_kind_from_template,
+    stage_kind_from_task, ExecutionMode, ExecutionTemplate, GenerationParams, ModelMetadata,
+    PipelineStage, RefinementSchedule,
 };
 
 // Re-export step types

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -251,9 +251,36 @@ impl RuntimeAdapter for CloudRuntimeAdapter {
 
         let response = {
             let _llm_span = trace::SpanGuard::new("llm_inference");
-            client
+            // Annotate the inner LLM span with the cost-accounting fields
+            // before the call so that even if `complete` returns early
+            // (errors propagated upstream), the in-flight span still
+            // carries the runtime/provider it was attempting against.
+            // The SDK telemetry hoist (see
+            // `xybrid_sdk::telemetry::extract_llm_inference_string_attr`)
+            // lifts these onto the wire payload's top level for the
+            // billing column.
+            trace::add_metadata("backend", "cloud");
+            trace::add_metadata("provider", provider.as_str());
+            let resp = client
                 .complete(request)
-                .map_err(|e| AdapterError::InferenceFailed(format!("LLM request failed: {}", e)))?
+                .map_err(|e| AdapterError::InferenceFailed(format!("LLM request failed: {}", e)))?;
+            // Mirror cloud-provider token usage onto the LLM span so the
+            // hoist sees the same shape as a local-inference span. The
+            // canonical keys (`tokens_in` / `tokens_out` /
+            // `cache_*_input_tokens`) match what the local LLM adapter
+            // emits, so analytics consumers don't branch on local vs
+            // cloud.
+            if let Some(ref usage) = resp.usage {
+                trace::add_metadata("tokens_in", usage.prompt_tokens.to_string());
+                trace::add_metadata("tokens_out", usage.completion_tokens.to_string());
+                if let Some(c) = usage.cache_read_input_tokens {
+                    trace::add_metadata("cache_read_input_tokens", c.to_string());
+                }
+                if let Some(c) = usage.cache_creation_input_tokens {
+                    trace::add_metadata("cache_creation_input_tokens", c.to_string());
+                }
+            }
+            resp
         };
 
         // Build output envelope with response metadata

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -46,7 +46,7 @@ use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy, RetryableError};
 
 pub const DEFAULT_REGISTRY_URL: &str = "https://registry.xybrid.dev";
@@ -99,6 +99,35 @@ fn build_client_header_with_optout(binding: &str, opted_out: bool) -> Option<Str
         current_platform(),
         backends,
     ))
+}
+
+/// Classify a download URL into the canonical telemetry `source` label
+/// emitted on `ModelDownload` events.
+///
+/// Recognised hosts:
+/// - `r2.xybrid.dev` / `*.r2.dev` / `r2.cloudflarestorage.com` → `"r2"`
+///   (Xybrid's Cloudflare R2 mirror, fronts both the registry-served
+///   bundles and the fallback URL list).
+/// - `huggingface.co` / `hf.co` → `"huggingface"` (direct HF pulls
+///   used for passthrough variants where the registry forwards the
+///   raw upstream URL).
+///
+/// Anything else passes through as `"other"` so cost attribution still
+/// produces a labelled event when a future variant adds a new origin
+/// — the analytics backend can then promote the new label into a
+/// recognised category without dropping rows in the meantime.
+fn classify_download_source(url: &str) -> &'static str {
+    let lower = url.to_ascii_lowercase();
+    if lower.contains("huggingface.co") || lower.contains("hf.co/") {
+        "huggingface"
+    } else if lower.contains("r2.xybrid.dev")
+        || lower.contains("r2.cloudflarestorage.com")
+        || lower.contains(".r2.dev")
+    {
+        "r2"
+    } else {
+        "other"
+    }
 }
 
 fn sanitize_binding(binding: &str) -> &str {
@@ -648,12 +677,35 @@ impl RegistryClient {
 
         // Download from HuggingFace
         info!("Downloading '{}' from {}", mask, resolved.download_url);
+        // Time only the wallclock spent inside the download itself so
+        // the emitted `ModelDownload.duration_ms` reflects bytes-on-the-
+        // wire latency. Hash verification + cache extraction run after
+        // this block and have their own (much cheaper) cost; conflating
+        // them would smear the network signal that operators actually
+        // care about for the cost dashboard.
+        let download_started = Instant::now();
         self.download_with_progress(
             &resolved.download_url,
             &cache_path,
             resolved.size_bytes,
             progress_callback,
         )?;
+        let download_duration = download_started.elapsed();
+
+        // Emit a ModelDownload telemetry event for cost accounting. Use
+        // the actual on-disk size — `resolved.size_bytes` is the
+        // registry-declared expected size, which can drift from what
+        // landed if the upstream changed between resolve and fetch. The
+        // helper honors XYBRID_TELEMETRY_OPTOUT internally.
+        let bytes_downloaded = std::fs::metadata(&cache_path)
+            .map(|m| m.len())
+            .unwrap_or(resolved.size_bytes);
+        crate::telemetry::publish_model_download(
+            mask,
+            bytes_downloaded,
+            classify_download_source(&resolved.download_url),
+            download_duration.as_millis().min(u32::MAX as u128) as u32,
+        );
 
         // Verify hash and cache it for fast future lookups
         if !resolved.sha256.is_empty() {
@@ -801,12 +853,27 @@ impl RegistryClient {
             "Passthrough download '{}' from {}",
             mask, resolved.download_url
         );
+        // Same reasoning as the standard fetch path: we time the
+        // network transfer alone so the cost dashboard sees a clean
+        // bytes-on-the-wire signal.
+        let download_started = Instant::now();
         self.download_with_progress(
             &resolved.download_url,
             &model_file_path,
             resolved.size_bytes,
             &progress_callback,
         )?;
+        let download_duration = download_started.elapsed();
+
+        let bytes_downloaded = std::fs::metadata(&model_file_path)
+            .map(|m| m.len())
+            .unwrap_or(resolved.size_bytes);
+        crate::telemetry::publish_model_download(
+            mask,
+            bytes_downloaded,
+            classify_download_source(&resolved.download_url),
+            download_duration.as_millis().min(u32::MAX as u128) as u32,
+        );
 
         // Verify SHA256
         if !resolved.sha256.is_empty() {
@@ -1250,6 +1317,53 @@ impl CacheStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_download_source_recognises_r2_hosts() {
+        // Xybrid's R2 mirror serves both the registry's primary bundle
+        // URLs and the `r2.xybrid.dev` fallback list. All three host
+        // shapes must label as `"r2"` so cost attribution doesn't split
+        // the row across CDN edges.
+        assert_eq!(
+            classify_download_source("https://r2.xybrid.dev/v1/kokoro/universal.xyb"),
+            "r2"
+        );
+        assert_eq!(
+            classify_download_source("https://abcd1234.r2.cloudflarestorage.com/bundles/x.xyb"),
+            "r2"
+        );
+        assert_eq!(
+            classify_download_source("https://pub-xxx.r2.dev/x.xyb"),
+            "r2"
+        );
+    }
+
+    #[test]
+    fn classify_download_source_recognises_huggingface_hosts() {
+        // Passthrough variants resolve to raw HuggingFace download URLs.
+        assert_eq!(
+            classify_download_source(
+                "https://huggingface.co/xybrid-ai/kokoro-82m/resolve/main/model.gguf"
+            ),
+            "huggingface"
+        );
+        assert_eq!(
+            classify_download_source("https://hf.co/owner/repo/resolve/main/m.gguf"),
+            "huggingface"
+        );
+    }
+
+    #[test]
+    fn classify_download_source_falls_back_to_other() {
+        // Unknown hosts must still produce a labelled event so a future
+        // origin doesn't silently drop attribution rows. The platform
+        // can promote `"other"` to a recognised category later.
+        assert_eq!(
+            classify_download_source("https://cdn.example.com/m.gguf"),
+            "other"
+        );
+        assert_eq!(classify_download_source(""), "other");
+    }
 
     #[test]
     fn test_default_client() {

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1000,6 +1000,22 @@ fn convert_to_platform_event(
                 }
             }
         }
+        // Hoist cost-accounting string attrs (`backend`, `provider`) from
+        // the LLM span. `backend` lands on every inference event; the
+        // local execution path emits values in the closed set
+        // {llamacpp, mlx, mistralrs, ort, candle} via
+        // `TemplateExecutor::execute_impl`, the cloud adapter emits
+        // `cloud` from its inner `llm_inference` span, and `provider`
+        // (openai / anthropic / …) is cloud-only. Hoisting the cloud
+        // fields here avoids dragging the analytics backend into the
+        // nested span tree for the billing column.
+        for key in ["backend", "provider"] {
+            if payload.get(key).is_none() {
+                if let Some(v) = extract_llm_inference_string_attr(&spans, key) {
+                    payload[key] = serde_json::json!(v);
+                }
+            }
+        }
         Some(spans)
     } else {
         None
@@ -1121,6 +1137,44 @@ fn extract_llm_token_counts(stages: &serde_json::Value) -> Option<(Option<u64>, 
     } else {
         None
     }
+}
+
+/// Walk a `stages` JSON (same shape as [`extract_llm_token_counts`]) and
+/// return the value of `key` from the LAST LLM-flavoured span that
+/// carries it as a string. Used to lift cost-accounting string attrs
+/// (`backend`, `provider`) onto the wire payload's top level alongside
+/// the token counts.
+///
+/// LLM-span detection is identical to [`extract_llm_token_counts`]
+/// (name prefix `llm_inference*` / `inference:*` or LLM-style metadata
+/// keys) so the two hoists agree on which span is "the" LLM span when
+/// a trace contains other inference spans (e.g. ASR/TTS).
+fn extract_llm_inference_string_attr(stages: &serde_json::Value, key: &str) -> Option<String> {
+    let spans = stages.get("spans")?.as_array()?;
+    let mut found: Option<String> = None;
+    for span in spans {
+        let name = span.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let meta = span.get("metadata");
+        let is_llm_span = name.starts_with("llm_inference")
+            || name.starts_with("inference:")
+            || meta
+                .map(|m| {
+                    m.get("ttft_ms").is_some()
+                        || m.get("tokens_generated").is_some()
+                        || m.get("tokens_out").is_some()
+                        || m.get("completion_tokens").is_some()
+                })
+                .unwrap_or(false);
+        if !is_llm_span {
+            continue;
+        }
+        if let Some(v) = meta.and_then(|m| m.get(key)).and_then(|v| v.as_str()) {
+            // Same last-span-wins rule as the token-count hoist: a retried
+            // run emits one span per attempt and we want the final value.
+            found = Some(v.to_string());
+        }
+    }
+    found
 }
 
 // ============================================================================
@@ -1627,6 +1681,77 @@ fn snapshot_context_into_event(event: TelemetryEvent) -> TelemetryEvent {
         data: Some(data.to_string()),
         ..event
     }
+}
+
+/// Build a `ModelDownload` event for a successful registry fetch.
+///
+/// Carries the cost-attribution fields agreed with the platform schema:
+/// `model_id` (registry mask), `bytes_downloaded` (final on-disk size of
+/// the model file or .xyb bundle), `source` (canonical download host
+/// label — `r2` for Xybrid's R2 mirror, `huggingface` for direct HF
+/// pulls; other hosts pass through as-is so a future provider doesn't
+/// silently lose attribution), and `duration_ms` (wallclock time spent
+/// inside the network download, excluding hash verification and cache
+/// extraction so the field reflects bytes-on-the-wire latency).
+///
+/// The wire `event_type` is the literal string `"ModelDownload"`. The
+/// fields land under `payload.data` after `convert_to_platform_event`
+/// runs; ingest reads them from there.
+///
+/// Pure builder — does not publish, allows unit tests to inspect the
+/// event shape without standing up the global exporter.
+fn build_model_download_event(
+    model_id: &str,
+    bytes_downloaded: u64,
+    source: &str,
+    duration_ms: u32,
+) -> TelemetryEvent {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let data = serde_json::json!({
+        "model_id": model_id,
+        "bytes_downloaded": bytes_downloaded,
+        "source": source,
+        "duration_ms": duration_ms,
+    });
+    TelemetryEvent {
+        event_type: "ModelDownload".to_string(),
+        stage_name: None,
+        target: None,
+        // Mirror duration onto the canonical `latency_ms` field so the
+        // platform's existing latency column lights up for downloads
+        // without a schema migration.
+        latency_ms: Some(duration_ms),
+        error: None,
+        data: Some(data.to_string()),
+        timestamp_ms: now_ms,
+    }
+}
+
+/// Publish a `ModelDownload` event for a successful registry fetch.
+///
+/// Honors [`crate::telemetry_optout::is_telemetry_opted_out`]: when the
+/// user has set `XYBRID_TELEMETRY_OPTOUT=1` no event is emitted, since
+/// the same opt-out already gates the registry call telemetry header
+/// and a model-download event would leak the same attribution surface
+/// (which model the user pulled, how big it was).
+///
+/// Cache hits MUST NOT call this — the event represents a real network
+/// transfer for cost accounting; emitting it on cache hits would
+/// double-count and hide cache-effectiveness metrics.
+pub fn publish_model_download(
+    model_id: &str,
+    bytes_downloaded: u64,
+    source: &str,
+    duration_ms: u32,
+) {
+    if crate::telemetry_optout::is_telemetry_opted_out() {
+        return;
+    }
+    let event = build_model_download_event(model_id, bytes_downloaded, source, duration_ms);
+    publish_telemetry_event(event);
 }
 
 /// Publish a telemetry event to all registered subscribers
@@ -2400,6 +2525,124 @@ mod tests {
         let (tin, tout) = extract_llm_token_counts(&stages).expect("should find llm spans");
         assert_eq!(tin, Some(64));
         assert_eq!(tout, Some(256));
+    }
+
+    #[test]
+    fn extract_llm_inference_string_attr_reads_backend_and_provider() {
+        // The cloud adapter writes both keys onto the inner
+        // `llm_inference` span (see `runtime_adapter::cloud::mod`).
+        // The hoist must read them through the same span-detection
+        // rule used by the token-count hoist so the two stay in sync.
+        let stages = serde_json::json!({
+            "spans": [
+                { "name": "execute:gpt-4o-mini", "metadata": {} },
+                {
+                    "name": "llm_inference",
+                    "metadata": {
+                        "backend": "cloud",
+                        "provider": "openai",
+                        "tokens_in": "120",
+                        "tokens_out": "32"
+                    }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_llm_inference_string_attr(&stages, "backend").as_deref(),
+            Some("cloud")
+        );
+        assert_eq!(
+            extract_llm_inference_string_attr(&stages, "provider").as_deref(),
+            Some("openai")
+        );
+    }
+
+    #[test]
+    fn extract_llm_inference_string_attr_skips_non_llm_spans() {
+        // A non-LLM span (e.g., the outer execute span or an ASR
+        // span) carrying a `backend` key MUST NOT win — the hoist's
+        // contract is "read from the LLM span, the same one the
+        // token-count hoist reads". Otherwise a TTS/ASR backend
+        // string could spuriously land on an LLM event's payload.
+        let stages = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:asr-whisper-tiny",
+                    "metadata": { "backend": "ort" }
+                },
+                {
+                    "name": "execute:gpt-4o-mini",
+                    "metadata": { "provider": "should-not-win" }
+                }
+            ]
+        });
+        assert!(extract_llm_inference_string_attr(&stages, "backend").is_none());
+        assert!(extract_llm_inference_string_attr(&stages, "provider").is_none());
+    }
+
+    #[test]
+    fn extract_llm_inference_string_attr_prefers_last_llm_span() {
+        // Mirror of `extract_llm_token_counts_prefers_last_authoritative_span`:
+        // a retried run emits one LLM span per attempt and the final
+        // attempt is the source of truth. Fields from earlier attempts
+        // must not leak through.
+        let stages = serde_json::json!({
+            "spans": [
+                {
+                    "name": "llm_inference",
+                    "metadata": { "backend": "cloud", "provider": "anthropic" }
+                },
+                {
+                    "name": "llm_inference",
+                    "metadata": { "backend": "cloud", "provider": "openai" }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_llm_inference_string_attr(&stages, "provider").as_deref(),
+            Some("openai"),
+            "must take last-span provider, not first"
+        );
+    }
+
+    #[test]
+    fn build_model_download_event_has_canonical_shape() {
+        // ModelDownload is the cost-attribution event for a successful
+        // registry fetch. The wire shape is fixed by the platform's
+        // billing pipeline: top-level `event_type` literal
+        // "ModelDownload", `latency_ms` mirrors `duration_ms`, and the
+        // four cost fields land under `data` as a JSON object.
+        let event = build_model_download_event("kokoro-82m", 1_234_567, "huggingface", 5_432);
+
+        assert_eq!(event.event_type, "ModelDownload");
+        assert_eq!(
+            event.latency_ms,
+            Some(5_432),
+            "latency_ms must mirror duration_ms so the existing latency column lights up without a schema migration"
+        );
+        assert!(event.error.is_none());
+        assert!(event.stage_name.is_none());
+        assert!(event.target.is_none());
+        assert!(event.timestamp_ms > 0, "timestamp must be populated");
+
+        let data: serde_json::Value =
+            serde_json::from_str(event.data.as_deref().expect("data present"))
+                .expect("data is valid JSON");
+        assert_eq!(data["model_id"].as_str(), Some("kokoro-82m"));
+        assert_eq!(data["bytes_downloaded"].as_u64(), Some(1_234_567));
+        assert_eq!(data["source"].as_str(), Some("huggingface"));
+        assert_eq!(data["duration_ms"].as_u64(), Some(5_432));
+    }
+
+    #[test]
+    fn build_model_download_event_carries_r2_source_label() {
+        // Sanity that the closed-set source label is passed through as-is.
+        // The classifier in `registry_client::classify_download_source`
+        // is responsible for mapping URLs to labels; this test guards
+        // the builder's pass-through contract.
+        let event = build_model_download_event("test-model", 42, "r2", 1);
+        let data: serde_json::Value = serde_json::from_str(event.data.as_deref().unwrap()).unwrap();
+        assert_eq!(data["source"].as_str(), Some("r2"));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1000,20 +1000,26 @@ fn convert_to_platform_event(
                 }
             }
         }
-        // Hoist cost-accounting string attrs (`backend`, `provider`) from
-        // the LLM span. `backend` lands on every inference event; the
-        // local execution path emits values in the closed set
-        // {llamacpp, mlx, mistralrs, ort, candle} via
-        // `TemplateExecutor::execute_impl`, the cloud adapter emits
-        // `cloud` from its inner `llm_inference` span, and `provider`
-        // (openai / anthropic / …) is cloud-only. Hoisting the cloud
-        // fields here avoids dragging the analytics backend into the
-        // nested span tree for the billing column.
-        for key in ["backend", "provider"] {
-            if payload.get(key).is_none() {
-                if let Some(v) = extract_llm_inference_string_attr(&spans, key) {
-                    payload[key] = serde_json::json!(v);
-                }
+        // Hoist cost-accounting string attrs onto the payload top level
+        // for the billing column.
+        //
+        // `backend` may live on any span — LLM events set it on the
+        // inner `llm_inference` span (via `LlmStrategy` / cloud adapter),
+        // non-LLM events (ASR/TTS) set it on the outer `execute:<model>`
+        // span via `backend_label_from_template`. Read from any span so
+        // both surfaces produce the same wire shape.
+        //
+        // `provider` is cloud-LLM-only and must stay gated to LLM spans:
+        // a non-LLM span carrying a stray `provider` key would emit a
+        // phantom value on an ASR/TTS payload.
+        if payload.get("backend").is_none() {
+            if let Some(v) = extract_string_attr_from_any_span(&spans, "backend") {
+                payload["backend"] = serde_json::json!(v);
+            }
+        }
+        if payload.get("provider").is_none() {
+            if let Some(v) = extract_llm_inference_string_attr(&spans, "provider") {
+                payload["provider"] = serde_json::json!(v);
             }
         }
         Some(spans)
@@ -1171,6 +1177,31 @@ fn extract_llm_inference_string_attr(stages: &serde_json::Value, key: &str) -> O
         if let Some(v) = meta.and_then(|m| m.get(key)).and_then(|v| v.as_str()) {
             // Same last-span-wins rule as the token-count hoist: a retried
             // run emits one span per attempt and we want the final value.
+            found = Some(v.to_string());
+        }
+    }
+    found
+}
+
+/// Walk a `stages` JSON and return the value of `key` from the LAST span
+/// (any flavour) that carries it as a string. Used for cost-accounting
+/// scalars that must surface on every inference event regardless of
+/// modality — chiefly `backend`, which is set on the outer
+/// `execute:<model>` span for non-LLM events (ASR/TTS via
+/// `backend_label_from_template`) and on the inner `llm_inference` span
+/// for LLM events.
+///
+/// Intentionally NOT used for `provider`: that field is cloud-LLM-only
+/// and a stray match on a non-LLM span would emit a nonsense provider
+/// value on an ASR/TTS payload. Use [`extract_llm_inference_string_attr`]
+/// for provider.
+fn extract_string_attr_from_any_span(stages: &serde_json::Value, key: &str) -> Option<String> {
+    let spans = stages.get("spans")?.as_array()?;
+    let mut found: Option<String> = None;
+    for span in spans {
+        let meta = span.get("metadata");
+        if let Some(v) = meta.and_then(|m| m.get(key)).and_then(|v| v.as_str()) {
+            // Same last-span-wins rule as the LLM-gated hoist.
             found = Some(v.to_string());
         }
     }
@@ -2602,6 +2633,52 @@ mod tests {
             extract_llm_inference_string_attr(&stages, "provider").as_deref(),
             Some("openai"),
             "must take last-span provider, not first"
+        );
+    }
+
+    #[test]
+    fn extract_string_attr_from_any_span_reads_outer_execute_span() {
+        // Non-LLM events (ASR/TTS) carry `backend` on the outer
+        // `execute:<model>` span via `backend_label_from_template` —
+        // the LLM-gated hoist would skip it, dropping backend
+        // attribution from the wire payload. The any-span hoist must
+        // pick it up so ASR/TTS rows aren't blank in the billing column.
+        let stages = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:wav2vec2-base-960h",
+                    "metadata": { "backend": "ort" }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_string_attr_from_any_span(&stages, "backend").as_deref(),
+            Some("ort")
+        );
+    }
+
+    #[test]
+    fn extract_string_attr_from_any_span_prefers_last() {
+        // Same last-wins rule as the LLM-gated hoist, applied across
+        // any span. If both inner and outer spans carry `backend` (an
+        // LLM run that also annotates the outer `execute:` span), the
+        // last one in the array wins — matching the existing
+        // token-count hoist behaviour for retried runs.
+        let stages = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:gpt-4o-mini",
+                    "metadata": { "backend": "first" }
+                },
+                {
+                    "name": "llm_inference",
+                    "metadata": { "backend": "second" }
+                }
+            ]
+        });
+        assert_eq!(
+            extract_string_attr_from_any_span(&stages, "backend").as_deref(),
+            Some("second")
         );
     }
 

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -213,6 +213,54 @@ The device profile is encoded as a typed `device` substructure. Platform ingest 
 
 Older SDKs continue to send the legacy top-level fields. Newer platform deployments should treat `device` as optional.
 
+## Cost-attribution fields
+
+Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attribution scalars on the payload top level so the platform can compute cost without descending into the span tree. All fields are optional and absent when unknown — consumers must tolerate missing keys.
+
+| field | type | events | values | source |
+|---|---|---|---|---|
+| `backend` | string | inference | `llamacpp` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint for GGUF; `cloud` for the cloud adapter |
+| `provider` | string | inference (cloud only) | `openai` \| `anthropic` \| `google` \| `elevenlabs` \| `openrouter` \| `custom` | Cloud `IntegrationProvider` resolved from envelope metadata |
+| `tokens_in` | u64 | inference | — | LLM span (`prompt_tokens` for OpenAI; synthesized total for Anthropic) |
+| `tokens_out` | u64 | inference | — | LLM span (`completion_tokens`) |
+| `cache_read_input_tokens` | u64 | inference | — | Anthropic-canonical; OpenAI's nested `prompt_tokens_details.cached_tokens` maps here |
+| `cache_creation_input_tokens` | u64 | inference | — | Anthropic-only |
+
+The closed set for `backend` is intentionally narrow — values outside it are not emitted (the field stays absent) so the analytics column can pin a closed enum without rejecting future runtimes mid-flight. Forward-declared backends (e.g. `mlx`) are added to the set only when a runtime adapter for them lands.
+
+For local LLM events `provider` is always absent; for cloud events it is always present alongside `backend = "cloud"`.
+
+## `ModelDownload` event
+
+Emitted exactly once per successful registry download, after the network transfer completes and (when applicable) SHA256 verification passes. Cache hits do **not** produce this event — the metric represents bytes-on-the-wire, not cache traffic.
+
+```json
+{
+  "event_type": "ModelDownload",
+  "session_id": "...",
+  "payload": {
+    "status": "success",
+    "latency_ms": 5432,
+    "data": {
+      "model_id": "kokoro-82m",
+      "bytes_downloaded": 132456789,
+      "source": "huggingface",
+      "duration_ms": 5432
+    }
+  },
+  "timestamp": "..."
+}
+```
+
+| field | type | description |
+|---|---|---|
+| `model_id` | string | Registry mask, e.g. `kokoro-82m` |
+| `bytes_downloaded` | u64 | Final on-disk size of the model file or `.xyb` bundle. Differs from the registry-declared expected size when upstream changed between resolve and fetch. |
+| `source` | string | Canonical download host: `r2` for Xybrid's R2 mirror, `huggingface` for direct HF pulls, `other` for any other host (forward-compat so a future provider doesn't lose attribution). |
+| `duration_ms` | u32 | Wallclock time inside the network download, excluding SHA256 verification and bundle extraction. Mirrored onto the top-level `latency_ms` so the existing latency column lights up. |
+
+The event respects the same opt-out as the registry call telemetry: when `XYBRID_TELEMETRY_OPTOUT=1` is set at process start, no `ModelDownload` event is emitted (the two leak the same kind of attribution surface — which model the user pulled — so they share one gate).
+
 ## Verification
 
 Run the SDK telemetry example from the repository root and inspect the JSON printed or received by your local ingest endpoint:

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -219,7 +219,7 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 
 | field | type | events | values | source |
 |---|---|---|---|---|
-| `backend` | string | inference | `llamacpp` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint for GGUF; `cloud` for the cloud adapter |
+| `backend` | string | inference | `llamacpp` \| `mlx` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint (GGUF requires the hint; SafeTensors defaults to `candle` and accepts `mlx` to override on Apple Silicon); `cloud` for the cloud adapter |
 | `provider` | string | inference (cloud only) | `openai` \| `anthropic` \| `google` \| `elevenlabs` \| `openrouter` \| `custom` | Cloud `IntegrationProvider` resolved from envelope metadata |
 | `tokens_in` | u64 | inference | — | LLM span (`prompt_tokens` for OpenAI; synthesized total for Anthropic) |
 | `tokens_out` | u64 | inference | — | LLM span (`completion_tokens`) |


### PR DESCRIPTION
## Summary

P0 cost-attribution fields for billing — Linear [INF-89](https://linear.app/xybrid/issue/INF-89/sdk-backend-provider-modeldownload-event-p0-billing-essentials). The telemetry payload tracked tokens and latency but lost three pieces of information needed to bill: which backend ran the inference, which cloud provider served it (when remote), and how many bytes a model bundle download cost in egress. This PR plumbs all three onto the wire so the platform can attribute cost without joining against the registry or descending into the span tree.

* **`backend`** (string, optional) — `llamacpp` | `mistralrs` | `ort` | `candle` | `cloud`. Derived from `ExecutionTemplate` + the GGUF `metadata.backend` hint via a new `backend_label_from_template` helper; legacy `mistral` alias normalises to canonical `mistralrs`. Omitted (not guessed) for runtimes outside the closed set so analytics sees "absent" not a fabricated value. `mlx` reserved for when an MLX adapter lands.
* **`provider`** (string, cloud-only) — `openai` / `anthropic` / etc. Plumbed from `IntegrationProvider` into the inner `llm_inference` span alongside the cloud token-usage breakdown (`tokens_in` / `tokens_out` / `cache_read_input_tokens` / `cache_creation_input_tokens`) so cloud events carry the same shape as local LLM events.
* **`ModelDownload`** event — fires once per successful registry fetch (cache hits skipped) with `model_id`, `bytes_downloaded`, `source` (`r2` | `huggingface` | `other` as forward-compat fallback), and `duration_ms`. Honors `XYBRID_TELEMETRY_OPTOUT=1` — same gate that suppresses the registry call telemetry header.

All fields are optional and additive. Existing consumers see no shape change. The hoist reuses the SDK's existing token-count machinery (`extract_llm_inference_string_attr`, last-span-wins for retried runs).

`PlatformEvent` is internal Rust and not part of `docs/sdk/api-surface.yaml` (which tracks cross-platform binding parity), so the surface YAML is unchanged. The wire format docs in `docs/sdk/telemetry.md` are updated with a Cost-attribution fields section and a `ModelDownload` wire example.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — 8 new unit tests covering `backend_label_from_template`, `normalize_llm_backend_hint`, `extract_llm_inference_string_attr`, `build_model_download_event`, `classify_download_source`
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md)) — `cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings` both clean
- [x] Documentation updated (if applicable) — `docs/sdk/telemetry.md` carries the new wire-format sections
- [x] No breaking changes (or breaking changes documented) — all new fields optional / additive