### PR TITLE
feat(telemetry): emit quantization label on PlatformEvent (INF-91)

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -21,8 +21,8 @@
 use log::{debug, info, warn};
 
 use super::template::{
-    backend_label_from_template, span_kind_from_template, stage_kind_from_task, ExecutionMode,
-    ExecutionTemplate, ModelMetadata, PipelineStage,
+    backend_label_from_template, quantization_label_from_metadata, span_kind_from_template,
+    stage_kind_from_task, ExecutionMode, ExecutionTemplate, ModelMetadata, PipelineStage,
 };
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 use super::template::{normalize_llm_backend_hint, PostprocessingStep};
@@ -263,6 +263,17 @@ impl TemplateExecutor {
         if let Some(label) = backend_label_from_template(&metadata.execution_template, backend_hint)
         {
             xybrid_trace::add_metadata("backend", label);
+        }
+
+        // Quantization label for cost-attribution telemetry
+        // (per `PlatformEvent.quantization`). Two runs of "the same
+        // model" can differ by 4× in size / speed / quality based on
+        // quantization, so the dashboard needs this to avoid
+        // collapsing `kokoro-82m@q4_0` and `kokoro-82m@fp16` into one
+        // row. Source priority: bundle metadata > GGUF filename >
+        // omitted. See `quantization_label_from_metadata`.
+        if let Some(quant) = quantization_label_from_metadata(metadata) {
+            xybrid_trace::add_metadata("quantization", quant);
         }
 
         // Step 1: Handling ModelGraph (multi-model DAG)

--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -470,6 +470,69 @@ pub fn backend_label_from_template(
     }
 }
 
+/// Normalise a quantization label to the canonical wire form.
+///
+/// GGUF filenames typically encode quantization in lowercase
+/// (`model-q4_k_m.gguf`); upstream tooling sometimes ships the label
+/// in uppercase (`Q4_K_M`) or with the GGUF-internal `f16` / `f32`
+/// instead of the platform-canonical `fp16` / `fp32`. This normaliser
+/// lowercases and rewrites those two aliases so the analytics column
+/// doesn't split a single quantization across multiple row keys.
+fn normalize_quantization_label(label: &str) -> String {
+    let lower = label.to_lowercase();
+    match lower.as_str() {
+        "f16" => "fp16".to_string(),
+        "f32" => "fp32".to_string(),
+        _ => lower,
+    }
+}
+
+/// Infer a quantization label from a GGUF model filename.
+///
+/// GGUF tooling encodes quantization in the filename by convention
+/// (`qwen2.5-0.5b-instruct-q4_k_m.gguf` → `q4_k_m`). Matched against
+/// the documented closed set; longer tokens are checked first so
+/// `q4_k_m` doesn't get clipped to `q4_0` by an earlier substring
+/// match. Returns `None` when no recognised pattern is found —
+/// callers must omit the field rather than emit a guess.
+fn infer_quantization_from_gguf_filename(filename: &str) -> Option<String> {
+    let lower = filename.to_lowercase();
+    // Order matters: check longer / more-specific patterns first.
+    for q in &[
+        "q3_k_l", "q3_k_m", "q3_k_s", "q4_k_m", "q4_k_s", "q5_k_m", "q5_k_s", "q2_k", "q4_0",
+        "q4_1", "q5_0", "q5_1", "q6_k", "q8_0", "f16", "f32",
+    ] {
+        if lower.contains(q) {
+            return Some(normalize_quantization_label(q));
+        }
+    }
+    None
+}
+
+/// Resolve the canonical quantization label for a model.
+///
+/// Source priority (per INF-91):
+///  1. Explicit `metadata.quantization` from `model_metadata.json` —
+///     publish-time, stable, preferred.
+///  2. GGUF filename inference (fallback) when the template is GGUF
+///     and the bundle didn't pin the label.
+///  3. `None` — when no signal is available the field stays absent
+///     rather than emitting an empty string or a guessed value.
+pub fn quantization_label_from_metadata(metadata: &ModelMetadata) -> Option<String> {
+    if let Some(declared) = metadata
+        .metadata
+        .get("quantization")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return Some(normalize_quantization_label(declared));
+    }
+    if let ExecutionTemplate::Gguf { model_file, .. } = &metadata.execution_template {
+        return infer_quantization_from_gguf_filename(model_file);
+    }
+    None
+}
+
 /// Map a model's execution template to the `span_kind` colour hint used by
 /// the swim-lane bar renderer (`gpu` / `cpu` / `io` / `tool`).
 ///
@@ -646,6 +709,128 @@ mod tests {
             config: HashMap::new(),
         };
         assert!(backend_label_from_template(&graph, None).is_none());
