### PR TITLE
feat(onnx): capture resolved execution provider via session profiling (INF-98)

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/onnx/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/mod.rs
@@ -11,6 +11,7 @@
 mod adapter;
 mod backend;
 mod execution_provider;
+mod profiling;
 mod runtime;
 mod session; // New runtime wrapper
 
@@ -25,6 +26,7 @@ pub use execution_provider::{
 };
 #[cfg(feature = "ort-coreml")]
 pub use execution_provider::{CoreMLComputeUnits, CoreMLConfig};
+pub use profiling::ResolvedExecutionProviders;
 pub use runtime::OnnxRuntime;
 pub use session::ONNXSession;
 

--- a/crates/xybrid-core/src/runtime_adapter/onnx/profiling.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/profiling.rs
@@ -1,0 +1,198 @@
+//! Resolved-execution-provider capture via ORT session profiling.
+//!
+//! ONNX Runtime's C API has no session-level "what providers did this session
+//! resolve to" getter. EPs are appended in fallback order and per-op
+//! resolution is opaque to the API. The only authoritative source is the
+//! per-session profiling JSON, which records `provider_type` on every Node
+//! event.
+//!
+//! This module exposes:
+//! - [`ResolvedExecutionProviders`] — the parsed summary surfaced to callers.
+//! - [`parse_profile_json`] — Chrome-trace-format profile parser used after
+//!   `Session::end_profiling()` finalizes the file.
+//!
+//! The lifecycle (enable profiling → run first inference → end profiling →
+//! parse → cache) lives on [`super::ONNXSession`]; this module is the pure
+//! parsing + summary side.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// Per-EP op-count breakdown for one ONNX session, computed from the
+/// session's profile JSON after the first inference.
+///
+/// `primary` is the EP that ran the most ops in the trace — the one most
+/// representative of "which engine actually executed this model". A model
+/// that requested CoreML but got 90 % CPU fallback will surface as
+/// `primary = "cpu"` with a breakdown showing both.
+///
+/// EP names are normalised (lower-cased and stripped of the
+/// `"ExecutionProvider"` suffix ORT bakes into its profile output), so
+/// callers see e.g. `"coreml"` and `"cpu"` rather than
+/// `"CoreMLExecutionProvider"`. This matches the wire format INF-90 will
+/// emit on telemetry events.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedExecutionProviders {
+    /// EP that ran the most ops. Suffix-stripped, lower-cased.
+    pub primary: String,
+    /// `(ep_name, op_count)` pairs sorted by count descending. Only EPs
+    /// with at least one Node event appear; empty list is impossible
+    /// because [`parse_profile_json`] errors out when no Node events
+    /// are found.
+    pub breakdown: Vec<(String, usize)>,
+}
+
+/// Errors the profile parser can produce. Bubbled up to the caller so the
+/// session can fall back to "no resolved info" rather than poisoning state
+/// when ORT writes something unexpected.
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileParseError {
+    #[error("failed to read profile file {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse profile JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("profile contained no Node events; session may not have run any inference")]
+    NoNodeEvents,
+}
+
+/// Read an ORT-emitted profile JSON file and aggregate the per-Node
+/// `provider_type` values into a [`ResolvedExecutionProviders`] summary.
+///
+/// ORT writes Chrome-trace-format JSON: an array of event objects, each
+/// with a `cat` and an `args` map. Node-execution events have
+/// `cat == "Node"` and carry `args.provider_type`; fence / kernel-internal
+/// events use other categories and are ignored. Events whose
+/// `provider_type` is missing are also skipped — they don't represent
+/// actual op execution.
+pub fn parse_profile_json(path: &Path) -> Result<ResolvedExecutionProviders, ProfileParseError> {
+    let raw = fs::read_to_string(path).map_err(|source| ProfileParseError::Io {
+        path: path.display().to_string(),
+        source,
+    })?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&raw)?;
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for event in events {
+        if event.get("cat").and_then(|c| c.as_str()) != Some("Node") {
+            continue;
+        }
+        let Some(provider) = event
+            .get("args")
+            .and_then(|a| a.get("provider_type"))
+            .and_then(|p| p.as_str())
+        else {
+            continue;
+        };
+        *counts.entry(normalise_provider(provider)).or_insert(0) += 1;
+    }
+
+    if counts.is_empty() {
+        return Err(ProfileParseError::NoNodeEvents);
+    }
+
+    let mut breakdown: Vec<(String, usize)> = counts.into_iter().collect();
+    // Stable secondary sort on EP name so the breakdown is deterministic when
+    // two EPs tie on op count — useful for snapshot tests.
+    breakdown.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let primary = breakdown[0].0.clone();
+    Ok(ResolvedExecutionProviders { primary, breakdown })
+}
+
+/// Strip ORT's `"ExecutionProvider"` suffix and lower-case the result so
+/// `"CoreMLExecutionProvider"` becomes `"coreml"`. Unknown shapes are
+/// returned lower-cased verbatim — the wire format is open-string.
+fn normalise_provider(raw: &str) -> String {
+    let trimmed = raw.strip_suffix("ExecutionProvider").unwrap_or(raw);
+    trimmed.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_profile(events: &[serde_json::Value]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        let body = serde_json::to_string(events).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_picks_majority_ep_as_primary() {
+        let events = vec![
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CPUExecutionProvider"}}),
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CPUExecutionProvider"}}),
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CoreMLExecutionProvider"}}),
+        ];
+        let f = write_profile(&events);
+
+        let summary = parse_profile_json(f.path()).unwrap();
+        assert_eq!(summary.primary, "cpu");
+        assert_eq!(
+            summary.breakdown,
+            vec![("cpu".to_string(), 2), ("coreml".to_string(), 1)]
+        );
+    }
+
+    #[test]
+    fn parse_ignores_non_node_events() {
+        let events = vec![
+            serde_json::json!({"cat": "Session", "args": {"provider_type": "CPUExecutionProvider"}}),
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CoreMLExecutionProvider"}}),
+        ];
+        let f = write_profile(&events);
+
+        let summary = parse_profile_json(f.path()).unwrap();
+        assert_eq!(summary.primary, "coreml");
+        assert_eq!(summary.breakdown.len(), 1);
+    }
+
+    #[test]
+    fn parse_skips_events_without_provider_type() {
+        let events = vec![
+            serde_json::json!({"cat": "Node", "args": {}}),
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CoreMLExecutionProvider"}}),
+        ];
+        let f = write_profile(&events);
+
+        let summary = parse_profile_json(f.path()).unwrap();
+        assert_eq!(summary.breakdown, vec![("coreml".to_string(), 1)]);
+    }
+
+    #[test]
+    fn parse_errors_when_no_node_events() {
+        let events = vec![serde_json::json!({"cat": "Session"})];
+        let f = write_profile(&events);
+
+        let err = parse_profile_json(f.path()).unwrap_err();
+        assert!(matches!(err, ProfileParseError::NoNodeEvents));
+    }
+
+    #[test]
+    fn parse_ties_break_alphabetically_for_determinism() {
+        let events = vec![
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CoreMLExecutionProvider"}}),
+            serde_json::json!({"cat": "Node", "args": {"provider_type": "CPUExecutionProvider"}}),
+        ];
+        let f = write_profile(&events);
+
+        let summary = parse_profile_json(f.path()).unwrap();
+        // Both have count = 1; "coreml" sorts before "cpu" alphabetically.
+        assert_eq!(summary.primary, "coreml");
+    }
+
+    #[test]
+    fn normalise_strips_suffix() {
+        assert_eq!(normalise_provider("CoreMLExecutionProvider"), "coreml");
+        assert_eq!(normalise_provider("CPUExecutionProvider"), "cpu");
+        assert_eq!(normalise_provider("CUDAExecutionProvider"), "cuda");
+        assert_eq!(normalise_provider("UnknownThing"), "unknownthing");
+    }
+}

--- a/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
@@ -26,17 +26,45 @@
 //! ```
 
 use super::execution_provider::ExecutionProviderKind;
+use super::profiling::{parse_profile_json, ResolvedExecutionProviders};
 use crate::runtime_adapter::{AdapterError, AdapterResult};
 use ndarray::{ArrayD, IxDyn};
 use ort::session::{builder::GraphOptimizationLevel, Session};
 use ort::tensor::TensorElementType;
 use ort::value::Value;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use tempfile::TempDir;
 
 /// Metadata extracted from ONNX model inputs: (names, shapes, element types).
 type InputMetadata = (Vec<String>, Vec<Vec<i64>>, Vec<Option<TensorElementType>>);
+
+/// Lifecycle state for the resolved-EP capture (INF-98).
+///
+/// `Disabled` is the legacy default and what every caller of
+/// [`ONNXSession::with_provider`] sees. `Pending` means profiling was
+/// enabled at construction and we're waiting for the first inference to
+/// produce a profile we can harvest. `Harvested` carries the parsed
+/// summary. `Failed` records the error string so callers can decide
+/// whether to retry or fall back to the requested EP — we don't poison
+/// the whole session over a profile-parse failure.
+///
+/// The `TempDir` keeps the profile file alive until harvest succeeds and
+/// drops it (with the file inside) automatically afterwards. ORT's
+/// profiling output goes into this directory; deleting it post-harvest
+/// is what satisfies the "no leaked tmp files" acceptance criterion.
+enum ResolvedEpState {
+    Disabled,
+    Pending {
+        /// Holds the profile-output directory open until we harvest. ORT
+        /// writes `<prefix>_<timestamp>.json` inside this dir; the dir
+        /// is dropped on transition to `Harvested`/`Failed`.
+        _tempdir: TempDir,
+    },
+    Harvested(ResolvedExecutionProviders),
+    Failed(String),
+}
 
 /// ONNX Runtime session wrapper.
 ///
@@ -60,6 +88,12 @@ pub struct ONNXSession {
     input_dtypes: Vec<Option<TensorElementType>>,
     /// The execution provider used for this session
     execution_provider: ExecutionProviderKind,
+    /// Resolved-EP capture state (INF-98). `Disabled` for sessions built
+    /// via [`ONNXSession::with_provider`]; `Pending → Harvested/Failed`
+    /// for sessions built via [`ONNXSession::with_resolved_ep_capture`].
+    /// Wrapped in [`Mutex`] so the auto-harvest path inside
+    /// [`run_with_values`] (which only has `&self`) can mutate it.
+    resolved_state: Mutex<ResolvedEpState>,
 }
 
 impl ONNXSession {
@@ -167,6 +201,95 @@ impl ONNXSession {
             output_shapes,
             input_dtypes,
             execution_provider,
+            resolved_state: Mutex::new(ResolvedEpState::Disabled),
+        })
+    }
+
+    /// Creates an ONNX session with profiling enabled so the *resolved*
+    /// execution provider (the one that actually ran each op) can be
+    /// captured after the first inference. INF-98.
+    ///
+    /// Same arguments + behaviour as [`ONNXSession::with_provider`], plus:
+    /// - profiling is turned on at session-build time, writing to a
+    ///   tempfile that's cleaned up on drop;
+    /// - the first call to [`ONNXSession::run_with_values`] (or
+    ///   [`ONNXSession::run`]) triggers a one-shot harvest that ends
+    ///   profiling, parses the JSON, and stores a
+    ///   [`ResolvedExecutionProviders`] summary readable via
+    ///   [`ONNXSession::resolved_providers`].
+    /// - subsequent calls run at normal cost (profiling is finalised
+    ///   after the first run, so there's no per-call overhead).
+    ///
+    /// ORT's profiling adds roughly 10-15 % wall-clock overhead, but
+    /// that hits exactly one inference — typically the warm-up call
+    /// telemetry already discards. Use this constructor only for
+    /// sessions where INF-90 needs the resolved EP for telemetry; the
+    /// default path stays on [`ONNXSession::with_provider`] with no
+    /// regression.
+    pub fn with_resolved_ep_capture(
+        model_path: &str,
+        execution_provider: ExecutionProviderKind,
+    ) -> AdapterResult<Self> {
+        let path = Path::new(model_path);
+        if !path.exists() {
+            return Err(AdapterError::ModelNotFound(format!(
+                "Model file not found: {}",
+                model_path
+            )));
+        }
+
+        let _ = ort::init().commit();
+
+        let tempdir = tempfile::tempdir().map_err(|e| {
+            AdapterError::RuntimeError(format!(
+                "Failed to create profile tempdir for resolved-EP capture: {}",
+                e
+            ))
+        })?;
+        // ORT appends `_<timestamp>.json` to whatever prefix we pass; this
+        // gives us a stable subpath inside the tempdir we own.
+        let profile_prefix: PathBuf = tempdir.path().join("xybrid-profile");
+
+        let mut builder = Session::builder()
+            .map_err(|e| {
+                AdapterError::RuntimeError(format!("Failed to create session builder: {}", e))
+            })?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| {
+                AdapterError::RuntimeError(format!("Failed to set optimization level: {}", e))
+            })?
+            .with_profiling(&profile_prefix)
+            .map_err(|e| {
+                AdapterError::RuntimeError(format!(
+                    "Failed to enable profiling for resolved-EP capture: {}",
+                    e
+                ))
+            })?;
+
+        builder = Self::configure_execution_provider(builder, &execution_provider)?;
+
+        let session = builder
+            .commit_from_file(model_path)
+            .map_err(|e| AdapterError::RuntimeError(format!("Failed to load ONNX model: {}", e)))?;
+
+        let (input_names, input_shapes, input_dtypes) = Self::extract_input_metadata(&session)?;
+        let (output_names, output_shapes) = Self::extract_output_metadata(&session)?;
+
+        log::info!(
+            "Created ONNX session with {} EP and resolved-EP profiling enabled for model: {}",
+            execution_provider,
+            model_path
+        );
+
+        Ok(Self {
+            session: Mutex::new(session),
+            input_names,
+            output_names,
+            input_shapes,
+            output_shapes,
+            input_dtypes,
+            execution_provider,
+            resolved_state: Mutex::new(ResolvedEpState::Pending { _tempdir: tempdir }),
         })
     }
 
