### PR TITLE
feat(telemetry): emit prompt_cached_tokens for local LLM KV cache hits

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -978,20 +978,22 @@ impl TemplateExecutor {
             cfg
         };
 
-        // Execute with streaming. Capture the backend name alongside
-        // the output so the metric mirror can label the resolved
-        // execution provider for the wire payload.
-        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            let out = adapter
-                .backend()
-                .generate_streaming(&messages, &gen_config, on_token)?;
-            let name = adapter.backend().name().to_string();
-            (out, name)
-        } else {
-            return Err(AdapterError::RuntimeError(
-                "LLM adapter cache unexpectedly empty".to_string(),
-            ));
-        };
+        // Execute with streaming. Capture the backend name + the prefix
+        // length the backend reused from its KV cache so the metric
+        // mirror can attach the resolved execution provider and the
+        // local-cache-hit count to the wire payload.
+        let (output, backend_name, cached_prefix) =
+            if let Some((_, adapter)) = &self.llm_adapter_cache {
+                let backend = adapter.backend();
+                let out = backend.generate_streaming(&messages, &gen_config, on_token)?;
+                let name = backend.name().to_string();
+                let cached = backend.last_cached_prefix_len();
+                (out, name, cached)
+            } else {
+                return Err(AdapterError::RuntimeError(
+                    "LLM adapter cache unexpectedly empty".to_string(),
+                ));
+            };
 
         // Build response envelope
         let mut response_metadata = std::collections::HashMap::new();
@@ -1009,7 +1011,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output, &backend_name);
+        mirror_llm_metrics_to_span(&output, &backend_name, cached_prefix);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1069,16 +1071,19 @@ impl TemplateExecutor {
         let gen_config = config.cloned().unwrap_or_default();
 
         // Execute with ChatMessages directly — backend applies template once.
-        // Capture backend name for the resolved-EP mirror.
-        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            let out = adapter.backend().generate(messages, &gen_config)?;
-            let name = adapter.backend().name().to_string();
-            (out, name)
-        } else {
-            return Err(AdapterError::RuntimeError(
-                "LLM adapter cache unexpectedly empty".to_string(),
-            ));
-        };
+        // Capture backend name + cached-prefix length for the metric mirror.
+        let (output, backend_name, cached_prefix) =
+            if let Some((_, adapter)) = &self.llm_adapter_cache {
+                let backend = adapter.backend();
+                let out = backend.generate(messages, &gen_config)?;
+                let name = backend.name().to_string();
+                let cached = backend.last_cached_prefix_len();
+                (out, name, cached)
+            } else {
+                return Err(AdapterError::RuntimeError(
+                    "LLM adapter cache unexpectedly empty".to_string(),
+                ));
+            };
 
         // Build response envelope
         let mut response_metadata = std::collections::HashMap::new();
@@ -1096,7 +1101,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output, &backend_name);
+        mirror_llm_metrics_to_span(&output, &backend_name, cached_prefix);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1159,18 +1164,19 @@ impl TemplateExecutor {
         let gen_config = config.cloned().unwrap_or_default();
 
         // Execute with streaming - pass ChatMessages directly to backend.
-        // Capture backend name for the resolved-EP mirror.
-        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            let out = adapter
-                .backend()
-                .generate_streaming(messages, &gen_config, on_token)?;
-            let name = adapter.backend().name().to_string();
-            (out, name)
-        } else {
-            return Err(AdapterError::RuntimeError(
-                "LLM adapter cache unexpectedly empty".to_string(),
-            ));
-        };
+        // Capture backend name + cached-prefix length for the metric mirror.
+        let (output, backend_name, cached_prefix) =
+            if let Some((_, adapter)) = &self.llm_adapter_cache {
+                let backend = adapter.backend();
+                let out = backend.generate_streaming(messages, &gen_config, on_token)?;
+                let name = backend.name().to_string();
+                let cached = backend.last_cached_prefix_len();
+                (out, name, cached)
+            } else {
+                return Err(AdapterError::RuntimeError(
+                    "LLM adapter cache unexpectedly empty".to_string(),
+                ));
+            };
 
         // Build response envelope
         let mut response_metadata = std::collections::HashMap::new();