+    }
+
+    #[test]
+    fn quantization_label_prefers_explicit_metadata_field() {
+        // Source-priority rule (INF-91): explicit `metadata.quantization`
+        // beats filename inference. Lets the bundle author override the
+        // filename-derived guess for cases where the filename is wrong
+        // or non-canonical (e.g. a re-uploaded model).
+        let mut metadata = ModelMetadata {
+            model_id: "qwen2.5-0.5b-instruct".into(),
+            version: "1".into(),
+            execution_template: ExecutionTemplate::Gguf {
+                model_file: "qwen2.5-0.5b-instruct-q4_k_m.gguf".into(),
+                chat_template: None,
+                context_length: 2048,
+                generation_params: None,
+            },
+            preprocessing: Vec::new(),
+            postprocessing: Vec::new(),
+            files: Vec::new(),
+            description: None,
+            metadata: HashMap::new(),
+            voices: None,
+            max_chunk_chars: None,
+            trim_trailing_samples: None,
+        };
+        // Explicit declaration wins over the filename's `q4_k_m`.
+        metadata
+            .metadata
+            .insert("quantization".into(), serde_json::json!("Q8_0"));
+        assert_eq!(
+            quantization_label_from_metadata(&metadata).as_deref(),
+            Some("q8_0"),
+            "explicit metadata.quantization must override filename inference and be lowercased"
+        );
+    }
+
+    #[test]
+    fn quantization_label_falls_back_to_gguf_filename() {
+        // No explicit metadata field → filename inference for GGUF.
+        // Must produce the lowercase canonical label, and `f16` /
+        // `f32` must rewrite to `fp16` / `fp32` for analytics-column
+        // stability.
+        let metadata = ModelMetadata {
+            model_id: "qwen2.5-0.5b".into(),
+            version: "1".into(),
+            execution_template: ExecutionTemplate::Gguf {
+                model_file: "qwen2.5-0.5b-instruct-q4_k_m.gguf".into(),
+                chat_template: None,
+                context_length: 2048,
+                generation_params: None,
+            },
+            preprocessing: Vec::new(),
+            postprocessing: Vec::new(),
+            files: Vec::new(),
+            description: None,
+            metadata: HashMap::new(),
+            voices: None,
+            max_chunk_chars: None,
+            trim_trailing_samples: None,
+        };
+        assert_eq!(
+            quantization_label_from_metadata(&metadata).as_deref(),
+            Some("q4_k_m")
+        );
+
+        let fp16 = ModelMetadata {
+            execution_template: ExecutionTemplate::Gguf {
+                model_file: "tinyllama-1.1b-chat-f16.gguf".into(),
+                chat_template: None,
+                context_length: 2048,
+                generation_params: None,
+            },
+            ..metadata.clone()
+        };
+        assert_eq!(
+            quantization_label_from_metadata(&fp16).as_deref(),
+            Some("fp16"),
+            "GGUF `f16` must rewrite to canonical `fp16`"
+        );
+    }
+
+    #[test]
+    fn quantization_label_omits_when_unknown() {
+        // Contract: the field stays absent (not empty string, not
+        // "unknown") when no signal is available — analytics rows
+        // with missing quantization must be distinguishable from
+        // legitimate `fp32` rows.
+        let onnx_no_meta = ModelMetadata {
+            model_id: "wav2vec2".into(),
+            version: "1".into(),
+            execution_template: ExecutionTemplate::Onnx {
+                model_file: "model.onnx".into(),
+            },
+            preprocessing: Vec::new(),
+            postprocessing: Vec::new(),
+            files: Vec::new(),
+            description: None,
+            metadata: HashMap::new(),
+            voices: None,
+            max_chunk_chars: None,
+            trim_trailing_samples: None,
+        };
+        assert!(
+            quantization_label_from_metadata(&onnx_no_meta).is_none(),
+            "ONNX with no metadata.quantization must omit the label"
+        );
+
+        // GGUF whose filename doesn't carry a recognised pattern.
+        let gguf_unknown = ModelMetadata {
+            execution_template: ExecutionTemplate::Gguf {
+                model_file: "custom-experimental.gguf".into(),
+                chat_template: None,
+                context_length: 2048,
+                generation_params: None,
+            },
+            ..onnx_no_meta
+        };
+        assert!(
+            quantization_label_from_metadata(&gguf_unknown).is_none(),
+            "GGUF with no quantization marker in filename must omit"
+        );
     }
 
     #[test]

--- a/crates/xybrid-core/src/execution/template/mod.rs
+++ b/crates/xybrid-core/src/execution/template/mod.rs
@@ -14,9 +14,9 @@ mod voice;
 
 // Re-export metadata types + swim-lane grouping helpers
 pub use metadata::{
-    backend_label_from_template, normalize_llm_backend_hint, span_kind_from_template,
-    stage_kind_from_task, ExecutionMode, ExecutionTemplate, GenerationParams, ModelMetadata,
-    PipelineStage, RefinementSchedule,
+    backend_label_from_template, normalize_llm_backend_hint, quantization_label_from_metadata,
+    span_kind_from_template, stage_kind_from_task, ExecutionMode, ExecutionTemplate,
+    GenerationParams, ModelMetadata, PipelineStage, RefinementSchedule,
 };
 
 // Re-export step types

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1033,6 +1033,16 @@ fn convert_to_platform_event(
                 payload["task"] = serde_json::json!(v);
             }
         }
