### PR TITLE
feat(llama-cpp): multi-turn KV cache prefix reuse

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -87,6 +87,35 @@ pub struct LlamaCppBackend {
     context: Mutex<Option<sys::LlamaContext>>,
     /// Current configuration
     config: Option<LlmConfig>,
+    /// Multi-turn KV cache reuse state. Records the tokenized prompt of
+    /// the last `generate*` call so the next call can find the longest
+    /// common prefix and skip re-prefilling that portion. Wrapped in
+    /// `Mutex` because `generate*` are `&self` and we need cross-call
+    /// mutation; lock order is always `context → kv_state` to match the
+    /// natural critical section (we already hold the context lock when
+    /// we mutate the cache via seq_rm).
+    kv_state: Mutex<KvCacheState>,
+}
+
+/// Cross-call state for the multi-turn KV cache reuse path. `Default::default()`
+/// gives an empty cache (`n_past = 0`, `cached_tokens.is_empty()`), which
+/// matches the post-load state of a fresh context.
+///
+/// `last_prefix_hit` records the prefix length the most recent call was able
+/// to reuse — the source of truth for the future `prompt_cached_tokens`
+/// telemetry field. Read it post-`generate*` to learn how many tokens were
+/// served from cache.
+#[cfg(feature = "llm-llamacpp")]
+#[derive(Default)]
+struct KvCacheState {
+    /// The exact token sequence currently sitting in the KV cache. Empty
+    /// when the cache is unpopulated (post-load, or post full-clear).
+    cached_tokens: Vec<i32>,
+    /// Prefix length the most recent prepare call was able to keep from
+    /// the prior cached_tokens. `None` when no `generate*` has run since
+    /// load; `Some(0)` when the most recent call had no shared prefix
+    /// (fully re-prefilled).
+    last_prefix_hit: Option<usize>,
 }
 
 #[cfg(feature = "llm-llamacpp")]
@@ -109,6 +138,7 @@ impl LlamaCppBackend {
             model: None,
             context: Mutex::new(None),
             config: None,
+            kv_state: Mutex::new(KvCacheState::default()),
         })
     }
 }
@@ -158,6 +188,98 @@ impl LlamaCppBackend {
         })?;
         f(model, context)
     }
