### PR TITLE
feat(device): UniFFI push-state surface (battery + thermal)

### DIFF
--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -133,8 +133,9 @@ pub use xybrid_core::cache_provider::CacheProvider;
 pub use xybrid_core::context;
 pub use xybrid_core::conversation::ConversationContext;
 pub use xybrid_core::device::{
-    DeviceProfile, MemoryPressure, ResourceMonitor, ResourceSnapshot, ResourceTelemetryMode,
-    ResourceUsageSummary, RunGuard as ResourceRunGuard,
+    clear_battery_level, clear_thermal_state, set_battery_level, set_thermal_state, DeviceProfile,
+    MemoryPressure, ResourceMonitor, ResourceSnapshot, ResourceTelemetryMode, ResourceUsageSummary,
+    RunGuard as ResourceRunGuard, ThermalState,
 };
 pub use xybrid_core::execution;
 pub use xybrid_core::features;

--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -84,6 +84,7 @@ fn resolve_binding(binding: &str) -> &'static str {
 /// with the same Celsius bands as the desktop pollers so host code can
 /// quantize the OS signal consistently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+#[non_exhaustive]
 pub enum XybridThermalState {
     /// Normal operating temperature (< 60 °C). No throttling expected.
     Normal,
@@ -91,7 +92,7 @@ pub enum XybridThermalState {
     Warm,
     /// Hot — performance reduced (70–80 °C).
     Hot,
-    /// Critical — heavy operations should pause (>= 80 °C).
+    /// Critical — heavy operations should pause (> 80 °C).
     Critical,
 }
 

--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -58,6 +58,98 @@ fn resolve_binding(binding: &str) -> &'static str {
     }
 }
 
+// -- Platform-state push API --
+//
+// Mobile telemetry APIs (`UIDevice.batteryLevel` on iOS,
+// `BatteryManager.ACTION_BATTERY_CHANGED` on Android,
+// `PowerManager.OnThermalStatusChangedListener` on Android) are
+// notification-based and live in the host runtime — there is no clean
+// in-Rust path on those platforms. The host SDK wrappers
+// (`Xybrid.init(context)` on Kotlin, `Xybrid.initialize()` on Swift)
+// register the OS observers and forward each value through these FFI
+// calls. The Rust side just stores into the same `RwLock<PlatformState>`
+// the desktop pollers feed, so routing decisions are uniform across
+// platforms.
+//
+// One-way push (host → Rust) is intentional: a callback-interface design
+// would marshal a `Context` / `NotificationCenter` handle across the
+// boundary and re-enter Rust on every change, which is much more surface
+// for marginal benefit.
+
+/// Thermal pressure state forwarded by the host.
+///
+/// Maps directly to [`xybrid_sdk::ThermalState`] — mirrored here as a
+/// UniFFI-exposed enum so Swift gets `enum XybridThermalState` and
+/// Kotlin gets `enum class XybridThermalState`. Variants are documented
+/// with the same Celsius bands as the desktop pollers so host code can
+/// quantize the OS signal consistently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum XybridThermalState {
+    /// Normal operating temperature (< 60 °C). No throttling expected.
+    Normal,
+    /// Warm — first throttling tier (60–70 °C).
+    Warm,
+    /// Hot — performance reduced (70–80 °C).
+    Hot,
+    /// Critical — heavy operations should pause (>= 80 °C).
+    Critical,
+}
+
+impl From<XybridThermalState> for xybrid_sdk::ThermalState {
+    fn from(value: XybridThermalState) -> Self {
+        match value {
+            XybridThermalState::Normal => xybrid_sdk::ThermalState::Normal,
+            XybridThermalState::Warm => xybrid_sdk::ThermalState::Warm,
+            XybridThermalState::Hot => xybrid_sdk::ThermalState::Hot,
+            XybridThermalState::Critical => xybrid_sdk::ThermalState::Critical,
+        }
+    }
+}
+
+impl From<xybrid_sdk::ThermalState> for XybridThermalState {
+    fn from(value: xybrid_sdk::ThermalState) -> Self {
+        match value {
+            xybrid_sdk::ThermalState::Normal => XybridThermalState::Normal,
+            xybrid_sdk::ThermalState::Warm => XybridThermalState::Warm,
+            xybrid_sdk::ThermalState::Hot => XybridThermalState::Hot,
+            xybrid_sdk::ThermalState::Critical => XybridThermalState::Critical,
+        }
+    }
+}
+
+/// Forward a battery charge percentage (0..=100) from the host.
+///
+/// Values above 100 are clamped by the underlying setter — pass through
+/// whatever the OS observer reports without rounding host-side, so the
+/// SDK has the freshest possible signal.
+#[uniffi::export]
+fn set_battery_level(percent: u8) {
+    xybrid_sdk::set_battery_level(percent);
+}
+
+/// Mark the battery level as unknown.
+///
+/// Hosts call this on observer teardown or when the OS reports an
+/// unknown / unavailable charge (e.g. desktop docks without battery
+/// sensors). The routing engine treats `None` as "no signal" rather
+/// than substituting an optimistic default.
+#[uniffi::export]
+fn clear_battery_level() {
+    xybrid_sdk::clear_battery_level();
+}
+
+/// Forward a thermal pressure reading from the host.
+#[uniffi::export]
+fn set_thermal_state(state: XybridThermalState) {
+    xybrid_sdk::set_thermal_state(state.into());
+}
+
+/// Mark the thermal state as unknown.
+#[uniffi::export]
+fn clear_thermal_state() {
+    xybrid_sdk::clear_thermal_state();
+}
+
 /// Error type exposed via UniFFI to Swift/Kotlin consumers.
 ///
 /// This enum represents all possible errors that can occur during
