### PR TITLE
feat(telemetry): emit task field on PlatformEvent (INF-93)

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -240,6 +240,13 @@ impl TemplateExecutor {
             if let Some(kind) = stage_kind_from_task(task) {
                 xybrid_trace::add_metadata("stage_kind", kind);
             }
+            // Semantic task label for cost-attribution telemetry
+            // (per `PlatformEvent.task`). Echoes the raw value from
+            // `model_metadata.json` so the dashboard can filter
+            // chat/vlm/asr/tts/embedding/etc. without joining against
+            // the registry at render time. Omitted when the model
+            // bundle didn't declare a task.
+            xybrid_trace::add_metadata("task", task);
         }
         xybrid_trace::add_metadata(
             "span_kind",

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1022,6 +1022,17 @@ fn convert_to_platform_event(
                 payload["provider"] = serde_json::json!(v);
             }
         }
+        // Semantic task label (chat / vlm / asr / tts / embedding / …)
+        // sourced from `model_metadata.json`. Lives on the outer
+        // `execute:<model>` span so it's always reachable via the
+        // any-span hoist regardless of modality. Promotes the field
+        // to the wire payload so the console can filter without
+        // joining model_id against the registry at render time.
+        if payload.get("task").is_none() {
+            if let Some(v) = extract_string_attr_from_any_span(&spans, "task") {
+                payload["task"] = serde_json::json!(v);
+            }
+        }
         Some(spans)
     } else {
         None
@@ -2720,6 +2731,88 @@ mod tests {
         let event = build_model_download_event("test-model", 42, "r2", 1);
         let data: serde_json::Value = serde_json::from_str(event.data.as_deref().unwrap()).unwrap();
         assert_eq!(data["source"].as_str(), Some("r2"));
+    }
+
+    #[test]
+    fn task_field_hoists_to_payload_top_level() {
+        // INF-93: `task` is a semantic label sourced from the model
+        // bundle's `metadata.task`, written by `TemplateExecutor` onto
+        // the outer `execute:<model>` span. This test exercises the
+        // full convert path so an accidental future regression (e.g.,
+        // dropping the hoist branch) is caught without depending on
+        // the executor.
+        //
+        // `convert_to_platform_event` only runs the hoist block when
+        // global tracing is on (it would otherwise have nothing to
+        // capture from the global collector); flip it on here so the
+        // embedded-spans branch fires.
+        xybrid_core::tracing::init_tracing(true);
+        let data = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:wav2vec2-base-960h",
+                    "metadata": { "task": "asr", "backend": "ort" }
+                }
+            ]
+        });
+        let event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("transcribe".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: Some(420),
+            error: None,
+            data: Some(data.to_string()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+        let payload_json = serde_json::to_string(&platform.payload).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&payload_json).unwrap();
+        assert_eq!(
+            parsed["task"].as_str(),
+            Some("asr"),
+            "task must be hoisted to payload top level: {}",
+            payload_json
+        );
+    }
+
+    #[test]
+    fn task_field_omitted_when_span_does_not_carry_it() {
+        // Contract: `task` is optional / additive. A bundle without a
+        // `task` declaration must produce a payload that omits the key
+        // entirely (not an empty string). Guards against a future
+        // refactor that emits `Some("")` or `Some("unknown")`.
+        //
+        // Tracing must be enabled for the hoist branch to fire;
+        // otherwise this test would pass trivially even if the hoist
+        // were emitting a stale empty-string default.
+        xybrid_core::tracing::init_tracing(true);
+        let data = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:custom-model",
+                    "metadata": { "backend": "ort" }
+                }
+            ]
+        });
+        let event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("custom".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: Some(10),
+            error: None,
+            data: Some(data.to_string()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+        let parsed: serde_json::Value =
+            serde_json::from_value(serde_json::to_value(&platform.payload).unwrap()).unwrap();
+        assert!(
+            parsed.get("task").is_none(),
+            "task must be absent (not empty string) when bundle didn't declare it: {}",
+            serde_json::to_string(&parsed).unwrap()
+        );
     }
 
     #[test]

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -221,6 +221,7 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 |---|---|---|---|---|
 | `backend` | string | inference | `llamacpp` \| `mlx` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint (GGUF requires the hint; SafeTensors defaults to `candle` and accepts `mlx` to override on Apple Silicon); `cloud` for the cloud adapter |
 | `provider` | string | inference (cloud only) | `openai` \| `anthropic` \| `google` \| `elevenlabs` \| `openrouter` \| `custom` | Cloud `IntegrationProvider` resolved from envelope metadata |
+| `task` | string | inference | `chat` \| `vlm` \| `asr` \| `tts` \| `embedding` \| `image-gen` \| `ocr` \| `rerank` \| `classify` (open string for forward-compat) | `ModelMetadata.metadata["task"]` from `model_metadata.json` |
 | `tokens_in` | u64 | inference | — | LLM span (`prompt_tokens` for OpenAI; synthesized total for Anthropic) |
 | `tokens_out` | u64 | inference | — | LLM span (`completion_tokens`) |
 | `cache_read_input_tokens` | u64 | inference | — | Anthropic-canonical; OpenAI's nested `prompt_tokens_details.cached_tokens` maps here |


### PR DESCRIPTION
## Summary
- Emits `task` (`chat` / `vlm` / `asr` / `tts` / `embedding` / `image-gen` / `ocr` / `rerank` / `classify`) on inference events, sourced from `ModelMetadata.metadata["task"]` in `model_metadata.json` — eliminates the console's render-time `model_id` → registry join when filtering by task.
- Annotated on the outer `execute:<model>` span in `executor.rs` and hoisted to payload top-level in `telemetry.rs` via the existing any-span helper, so the recipe matches `backend` from INF-89.
- Wire schema documented in `docs/sdk/telemetry.md`. Two unit tests at the `convert_to_platform_event` integration level cover presence and absence (absent ≠ empty string when bundle doesn't declare `task`).

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` ✅ (run locally — clean)
- [ ] `cargo test --workspace` ✅ (838 pass, 1 unrelated env failure for missing `~/.xybrid/cmudict.dict`)
- [ ] After merge: dashboard surfaces `task` filter in a follow-up issue (INF-95 / console-existing-surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)