### PR TITLE
feat(telemetry): emit resolved execution_provider on inference events

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -978,11 +978,15 @@ impl TemplateExecutor {
             cfg
         };
 
-        // Execute with streaming
-        let output = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            adapter
+        // Execute with streaming. Capture the backend name alongside
+        // the output so the metric mirror can label the resolved
+        // execution provider for the wire payload.
+        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
+            let out = adapter
                 .backend()
-                .generate_streaming(&messages, &gen_config, on_token)?
+                .generate_streaming(&messages, &gen_config, on_token)?;
+            let name = adapter.backend().name().to_string();
+            (out, name)
         } else {
             return Err(AdapterError::RuntimeError(
                 "LLM adapter cache unexpectedly empty".to_string(),
@@ -1005,7 +1009,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output);
+        mirror_llm_metrics_to_span(&output, &backend_name);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1064,9 +1068,12 @@ impl TemplateExecutor {
         // Use explicit config or fall back to defaults
         let gen_config = config.cloned().unwrap_or_default();
 
-        // Execute with ChatMessages directly — backend applies template once
-        let output = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            adapter.backend().generate(messages, &gen_config)?
+        // Execute with ChatMessages directly — backend applies template once.
+        // Capture backend name for the resolved-EP mirror.
+        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
+            let out = adapter.backend().generate(messages, &gen_config)?;
+            let name = adapter.backend().name().to_string();
+            (out, name)
         } else {
             return Err(AdapterError::RuntimeError(
                 "LLM adapter cache unexpectedly empty".to_string(),
@@ -1089,7 +1096,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output);
+        mirror_llm_metrics_to_span(&output, &backend_name);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1151,11 +1158,14 @@ impl TemplateExecutor {
         // Use explicit config or fall back to defaults
         let gen_config = config.cloned().unwrap_or_default();
 
-        // Execute with streaming - pass ChatMessages directly to backend
-        let output = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            adapter
+        // Execute with streaming - pass ChatMessages directly to backend.
+        // Capture backend name for the resolved-EP mirror.
+        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
+            let out = adapter
                 .backend()
-                .generate_streaming(messages, &gen_config, on_token)?
+                .generate_streaming(messages, &gen_config, on_token)?;
+            let name = adapter.backend().name().to_string();
+            (out, name)
         } else {
             return Err(AdapterError::RuntimeError(
                 "LLM adapter cache unexpectedly empty".to_string(),
@@ -1178,7 +1188,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output);
+        mirror_llm_metrics_to_span(&output, &backend_name);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1304,9 +1314,12 @@ impl TemplateExecutor {
         }
         messages.push(ChatMessage::user(&prompt));
 
-        // Execute inference using cached adapter's backend directly
-        let output = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            adapter.backend().generate(&messages, &gen_config)?
+        // Execute inference using cached adapter's backend directly.
+        // Capture backend name for the resolved-EP mirror.
+        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
+            let out = adapter.backend().generate(&messages, &gen_config)?;
+            let name = adapter.backend().name().to_string();
+            (out, name)
         } else {
             return Err(AdapterError::RuntimeError(
                 "LLM adapter cache unexpectedly empty".to_string(),
@@ -1334,7 +1347,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output);
+        mirror_llm_metrics_to_span(&output, &backend_name);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -2086,7 +2099,10 @@ fn insert_llm_streaming_metrics(
 }
 
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-fn mirror_llm_metrics_to_span(output: &crate::runtime_adapter::llm::GenerationOutput) {
+fn mirror_llm_metrics_to_span(
+    output: &crate::runtime_adapter::llm::GenerationOutput,
+    backend_name: &str,
+) {
     // Always-present scalars. These reach the platform via
     // `PlatformEvent.stages[].spans[].metadata` (populated by
     // `xybrid_core::tracing::add_metadata` on the currently active span).
@@ -2097,6 +2113,17 @@ fn mirror_llm_metrics_to_span(output: &crate::runtime_adapter::llm::GenerationOu
         format!("{:.2}", output.tokens_per_second),
     );
     xybrid_trace::add_metadata("finish_reason", &output.finish_reason);
+
+    // Resolved execution provider: which on-device engine path actually
+    // ran. Cost-attribution telemetry uses this to explain latency
+    // variance on the same chip + model. Sourced from build flags via
+    // `local_execution_provider` because backend selection is compile-
+    // time. Cloud LLMs go through a different adapter and get
+    // attribution from the `provider` field instead.
+    xybrid_trace::add_metadata(
+        "execution_provider",
+        crate::runtime_adapter::llm::local_execution_provider(backend_name),
+    );
 
     // Streaming-derived scalars. Only mirror when the backend reported them;
     // the `Option<_>` + `nonzero` filter in mistral keeps misleading zeros

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -35,6 +35,60 @@ pub use super::types::{
 /// Result type for LLM backend operations.
 pub type LlmResult<T> = Result<T, AdapterError>;
 
+/// Resolve the execution-provider label for the local LLM path. The
+/// value lands on the inference span via `add_metadata` and is hoisted
+/// to the wire payload by the SDK so the analytics backend can attribute
+/// latency to the engine that actually ran (Metal vs CPU vs CUDA).
+///
+/// Build flags determine the answer because backend selection happens at
+/// compile time: `llm-mistral-metal` and `llm-mistral-cuda` switch
+/// mistralrs to the corresponding accelerator; `llm-llamacpp` on macOS
+/// builds with `GGML_METAL=ON` by default (see `build.rs`). For unknown
+/// or mock backends we report `cpu` rather than guessing — wrong is
+/// worse than missing on a diagnostic field.
+pub(crate) fn local_execution_provider(backend_name: &str) -> &'static str {
+    match backend_name {
+        "llama-cpp" => llamacpp_execution_provider(),
+        "mistral" => mistral_execution_provider(),
+        _ => "cpu",
+    }
+}
+
+#[cfg(all(feature = "llm-llamacpp", target_os = "macos"))]
+fn llamacpp_execution_provider() -> &'static str {
+    // build.rs sets GGML_METAL=ON unconditionally on macOS targets.
+    "metal"
+}
+
+#[cfg(all(feature = "llm-llamacpp", not(target_os = "macos")))]
+fn llamacpp_execution_provider() -> &'static str {
+    // Linux / Windows / Android currently build llama.cpp without
+    // GGML_CUDA. When we add a CUDA build flag, switch on it here.
+    "cpu"
+}
+
+#[cfg(not(feature = "llm-llamacpp"))]
+fn llamacpp_execution_provider() -> &'static str {
+    // Compiled without llama.cpp — should be unreachable from a
+    // LlamaCppBackend instance, but pick a safe fallback for tests.
+    "cpu"
+}
+
+#[cfg(feature = "llm-mistral-metal")]
+fn mistral_execution_provider() -> &'static str {
+    "metal"
+}
+
+#[cfg(all(feature = "llm-mistral-cuda", not(feature = "llm-mistral-metal")))]
+fn mistral_execution_provider() -> &'static str {
+    "cuda"
+}
+
+#[cfg(not(any(feature = "llm-mistral-metal", feature = "llm-mistral-cuda")))]
+fn mistral_execution_provider() -> &'static str {
+    "cpu"
+}
+
 // =============================================================================
 // Generation Output
 // =============================================================================
@@ -488,6 +542,16 @@ impl RuntimeAdapter for LlmRuntimeAdapter {
                 )))]
                 crate::tracing::add_metadata("span_kind", "cpu");
 
