### PR TITLE
feat(flutter): wire battery observer into Xybrid.init via battery_plus

### DIFF
--- a/bindings/flutter/lib/src/xybrid.dart
+++ b/bindings/flutter/lib/src/xybrid.dart
@@ -6,7 +6,9 @@ library;
 import 'dart:async';
 import 'dart:io' show Platform;
 
+import 'package:battery_plus/battery_plus.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:xybrid_flutter/src/rust/api/device.dart';
 import 'package:xybrid_flutter/src/rust/api/sdk_client.dart';
 import 'package:path_provider/path_provider.dart';
 import 'rust/frb_generated.dart';
@@ -31,6 +33,19 @@ class Xybrid {
   static bool _initialized = false;
   static final Completer<void> _initCompleter = Completer<void>();
   static bool _initializing = false;
+
+  /// Battery state subscription retained for the process lifetime so
+  /// the underlying platform stream isn't garbage-collected. `null`
+  /// outside iOS / Android — desktop platforms use xybrid-core's
+  /// in-process pollers and don't subscribe here.
+  ///
+  /// The two lints below are intentional: the field exists solely
+  /// to anchor the subscription against GC, and the SDK is a
+  /// process-lifetime singleton (matches the Kotlin
+  /// `Xybrid.init(context)` and Swift `Xybrid.initialize()` shapes —
+  /// neither of which exposes a teardown either).
+  // ignore: cancel_subscriptions, unused_field
+  static StreamSubscription<BatteryState>? _batterySubscription;
 
   /// Private constructor to prevent instantiation.
   Xybrid._();
@@ -78,6 +93,8 @@ class Xybrid {
         final cacheDir = '${appDir.path}/xybrid/models';
         XybridSdkClient.initSdkCacheDir(cacheDir: cacheDir);
       }
+
+      await _registerPlatformObservers();
 
       _initialized = true;
       _initCompleter.complete();
@@ -171,5 +188,57 @@ class Xybrid {
     }
 
     return XybridPipeline.fromFile(filePath!);
+  }
+
+  /// Subscribe to OS-level battery state on mobile platforms and
+  /// forward each reading into the routing engine via the FRB
+  /// push-state surface. Desktop platforms (macOS / Linux / Windows)
+  /// use xybrid-core's in-process pollers, and Flutter on iOS gets
+  /// thermal in-Rust via NSProcessInfo, so this only runs on iOS and
+  /// Android.
+  ///
+  /// `battery_plus` exposes a snapshot getter (`batteryLevel`) and a
+  /// stream of high-level state changes (`onBatteryStateChanged`) but
+  /// no continuous level stream. The level is therefore re-read on
+  /// each state-change event (plug/unplug, charge full, etc.) plus
+  /// once at init so the first cache miss isn't blind. Routing
+  /// decisions are bucket-based (low / mid / high), so the resulting
+  /// granularity is sufficient — the cache TTL inside `ResourceMonitor`
+  /// is the limiting factor on freshness regardless.
+  ///
+  /// Thermal on Flutter Android is currently a gap: Dart has no
+  /// cross-platform package wrapping `PowerManager.OnThermalStatusChangedListener`,
+  /// and adding a Kotlin plugin layer is out of scope here. Consumer
+  /// apps that need it can call `XybridDevice.setThermalState(...)`
+  /// directly from their own platform channel.
+  static Future<void> _registerPlatformObservers() async {
+    if (!(Platform.isAndroid || Platform.isIOS)) {
+      return;
+    }
+    final battery = Battery();
+    await _pushBatteryLevel(battery);
+    _batterySubscription = battery.onBatteryStateChanged.listen((_) {
+      // Re-read the level on each state transition; battery_plus
+      // doesn't expose a level stream so this is the canonical
+      // refresh point.
+      unawaited(_pushBatteryLevel(battery));
+    });
+  }
+
+  static Future<void> _pushBatteryLevel(Battery battery) async {
+    try {
+      final level = await battery.batteryLevel;
+      // battery_plus returns 0..=100 already; clamp defensively in case
+      // a future platform impl reports out-of-range values rather than
+      // throwing.
+      final pct = level.clamp(0, 100);
+      XybridDevice.setBatteryLevel(percent: pct);
+    } catch (_) {
+      // Sensor unavailable (emulator, sandboxed context, etc.) —
+      // surface as "unknown" rather than a fake reading. The routing
+      // engine treats `None` as "no signal" and falls back to other
+      // evidence.
+      XybridDevice.clearBatteryLevel();
+    }
   }
 }

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -21,6 +21,12 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   freezed_annotation: ^2.0.0
   path_provider: ^2.1.5