+
+    /// Multi-turn KV cache reuse: compute the longest common prefix between
+    /// the new prompt's tokens and what's already in the cache from the
+    /// previous call, truncate the cache to that prefix, and return the
+    /// diverged tail along with the prefix length the caller should pass
+    /// as `n_past_in` to [`sys::llama_generate_streaming`].
+    ///
+    /// On a fresh context (no prior call) or when the prompts share no
+    /// prefix, returns `(full_tokens, 0)` and full-clears the cache so the
+    /// generate call below starts from scratch — same behaviour as before
+    /// this helper existed.
+    ///
+    /// Safety net: when the prefilled prefix plus new tail plus
+    /// `max_tokens` would overflow the context window, fall back to a
+    /// full clear so the generation call doesn't trip the
+    /// `n_past + n_input >= n_ctx` bail-out in the C wrapper. The simple
+    /// LCP path doesn't implement context-window eviction yet — that's
+    /// deliberately out of scope, the fallback keeps correctness.
+    ///
+    /// Updates `kv_state.cached_tokens` to reflect the post-call cache
+    /// (which will be `[prefix; new_tail; generated_tokens]` after the
+    /// generation runs). Records `last_prefix_hit` for the telemetry
+    /// accessor [`Self::last_cached_prefix_len`].
+    fn prepare_kv_cache_and_get_tail(
+        &self,
+        context: &sys::LlamaContext,
+        new_tokens: &[i32],
+        max_new_tokens: usize,
+    ) -> LlmResult<(Vec<i32>, usize)> {
+        let mut state = self
+            .kv_state
+            .lock()
+            .map_err(|_| AdapterError::RuntimeError("KV state mutex poisoned".to_string()))?;
+
+        let n_ctx = sys::llama_n_ctx(context);
+        let prefix_len = compute_reusable_prefix_len(&state.cached_tokens, new_tokens);
+
+        // Safety net: if the prefilled prefix + new tail + max_new_tokens
+        // would push us past the context window, the simple LCP path
+        // can't help — drop the cache and let the standard "input too
+        // long" check in the C wrapper produce a clear error. This also
+        // covers the eviction case the issue explicitly punts on.
+        let would_overflow = prefix_len
+            .saturating_add(new_tokens.len() - prefix_len)
+            .saturating_add(max_new_tokens)
+            >= n_ctx;
+        if prefix_len == 0 || would_overflow {
+            sys::llama_kv_cache_clear(context);
+            state.cached_tokens = new_tokens.to_vec();
+            state.last_prefix_hit = Some(0);
+            return Ok((new_tokens.to_vec(), 0));
+        }
+
+        // Truncate the cache to the prefix. seq_id = 0 because the
+        // wrapper's batch.seq_id[..][0] = 0 path uses a single sequence;
+        // when we add multi-sequence support the seq_id needs to flow
+        // through prepare too.
+        sys::llama_kv_cache_seq_rm(context, 0, prefix_len);
+        let tail = new_tokens[prefix_len..].to_vec();
+        state.cached_tokens = new_tokens.to_vec();
+        state.last_prefix_hit = Some(prefix_len);
+        Ok((tail, prefix_len))
+    }
+
+    /// Number of tokens served from the KV cache on the most recent
+    /// `generate*` call (= the longest-common-prefix length between the
+    /// previous prompt and this one). `None` before the first call.
+    /// Telemetry hook for surfacing `prompt_cached_tokens` on the wire.
+    pub fn last_cached_prefix_len(&self) -> Option<usize> {
+        self.kv_state.lock().ok().and_then(|s| s.last_prefix_hit)
+    }
+}
+
+/// Longest-common-prefix length between the cached tokens and the new
+/// prompt tokens, capped at `new_tokens.len() - 1` so the post-prefill
+/// batch always has at least one token to feed the C decoder.
+///
+/// Pulled out so the LCP arithmetic is unit-testable without needing a
+/// real `LlamaContext`. Behaviour:
+/// - empty `new_tokens` ⇒ 0 (caller should bail before reaching the helper)
+/// - empty `cached` ⇒ 0 (first call)
+/// - identical sequences ⇒ `new_tokens.len() - 1` (keep last token for the C decoder)
+/// - common prefix shorter than either ⇒ that prefix length
+#[cfg(feature = "llm-llamacpp")]
+fn compute_reusable_prefix_len(cached: &[i32], new_tokens: &[i32]) -> usize {
+    let max_reuse = new_tokens.len().saturating_sub(1);
+    cached
+        .iter()
+        .zip(new_tokens.iter())
+        .take(max_reuse)
+        .take_while(|(a, b)| a == b)
+        .count()
 }
 
 #[cfg(feature = "llm-llamacpp")]
@@ -245,6 +367,10 @@ impl LlmBackend for LlamaCppBackend {
         let _ = self.context.get_mut().unwrap().take();
         let _ = self.model.take();
         self.config = None;
+        // Reset KV cache reuse state — the next load gets a fresh cache,
+        // so any cached prefix from a prior model would be a use-after-free
+        // waiting to happen.
+        *self.kv_state.get_mut().unwrap() = KvCacheState::default();
         Ok(())
     }
 
@@ -254,10 +380,6 @@ impl LlmBackend for LlamaCppBackend {
         config: &GenerationConfig,
     ) -> LlmResult<GenerationOutput> {
         self.with_model_and_context(|model, context| {
-            // Clear KV cache to reset context state for new conversation
-            // This is essential when reusing the context across multiple queries
-            sys::llama_kv_cache_clear(context);
-
             // Format messages into prompt using chat template
             let prompt = sys::llama_format_chat(model, messages)?;
 
@@ -276,6 +398,15 @@ impl LlmBackend for LlamaCppBackend {
                     n_ctx
                 )));
             }
+
+            // Multi-turn KV cache reuse: keep the prefix the previous call
+            // already prefilled, only re-prefill the diverged tail. On a
+            // first turn (or no shared prefix) `tail == tokens` and
+            // `n_past == 0` — same observable behaviour as the legacy
+            // unconditional clear, just without the duplicate work in
+            // multi-turn chats.
+            let (tail, n_past) =
+                self.prepare_kv_cache_and_get_tail(context, &tokens, config.max_tokens)?;
 
             // Per-chunk timestamps capture the streaming cadence for TTFT +
             // inter-token-latency telemetry. The closure is observation-only