+                // Resolved execution provider: which on-device engine
+                // path actually ran. Cost-attribution telemetry needs
+                // this to explain latency variance on the same chip +
+                // model. Cloud LLMs get attribution from the `provider`
+                // field on their adapter span instead, so we omit here.
+                crate::tracing::add_metadata(
+                    "execution_provider",
+                    local_execution_provider(self.backend.name()),
+                );
+
                 Ok(Envelope {
                     kind: EnvelopeKind::Text(output.text),
                     metadata: response_metadata,
@@ -547,6 +611,28 @@ mod tests {
 
     // Note: Tests for PartialToken, ChatMessage, GenerationConfig, and LlmConfig
     // are in runtime_adapter/types.rs since those types are now defined there.
+
+    #[test]
+    fn local_execution_provider_maps_known_backends() {
+        // We only assert the names we ship: backend names "llama-cpp"
+        // and "mistral" must round-trip through the helper into a
+        // non-empty string. Exact label depends on build flags + target,
+        // so the assertions here stay shape-only — full per-cfg coverage
+        // is enforced at compile time by the `#[cfg]` arms themselves.
+        let llama = local_execution_provider("llama-cpp");
+        assert!(!llama.is_empty(), "llama-cpp must map to a label");
+        let mistral = local_execution_provider("mistral");
+        assert!(!mistral.is_empty(), "mistral must map to a label");
+    }
+
+    #[test]
+    fn local_execution_provider_unknown_backend_falls_back_to_cpu() {
+        // Mock backends in tests, or any name we don't recognise, get
+        // "cpu" rather than a guess — wrong is worse than missing on
+        // a diagnostic field.
+        assert_eq!(local_execution_provider("mock"), "cpu");
+        assert_eq!(local_execution_provider(""), "cpu");
+    }
 
     #[test]
     fn test_generation_output_structure() {

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -54,13 +54,19 @@ pub(crate) fn local_execution_provider(backend_name: &str) -> &'static str {
     }
 }
 
-#[cfg(all(feature = "llm-llamacpp", target_os = "macos"))]
+#[cfg(all(
+    feature = "llm-llamacpp",
+    any(target_os = "macos", target_os = "ios")
+))]
 fn llamacpp_execution_provider() -> &'static str {