+  # Cross-platform battery level observer used by Xybrid.init on
+  # iOS / Android to forward host battery state into the routing
+  # engine via the FRB push-state surface (XybridDevice.setBatteryLevel).
+  # Flutter on macOS / Linux / Windows uses xybrid-core's in-process
+  # pollers and does not rely on this package at runtime.
+  battery_plus: ^6.0.0
 
 dev_dependencies:
   ffi: ^2.1.3


### PR DESCRIPTION
## Summary

`Xybrid.init()` on Flutter now subscribes to OS-level battery state on iOS and Android and forwards each reading through the FRB push-state surface (`XybridDevice.setBatteryLevel`) so the routing engine has live telemetry without consumer apps writing platform-channel boilerplate.

Closes the host-wrapper sequence: Kotlin (#86), Swift (#88), Flutter (this PR). Desktop platforms (macOS / Linux / Windows) use the in-process xybrid-core pollers and don't subscribe here. Flutter on iOS gets thermal in-Rust via NSProcessInfo (#88), so this PR only needs to wire battery.

## Cross-platform status after this merges

| Platform | Battery | Thermal | Host wiring |
|----------|---------|---------|-------------|
| Linux    | sysfs (#72) | sysfs (#72) | n/a |
| macOS    | IOKit (#76) | NSProcessInfo (#74) | n/a |
| Windows  | `GetSystemPowerStatus` (#75) | WMI (#77) | n/a |
| iOS      | host push via UniFFI (#78) | NSProcessInfo (#88) | Swift ✅ #88, Flutter ✅ this PR |
| Android  | host push (#78) | host push (#78) | Kotlin ✅ #86, **Flutter battery ✅ this PR** |
| Flutter (desktop) | xybrid-core in-process | xybrid-core in-process | n/a |

## Implementation notes

- Adds `battery_plus: ^6.0.0` to `pubspec.yaml`. It's the de-facto cross-platform Flutter battery package, low-controversy.
- Subscribes only on `Platform.isAndroid || Platform.isIOS` — desktops have in-Rust pollers.
- `battery_plus` exposes `batteryLevel` (snapshot getter) and `onBatteryStateChanged` (stream of `BatteryState`) but **no continuous level stream**. Level is re-read on each state-transition event (plug/unplug, charge full, etc.) plus once at init to seed. Routing decisions are bucket-based and `ResourceMonitor`'s 500ms cache TTL is the limiting factor on freshness regardless.
- Sensor failures (emulator, sandboxed contexts, no battery hardware) surface as `clearBatteryLevel()` so the routing engine sees `None` rather than a fake 0%.
- Subscription is retained in a static field for the process lifetime — symmetric with Kotlin and Swift wrappers, neither of which exposes a teardown. Lints `cancel_subscriptions` + `unused_field` suppressed at the field with rationale.

## Out of scope

- **Thermal on Flutter Android**: documented gap. Dart has no cross-platform package wrapping `PowerManager.OnThermalStatusChangedListener`, and adding a Kotlin plugin layer (which doesn't exist today under `bindings/flutter/android/src/`) is substantial new surface. Consumer apps that need it can call `XybridDevice.setThermalState(...)` from their own `MethodChannel`. Logical follow-up.
- **Docs page** on host integration expectations — last item on the original roadmap. Now that all three host wrappers ship, can be written from a stable picture.

## Test plan

- [x] `flutter pub get` resolves clean
- [x] `flutter analyze lib/` — no issues from this PR
- [x] `flutter analyze lib/src/xybrid.dart` — clean (the two intentional lints are suppressed with rationale)
- [ ] CI Android + iOS Flutter build matrix