@@ -299,7 +430,7 @@ impl LlmBackend for LlamaCppBackend {
             let (output_tokens, stopped_by_callback) = sys::llama_generate_streaming(
                 context,
                 model,
-                &tokens,
+                &tail,
                 config.max_tokens,
                 config.temperature,
                 config.top_p,
@@ -311,6 +442,7 @@ impl LlmBackend for LlamaCppBackend {
                     tel.record_chunk();
                     Ok(())
                 },
+                n_past,
             )?;
 
             // Finalize telemetry before the post-processing work below so
@@ -382,8 +514,6 @@ impl LlmBackend for LlamaCppBackend {
 
     fn generate_raw(&self, prompt: &str, config: &GenerationConfig) -> LlmResult<GenerationOutput> {
         self.with_model_and_context(|model, context| {
-            sys::llama_kv_cache_clear(context);
-
             // Tokenize with parse_special=true so boundary tokens like
             // <|SPEECH_GENERATION_START|>, <|TEXT_PROMPT_START|>, <|im_start|>, etc.
             // collapse to single vocab IDs instead of 8-10 subword pieces each.
@@ -399,6 +529,14 @@ impl LlmBackend for LlamaCppBackend {
                     n_ctx
                 )));
             }
+
+            // Multi-turn KV cache reuse: see prepare_kv_cache_and_get_tail
+            // for the LCP + truncate-or-clear contract. raw-prompt callers
+            // (TTS codec preludes etc.) typically don't share prefixes
+            // across calls so the LCP path will mostly clear-and-refill,
+            // but the unified helper keeps behaviour consistent.
+            let (tail, n_past) =
+                self.prepare_kv_cache_and_get_tail(context, &tokens, config.max_tokens)?;
 
             // Use the streaming-capable API with an observation-only
             // callback so raw generation gets the same TTFT / ITL /
@@ -416,7 +554,7 @@ impl LlmBackend for LlamaCppBackend {
             let (output_tokens, stopped_by_callback) = sys::llama_generate_streaming(
                 context,
                 model,
-                &tokens,
+                &tail,
                 config.max_tokens,
                 config.temperature,
                 config.top_p,
@@ -428,6 +566,7 @@ impl LlmBackend for LlamaCppBackend {
                     tel.record_chunk();
                     Ok(())
                 },
+                n_past,
             )?;
             let fields = tel.finalize(output_tokens.len());
 
@@ -467,9 +606,6 @@ impl LlmBackend for LlamaCppBackend {
         let mut on_token = on_token;
 
         self.with_model_and_context(|model, context| {
-            // Clear KV cache to reset context state for new conversation
-            sys::llama_kv_cache_clear(context);
-
             // Format messages into prompt using chat template
             let prompt = sys::llama_format_chat(model, messages)?;
 
@@ -486,6 +622,12 @@ impl LlmBackend for LlamaCppBackend {
                     n_ctx
                 )));
             }
+
+            // Multi-turn KV cache reuse: keep the prefix the previous call
+            // already prefilled, only re-prefill the diverged tail. See
+            // prepare_kv_cache_and_get_tail for the full contract.
+            let (tail, n_past) =
+                self.prepare_kv_cache_and_get_tail(context, &tokens, config.max_tokens)?;
 
             // Shared streaming state: telemetry recorder + text filter.
             // The filter owns cumulative text, think-block state, stop-pattern
@@ -514,7 +656,7 @@ impl LlmBackend for LlamaCppBackend {
             let (output_tokens, stopped_by_callback) = sys::llama_generate_streaming(
                 context,
                 model,
-                &tokens,
+                &tail,
                 config.max_tokens,
                 config.temperature,
                 config.top_p,
@@ -541,6 +683,7 @@ impl LlmBackend for LlamaCppBackend {
 
                     Ok(())
                 },
+                n_past,
             )?;
 
             // Finalize telemetry before post-processing so `generation_time_ms`
@@ -674,5 +817,66 @@ impl LlmBackend for LlamaCppBackend {
         Err(AdapterError::RuntimeError(
             "llm-llamacpp feature not enabled".to_string(),
         ))
+    }
+}
+
+#[cfg(all(test, feature = "llm-llamacpp"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lcp_empty_inputs_return_zero() {
+        // First-call shape: nothing cached yet. The KV cache is empty so
+        // there's nothing to reuse; caller falls back to a full prefill.
+        assert_eq!(compute_reusable_prefix_len(&[], &[1, 2, 3]), 0);
+        // Defensive: an empty new prompt would be rejected by the caller
+        // before reaching here, but the helper must not panic on it.
+        assert_eq!(compute_reusable_prefix_len(&[1, 2, 3], &[]), 0);
+        assert_eq!(compute_reusable_prefix_len(&[], &[]), 0);
+    }
+
+    #[test]
+    fn lcp_identical_prompts_keep_one_token_for_decoder() {
+        // Multi-turn replay of the exact same prompt. We could in
+        // principle reuse the entire cache, but the C wrapper rejects
+        // an empty input slice, so the helper caps reuse at len-1 to
+        // guarantee one fresh token feeds the decode loop.
+        let same = vec![10, 20, 30, 40];
+        assert_eq!(compute_reusable_prefix_len(&same, &same), 3);
+    }
+
+    #[test]
+    fn lcp_partial_match_returns_shared_length() {
+        // Typical multi-turn shape: shared system prompt + earlier turns,
+        // diverging at the new user turn. The shared prefix is the part
+        // worth keeping in the cache.
+        let cached = vec![1, 2, 3, 4, 99, 99];
+        let new = vec![1, 2, 3, 4, 50, 60, 70];
+        assert_eq!(compute_reusable_prefix_len(&cached, &new), 4);
+    }
+
+    #[test]
+    fn lcp_no_overlap_returns_zero() {
+        // Totally divergent prompts (e.g. user starts a new conversation
+        // without clearing context). The caller will full-clear the cache
+        // when this returns 0.
+        assert_eq!(compute_reusable_prefix_len(&[1, 2, 3], &[9, 8, 7]), 0);
+    }
+
+    #[test]
+    fn lcp_caps_at_new_tokens_minus_one() {
+        // Cached is longer than the new prompt and shares it entirely.
+        // We still cap at len-1 so the decoder gets a fresh token to
+        // process — otherwise the C wrapper bails on empty input.
+        let cached = vec![1, 2, 3, 4, 5, 6];
+        let new = vec![1, 2, 3];
+        assert_eq!(compute_reusable_prefix_len(&cached, &new), 2);
+    }
+
+    #[test]
+    fn lcp_single_token_new_prompt_returns_zero() {
+        // Edge case: new prompt is one token long (rare but possible —
+        // think test fixtures). max_reuse = 0 ⇒ we always re-prefill.
+        assert_eq!(compute_reusable_prefix_len(&[1, 2, 3], &[1]), 0);
     }
 }

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
@@ -207,7 +207,13 @@ extern "C" {
         n_stop_seqs: c_int,
         callback: Option<TokenCallback>,
         user_data: *mut c_void,
+        n_past_in: c_int,
     ) -> c_int;
+
+    // Truncate the KV cache to a prefix length, dropping tokens past it.
+    // Pairs with the n_past_in parameter on llama_generate_streaming_c —
+    // see the C wrapper for the prefix-reuse contract.
+    fn llama_kv_cache_seq_rm_c(ctx: *mut c_void, seq_id: c_int, p_keep: c_int) -> c_int;
 }
 
 /// Callback type for streaming token generation.
