### PR TITLE
docs(cli): correct xybrid run examples in installers and READMEs

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -134,7 +134,7 @@ irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 **モデルを実行:**
 
 ```sh
-xybrid run kokoro-82m --input "Hello world" -o output.wav
+xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 ```
 
 </details>
@@ -260,7 +260,7 @@ stages:
 
 **CLI:**
 ```sh
-xybrid run voice-assistant.yaml --input question.wav -o response.wav
+xybrid run --config voice-assistant.yaml --input-audio question.wav -o response.wav
 ```
 
 **Flutter:**

--- a/agents/skills/xybrid-init/SKILL.md
+++ b/agents/skills/xybrid-init/SKILL.md
@@ -315,8 +315,8 @@ After saving, print:
 ```
 Your model is ready. Next steps:
 
-# Test it works
-xybrid run {model_id} --input "test input"
+# Test it works (use --input-audio <file>.wav for ASR models)
+xybrid run --model {model_id} --input-text "test input"
 
 # Or from Rust
 cargo run --example your_test -p xybrid-core

--- a/install.ps1
+++ b/install.ps1
@@ -65,5 +65,5 @@ Write-Host ""
 Write-Host "  Get started:"
 Write-Host "    xybrid --help"
 Write-Host "    xybrid models list"
-Write-Host '    xybrid run kokoro-82m --input "Hello world" -o output.wav'
+Write-Host '    xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav'
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -151,7 +151,7 @@ verify_install() {
     printf "  Get started:\n"
     printf "    xybrid --help\n"
     printf "    xybrid models list\n"
-    printf "    xybrid run kokoro-82m --input \"Hello world\" -o output.wav\n"
+    printf "    xybrid run --model kokoro-82m --input-text \"Hello world\" -o output.wav\n"
     printf "\n"
   fi
 }


### PR DESCRIPTION
The post-install hint and a few docs suggested `xybrid run kokoro-82m --input "..."`, but `run` requires `--model <id>` and `--input-text` (or `--input-audio`); positional model and bare `--input` are rejected.

- install.sh / install.ps1: fix Get started hint
- README.ja-JP.md: fix model and pipeline run examples
- agents/skills/xybrid-init: fix Next steps template

## Summary

<!-- What does this PR do and why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [ ] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or breaking changes documented)
