### PR TITLE
docs: address review feedback on AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,15 @@ The compiler and lints are your automatic reviewer. Before declaring a task
 done, run these three commands locally — and assume CI will run them again:
 
 ```bash
-cargo fmt --all -- --check        # formatting (CI: .github/workflows/ci.yml job `fmt`)
+cargo fmt --all -- --check                              # CI: job `fmt`
 cargo clippy --workspace --all-targets -- -D warnings   # CI: job `clippy`
-cargo test  --workspace           # CI: job `test` (per-OS matrix)
+cargo test  --workspace --features ort-download         # CI: job `test` (per-OS matrix)
 ```
+
+CI's `test` job runs with `--features ort-download` — match it locally so you
+don't get surprised by feature-gated failures. `just test` (plain
+`cargo test --workspace`) still runs most tests, but may skip or compile
+differently against ORT-backed paths.
 
 Equivalent `just` recipes are defined in `/justfile`:
 
@@ -56,9 +61,6 @@ the lint locally if it's a real issue.
 
 Never bypass hooks (`--no-verify`) or skip CI gates to land code. If a check
 fails, fix the cause.
-
----
-
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,33 +35,54 @@ xtask ────────────────────────�
 integration-tests ──────────────► xybrid-core
 ```
 
-Workspace dependencies are inherited via `[workspace.dependencies]` in the
-root `Cargo.toml`. **Add new shared deps there**, then `dep.workspace = true`
-in the member `Cargo.toml` (rust-skills `proj-workspace-deps`).
+Workspace **package metadata** is inherited via `[workspace.package]` —
+member crates use `version.workspace = true`, `edition.workspace = true`,
+etc. Keep that pattern.
+
+Workspace **dependencies** are *not* uniformly inherited today. The root
+`[workspace.dependencies]` block exists, but most member crates still pin
+versions per-crate (e.g. `serde = "1.0"`, `tokio = { version = "1.0", … }`).
+When adding a dep, match the surrounding crate's existing style — don't
+unilaterally migrate one crate to `dep.workspace = true` while the rest stay
+version-pinned. Full `proj-workspace-deps` migration is a deliberate
+refactor, not a drive-by change.
 
 ---
 
 ## Error handling
 
-Library crates (`xybrid-core`, `xybrid-sdk`, FFI crates) use **`thiserror`**
-with a single canonical error enum and a `Result` alias per crate:
+Rust-API library crates (`xybrid-core`, `xybrid-sdk`, `xybrid-uniffi`) use
+**`thiserror`** with a single canonical error enum and a `Result` alias per
+crate:
 
-| Crate         | Error type     | Result alias    | Defined in                        |
-|---------------|----------------|-----------------|-----------------------------------|
-| `xybrid-core` | `XybridError`  | `XybridResult`  | `crates/xybrid-core/src/error.rs` |
-| `xybrid-sdk`  | `SdkError`     | `SdkResult`     | `crates/xybrid-sdk/src/model.rs`  |
+| Crate           | Error type     | Result alias    | Defined in                        |
+|-----------------|----------------|-----------------|-----------------------------------|
+| `xybrid-core`   | `XybridError`  | `XybridResult`  | `crates/xybrid-core/src/error.rs` |
+| `xybrid-sdk`    | `SdkError`     | `SdkResult`     | `crates/xybrid-sdk/src/model.rs`  |
+| `xybrid-uniffi` | `XybridError`  | —               | `crates/xybrid-uniffi/src/lib.rs` (also derives `uniffi::Error`) |
 
 Sub-error enums (`InferenceError`, `PipelineError`, `AdapterError`, …) live
 next to the modules that raise them and convert into the canonical type via
 `#[from]` / `impl From`. Follow that pattern for new modules — don't invent
 parallel top-level error types.
 
+`xybrid-ffi` is **different**: it's a C-ABI crate and uses opaque handles
+plus error strings/codes carried in result structs (see
+`crates/xybrid-ffi/src/lib.rs`). Don't bolt a public `thiserror` enum onto
+it — match the existing C-ABI pattern when adding new endpoints, and only
+surface error info through the documented handle/result conventions.
+
 Binaries (`xybrid-cli`, `xtask`) use **`anyhow`** with `.context(...)` at the
 boundaries where errors get printed.
 
 `SdkError` implements a `RetryableError` trait (`is_retryable`, `retry_after`)
-— preserve those semantics when adding variants. Rate-limit / circuit-breaker
-/ timeout / network errors are retryable; config and not-found errors are not.
+— preserve those semantics when adding variants. As of today
+(`crates/xybrid-sdk/src/model.rs`) the retryable variants are
+`NetworkError`, `RateLimited`, `Timeout`, and `Offline`; everything else
+(including `CircuitOpen`, `ConfigError`, `ModelNotFound`, `LoadError`,
+`InferenceError`, `IoError`, `CacheError`, `PipelineError`, …) is
+explicitly **non-retryable**. Read the current `is_retryable` match arm
+before changing or extending it — don't infer the rule from the variant name.
 
 Don't use `Box<dyn Error>` in public signatures. Don't `.unwrap()` outside
 tests, examples, and clearly-marked invariant checks (use `.expect("...")`


### PR DESCRIPTION
## Summary

Follow-up to PR #69 addressing reviewer feedback on the agent-guidance docs. AGENTS.md now suggests the same `cargo test --workspace --features ort-download` invocation that CI runs (so local test runs match CI) and drops a duplicate horizontal rule before Section 1. CLAUDE.md is corrected in three places: the workspace-deps paragraph now reflects that only `[workspace.package]` metadata is uniformly inherited today (deps are still version-pinned per-crate); the thiserror-canonical pattern is narrowed to `xybrid-core` / `xybrid-sdk` / `xybrid-uniffi` with `xybrid-ffi`'s C-ABI handle/error-string convention documented separately; and the retryability guidance is rewritten to match the actual `SdkError::is_retryable` arms (`NetworkError` / `RateLimited` / `Timeout` / `Offline` retry; `CircuitOpen` and everything else are explicitly non-retryable).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — docs-only change, no code touched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)