+        // Quantization label (q4_0 / q4_k_m / fp16 / …) sourced from
+        // `model_metadata.json` first, GGUF filename second. Two runs
+        // of "the same model" at different quantizations are now
+        // distinguishable in the analytics rollup. Open string —
+        // values outside the documented set still flow through.
+        if payload.get("quantization").is_none() {
+            if let Some(v) = extract_string_attr_from_any_span(&spans, "quantization") {
+                payload["quantization"] = serde_json::json!(v);
+            }
+        }
         Some(spans)
     } else {
         None
@@ -2773,6 +2783,44 @@ mod tests {
             Some("asr"),
             "task must be hoisted to payload top level: {}",
             payload_json
+        );
+    }
+
+    #[test]
+    fn quantization_field_hoists_to_payload_top_level() {
+        // INF-91: `quantization` is sourced by `TemplateExecutor` from
+        // `metadata.quantization` (or GGUF filename inference) and
+        // written onto the outer `execute:<model>` span. The hoist
+        // must surface it on the wire payload alongside `task` and
+        // `backend` so analytics rolls up
+        // `model_id × quantization` as distinct rows.
+        xybrid_core::tracing::init_tracing(true);
+        let data = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:qwen2.5-0.5b-instruct",
+                    "metadata": { "quantization": "q4_k_m", "backend": "llamacpp" }
+                }
+            ]
+        });
+        let event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("chat".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: Some(1_200),
+            error: None,
+            data: Some(data.to_string()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+        let parsed: serde_json::Value =
+            serde_json::from_value(serde_json::to_value(&platform.payload).unwrap()).unwrap();
+        assert_eq!(
+            parsed["quantization"].as_str(),
+            Some("q4_k_m"),
+            "quantization must be hoisted: {}",
+            serde_json::to_string(&parsed).unwrap()
         );
     }
 

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -222,6 +222,7 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 | `backend` | string | inference | `llamacpp` \| `mlx` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint (GGUF requires the hint; SafeTensors defaults to `candle` and accepts `mlx` to override on Apple Silicon); `cloud` for the cloud adapter |
 | `provider` | string | inference (cloud only) | `openai` \| `anthropic` \| `google` \| `elevenlabs` \| `openrouter` \| `custom` | Cloud `IntegrationProvider` resolved from envelope metadata |
 | `task` | string | inference | `chat` \| `vlm` \| `asr` \| `tts` \| `embedding` \| `image-gen` \| `ocr` \| `rerank` \| `classify` (open string for forward-compat) | `ModelMetadata.metadata["task"]` from `model_metadata.json` |
+| `quantization` | string | inference | `q4_0` \| `q4_k_m` \| `q5_k_m` \| `q8_0` \| `fp16` \| `fp32` (open string — common GGUF labels) | `ModelMetadata.metadata["quantization"]` first; falls back to GGUF filename inference; absent (not empty) when unknown |
 | `tokens_in` | u64 | inference | — | LLM span (`prompt_tokens` for OpenAI; synthesized total for Anthropic) |
 | `tokens_out` | u64 | inference | — | LLM span (`completion_tokens`) |
 | `cache_read_input_tokens` | u64 | inference | — | Anthropic-canonical; OpenAI's nested `prompt_tokens_details.cached_tokens` maps here |


### PR DESCRIPTION
## Summary
- Emits `quantization` (`q4_0` / `q4_k_m` / `q5_k_m` / `q8_0` / `fp16` / `fp32`, open string) on inference events so the dashboard stops collapsing two runs of "the same model" at different quantizations into one row.
- Source priority per the issue spec: explicit `metadata.quantization` from `model_metadata.json` wins, GGUF filename inference fallback, omitted when unknown — never empty string. New `quantization_label_from_metadata` helper in `xybrid-core::execution::template::metadata` plus `f16`/`f32` → `fp16`/`fp32` normalisation so analytics doesn't split labels.
- Annotated on the outer `execute:<model>` span and hoisted via the existing `extract_string_attr_from_any_span`. Three unit tests in `metadata.rs` cover the three priority branches; one integration test in `telemetry.rs` covers the convert-path hoist. `docs/sdk/telemetry.md` updated.

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` ✅
- [ ] `cargo test -p xybrid-core --lib -- quantization` ✅ 3/3
- [ ] `cargo test -p xybrid-sdk --lib --features platform-macos -- quantization` ✅ 2/2
- [ ] After merge: console rolls up `model_id × quantization` in a follow-up issue (INF-95)

🤖 Generated with [Claude Code](https://claude.com/claude-code)