@@ -578,5 +670,44 @@ mod tests {
         // exercised directly by `resolve_binding_unknown_returns_default`.
         set_binding("evil_unknown".to_string());
         assert_eq!(xybrid_sdk::get_binding(), "kotlin");
+    }
+
+    // Pure conversion tests for XybridThermalState. The push setters
+    // themselves write into a process-global RwLock that other tests
+    // (and other crates' integration tests) also touch — covering the
+    // mapping at the conversion layer keeps these tests deterministic
+    // regardless of test ordering.
+    #[test]
+    fn thermal_state_round_trips_through_sdk_type() {
+        for variant in [
+            XybridThermalState::Normal,
+            XybridThermalState::Warm,
+            XybridThermalState::Hot,
+            XybridThermalState::Critical,
+        ] {
+            let sdk: xybrid_sdk::ThermalState = variant.into();
+            let back: XybridThermalState = sdk.into();
+            assert_eq!(variant, back);
+        }
+    }
+
+    #[test]
+    fn thermal_state_maps_to_documented_sdk_variants() {
+        assert_eq!(
+            xybrid_sdk::ThermalState::from(XybridThermalState::Normal),
+            xybrid_sdk::ThermalState::Normal
+        );
+        assert_eq!(
+            xybrid_sdk::ThermalState::from(XybridThermalState::Warm),
+            xybrid_sdk::ThermalState::Warm
+        );
+        assert_eq!(
+            xybrid_sdk::ThermalState::from(XybridThermalState::Hot),
+            xybrid_sdk::ThermalState::Hot
+        );
+        assert_eq!(
+            xybrid_sdk::ThermalState::from(XybridThermalState::Critical),
+            xybrid_sdk::ThermalState::Critical
+        );
     }
 }


### PR DESCRIPTION
## Summary

Exposes the platform-state push API to Swift and Kotlin consumers via UniFFI. Hosts subscribe to `UIDevice.batteryLevelDidChangeNotification` / `BatteryManager.ACTION_BATTERY_CHANGED` / `PowerManager.OnThermalStatusChangedListener` and forward each value with one FFI call — same shape as the desktop pollers feed in-process. The Rust side just stores into the same `RwLock<PlatformState>` the desktop pollers write, so routing decisions are uniform across platforms.

## Cross-platform status table

| Platform | Battery | Thermal |
|----------|---------|---------|
| Linux    | sysfs (#72) | sysfs (#72) |
| macOS    | IOKit `IOPSCopyPowerSourcesInfo` (#76) | NSProcessInfo (#74) |
| Windows  | `GetSystemPowerStatus` (#75) | WMI `MSAcpi_ThermalZoneTemperature` (#77) |
| iOS      | host push (this PR) | host push (this PR) |
| Android  | host push (this PR) | host push (this PR) |
| Flutter  | host push (FRB re-export — follow-up) | host push (FRB re-export — follow-up) |

## Why push-state, not callback interfaces

Mobile telemetry APIs are notification-based and bound to platform-runtime objects (`Context` on Android, `NotificationCenter` on iOS) that only the host has. We could marshal those across the FFI, but that means callback interfaces / `DartFn`s reaching back into Rust on every change — much more surface for marginal benefit. Hosts already get these notifications routinely; one-way push (host → Rust) is the simplest possible shape.

## Surface added

```rust
#[derive(uniffi::Enum)]
pub enum XybridThermalState { Normal, Warm, Hot, Critical }

#[uniffi::export] fn set_battery_level(percent: u8);
#[uniffi::export] fn clear_battery_level();
#[uniffi::export] fn set_thermal_state(state: XybridThermalState);
#[uniffi::export] fn clear_thermal_state();
```

`xybrid-sdk` gains re-exports of the underlying `xybrid_core::device` setters so `xybrid-uniffi` stays one layer up the dependency chain (FFI crates depend on `xybrid-sdk`, never directly on `xybrid-core`).

## Out of scope

- **Host wrapper wiring** (`bindings/kotlin/Xybrid.kt`, `bindings/apple/Sources/Xybrid/Xybrid.swift`): registering `BroadcastReceiver` / `NotificationCenter` observers in `Xybrid.init(...)` so consumer apps don't have to write the boilerplate themselves. Belongs in a follow-up per host — keeps this PR single-concern Rust FFI.
- **flutter_rust_bridge re-export**: same shape but FRB-flavored, lives in `bindings/flutter/rust`. Next PR in the sequence.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features ort-download -- -D warnings`
- [x] `cargo test -p xybrid-sdk -p xybrid-uniffi --features ort-download`
- [x] New `thermal_state_round_trips_through_sdk_type` and `thermal_state_maps_to_documented_sdk_variants` tests covering the enum mapping at the conversion layer (avoids touching the process-global `RwLock` other tests share)
- [ ] CI on the per-OS matrix