### PR TITLE
feat(swift): wire iOS battery observer + extend NSProcessInfo poller to iOS

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if os(iOS)
+import UIKit
+#endif
 
 // MARK: - SDK Initialization
 
@@ -23,17 +26,34 @@ import Foundation
 public enum Xybrid {
     private static let initLock = NSLock()
     nonisolated(unsafe) private static var initialized = false
+    #if os(iOS)
+    // Retained so the NotificationCenter block-based observer keeps
+    // firing for the process lifetime. NotificationCenter holds the
+    // observer weakly through this token; losing the reference would
+    // silently drop battery updates.
+    nonisolated(unsafe) private static var batteryObserver: NSObjectProtocol?
+    #endif
 
     /// Initialize the Xybrid runtime.
     ///
     /// Registers the Swift binding identifier with the SDK so that the
     /// `X-Xybrid-Client` header on registry HTTP calls reports
     /// `binding=swift`. Idempotent and thread-safe.
+    ///
+    /// On iOS, also enables `UIDevice` battery monitoring and subscribes
+    /// to `UIDevice.batteryLevelDidChangeNotification`, forwarding each
+    /// reading through the SDK's push-state surface so the routing
+    /// engine has live battery telemetry. Thermal state on Apple
+    /// platforms is sourced from `NSProcessInfo.thermalState` directly
+    /// in `xybrid-core` (no host wiring needed). On macOS, both
+    /// battery (IOKit) and thermal (NSProcessInfo) are in-Rust, so
+    /// nothing extra is registered here.
     public static func initialize() {
         initLock.lock()
         defer { initLock.unlock() }
         if initialized { return }
         setBinding(binding: "swift")
+        registerPlatformObservers()
         initialized = true
     }
 
@@ -43,6 +63,45 @@ public enum Xybrid {
         defer { initLock.unlock() }
         return initialized
     }
+
+    private static func registerPlatformObservers() {
+        #if os(iOS)
+        let device = UIDevice.current
+        // Battery monitoring is opt-in on iOS — without this flag,
+        // `batteryLevel` returns -1.0 and the notification never fires.
+        device.isBatteryMonitoringEnabled = true
+
+        // Push the current value immediately so the first cache miss
+        // isn't blind, then keep updating on every notification.
+        pushBatteryLevel(device.batteryLevel)
+
+        batteryObserver = NotificationCenter.default.addObserver(
+            forName: UIDevice.batteryLevelDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            pushBatteryLevel(UIDevice.current.batteryLevel)
+        }
+        #endif
+    }
+
+    #if os(iOS)
+    /// Convert `UIDevice.batteryLevel` (Float in 0.0...1.0, or -1.0 for
+    /// unknown) into the SDK's `UInt8` 0..=100 representation. Negative
+    /// or non-finite values surface as "unknown" via [`clearBatteryLevel`]
+    /// so the routing engine doesn't see a fake 0% reading.
+    private static func pushBatteryLevel(_ level: Float) {
+        guard level.isFinite, level >= 0 else {
+            clearBatteryLevel()
+            return
+        }
+        let pct = (level * 100).rounded()
+        // Clamp defensively; iOS has been observed to report 1.01 briefly
+        // near a full charge during recalibration.
+        let bounded = max(0, min(100, Int(pct)))
+        setBatteryLevel(percent: UInt8(bounded))
+    }
+    #endif
 }
 
 // MARK: - Public Type Re-exports

