### PR TITLE
feat(kotlin): wire Android battery/thermal observers into Xybrid.init

### DIFF
--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -7,7 +7,13 @@
 
 package ai.xybrid
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
+import android.os.PowerManager
 import java.io.File
 
 // -- SDK Initialization --
@@ -38,6 +44,18 @@ object Xybrid {
      *
      * Typically called from `Application.onCreate()` or `Activity.onCreate()`.
      *
+     * Also subscribes to OS-level battery and thermal notifications and
+     * forwards each value through the SDK's push-state surface so the
+     * routing engine has live telemetry without consumer apps writing
+     * boilerplate. Receivers/listeners are registered against the
+     * application context so they survive Activity rotation. Battery
+     * monitoring uses the sticky `ACTION_BATTERY_CHANGED` broadcast,
+     * which delivers the current value immediately on registration —
+     * no separate seed call is needed. Thermal monitoring requires
+     * API 29+ ([`PowerManager.OnThermalStatusChangedListener`]); on
+     * older devices the routing engine sees `thermal_state = None`
+     * (treated as "no signal" rather than an optimistic default).
+     *
      * @param context Android context (application or activity).
      */
     @JvmStatic
@@ -48,6 +66,7 @@ object Xybrid {
             setBinding("kotlin")
             val cacheDir = File(context.filesDir, "xybrid/models")
             initSdkCacheDir(cacheDir.absolutePath)
+            registerPlatformObservers(context.applicationContext)
             initialized = true
         }
     }
@@ -55,6 +74,59 @@ object Xybrid {
     /** Returns `true` if [init] has been called successfully. */
     @JvmStatic
     val isInitialized: Boolean get() = initialized
+
+    private fun registerPlatformObservers(appContext: Context) {
+        // Sticky-broadcast registration delivers the latest battery state
+        // synchronously, so the receiver's first onReceive seeds the value
+        // without a separate read.
+        val batteryReceiver = object : BroadcastReceiver() {
+            override fun onReceive(received: Context, intent: Intent) {
+                val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+                val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+                if (level < 0 || scale <= 0) {
+                    clearBatteryLevel()
+                    return
+                }
+                // Scale to 0..=100; clamp so a brief sensor blip can't
+                // overflow the UByte the FFI expects.
+                val pct = ((level * 100) / scale).coerceIn(0, 100)
+                setBatteryLevel(pct.toUByte())
+            }
+        }
+        appContext.registerReceiver(batteryReceiver, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+
+        // Thermal status listener is API 29+ — older devices simply
+        // don't get a thermal signal, which the routing engine treats
+        // as `thermal_state = None`.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val pm = appContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+            // Push the current status immediately so first cache miss isn't
+            // blind, then keep updating on every transition.
+            setThermalState(thermalStatusToXybrid(pm.currentThermalStatus))
+            pm.addThermalStatusListener { status ->
+                setThermalState(thermalStatusToXybrid(status))
+            }
+        }
+    }
+
+    /**
+     * Map Android's 7-bucket thermal status to xybrid's 4-band
+     * [`XybridThermalState`].
+     *
+     * Android (API 29+) reports `THERMAL_STATUS_NONE`/`LIGHT`/`MODERATE`/
+     * `SEVERE`/`CRITICAL`/`EMERGENCY`/`SHUTDOWN`. The last three all
+     * indicate the device is on the verge of forced throttling or shutdown,
+     * so they collapse to `Critical` — the routing engine should treat
+     * them identically (pause heavy work).
+     */
+    private fun thermalStatusToXybrid(status: Int): XybridThermalState = when (status) {
+        PowerManager.THERMAL_STATUS_NONE,
+        PowerManager.THERMAL_STATUS_LIGHT,
+        -> XybridThermalState.NORMAL
+        PowerManager.THERMAL_STATUS_MODERATE -> XybridThermalState.WARM
+        PowerManager.THERMAL_STATUS_SEVERE -> XybridThermalState.HOT
+        else -> XybridThermalState.CRITICAL
+    }
 }
 
 // -- Public Type Aliases --

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/uniffi/xybrid_uniffi/xybrid_uniffi.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/uniffi/xybrid_uniffi/xybrid_uniffi.kt
@@ -411,9 +411,17 @@ internal interface _UniFFILib : Library {
     ): Pointer
     fun uniffi_xybrid_uniffi_fn_method_xybridmodelloader_load(`ptr`: Pointer,
     ): Pointer