-    // build.rs sets GGML_METAL=ON unconditionally on macOS targets.
+    // build.rs sets GGML_METAL=ON for both macOS and iOS Apple targets.
     "metal"
 }
 
-#[cfg(all(feature = "llm-llamacpp", not(target_os = "macos")))]
+#[cfg(all(
+    feature = "llm-llamacpp",
+    not(any(target_os = "macos", target_os = "ios"))
+))]
 fn llamacpp_execution_provider() -> &'static str {
     // Linux / Windows / Android currently build llama.cpp without
     // GGML_CUDA. When we add a CUDA build flag, switch on it here.

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -54,10 +54,7 @@ pub(crate) fn local_execution_provider(backend_name: &str) -> &'static str {
     }
 }
 
-#[cfg(all(
-    feature = "llm-llamacpp",
-    any(target_os = "macos", target_os = "ios")
-))]
+#[cfg(all(feature = "llm-llamacpp", any(target_os = "macos", target_os = "ios")))]
 fn llamacpp_execution_provider() -> &'static str {
     // build.rs sets GGML_METAL=ON for both macOS and iOS Apple targets.
     "metal"

--- a/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
@@ -214,6 +214,17 @@ impl OnnxRuntimeAdapter {
             AdapterError::InferenceFailed(format!("ONNX Runtime inference failed: {e}"))
         })?;
 
+        // Hoist the resolved execution provider onto the current span as
+        // soon as we have it. The session caches the first-inference
+        // harvest so this is a cheap accessor on every subsequent call;
+        // emitting on every run keeps the span metadata uniform across
+        // warm-up and steady-state inferences. Absent on the very first
+        // call only if profiling failed (logged inside the session); we
+        // skip emission in that case rather than emit a bogus value.
+        if let Some(resolved) = session.resolved_providers() {
+            crate::tracing::add_metadata("execution_provider", resolved.primary);
+        }
+
         // DEBUG: Log raw output tensor info before conversion
         eprintln!("🔵 DEBUG: Raw ONNX Output Tensors");
         eprintln!("   Number of outputs: {}", output_tensors.len());
@@ -318,8 +329,14 @@ impl RuntimeAdapter for OnnxRuntimeAdapter {
             return Ok(());
         }
 
-        // Create ONNX Runtime session with configured execution provider
-        let session = ONNXSession::with_provider(path, self.execution_provider)?;
+        // Build with resolved-EP capture so the first inference will
+        // surface the EP that *actually* ran (not just the one we
+        // requested) — ORT can silently fall back from CoreML to CPU
+        // per-op when an op isn't supported, and that fallback is the
+        // single biggest reason latency varies on the same chip + model.
+        // The capture costs ~10-15% on the first inference (the warm-up
+        // call) and zero on every subsequent call.
+        let session = ONNXSession::with_resolved_ep_capture(path, self.execution_provider)?;
 
         log::info!(
             "Loaded model '{}' with {} execution provider",

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1076,6 +1076,20 @@ fn convert_to_platform_event(
                 payload["quantization"] = serde_json::json!(v);
             }
         }