--- a/bindings/apple/Sources/Xybrid/xybrid_uniffi.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_uniffi.swift
@@ -297,6 +297,19 @@ private func uniffiCheckCallStatus(
 // Public interface members begin here.
 
 
+fileprivate struct FfiConverterUInt8: FfiConverterPrimitive {
+    typealias FfiType = UInt8
+    typealias SwiftType = UInt8
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt8 {
+        return try lift(readInt(&buf))
+    }
+
+    public static func write(_ value: UInt8, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
 fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
     typealias FfiType = UInt32
     typealias SwiftType = UInt32
@@ -1182,6 +1195,72 @@ extension XybridError: Equatable, Hashable {}
 
 extension XybridError: Error { }
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+public enum XybridThermalState {
+    
+    case normal
+    case warm
+    case hot
+    case critical
+}
+
+public struct FfiConverterTypeXybridThermalState: FfiConverterRustBuffer {
+    typealias SwiftType = XybridThermalState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> XybridThermalState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .normal
+        
+        case 2: return .warm
+        
+        case 3: return .hot
+        
+        case 4: return .critical
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: XybridThermalState, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .normal:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .warm:
+            writeInt(&buf, Int32(2))
+        
+        
+        case .hot:
+            writeInt(&buf, Int32(3))
+        
+        
+        case .critical:
+            writeInt(&buf, Int32(4))
+        
+        }
+    }
+}
+
+
+public func FfiConverterTypeXybridThermalState_lift(_ buf: RustBuffer) throws -> XybridThermalState {
+    return try FfiConverterTypeXybridThermalState.lift(buf)
+}
+
+public func FfiConverterTypeXybridThermalState_lower(_ value: XybridThermalState) -> RustBuffer {
+    return FfiConverterTypeXybridThermalState.lower(value)
+}
+
+
+extension XybridThermalState: Equatable, Hashable {}
+
+
+
 fileprivate struct FfiConverterOptionUInt32: FfiConverterRustBuffer {
     typealias SwiftType = UInt32?
 
@@ -1520,6 +1599,22 @@ fileprivate func uniffiInitContinuationCallback() {
     ffi_xybrid_uniffi_rust_future_continuation_callback_set(uniffiFutureContinuationCallback)
 }
 
+public func clearBatteryLevel()  {
+    try! rustCall() {
+    uniffi_xybrid_uniffi_fn_func_clear_battery_level($0)
+}
+}
+
+
+
+public func clearThermalState()  {
+    try! rustCall() {
+    uniffi_xybrid_uniffi_fn_func_clear_thermal_state($0)
+}
+}
+
+
+
 public func initSdkCacheDir(cacheDir: String)  {
     try! rustCall() {
     uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(
@@ -1529,10 +1624,28 @@ public func initSdkCacheDir(cacheDir: String)  {
 
 
 
+public func setBatteryLevel(percent: UInt8)  {
+    try! rustCall() {
+    uniffi_xybrid_uniffi_fn_func_set_battery_level(
+        FfiConverterUInt8.lower(percent),$0)
+}
+}
+
+
+
 public func setBinding(binding: String)  {
     try! rustCall() {
     uniffi_xybrid_uniffi_fn_func_set_binding(
         FfiConverterString.lower(binding),$0)
+}
+}
+
+
+
+public func setThermalState(state: XybridThermalState)  {
+    try! rustCall() {
+    uniffi_xybrid_uniffi_fn_func_set_thermal_state(
+        FfiConverterTypeXybridThermalState.lower(state),$0)
 }
 }
 
@@ -1553,10 +1666,22 @@ private var initializationResult: InitializationResult {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
+    if (uniffi_xybrid_uniffi_checksum_func_clear_battery_level() != 40326) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xybrid_uniffi_checksum_func_clear_thermal_state() != 36495) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xybrid_uniffi_checksum_func_set_battery_level() != 57690) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xybrid_uniffi_checksum_func_set_binding() != 53803) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xybrid_uniffi_checksum_func_set_thermal_state() != 59048) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id() != 623) {

--- a/bindings/apple/Sources/xybrid_uniffiFFI/include/xybrid_uniffiFFI.h
+++ b/bindings/apple/Sources/xybrid_uniffiFFI/include/xybrid_uniffiFFI.h
@@ -87,9 +87,19 @@ void*_Nonnull uniffi_xybrid_uniffi_fn_constructor_xybridmodelloader_from_registr
 );
 void* _Nonnull uniffi_xybrid_uniffi_fn_method_xybridmodelloader_load(void*_Nonnull ptr
 );
+void uniffi_xybrid_uniffi_fn_func_clear_battery_level(RustCallStatus *_Nonnull out_status
+    
+);
+void uniffi_xybrid_uniffi_fn_func_clear_thermal_state(RustCallStatus *_Nonnull out_status
+    
+);
 void uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(RustBuffer cache_dir, RustCallStatus *_Nonnull out_status
 );
+void uniffi_xybrid_uniffi_fn_func_set_battery_level(uint8_t percent, RustCallStatus *_Nonnull out_status
+);
 void uniffi_xybrid_uniffi_fn_func_set_binding(RustBuffer binding, RustCallStatus *_Nonnull out_status
+);
+void uniffi_xybrid_uniffi_fn_func_set_thermal_state(RustBuffer state, RustCallStatus *_Nonnull out_status
 );
 RustBuffer ffi_xybrid_uniffi_rustbuffer_alloc(int32_t size, RustCallStatus *_Nonnull out_status
 );
@@ -205,10 +215,22 @@ void ffi_xybrid_uniffi_rust_future_free_void(void* _Nonnull handle
 );
 void ffi_xybrid_uniffi_rust_future_complete_void(void* _Nonnull handle, RustCallStatus *_Nonnull out_status
 );
+uint16_t uniffi_xybrid_uniffi_checksum_func_clear_battery_level(void
+    
+);
+uint16_t uniffi_xybrid_uniffi_checksum_func_clear_thermal_state(void
+    
+);
 uint16_t uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(void
     
 );
+uint16_t uniffi_xybrid_uniffi_checksum_func_set_battery_level(void
+    
+);
 uint16_t uniffi_xybrid_uniffi_checksum_func_set_binding(void
+    
+);
+uint16_t uniffi_xybrid_uniffi_checksum_func_set_thermal_state(void
     
 );
 uint16_t uniffi_xybrid_uniffi_checksum_method_xybridmodel_default_voice_id(void

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -150,14 +150,22 @@ ureq = { version = "2.8", default-features = false, features = ["json", "tls"] }
 # Force rustls to use ring crypto backend instead of aws-lc-rs
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
-# macOS native platform-state poller: NSProcessInfo.thermalState (Foundation)
-# for thermal, IOKit IOPSCopyPowerSourcesInfo for battery — both in-process
-# and microsecond-class. A `pmset` shellout would fork+exec on every cache
-# miss inside the orchestrator hot path; IOKit's IOPS APIs are documented
-# thread-safe and avoid that.
-[target.'cfg(target_os = "macos")'.dependencies]
+# Apple thermal poller (macOS + iOS): NSProcessInfo.thermalState — same
+# Foundation API on both, no entitlement, microsecond-class. The
+# Foundation crates work cross-platform under the same target_os check
+# clang's apple compilation matrix uses.
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc2 = "0.5"
 objc2-foundation = { version = "0.2", features = ["NSProcessInfo", "NSString"] }
+
+# macOS-only battery poller: IOKit IOPSCopyPowerSourcesInfo. The IOPS
+# APIs are gated behind a private entitlement on iOS; the public
+# UIDevice.batteryLevel path requires UIKit which doesn't belong in
+# xybrid-core, so iOS hosts push battery via the UniFFI surface.
+# A `pmset` shellout would fork+exec on every cache miss inside the
+# orchestrator hot path; IOKit's IOPS APIs are documented thread-safe
+# and avoid that.
+[target.'cfg(target_os = "macos")'.dependencies]
 objc2-io-kit = "0.3"
 objc2-core-foundation = { version = "0.3", features = ["CFString", "CFNumber", "CFArray", "CFDictionary"] }
 

--- a/crates/xybrid-core/src/device/platform_state.rs
+++ b/crates/xybrid-core/src/device/platform_state.rs
@@ -105,6 +105,11 @@ pub fn clear_thermal_state() {
 ///   in-process and thread-safe per Apple's docs — no fork/exec, no
 ///   COM, safe on the runtime thread that
 ///   `Orchestrator::execute_stage_async` lands on.
+/// - **iOS**: reads `NSProcessInfo.thermalState` (same Foundation API
+///   as macOS, no entitlement). Battery comes from the host via the
+///   UniFFI surface — `UIDevice.batteryLevel` requires UIKit which
+///   doesn't belong in `xybrid-core`, so the Swift wrapper subscribes
+///   to `UIDevice.batteryLevelDidChangeNotification` and pushes.
 /// - **Windows**: reads `GetSystemPowerStatus` (Win32, in-process)
 ///   for battery on the cache-miss path. Thermal is sourced from
 ///   `MSAcpi_ThermalZoneTemperature` over WMI (`ROOT\WMI`); COM
@@ -112,9 +117,10 @@ pub fn clear_thermal_state() {
 ///   thread that `Orchestrator::execute_stage_async` lands on, so
 ///   the WMI loop runs on a dedicated background thread that pushes
 ///   results through the public setters.
-/// - **iOS, Android**: no-op for now. Hosts push state via the public
-///   setters from platform observers; native in-process pollers come
-///   later.
+/// - **Android**: no-op. Hosts push state via the public setters
+///   from platform observers; the Kotlin `Xybrid.init(context)`
+///   wrapper registers `BatteryManager.ACTION_BATTERY_CHANGED` and
+///   `PowerManager.OnThermalStatusChangedListener`.
 ///
 /// All in-process refreshers go through the same setters a host would
 /// use, so behaviour is uniform whether data comes from sysfs, IOKit, or
@@ -125,8 +131,8 @@ pub fn clear_thermal_state() {
 pub fn refresh_native_platform_state() {
     #[cfg(target_os = "linux")]
     linux::refresh();
-    #[cfg(target_os = "macos")]
-    macos::refresh();
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    apple::refresh();
     #[cfg(target_os = "windows")]
     windows::refresh();
 }
@@ -214,38 +220,51 @@ mod linux {
     }
 }
 
-#[cfg(target_os = "macos")]
-mod macos {
-    //! macOS native pollers.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod apple {
+    //! Apple native pollers (macOS + iOS).
     //!
     //! Thermal: `NSProcessInfo.thermalState` — direct Foundation call,
-    //! no entitlement, microsecond-class.
+    //! no entitlement, microsecond-class. Same Foundation API on both
+    //! platforms, so a single code path covers macOS and iOS.
     //!
     //! Battery: IOKit `IOPSCopyPowerSourcesInfo` →
     //! `IOPSCopyPowerSourcesList` → `IOPSGetPowerSourceDescription`,
     //! reading `kIOPSCurrentCapacityKey` / `kIOPSMaxCapacityKey` from
-    //! the per-source dictionary. All three calls are in-process and
-    //! documented thread-safe; no fork+exec (which is what a `pmset
-    //! -g batt` shellout would cost on every cache miss).
+    //! the per-source dictionary. **macOS only** — iOS gates the IOPS
+    //! APIs behind a private entitlement, and the public path
+    //! (`UIDevice.batteryLevel`) requires UIKit which doesn't belong in
+    //! `xybrid-core`. iOS hosts therefore push battery via the UniFFI
+    //! surface; the Swift wrapper subscribes to
+    //! `UIDevice.batteryLevelDidChangeNotification`.
     //!
-    //! Both pollers are safe on the cache-miss hot path that
+    //! All in-process pollers are safe on the cache-miss hot path that
     //! `Orchestrator::execute_stage_async` invokes via
-    //! `ResourceMonitor::current_snapshot`. Devices without a battery
-    //! (Mac mini, Mac Studio, etc.) return an empty source list and
-    //! we report `None`.
+    //! `ResourceMonitor::current_snapshot`. macOS devices without a
+    //! battery (Mac mini, Mac Studio, Mac Pro) return an empty source
+    //! list and we report `None`.
 
-    use core::ffi::{c_void, CStr};
-
-    use super::{set_battery_level, set_thermal_state, ThermalState};
-    use objc2_core_foundation::{CFDictionary, CFNumber, CFString, CFType};
     use objc2_foundation::NSProcessInfo;
+
+    #[cfg(target_os = "macos")]
+    use core::ffi::{c_void, CStr};
+    #[cfg(target_os = "macos")]
+    use objc2_core_foundation::{CFDictionary, CFNumber, CFString, CFType};
+    #[cfg(target_os = "macos")]
     use objc2_io_kit::{
         kIOPSCurrentCapacityKey, kIOPSMaxCapacityKey, IOPSCopyPowerSourcesInfo,
         IOPSCopyPowerSourcesList, IOPSGetPowerSourceDescription,
     };
 
+    #[cfg(target_os = "macos")]
+    use super::set_battery_level;
+    use super::{set_thermal_state, ThermalState};
+
     pub(super) fn refresh() {
         set_thermal_state(read_thermal_state());
+        // iOS routes battery through the host (Swift wrapper) since the
+        // public path needs UIKit. macOS uses IOKit in-process.
+        #[cfg(target_os = "macos")]
         if let Some(pct) = read_battery_pct() {
             set_battery_level(pct);
         }
@@ -286,6 +305,7 @@ mod macos {
         }
     }
 
+    #[cfg(target_os = "macos")]
     fn read_battery_pct() -> Option<u8> {
         // `IOPSCopyPowerSourcesInfo` is the documented entry point; per
         // Apple's docs it does no I/O of its own, just snapshots a
@@ -343,6 +363,7 @@ mod macos {
         None
     }
 
+    #[cfg(target_os = "macos")]
     fn lookup_int(dict: &CFDictionary, key_cstr: &CStr) -> Option<i64> {
         // IOKit defines its dictionary keys as C strings (e.g.
         // `kIOPSCurrentCapacityKey == "Current Capacity"`). The
@@ -375,6 +396,7 @@ mod macos {
     /// sensor glitch or uninitialized source) or `current < 0`.
     /// Otherwise clamps to 0..=100 — some power sources briefly report
     /// `current > max` while recalibrating.
+    #[cfg(target_os = "macos")]
     fn compute_pct(current: i64, max: i64) -> Option<u8> {
         if max <= 0 || current < 0 {
             return None;
@@ -418,6 +440,7 @@ mod macos {
             let _ = state;
         }
 
+        #[cfg(target_os = "macos")]
         #[test]
         fn compute_pct_handles_normal_values() {
             assert_eq!(compute_pct(0, 100), Some(0));
@@ -428,12 +451,14 @@ mod macos {
             assert_eq!(compute_pct(4_200, 5_000), Some(84));
         }
 
+        #[cfg(target_os = "macos")]
         #[test]
         fn compute_pct_zero_or_negative_max_is_none() {
             assert_eq!(compute_pct(50, 0), None);
             assert_eq!(compute_pct(50, -100), None);
         }
 
+        #[cfg(target_os = "macos")]
         #[test]
         fn compute_pct_negative_current_is_none() {
             // A negative `current` is a sensor glitch — don't fold that
@@ -441,6 +466,7 @@ mod macos {
             assert_eq!(compute_pct(-1, 100), None);
         }
 
+        #[cfg(target_os = "macos")]
         #[test]
         fn compute_pct_clamps_above_max() {
             // Power sources can briefly report current > max during
@@ -449,6 +475,7 @@ mod macos {
             assert_eq!(compute_pct(200, 100), Some(100));
         }
 
+        #[cfg(target_os = "macos")]
         #[test]
         fn read_battery_pct_returns_none_or_valid_percent() {
             // Smoke test: don't assert exact values — laptops, desktops,


### PR DESCRIPTION
## Summary

Two coupled changes lifting iOS thermal into in-Rust territory and adding the iOS battery observer to the Swift wrapper.

### 1. NSProcessInfo poller extended to iOS (Rust)

`crates/xybrid-core/src/device/platform_state.rs`:
- Renamed `mod macos` → `mod apple` and changed the outer cfg to `any(macos, ios)`. `NSProcessInfo.thermalState` is the same Foundation API on both platforms — no entitlement, microsecond-class.
- IOKit `IOPSCopyPowerSourcesInfo` stays macOS-only via inner `#[cfg(target_os = "macos")]` gates on `read_battery_pct`, `lookup_int`, `compute_pct`, and their tests. The IOPS APIs are entitlement-locked on iOS, and the public path (`UIDevice.batteryLevel`) requires UIKit which doesn't belong in core.
- `Cargo.toml` split: `objc2` + `objc2-foundation` build for both platforms now; `objc2-io-kit` + `objc2-core-foundation` remain macOS-only.

Net effect: iOS gets thermal telemetry for free, no host wiring required.

### 2. Swift wrapper iOS battery observer

`bindings/apple/Sources/Xybrid/Xybrid.swift`:
- iOS-only `#if os(iOS)` block in `Xybrid.initialize()`:
  - Sets `UIDevice.current.isBatteryMonitoringEnabled = true` (required — without it `batteryLevel` returns -1.0 and the notification never fires).
  - Pushes the current value immediately so the first cache miss isn't blind.
  - Subscribes to `UIDevice.batteryLevelDidChangeNotification` and forwards each reading.
- Observer token retained in a `nonisolated(unsafe) static var` so the block-based observer keeps firing for the process lifetime — `NotificationCenter` holds these weakly through the token.
- macOS path unchanged: both battery (IOKit, #76) and thermal (NSProcessInfo, #74) are already in-Rust.
- Defensive value handling: negative or non-finite levels (sensor unavailable / monitoring not enabled / transient glitch) surface as `clearBatteryLevel()` rather than a fake 0%. Levels are clamped to 0..=100 (iOS has been observed to report 1.01 briefly during recalibration).

Also regenerates `xybrid_uniffi.swift` + the FFI header to expose the push-state surface from #78. Diff is purely additive.

## Cross-platform status

| Platform | Battery | Thermal | Host wiring |
|----------|---------|---------|-------------|
| Linux    | sysfs (#72) | sysfs (#72) | n/a |
| macOS    | IOKit (#76) | NSProcessInfo (#74) | n/a |
| Windows  | `GetSystemPowerStatus` (#75) | WMI (#77) | n/a |
| **iOS**  | host push via UniFFI (#78) | **NSProcessInfo (this PR)** | **this PR** |
| Android  | host push (#78) | host push (#78) | #86 |
| Flutter  | host push (#84) | host push (#84) | follow-up |

## Test plan

- [x] `cargo test -p xybrid-core --lib device::platform_state` — all 15 tests pass on macOS host (the macOS-gated battery tests + the shared thermal tests + the apple-bucketed enum mapping)
- [x] `cargo check -p xybrid-core --target aarch64-apple-ios --no-default-features` — iOS build clean with the new cfg gating
- [x] `cargo clippy -p xybrid-core --all-targets -- -D warnings` — no new warnings
- [x] `swiftc -typecheck` against both iPhoneOS and macOSX SDKs — zero errors in `Xybrid.swift` (only the expected missing-FFI-extern noise from the generated `xybrid_uniffi.swift`, which links against a real `.dylib` in production builds)
- [ ] CI macOS + iOS builds

## Out of scope

- Dart wrapper wiring — last host PR.
- Docs page on host integration expectations.