### PR TITLE
ci: scope test-candle to xybrid-core and path-filter the macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,21 +171,6 @@ jobs:
       - name: Build CLI
         run: cargo build --release -p xybrid-cli --target x86_64-unknown-linux-gnu --features platform-desktop
 
-  # Candle feature (optional, macOS only for Metal)
-  test-candle:
-    name: Test Candle
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: candle
-      - name: Test with Candle
-        run: cargo test --workspace --features "ort-download,candle"
-
   # API contract validation (soft warning — does not block CI)
   api-contract:
     name: API Contract Check

--- a/.github/workflows/test-candle.yml
+++ b/.github/workflows/test-candle.yml
@@ -1,0 +1,48 @@
+name: Test Candle
+
+# Candle is the pure-Rust ML framework gated behind a feature flag in
+# xybrid-core. macOS is the only place its Metal backend can run, so this
+# workflow lives outside ci.yml and is scoped to paths that can actually
+# affect Candle compilation or runtime behavior.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'crates/xybrid-core/src/runtime_adapter/candle/**'
+      - 'crates/xybrid-core/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/test-candle.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'crates/xybrid-core/src/runtime_adapter/candle/**'
+      - 'crates/xybrid-core/Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/test-candle.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test-candle:
+    name: Test Candle
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: candle
+      - name: Test Candle (xybrid-core only)
+        run: cargo test -p xybrid-core --features "ort-download,candle" --lib --tests


### PR DESCRIPTION
## Summary

Follow-up to #73. The remaining macOS spend on per-push CI was the `test-candle` job, which ran `cargo test --workspace --features "ort-download,candle"` on `macos-14` for every PR — duplicating Linux's `test` job coverage on a 10x-cost runner just to exercise the Candle/Metal backend in `xybrid-core`.

This moves `test-candle` out of `ci.yml` into its own workflow with `paths:` filters scoped to `crates/xybrid-core/src/runtime_adapter/candle/**`, that crate's `Cargo.toml`, `Cargo.lock`, and the workflow file itself, so most PRs no longer spin up a macOS runner at all. It also narrows the command to `cargo test -p xybrid-core --features "ort-download,candle" --lib --tests`, dropping the rest-of-workspace duplication. Job remains non-blocking (it wasn't in `ci-success`'s `needs` before either).

## Type of Change

- [x] Other (CI cost reduction)

## Checklist

- [x] No code changes; CI-only
- [x] No breaking changes