+    fun uniffi_xybrid_uniffi_fn_func_clear_battery_level(_uniffi_out_err: RustCallStatus, 
+    ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(`cacheDir`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_set_battery_level(`percent`: Byte,_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun uniffi_xybrid_uniffi_fn_func_set_binding(`binding`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_set_thermal_state(`state`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
     fun ffi_xybrid_uniffi_rustbuffer_alloc(`size`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
@@ -529,9 +537,17 @@ internal interface _UniFFILib : Library {
     ): Unit
     fun ffi_xybrid_uniffi_rust_future_complete_void(`handle`: Pointer,_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_checksum_func_clear_battery_level(
+    ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_clear_thermal_state(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(
     ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_set_battery_level(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_func_set_binding(
+    ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_set_thermal_state(
     ): Short
     fun uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id(
     ): Short
@@ -570,10 +586,22 @@ private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
 
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
+    if (lib.uniffi_xybrid_uniffi_checksum_func_clear_battery_level() != 40326.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_clear_thermal_state() != 36495.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_set_battery_level() != 57690.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_xybrid_uniffi_checksum_func_set_binding() != 53803.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_set_thermal_state() != 59048.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id() != 623.toShort()) {
@@ -656,6 +684,26 @@ internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
 
 // Public interface members begin here.
 
+
+public object FfiConverterUByte: FfiConverter<UByte, Byte> {
+    override fun lift(value: Byte): UByte {
+        return value.toUByte()
+    }
+
+    override fun read(buf: ByteBuffer): UByte {
+        return lift(buf.get())
+    }
+
+    override fun lower(value: UByte): Byte {
+        return value.toByte()
+    }
+
+    override fun allocationSize(value: UByte) = 1
+
+    override fun write(value: UByte, buf: ByteBuffer) {
+        buf.put(value.toByte())
+    }
+}
 
 public object FfiConverterUInt: FfiConverter<UInt, Int> {
     override fun lift(value: Int): UInt {
@@ -1795,6 +1843,30 @@ public object FfiConverterTypeXybridError : FfiConverterRustBuffer<XybridExcepti
 
 
 
+enum class XybridThermalState {
+    NORMAL,WARM,HOT,CRITICAL;
+    companion object
+}
+
+public object FfiConverterTypeXybridThermalState: FfiConverterRustBuffer<XybridThermalState> {
+    override fun read(buf: ByteBuffer) = try {
+        XybridThermalState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: XybridThermalState) = 4
+
+    override fun write(value: XybridThermalState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+
 public object FfiConverterOptionalUInt: FfiConverterRustBuffer<UInt?> {
     override fun read(buf: ByteBuffer): UInt? {
         if (buf.get().toInt() == 0) {
@@ -2161,6 +2233,22 @@ public object FfiConverterSequenceTypeXybridVoiceInfo: FfiConverterRustBuffer<Li
 
 
 
+fun `clearBatteryLevel`() =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_clear_battery_level(_status)
+}
+
+
+
+fun `clearThermalState`() =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_status)
+}
+
+
+
 fun `initSdkCacheDir`(`cacheDir`: String) =
     
     rustCall() { _status ->
@@ -2169,10 +2257,26 @@ fun `initSdkCacheDir`(`cacheDir`: String) =
 
 
 
+fun `setBatteryLevel`(`percent`: UByte) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_battery_level(FfiConverterUByte.lower(`percent`),_status)
+}
+
+
+
 fun `setBinding`(`binding`: String) =
     
     rustCall() { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_binding(FfiConverterString.lower(`binding`),_status)
+}
+
+
+
+fun `setThermalState`(`state`: XybridThermalState) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_thermal_state(FfiConverterTypeXybridThermalState.lower(`state`),_status)
 }
 
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/xybrid_uniffi.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/xybrid_uniffi.kt
@@ -411,9 +411,17 @@ internal interface _UniFFILib : Library {
     ): Pointer
     fun uniffi_xybrid_uniffi_fn_method_xybridmodelloader_load(`ptr`: Pointer,
     ): Pointer
+    fun uniffi_xybrid_uniffi_fn_func_clear_battery_level(_uniffi_out_err: RustCallStatus, 
+    ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(`cacheDir`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_set_battery_level(`percent`: Byte,_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun uniffi_xybrid_uniffi_fn_func_set_binding(`binding`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_set_thermal_state(`state`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
     fun ffi_xybrid_uniffi_rustbuffer_alloc(`size`: Int,_uniffi_out_err: RustCallStatus, 
     ): RustBuffer.ByValue
@@ -529,9 +537,17 @@ internal interface _UniFFILib : Library {
     ): Unit
     fun ffi_xybrid_uniffi_rust_future_complete_void(`handle`: Pointer,_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_checksum_func_clear_battery_level(
+    ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_clear_thermal_state(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(
     ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_set_battery_level(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_func_set_binding(
+    ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_set_thermal_state(
     ): Short
     fun uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id(
     ): Short
@@ -570,10 +586,22 @@ private fun uniffiCheckContractApiVersion(lib: _UniFFILib) {
 
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
+    if (lib.uniffi_xybrid_uniffi_checksum_func_clear_battery_level() != 40326.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_clear_thermal_state() != 36495.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_set_battery_level() != 57690.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_xybrid_uniffi_checksum_func_set_binding() != 53803.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_set_thermal_state() != 59048.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id() != 623.toShort()) {
@@ -656,6 +684,26 @@ internal suspend fun<T, F, E: Exception> uniffiRustCallAsync(
 
 // Public interface members begin here.
 
+
+public object FfiConverterUByte: FfiConverter<UByte, Byte> {
+    override fun lift(value: Byte): UByte {
+        return value.toUByte()
+    }
+
+    override fun read(buf: ByteBuffer): UByte {
+        return lift(buf.get())
+    }
+
+    override fun lower(value: UByte): Byte {
+        return value.toByte()
+    }
+
+    override fun allocationSize(value: UByte) = 1
+
+    override fun write(value: UByte, buf: ByteBuffer) {
+        buf.put(value.toByte())
+    }
+}
 
 public object FfiConverterUInt: FfiConverter<UInt, Int> {
     override fun lift(value: Int): UInt {
@@ -1795,6 +1843,30 @@ public object FfiConverterTypeXybridError : FfiConverterRustBuffer<XybridExcepti
 
 
 
+enum class XybridThermalState {
+    NORMAL,WARM,HOT,CRITICAL;
+    companion object
+}
+
+public object FfiConverterTypeXybridThermalState: FfiConverterRustBuffer<XybridThermalState> {
+    override fun read(buf: ByteBuffer) = try {
+        XybridThermalState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: XybridThermalState) = 4
+
+    override fun write(value: XybridThermalState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+
 public object FfiConverterOptionalUInt: FfiConverterRustBuffer<UInt?> {
     override fun read(buf: ByteBuffer): UInt? {
         if (buf.get().toInt() == 0) {
@@ -2161,6 +2233,22 @@ public object FfiConverterSequenceTypeXybridVoiceInfo: FfiConverterRustBuffer<Li
 
 
 
+fun `clearBatteryLevel`() =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_clear_battery_level(_status)
+}
+
+
+
+fun `clearThermalState`() =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_status)
+}
+
+
+
 fun `initSdkCacheDir`(`cacheDir`: String) =
     
     rustCall() { _status ->
@@ -2169,10 +2257,26 @@ fun `initSdkCacheDir`(`cacheDir`: String) =
 
 
 
+fun `setBatteryLevel`(`percent`: UByte) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_battery_level(FfiConverterUByte.lower(`percent`),_status)
+}
+
+
+
 fun `setBinding`(`binding`: String) =
     
     rustCall() { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_binding(FfiConverterString.lower(`binding`),_status)
+}
+
+
+
+fun `setThermalState`(`state`: XybridThermalState) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_set_thermal_state(FfiConverterTypeXybridThermalState.lower(`state`),_status)
 }
 
 


### PR DESCRIPTION
## Summary

`Xybrid.init(context)` on Android now automatically subscribes to OS-level battery and thermal notifications and forwards each value through the SDK's push-state surface (#78). Consumer apps no longer need to write the boilerplate themselves — `Xybrid.init(this)` in `Application.onCreate()` is sufficient to keep the routing engine's telemetry live.

## Cross-platform status

| Platform | Battery | Thermal | Host wiring |
|----------|---------|---------|-------------|
| Linux    | sysfs (#72) | sysfs (#72) | n/a — desktop |
| macOS    | IOKit (#76) | NSProcessInfo (#74) | n/a — desktop |
| Windows  | `GetSystemPowerStatus` (#75) | WMI (#77) | n/a — desktop |
| iOS      | UniFFI push (#78) | UniFFI push (#78) | follow-up |
| **Android** | **UniFFI push (this PR)** | **UniFFI push (this PR)** | **this PR** |
| Flutter  | FRB push (#84) | FRB push (#84) | follow-up |

## What's new

- **Battery**: sticky `ACTION_BATTERY_CHANGED` broadcast. Registration delivers the latest value immediately, so the receiver's first `onReceive` seeds the SDK without a separate read. Subsequent level/scale transitions flow through the same path. Negative or zero scale (sensor glitch) maps to `clearBatteryLevel()` rather than a fake percent.
- **Thermal**: `PowerManager.OnThermalStatusChangedListener` (API 29+). Current status pushed immediately, then on every transition. On API 24–28 there's no thermal source — the routing engine sees `thermal_state = None`, which it treats as "no signal" rather than an optimistic default.
- **Android → xybrid mapping**: Android's 7 thermal buckets collapse to 4: `NONE/LIGHT → Normal`, `MODERATE → Warm`, `SEVERE → Hot`, `CRITICAL/EMERGENCY/SHUTDOWN → Critical`. The last three all warrant pausing heavy work, so they share a band.

## Generated bindings

`cargo xtask generate-bindings --language kotlin` ran to refresh `xybrid_uniffi.kt` (both copies — the canonical and the `ai.xybrid` re-package). Diff is purely additive: the four new functions (`setBatteryLevel`, `clearBatteryLevel`, `setThermalState`, `clearThermalState`), `XybridThermalState`, and the `FfiConverterUByte` plumbing for the new `UByte` parameter type. No drift in any existing surface.

## Test plan

- [ ] CI Android module build (JDK 17 unavailable on dev box — relying on CI for the Gradle compile)
- [x] Symbol names and signatures cross-checked against the regenerated `xybrid_uniffi.kt`
- [x] API 29 gate (`Build.VERSION_CODES.Q`) protects every thermal call
- [x] Sticky-broadcast registration and `currentThermalStatus` seed both push immediately so first cache miss isn't blind

## Out of scope

- Swift wrapper (`Xybrid.swift`) wiring — next host PR.
- Optional iOS thermal cfg flip on the macOS NSProcessInfo poller — folds into the Swift PR.
- Dart wrapper (`xybrid.dart`) wiring — last host PR.
- Docs page on host integration expectations — once all wrappers ship.