+        // Resolved execution provider — which on-device engine path
+        // actually ran (coreml / cpu / metal / cuda / mlx-metal / …).
+        // ORT path: harvested from per-session profiling JSON after the
+        // first inference (bypasses the API gap where ORT exposes no
+        // session-level resolved-EP getter). LLM path: build-flag-derived
+        // label keyed on the backend name. Cloud paths omit — `provider`
+        // already carries the attribution. Lives on whichever inner span
+        // emitted it, hoisted via the any-span lookup so all modalities
+        // produce the same wire shape.
+        if payload.get("execution_provider").is_none() {
+            if let Some(v) = extract_string_attr_from_any_span(&spans, "execution_provider") {
+                payload["execution_provider"] = serde_json::json!(v);
+            }
+        }
         Some(spans)
     } else {
         None

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -223,6 +223,7 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 | `provider` | string | inference (cloud only) | `openai` \| `anthropic` \| `google` \| `elevenlabs` \| `openrouter` \| `custom` | Cloud `IntegrationProvider` resolved from envelope metadata |
 | `task` | string | inference | `chat` \| `vlm` \| `asr` \| `tts` \| `embedding` \| `image-gen` \| `ocr` \| `rerank` \| `classify` (open string for forward-compat) | `ModelMetadata.metadata["task"]` from `model_metadata.json` |
 | `quantization` | string | inference | `q4_0` \| `q4_k_m` \| `q5_k_m` \| `q8_0` \| `fp16` \| `fp32` (open string — common GGUF labels) | `ModelMetadata.metadata["quantization"]` first; falls back to GGUF filename inference; absent (not empty) when unknown |
+| `execution_provider` | string | inference (local only) | `coreml` \| `cpu` \| `metal` \| `cuda` \| `mlx-metal` \| `ane` (open string) | ORT path: harvested from per-session profiling JSON after the first inference (ORT exposes no session-level resolved-EP getter, so we read `args.provider` from the Chrome-trace output and pick the EP that ran the most ops). LLM path: build-flag-derived label keyed on the backend name. Cloud paths omit — `provider` carries attribution. |
 | `tokens_in` | u64 | inference | — | LLM span (`prompt_tokens` for OpenAI; synthesized total for Anthropic) |
 | `tokens_out` | u64 | inference | — | LLM span (`completion_tokens`) |
 | `cache_read_input_tokens` | u64 | inference | — | Anthropic-canonical; OpenAI's nested `prompt_tokens_details.cached_tokens` maps here |
@@ -231,6 +232,8 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 The closed set for `backend` is intentionally narrow — values outside it are not emitted (the field stays absent) so the analytics column can pin a closed enum without rejecting future runtimes mid-flight. Forward-declared backends (e.g. `mlx`) are added to the set only when a runtime adapter for them lands.
 
 For local LLM events `provider` is always absent; for cloud events it is always present alongside `backend = "cloud"`.
+
+`execution_provider` is the diagnostic complement to `backend`: `backend` says *which engine we asked for*, `execution_provider` says *what actually ran*. The two diverge most often on the ORT path (CoreML can silently fall back to CPU per-op when an op isn't supported) — the field is the analytics signal that explains "why is this run slow on this chip?" The field is absent for cloud events because cloud `provider` already attributes execution end-to-end.
 
 ## `ModelDownload` event
 


### PR DESCRIPTION
## Summary

Hoists the *actually-ran* engine label onto inference spans and lifts it to the wire payload as `execution_provider`, so cost-attribution telemetry can explain latency variance on the same chip + model. ORT path uses the resolved-EP harvest from per-session profiling JSON (the only authoritative source — ORT exposes no session-level resolved-EP getter); LLM path derives the label from build flags keyed on backend name (`metal` on macOS *and* iOS for llama.cpp, `metal`/`cuda` from `llm-mistral-*` features for mistralrs, `cpu` otherwise). Cloud paths omit since `provider` already attributes execution. SDK lifts the value via the any-span lookup so all modalities produce the same wire shape; doc table + closed-set notes updated.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — unit tests for the local-EP helper added; shape-only assertions stay robust across feature combos
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (`docs/sdk/telemetry.md` table + notes cover the new field and its diagnostic role vs `backend`)
- [x] No breaking changes (additive field on `PlatformEvent` payload; existing call sites unchanged)