@@ -401,6 +524,15 @@ impl ONNXSession {
             result.insert(output_name.clone(), array_d);
         }
 
+        // INF-98: after the first inference, end profiling and parse
+        // the JSON to surface the resolved EP. `outputs` has been fully
+        // converted into owned `result` entries above, so we no longer
+        // borrow from `session_guard` and can take a `&mut` reborrow
+        // for `end_profiling`. Drop `outputs` explicitly to make that
+        // borrow lifetime obvious to the reader.
+        drop(outputs);
+        self.maybe_harvest_resolved_ep(&mut session_guard);
+
         Ok(result)
     }
 
@@ -432,6 +564,71 @@ impl ONNXSession {
     /// Returns the execution provider used for this session.
     pub fn execution_provider(&self) -> &ExecutionProviderKind {
         &self.execution_provider
+    }
+
+    /// Returns the resolved-EP summary from the first inference's
+    /// profile output (INF-98), if and only if the session was built
+    /// with [`ONNXSession::with_resolved_ep_capture`] **and** at least
+    /// one inference has completed since.
+    ///
+    /// Returns `None` for sessions without capture enabled, sessions
+    /// where capture is still pending, or sessions where harvest
+    /// failed (the failure reason is logged but not surfaced — INF-90's
+    /// telemetry layer treats absence as "EP unknown").
+    pub fn resolved_providers(&self) -> Option<ResolvedExecutionProviders> {
+        let state = self.resolved_state.lock().ok()?;
+        match &*state {
+            ResolvedEpState::Harvested(summary) => Some(summary.clone()),
+            _ => None,
+        }
+    }
+
+    /// Idempotent hook called after every successful inference: when the
+    /// session is in [`ResolvedEpState::Pending`], end profiling, parse
+    /// the resulting JSON, and transition to `Harvested`/`Failed`.
+    /// No-op for any other state.
+    fn maybe_harvest_resolved_ep(&self, session_guard: &mut Session) {
+        let mut state = match self.resolved_state.lock() {
+            Ok(g) => g,
+            Err(e) => {
+                log::warn!("resolved-EP state mutex poisoned: {e}");
+                return;
+            }
+        };
+        if !matches!(*state, ResolvedEpState::Pending { .. }) {
+            return;
+        }
+
+        // `end_profiling()` finalises the JSON file and returns the
+        // actual on-disk path (ORT appends `_<timestamp>.json` to our
+        // prefix). On failure we record the error so subsequent calls
+        // don't retry.
+        let next = match session_guard.end_profiling() {
+            Ok(profile_path) => {
+                let path = std::path::Path::new(&profile_path);
+                match parse_profile_json(path) {
+                    Ok(summary) => {
+                        log::debug!(
+                            "Resolved EP for ONNX session: primary={}, breakdown={:?}",
+                            summary.primary,
+                            summary.breakdown
+                        );
+                        ResolvedEpState::Harvested(summary)
+                    }
+                    Err(parse_err) => {
+                        log::warn!("Failed to parse ONNX profile {profile_path}: {parse_err}");
+                        ResolvedEpState::Failed(parse_err.to_string())
+                    }
+                }
+            }
+            Err(end_err) => {
+                log::warn!("Failed to end ONNX profiling: {end_err}");
+                ResolvedEpState::Failed(end_err.to_string())
+            }
+        };
+        *state = next;
+        // Dropping the previous `Pending { _tempdir }` cleans up the
+        // profile file along with the directory.
     }
 }
 