@@ -345,6 +351,24 @@ pub fn llama_free(mut ctx: LlamaContext) {
 pub fn llama_kv_cache_clear(ctx: &LlamaContext) {
     unsafe {
         llama_kv_cache_clear_c(ctx.ptr);
+    }
+}
+
+/// Truncate the KV cache for `seq_id` to a prefix length, dropping tokens
+/// at positions `[p_keep, ∞)`. Used by the multi-turn prefix-reuse path:
+/// caller computes the longest common prefix between the new prompt and
+/// the previously-tokenized prompt, then calls this to drop the diverged
+/// tail before re-prefilling only the new tail at position `p_keep`.
+/// Pairs with `n_past_in` on [`llama_generate_streaming`].
+#[cfg(feature = "llm-llamacpp")]
+pub fn llama_kv_cache_seq_rm(ctx: &LlamaContext, seq_id: i32, p_keep: usize) {
+    unsafe {
+        // Caller-side bounds check: p_keep is unsigned in our API but
+        // the C signature is c_int. Saturate at i32::MAX to keep the
+        // FFI call total — the legitimate range is [0, n_ctx) which is
+        // always well below i32::MAX in practice.
+        let p_keep_c = p_keep.min(c_int::MAX as usize) as c_int;
+        let _ = llama_kv_cache_seq_rm_c(ctx.ptr, seq_id, p_keep_c);
     }
 }
 
@@ -914,6 +938,7 @@ where
 /// # Returns
 /// Vector of generated token IDs and whether generation was stopped by callback.
 #[cfg(feature = "llm-llamacpp")]
+#[allow(clippy::too_many_arguments)]
 pub fn llama_generate_streaming<F>(
     ctx: &LlamaContext,
     model: &LlamaModel,
@@ -926,6 +951,12 @@ pub fn llama_generate_streaming<F>(
     repeat_penalty: f32,
     stop_sequences: &[String],
     mut on_token: F,
+    // Position in the KV cache where `input_tokens` should be prefilled.
+    // Pass 0 for the legacy "fresh prefill from scratch" behaviour.
+    // Positive values let the caller skip prefill for a shared prefix
+    // already in the cache (truncate the cache via
+    // [`llama_kv_cache_seq_rm`] first, then call with the diverged tail).
+    n_past_in: usize,
 ) -> Result<(Vec<i32>, bool), AdapterError>
 where
     F: FnMut(i32, &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>,
@@ -992,6 +1023,7 @@ where
             n_stop_seqs,
             Some(streaming_trampoline::<F>),
             &mut streaming_ctx as *mut StreamingContext<F> as *mut c_void,
+            n_past_in.min(c_int::MAX as usize) as c_int,
         )
     };
 
@@ -1078,6 +1110,9 @@ pub fn llama_free(_ctx: LlamaContext) {}
 pub fn llama_kv_cache_clear(_ctx: &LlamaContext) {}
 
 #[cfg(not(feature = "llm-llamacpp"))]
+pub fn llama_kv_cache_seq_rm(_ctx: &LlamaContext, _seq_id: i32, _p_keep: usize) {}
+
+#[cfg(not(feature = "llm-llamacpp"))]
 pub fn llama_format_chat(
     _model: &LlamaModel,
     _messages: &[ChatMessage],
@@ -1150,6 +1185,7 @@ pub fn llama_generate(
 }
 
 #[cfg(not(feature = "llm-llamacpp"))]
+#[allow(clippy::too_many_arguments)]
 pub fn llama_generate_streaming<F>(
     _ctx: &LlamaContext,
     _model: &LlamaModel,
@@ -1162,6 +1198,7 @@ pub fn llama_generate_streaming<F>(
     _repeat_penalty: f32,
     _stop_sequences: &[String],
     _on_token: F,
+    _n_past_in: usize,
 ) -> Result<(Vec<i32>, bool), AdapterError>
 where
     F: FnMut(i32, &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>,

--- a/crates/xybrid-core/vendor/llama_wrapper.cpp
+++ b/crates/xybrid-core/vendor/llama_wrapper.cpp
@@ -151,6 +151,30 @@ void llama_kv_cache_clear_c(llama_context* ctx) {
     }
 }
 
+// Truncate the KV cache for a single sequence to a prefix length, keeping
+// positions [0, p_keep) and dropping [p_keep, ∞). Used by the multi-turn
+// prefix-reuse path: caller computes the longest common prefix between the
+// new prompt and the previously-tokenized prompt, then calls this to drop
+// the diverged tail from the cache before re-prefilling only the new tail
+// at position p_keep. Pairs with the n_past_in parameter on
+// llama_generate_streaming_c.
+//
+// Returns 0 on success, -1 on null context / no memory available.
+int llama_kv_cache_seq_rm_c(llama_context* ctx, int seq_id, int p_keep) {
+    if (!ctx) {
+        return -1;
+    }
+    llama_memory_t mem = llama_get_memory(ctx);
+    if (!mem) {
+        return -1;
+    }
+    // llama.cpp's seq_rm semantics: remove tokens in the half-open range
+    // [p0, p1). p1 = -1 means "to the end". We keep [0, p_keep) and drop
+    // everything from p_keep onward.
+    llama_memory_seq_rm(mem, (llama_seq_id) seq_id, (llama_pos) p_keep, -1);
+    return 0;
+}
+
 // =============================================================================
 // Tokenization (using new vocab API)
 // =============================================================================
@@ -670,16 +694,29 @@ int llama_generate_streaming_c(
     const int* stop_lens,
     int n_stop_seqs,
     token_callback_t callback,
-    void* user_data
+    void* user_data,
+    // Position in the KV cache where input_tokens should be prefilled.
+    // Pass 0 for the legacy "fresh prefill from scratch" behaviour. Positive
+    // values let the caller skip prefill for a shared prefix that's already
+    // in the cache: truncate the cache to length n_past_in (via
+    // llama_kv_cache_seq_rm_c above), then call this with input_tokens =
+    // the diverged tail and n_past_in = the prefix length. The wrapper
+    // prefills the tail at positions [n_past_in, n_past_in + n_input).
+    int n_past_in
 ) {
     if (!ctx || !model || !input_tokens || !output_tokens || n_input <= 0 || max_tokens <= 0) {
         return -1;
     }
+    if (n_past_in < 0) {
+        return -1;
+    }
 
-    // Validate input tokens fit within context window.
+    // Validate the prefilled prefix + new tail fits within the context window.
+    // Without n_past_in this collapses to the original n_input >= n_ctx check.
     const int n_ctx = llama_n_ctx(ctx);
-    if (n_input >= n_ctx) {
-        fprintf(stderr, "llama_generate_streaming_c: input tokens (%d) >= context window (%d)\n", n_input, n_ctx);
+    if (n_past_in + n_input >= n_ctx) {
+        fprintf(stderr, "llama_generate_streaming_c: prefix (%d) + input (%d) >= context window (%d)\n",
+                n_past_in, n_input, n_ctx);
         return -4;  // Input too long for context window
     }
 
@@ -699,7 +736,10 @@ int llama_generate_streaming_c(
     llama_batch batch = llama_batch_init(n_batch > 0 ? n_batch : 512, 0, 1);
 
     int n_generated = 0;
-    int n_cur = 0;  // Current position in context
+    // Start prefill at the caller-supplied position so we slot the new
+    // tail in right after whatever shared prefix is already in the cache.
+    // Generation loop continues from the same counter post-prefill.
+    int n_cur = n_past_in;
     bool stopped_by_callback = false;
 
     // Pre-allocate candidates buffer once — reused every token.


### PR DESCRIPTION
## Summary

Replaces the unconditional `llama_kv_cache_clear` at the top of every `generate*` call with a longest-common-prefix path: the backend now compares the new prompt's tokens to the prior call's, truncates the KV cache to the shared prefix via a new `llama_kv_cache_seq_rm` FFI, and prefills only the diverged tail. The C wrapper grows an `n_past_in` parameter on `llama_generate_streaming_c` (plus a context-window check that includes the prefix); the Rust side adds a `KvCacheState` mutex, a unit-tested `compute_reusable_prefix_len` helper, and a `last_cached_prefix_len` accessor that future `prompt_cached_tokens` telemetry will read. When the prefilled prefix + new tail + `max_tokens` would overflow the context window, the path falls back to a full clear so eviction stays out of scope without sacrificing correctness, and `unload` resets the state to avoid stale prefixes leaking across model loads.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — six LCP unit tests cover empty / identical / partial-match / no-overlap / cap / single-token edges
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (inline doc comments on the helper, FFI, and `KvCacheState`; `prompt_cached_tokens` wire field is a follow-up)
- [x] No breaking changes (default `n_past_in = 0` matches legacy "fresh prefill" behaviour; non-llamacpp shim updated to match the new signature)