@@ -1188,7 +1194,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output, &backend_name);
+        mirror_llm_metrics_to_span(&output, &backend_name, cached_prefix);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -1315,16 +1321,19 @@ impl TemplateExecutor {
         messages.push(ChatMessage::user(&prompt));
 
         // Execute inference using cached adapter's backend directly.
-        // Capture backend name for the resolved-EP mirror.
-        let (output, backend_name) = if let Some((_, adapter)) = &self.llm_adapter_cache {
-            let out = adapter.backend().generate(&messages, &gen_config)?;
-            let name = adapter.backend().name().to_string();
-            (out, name)
-        } else {
-            return Err(AdapterError::RuntimeError(
-                "LLM adapter cache unexpectedly empty".to_string(),
-            ));
-        };
+        // Capture backend name + cached-prefix length for the metric mirror.
+        let (output, backend_name, cached_prefix) =
+            if let Some((_, adapter)) = &self.llm_adapter_cache {
+                let backend = adapter.backend();
+                let out = backend.generate(&messages, &gen_config)?;
+                let name = backend.name().to_string();
+                let cached = backend.last_cached_prefix_len();
+                (out, name, cached)
+            } else {
+                return Err(AdapterError::RuntimeError(
+                    "LLM adapter cache unexpectedly empty".to_string(),
+                ));
+            };
 
         info!(
             target: "xybrid_core",
@@ -1347,7 +1356,7 @@ impl TemplateExecutor {
         );
         response_metadata.insert("finish_reason".to_string(), output.finish_reason.clone());
         insert_llm_streaming_metrics(&mut response_metadata, &output);
-        mirror_llm_metrics_to_span(&output, &backend_name);
+        mirror_llm_metrics_to_span(&output, &backend_name, cached_prefix);
 
         Ok(Envelope {
             kind: EnvelopeKind::Text(output.text),
@@ -2102,6 +2111,7 @@ fn insert_llm_streaming_metrics(
 fn mirror_llm_metrics_to_span(
     output: &crate::runtime_adapter::llm::GenerationOutput,
     backend_name: &str,
+    cached_prefix_tokens: Option<usize>,
 ) {
     // Always-present scalars. These reach the platform via
     // `PlatformEvent.stages[].spans[].metadata` (populated by
@@ -2124,6 +2134,20 @@ fn mirror_llm_metrics_to_span(
         "execution_provider",
         crate::runtime_adapter::llm::local_execution_provider(backend_name),
     );
+
+    // Local KV cache hits: how many prompt tokens this call reused from
+    // the cache the previous turn left behind. Only emit when positive
+    // — `Some(0)` means a first turn or a totally divergent prompt
+    // (telemetry should look like a non-cached call), and `None` means
+    // the backend doesn't track prefix reuse at all (cloud, mistralrs,
+    // mock test backends). The local mirror of cloud's
+    // `cache_read_input_tokens` so analytics can stack them on the
+    // same axis.
+    if let Some(n) = cached_prefix_tokens {
+        if n > 0 {
+            xybrid_trace::add_metadata("prompt_cached_tokens", n.to_string());
+        }
+    }
 
     // Streaming-derived scalars. Only mirror when the backend reported them;
     // the `Option<_>` + `nonzero` filter in mistral keeps misleading zeros

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -251,14 +251,6 @@ impl LlamaCppBackend {
         state.last_prefix_hit = Some(prefix_len);
         Ok((tail, prefix_len))
     }
-
-    /// Number of tokens served from the KV cache on the most recent
-    /// `generate*` call (= the longest-common-prefix length between the
-    /// previous prompt and this one). `None` before the first call.
-    /// Telemetry hook for surfacing `prompt_cached_tokens` on the wire.
-    pub fn last_cached_prefix_len(&self) -> Option<usize> {
-        self.kv_state.lock().ok().and_then(|s| s.last_prefix_hit)
-    }
 }
 
 /// Longest-common-prefix length between the cached tokens and the new
@@ -756,6 +748,15 @@ impl LlmBackend for LlamaCppBackend {
 
     fn context_length(&self) -> Option<usize> {
         self.config.as_ref().map(|c| c.context_length)
+    }
+
+    /// Surface the prefix length the most recent `generate*` reused from
+    /// the persisted KV cache. `Some(0)` on a first turn or a totally
+    /// divergent prompt, `None` only before any `generate*` has run.
+    /// Telemetry hoists this as `prompt_cached_tokens` on inference
+    /// events when the value is positive.
+    fn last_cached_prefix_len(&self) -> Option<usize> {
+        self.kv_state.lock().ok().and_then(|s| s.last_prefix_hit)
     }
 }
 

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -220,6 +220,24 @@ pub trait LlmBackend: Send + Sync {
     fn context_length(&self) -> Option<usize> {
         None
     }
+
+    /// Number of prompt tokens served from the backend's local KV cache
+    /// on the most recent `generate*` call, when the backend supports
+    /// multi-turn cache reuse. `None` for backends without cross-call
+    /// cache state (the default — covers cloud, mistralrs, mock test
+    /// backends). `Some(0)` for backends that *do* keep cache state but
+    /// had no shared prefix on the most recent call (a fresh first
+    /// turn, or a totally divergent prompt).
+    ///
+    /// Telemetry uses this to surface `prompt_cached_tokens` on
+    /// inference events — the local-LLM mirror of the cloud-side
+    /// `cache_read_input_tokens` field. Multi-turn workloads with a
+    /// stable system prompt typically see 70-90% cache hits on every
+    /// call after the first, which is the difference between a 7B
+    /// model feeling responsive and feeling sluggish.
+    fn last_cached_prefix_len(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Factory function type for creating LLM backends.
@@ -554,6 +572,17 @@ impl RuntimeAdapter for LlmRuntimeAdapter {
                     "execution_provider",
                     local_execution_provider(self.backend.name()),
                 );
+
+                // Local KV cache hits: only emit when the backend
+                // actually reused a prefix (n > 0). `Some(0)` means
+                // first-turn / divergent prompt and we want telemetry
+                // to read like a non-cached call. `None` means the
+                // backend doesn't track prefix reuse at all.
+                if let Some(n) = self.backend.last_cached_prefix_len() {
+                    if n > 0 {
+                        crate::tracing::add_metadata("prompt_cached_tokens", n.to_string());
+                    }
+                }
 
                 Ok(Envelope {
                     kind: EnvelopeKind::Text(output.text),

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1090,6 +1090,17 @@ fn convert_to_platform_event(
                 payload["execution_provider"] = serde_json::json!(v);
             }
         }
+        // Local KV cache hits (llama.cpp's multi-turn prefix reuse). The
+        // backend only emits this metadata key when the most recent call
+        // actually reused a prefix (n > 0), so a present value here is
+        // always meaningful — no need to filter out zeros at the SDK
+        // layer. Mirror of cloud's `cache_read_input_tokens` so the
+        // analytics column can stack local + cloud cache hits.
+        if payload.get("prompt_cached_tokens").is_none() {
+            if let Some(n) = extract_llm_prompt_cached_tokens(&spans) {
+                payload["prompt_cached_tokens"] = serde_json::json!(n);
+            }
+        }
         Some(spans)
     } else {
         None
@@ -1214,6 +1225,48 @@ fn extract_llm_token_counts(stages: &serde_json::Value) -> Option<(Option<u64>, 
     } else {
         None
     }
+}
+
+/// Lift the local-LLM `prompt_cached_tokens` value (count of prompt
+/// tokens served from the backend's KV cache on the most recent call)
+/// off the LAST LLM span. The local mirror of cloud's
+/// `cache_read_input_tokens` — emitted only when a backend that tracks
+/// prefix reuse (today: llama.cpp) actually reused tokens, so reading
+/// `Some(n)` from this helper means the value is meaningful and worth
+/// hoisting verbatim. Same last-span-wins / LLM-span detection rule as
+/// [`extract_llm_token_counts`] so retried runs and timing-only spans
+/// don't fight the count-bearing span.
+fn extract_llm_prompt_cached_tokens(stages: &serde_json::Value) -> Option<u64> {
+    let spans = stages.get("spans")?.as_array()?;
+    let mut latest: Option<u64> = None;
+    for span in spans {
+        let name = span.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let meta = span.get("metadata");
+        let is_llm_span = name.starts_with("llm_inference")
+            || name.starts_with("inference:")
+            || meta
+                .map(|m| {
+                    m.get("ttft_ms").is_some()
+                        || m.get("tokens_generated").is_some()
+                        || m.get("tokens_out").is_some()
+                        || m.get("completion_tokens").is_some()
+                })
+                .unwrap_or(false);
+        if !is_llm_span {
+            continue;
+        }
+        let Some(v) = meta.and_then(|m| m.get("prompt_cached_tokens")) else {
+            continue;
+        };
+        if let Some(n) = v.as_u64() {
+            latest = Some(n);
+        } else if let Some(s) = v.as_str() {
+            if let Ok(n) = s.parse::<u64>() {
+                latest = Some(n);
+            }
+        }
+    }
+    latest
 }
 
 /// Walk a `stages` JSON (same shape as [`extract_llm_token_counts`]) and
@@ -2968,6 +3021,73 @@ mod tests {
             ]
         });
         assert!(extract_llm_token_counts(&stages).is_none());
+    }
+
+    #[test]
+    fn extract_llm_prompt_cached_tokens_picks_last_llm_span_with_value() {
+        // Mirrors the token-count extractor's last-span-wins rule: a
+        // streaming run emits a timing-only span first, then a final
+        // span with the accounting numbers. The cached-tokens hoist
+        // must read from the final span — earlier values should be
+        // shadowed when a later span has its own.
+        let stages = serde_json::json!({
+            "spans": [
+                {
+                    "name": "llm_inference_streaming",
+                    "metadata": { "ttft_ms": 120, "prompt_cached_tokens": "0" }
+                },
+                {
+                    "name": "llm_inference_with_messages",
+                    "metadata": { "tokens_in": 200, "prompt_cached_tokens": "150" }
+                }
+            ]
+        });
+        assert_eq!(extract_llm_prompt_cached_tokens(&stages), Some(150));
+    }
+
+    #[test]
+    fn extract_llm_prompt_cached_tokens_handles_numeric_value() {
+        // The runtime emits via add_metadata which always stringifies,
+        // but a future emit path or external producer might supply a
+        // raw number. Both shapes must extract correctly.
+        let stages = serde_json::json!({
+            "spans": [{
+                "name": "llm_inference_with_messages",
+                "metadata": { "prompt_cached_tokens": 96 }
+            }]
+        });
+        assert_eq!(extract_llm_prompt_cached_tokens(&stages), Some(96));
+    }
+
+    #[test]
+    fn extract_llm_prompt_cached_tokens_returns_none_when_absent() {
+        // Backends that don't track prefix reuse never emit the key —
+        // the SDK hoist must produce None so the wire payload omits the
+        // field entirely (rather than emitting a misleading 0).
+        let stages = serde_json::json!({
+            "spans": [{
+                "name": "llm_inference_with_messages",
+                "metadata": { "tokens_in": 32, "tokens_out": 96 }
+            }]
+        });
+        assert_eq!(extract_llm_prompt_cached_tokens(&stages), None);
+    }
+
+    #[test]
+    fn extract_llm_prompt_cached_tokens_ignores_non_llm_spans() {
+        // An ASR/TTS span carrying a stray `prompt_cached_tokens` would
+        // be a real bug to flag, but the extractor must not let that
+        // value leak onto the LLM hoist axis. Same LLM-span detection
+        // as the token-count extractor.
+        let stages = serde_json::json!({
+            "spans": [
+                {
+                    "name": "execute:asr.whisper-tiny",
+                    "metadata": { "prompt_cached_tokens": "999" }
+                }
+            ]
+        });
+        assert_eq!(extract_llm_prompt_cached_tokens(&stages), None);
     }
 
     #[test]

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -224,6 +224,7 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 | `task` | string | inference | `chat` \| `vlm` \| `asr` \| `tts` \| `embedding` \| `image-gen` \| `ocr` \| `rerank` \| `classify` (open string for forward-compat) | `ModelMetadata.metadata["task"]` from `model_metadata.json` |
 | `quantization` | string | inference | `q4_0` \| `q4_k_m` \| `q5_k_m` \| `q8_0` \| `fp16` \| `fp32` (open string — common GGUF labels) | `ModelMetadata.metadata["quantization"]` first; falls back to GGUF filename inference; absent (not empty) when unknown |
 | `execution_provider` | string | inference (local only) | `coreml` \| `cpu` \| `metal` \| `cuda` \| `mlx-metal` \| `ane` (open string) | ORT path: harvested from per-session profiling JSON after the first inference (ORT exposes no session-level resolved-EP getter, so we read `args.provider` from the Chrome-trace output and pick the EP that ran the most ops). LLM path: build-flag-derived label keyed on the backend name. Cloud paths omit — `provider` carries attribution. |
+| `prompt_cached_tokens` | u64 | inference (local LLM, llama.cpp only) | — | Count of prompt tokens served from the backend's KV cache on this call (longest common prefix with the previous turn). Local mirror of cloud's `cache_read_input_tokens`. Absent on first turns and for backends that don't track prefix reuse (cloud, mistralrs, mock). Only emitted when positive — `0` looks indistinguishable from "no cache" so the field stays absent rather than reporting a misleading zero. |
 | `tokens_in` | u64 | inference | — | LLM span (`prompt_tokens` for OpenAI; synthesized total for Anthropic) |
 | `tokens_out` | u64 | inference | — | LLM span (`completion_tokens`) |
 | `cache_read_input_tokens` | u64 | inference | — | Anthropic-canonical; OpenAI's nested `prompt_tokens_details.cached_tokens` maps here |
@@ -234,6 +235,8 @@ The closed set for `backend` is intentionally narrow — values outside it are n
 For local LLM events `provider` is always absent; for cloud events it is always present alongside `backend = "cloud"`.
 
 `execution_provider` is the diagnostic complement to `backend`: `backend` says *which engine we asked for*, `execution_provider` says *what actually ran*. The two diverge most often on the ORT path (CoreML can silently fall back to CPU per-op when an op isn't supported) — the field is the analytics signal that explains "why is this run slow on this chip?" The field is absent for cloud events because cloud `provider` already attributes execution end-to-end.
+
+`prompt_cached_tokens` is the local-LLM analogue of cloud's `cache_read_input_tokens`. Multi-turn workloads with a stable system prompt and conversation prefix routinely see 70-90% of the prompt served from the backend's KV cache on every call after the first — that's the difference between a 7B model feeling responsive and feeling sluggish, and it's also a billing-correctness signal (prefill is the expensive part; cached tokens shouldn't count toward "tokens processed"). Stack with `cache_read_input_tokens` on the same dashboard axis to compare local vs cloud cache savings.
 
 ## `ModelDownload` event
 


### PR DESCRIPTION
## Summary

Surfaces the llama.cpp KV cache prefix-reuse count as an inference-event field, mirroring cloud's `cache_read_input_tokens` so multi-turn workloads can see "tokens served from cache" stacked on the same dashboard axis whether the call ran locally or remotely. Promotes `last_cached_prefix_len` from a llama.cpp-only accessor to an `LlmBackend` trait method (default `None` keeps mistralrs/cloud/mock backends silent), threads it through every `TemplateExecutor` generate path into the metric mirror, and adds an SDK last-LLM-span hoist that omits the field unless the backend reports a positive count — `Some(0)` reads like a non-cached call and stays absent rather than reporting a misleading zero. Doc table + notes updated; four extractor tests cover last-span-wins, numeric/string shapes, absent value, and non-LLM-span isolation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — 4 new SDK extractor tests; existing llama.cpp LCP tests still cover the source side
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (`docs/sdk/telemetry.md` table row + analytics-axis note)
- [x] No breaking changes (additive trait method with `None` default; existing call sites unchanged)