@@ -608,5 +805,94 @@ mod tests {
             10,
             "MNIST output should have 10 elements"
         );
+    }
+
+    #[test]
+    fn resolved_providers_returns_none_when_capture_disabled() {
+        // Default `with_provider` path must leave the resolved-EP API
+        // dormant — INF-98's contract is that capture is opt-in and the
+        // legacy code path is unaffected. Uses a nonexistent model so we
+        // never have to load the runtime; constructor errors before the
+        // accessor is reachable, so we skip the assertion when ort fails
+        // to initialise (e.g. in environments without the binary).
+        let result =
+            ONNXSession::with_provider("/nonexistent/model.onnx", ExecutionProviderKind::Cpu);
+        assert!(matches!(result, Err(AdapterError::ModelNotFound(_))));
+    }
+
+    #[test]
+    fn resolved_providers_populates_after_first_inference() {
+        // INF-98 end-to-end: build with `with_resolved_ep_capture`, run
+        // one inference, expect `resolved_providers()` to surface a
+        // primary EP. Skips when the MNIST fixture isn't present so CI
+        // without the model still passes.
+        let possible_paths = [
+            PathBuf::from("test_models/mnist-12.onnx"),
+            PathBuf::from("../test_models/mnist-12.onnx"),
+            PathBuf::from("../../test_models/mnist-12.onnx"),
+        ];
+        let model_path = match possible_paths.iter().find(|p| p.exists()) {
+            Some(p) => p.clone(),
+            None => {
+                eprintln!("MNIST model not found; skipping resolved-EP capture test.");
+                return;
+            }
+        };
+
+        let session = ONNXSession::with_resolved_ep_capture(
+            model_path.to_str().unwrap(),
+            ExecutionProviderKind::Cpu,
+        )
+        .expect("Failed to load MNIST model with resolved-EP capture enabled");
+
+        // Pre-inference: capture is Pending — accessor returns None.
+        assert!(
+            session.resolved_providers().is_none(),
+            "resolved_providers() should be None before the first inference"
+        );
+
+        // Run one inference (same shape as `test_mnist_inference`).
+        let input_names = session.input_names();
+        let input_name = &input_names[0];
+        let mut inputs = HashMap::new();
+        let input_tensor =
+            ArrayD::<f32>::from_shape_vec(IxDyn(&[1, 1, 28, 28]), vec![0.0f32; 784]).unwrap();
+        inputs.insert(input_name.clone(), input_tensor);
+        session.run(inputs).expect("MNIST inference must succeed");
+
+        // Post-inference: harvest should have populated a summary. On a
+        // CPU-only build of ORT, every op runs on `cpu`; on a CoreML
+        // build asking for CPU, same result. We only assert the shape
+        // (non-empty primary, breakdown sums >= 1) so the test is
+        // robust across feature combinations and ORT versions.
+        let summary = session
+            .resolved_providers()
+            .expect("resolved_providers() must populate after the first inference");
+        assert!(
+            !summary.primary.is_empty(),
+            "primary EP should be a non-empty string; got {:?}",
+            summary
+        );
+        assert!(
+            !summary.breakdown.is_empty(),
+            "breakdown should list at least one EP; got {:?}",
+            summary
+        );
+        let total_ops: usize = summary.breakdown.iter().map(|(_, n)| *n).sum();
+        assert!(
+            total_ops >= 1,
+            "breakdown should account for at least one Node event; got {:?}",
+            summary
+        );
+        // The MNIST graph is small enough that on a CPU-only feature set
+        // the primary should be `cpu`. Don't hard-code on Apple builds
+        // where CoreML may legitimately handle some ops.
+        if cfg!(not(feature = "ort-coreml")) {
+            assert_eq!(
+                summary.primary, "cpu",
+                "non-CoreML build should resolve to CPU; got {:?}",
+                summary
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds opt-in capture of the *resolved* ONNX execution provider — the EP that actually ran each op — by enabling ORT session profiling, harvesting the trace after the first inference, and exposing a normalised `{primary, breakdown}` summary on `ONNXSession`. New `with_resolved_ep_capture` constructor opts into the lifecycle; the existing `with_provider` path is untouched, so there's no per-call overhead on the default code path. A new `profiling` module owns the Chrome-trace JSON parser and `ResolvedExecutionProviders` type, feeding INF-90 telemetry.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — unit tests for parser + end-to-end MNIST capture test (gated on fixture)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (module + item docs cover lifecycle, overhead, and harvest semantics)
- [x] No breaking changes (legacy `with_provider` constructor and call paths are unchanged)