### PR TITLE
feat(flutter): expose currentDeviceSnapshot for app diagnostics

### DIFF
--- a/bindings/flutter/lib/src/device_snapshot.dart
+++ b/bindings/flutter/lib/src/device_snapshot.dart
@@ -1,0 +1,111 @@
+/// Public Dart types for the routing-engine's view of device state.
+///
+/// Mirrors `xybrid_sdk::ResourceSnapshot`. Optional fields are `null`
+/// when the underlying sensor isn't available on the running platform —
+/// a `null` here is what the routing engine reads as "no signal," and
+/// downstream gates treat that as "do not penalize." The FRB-generated
+/// types live in `src/rust/api/device.dart`; this file is the
+/// host-facing surface so apps don't depend on the generated symbols.
+library;
+
+import 'rust/api/device.dart' as ffi;
+
+/// Derived memory-pressure classification from `available / total`.
+///
+/// `unknown` means the runtime couldn't compute the ratio — either
+/// sysinfo refused to answer or the host hasn't pushed a memory-warning
+/// observer. The routing engine treats `unknown` as "no penalty," not
+/// "memory is fine."
+enum MemoryPressure { unknown, normal, warn, critical }
+
+/// Thermal pressure classification matching the desktop pollers'
+/// Celsius bands (Normal < 60, Warm 60–70, Hot 70–80, Critical >= 80).
+enum ThermalState { normal, warm, hot, critical }
+
+/// Snapshot of the routing-engine's current view of device state.
+///
+/// Read via [Xybrid.currentDeviceSnapshot]. Intended for diagnostics
+/// surfaces only — production code should not poll this. The engine
+/// reads it internally on each routing decision.
+class DeviceSnapshot {
+  /// Global CPU usage at sample time, 0–100. `null` if sysinfo couldn't
+  /// produce a reading on the running platform.
+  final double? cpuPct;
+
+  /// Resident set size of the current process in MB. `null` when the
+  /// runtime couldn't resolve the current PID.
+  final int? processRssMb;
+
+  /// Available system memory in MB at sample time.
+  final int? availableMemMb;
+
+  /// Total system memory in MB.
+  final int? totalMemMb;
+
+  /// Derived memory pressure. See [MemoryPressure] for thresholds.
+  final MemoryPressure memoryPressure;
+
+  /// Current thermal state.
+  final ThermalState thermalState;
+
+  /// Battery charge percent, 0–100. `null` when no battery is present
+  /// or the host hasn't pushed a level yet.
+  final int? batteryPct;
+
+  /// Monotonic-ish capture timestamp (epoch millis). Useful for
+  /// detecting whether a UI is reading stale cached snapshots.
+  final DateTime capturedAt;
+
+  const DeviceSnapshot({
+    this.cpuPct,
+    this.processRssMb,
+    this.availableMemMb,
+    this.totalMemMb,
+    required this.memoryPressure,
+    required this.thermalState,
+    this.batteryPct,
+    required this.capturedAt,
+  });
+
+  /// Adapter from the FRB-generated snapshot struct. Intentionally
+  /// package-private — apps reach for [Xybrid.currentDeviceSnapshot]
+  /// which calls this internally.
+  factory DeviceSnapshot.fromFfi(ffi.FfiResourceSnapshot s) {
+    return DeviceSnapshot(
+      cpuPct: s.cpuPct,
+      processRssMb: s.processRssMb,
+      availableMemMb: s.availableMemMb,
+      totalMemMb: s.totalMemMb,
+      memoryPressure: _memoryPressureFromFfi(s.memoryPressure),
+      thermalState: _thermalStateFromFfi(s.thermalState),
+      batteryPct: s.batteryPct,
+      capturedAt: DateTime.fromMillisecondsSinceEpoch(s.capturedAtMs.toInt()),
+    );
+  }
+}
+
+MemoryPressure _memoryPressureFromFfi(ffi.FfiMemoryPressure value) {
+  switch (value) {
+    case ffi.FfiMemoryPressure.unknown:
+      return MemoryPressure.unknown;
+    case ffi.FfiMemoryPressure.normal:
+      return MemoryPressure.normal;
+    case ffi.FfiMemoryPressure.warn:
+      return MemoryPressure.warn;
+    case ffi.FfiMemoryPressure.critical:
+      return MemoryPressure.critical;
+  }
+}
+
+ThermalState _thermalStateFromFfi(ffi.FfiThermalState value) {
+  switch (value) {
+    case ffi.FfiThermalState.normal:
+      return ThermalState.normal;
+    case ffi.FfiThermalState.warm:
+      return ThermalState.warm;
+    case ffi.FfiThermalState.hot:
+      return ThermalState.hot;
+    case ffi.FfiThermalState.critical:
+      return ThermalState.critical;
+  }
+}

--- a/bindings/flutter/lib/src/rust/api/device.dart
+++ b/bindings/flutter/lib/src/rust/api/device.dart
@@ -10,7 +10,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `eq`, `fmt`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<XybridDevice>>
 abstract class XybridDevice implements RustOpaqueInterface {
@@ -27,6 +27,23 @@ abstract class XybridDevice implements RustOpaqueInterface {
   static void clearThermalState() =>
       XybridRustLib.instance.api.crateApiDeviceXybridDeviceClearThermalState();
 
+  /// Read the routing-engine's current device snapshot.
+  ///
+  /// Returns whatever the global [`xybrid_sdk::ResourceMonitor`] last
+  /// observed — battery + thermal from the platform pollers / host
+  /// pushes, CPU + memory from sysinfo. Force-refreshes on every
+  /// call (passes [`Duration::ZERO`]) so a diagnostics surface that
+  /// polls at ~1 Hz sees fresh data each tick. The refresh cost is
+  /// bounded; the contract is documented in `resource-telemetry.md`
+  /// at `< 1 ms` on a warm monitor.
+  ///
+  /// Intended for app-side diagnostics views ("what does the routing
+  /// engine see on this device right now?"). Production code should
+  /// not poll this — the engine reads it internally on each routing
+  /// decision.
+  static FfiResourceSnapshot currentSnapshot() =>
+      XybridRustLib.instance.api.crateApiDeviceXybridDeviceCurrentSnapshot();
+
   /// Forward a battery charge percent (0..=100) from the host.
   ///
   /// Values above 100 are clamped by the underlying setter — pass
@@ -40,6 +57,72 @@ abstract class XybridDevice implements RustOpaqueInterface {
   static void setThermalState({required FfiThermalState state}) =>
       XybridRustLib.instance.api
           .crateApiDeviceXybridDeviceSetThermalState(state: state);
+}
+
+/// Derived memory-pressure classification mirrored onto the FFI surface.
+///
+/// Maps directly to [`xybrid_sdk::MemoryPressure`]. `Unknown` means the
+/// snapshot couldn't be computed (sysinfo refused to answer, or the
+/// host hasn't pushed an iOS / Android memory-warning observer yet).
+enum FfiMemoryPressure {
+  unknown,
+  normal,
+  warn,
+  critical,
+  ;
+}
+
+/// Snapshot of routing-engine signals as the runtime currently sees them.
+///
+/// Field-for-field mirror of [`xybrid_sdk::ResourceSnapshot`]. `Option`
+/// fields are `None` when the underlying sensor isn't available on the
+/// running platform — a `None` here is what the routing engine reads as
+/// "no signal," which downstream gates treat as "do not penalize."
+class FfiResourceSnapshot {
+  final double? cpuPct;
+  final int? processRssMb;
+  final int? availableMemMb;
+  final int? totalMemMb;
+  final FfiMemoryPressure memoryPressure;
+  final FfiThermalState thermalState;
+  final int? batteryPct;
+  final BigInt capturedAtMs;
+
+  const FfiResourceSnapshot({
+    this.cpuPct,
+    this.processRssMb,
+    this.availableMemMb,
+    this.totalMemMb,
+    required this.memoryPressure,
+    required this.thermalState,
+    this.batteryPct,
+    required this.capturedAtMs,
+  });
+
+  @override
+  int get hashCode =>
+      cpuPct.hashCode ^
+      processRssMb.hashCode ^
+      availableMemMb.hashCode ^
+      totalMemMb.hashCode ^
+      memoryPressure.hashCode ^
+      thermalState.hashCode ^
+      batteryPct.hashCode ^
+      capturedAtMs.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FfiResourceSnapshot &&
+          runtimeType == other.runtimeType &&
+          cpuPct == other.cpuPct &&
+          processRssMb == other.processRssMb &&
+          availableMemMb == other.availableMemMb &&
+          totalMemMb == other.totalMemMb &&
+          memoryPressure == other.memoryPressure &&
+          thermalState == other.thermalState &&
+          batteryPct == other.batteryPct &&
+          capturedAtMs == other.capturedAtMs;
 }
 
 /// Thermal pressure state forwarded by the host.

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class XybridRustLib extends BaseEntrypoint<XybridRustLibApi,
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1487364937;
+  int get rustContentHash => 1942786553;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -203,6 +203,8 @@ abstract class XybridRustLibApi extends BaseApi {
   void crateApiDeviceXybridDeviceClearBatteryLevel();
 
   void crateApiDeviceXybridDeviceClearThermalState();
+
+  FfiResourceSnapshot crateApiDeviceXybridDeviceCurrentSnapshot();
 
   void crateApiDeviceXybridDeviceSetBatteryLevel({required int percent});
 
@@ -1300,12 +1302,35 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  FfiResourceSnapshot crateApiDeviceXybridDeviceCurrentSnapshot() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_ffi_resource_snapshot,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiDeviceXybridDeviceCurrentSnapshotConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiDeviceXybridDeviceCurrentSnapshotConstMeta =>
+      const TaskConstMeta(
+        debugName: "XybridDevice_current_snapshot",
+        argNames: [],
+      );
+
+  @override
   void crateApiDeviceXybridDeviceSetBatteryLevel({required int percent}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_8(percent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1330,7 +1355,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_ffi_thermal_state(state, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1355,7 +1380,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(cacheDir, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1380,7 +1405,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(modelId, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1404,7 +1429,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1427,7 +1452,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -1450,7 +1475,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -1761,6 +1786,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  int dco_decode_box_autoadd_u_8(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
+  }
+
+  @protected
   double dco_decode_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
@@ -1809,9 +1840,33 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  FfiMemoryPressure dco_decode_ffi_memory_pressure(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return FfiMemoryPressure.values[raw as int];
+  }
+
+  @protected
   FfiMessageRole dco_decode_ffi_message_role(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return FfiMessageRole.values[raw as int];
+  }
+
+  @protected
+  FfiResourceSnapshot dco_decode_ffi_resource_snapshot(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return FfiResourceSnapshot(
+      cpuPct: dco_decode_opt_box_autoadd_f_32(arr[0]),
+      processRssMb: dco_decode_opt_box_autoadd_u_32(arr[1]),
+      availableMemMb: dco_decode_opt_box_autoadd_u_32(arr[2]),
+      totalMemMb: dco_decode_opt_box_autoadd_u_32(arr[3]),
+      memoryPressure: dco_decode_ffi_memory_pressure(arr[4]),
+      thermalState: dco_decode_ffi_thermal_state(arr[5]),
+      batteryPct: dco_decode_opt_box_autoadd_u_8(arr[6]),
+      capturedAtMs: dco_decode_u_64(arr[7]),
+    );
   }
 
   @protected
@@ -1959,6 +2014,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  int? dco_decode_opt_box_autoadd_u_8(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_u_8(raw);
+  }
+
+  @protected
   List<String>? dco_decode_opt_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_list_String(raw);
@@ -1980,6 +2041,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   int dco_decode_u_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
+  }
+
+  @protected
+  BigInt dco_decode_u_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeU64(raw);
   }
 
   @protected
@@ -2257,6 +2324,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  int sse_decode_box_autoadd_u_8(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_u_8(deserializer));
+  }
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat32();
@@ -2309,10 +2382,41 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  FfiMemoryPressure sse_decode_ffi_memory_pressure(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return FfiMemoryPressure.values[inner];
+  }
+
+  @protected
   FfiMessageRole sse_decode_ffi_message_role(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return FfiMessageRole.values[inner];
+  }
+
+  @protected
+  FfiResourceSnapshot sse_decode_ffi_resource_snapshot(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_cpuPct = sse_decode_opt_box_autoadd_f_32(deserializer);
+    var var_processRssMb = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_availableMemMb = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_totalMemMb = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_memoryPressure = sse_decode_ffi_memory_pressure(deserializer);
+    var var_thermalState = sse_decode_ffi_thermal_state(deserializer);
+    var var_batteryPct = sse_decode_opt_box_autoadd_u_8(deserializer);
+    var var_capturedAtMs = sse_decode_u_64(deserializer);
+    return FfiResourceSnapshot(
+        cpuPct: var_cpuPct,
+        processRssMb: var_processRssMb,
+        availableMemMb: var_availableMemMb,
+        totalMemMb: var_totalMemMb,
+        memoryPressure: var_memoryPressure,
+        thermalState: var_thermalState,
+        batteryPct: var_batteryPct,
+        capturedAtMs: var_capturedAtMs);
   }
 
   @protected
@@ -2506,6 +2610,17 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  int? sse_decode_opt_box_autoadd_u_8(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_u_8(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   List<String>? sse_decode_opt_list_String(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -2543,6 +2658,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   int sse_decode_u_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getUint32();
+  }
+
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getBigUint64();
   }
 
   @protected
@@ -2844,6 +2965,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  void sse_encode_box_autoadd_u_8(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_8(self, serializer);
+  }
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat32(self);
@@ -2884,10 +3011,31 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  void sse_encode_ffi_memory_pressure(
+      FfiMemoryPressure self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
   void sse_encode_ffi_message_role(
       FfiMessageRole self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_ffi_resource_snapshot(
+      FfiResourceSnapshot self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_box_autoadd_f_32(self.cpuPct, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.processRssMb, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.availableMemMb, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.totalMemMb, serializer);
+    sse_encode_ffi_memory_pressure(self.memoryPressure, serializer);
+    sse_encode_ffi_thermal_state(self.thermalState, serializer);
+    sse_encode_opt_box_autoadd_u_8(self.batteryPct, serializer);
+    sse_encode_u_64(self.capturedAtMs, serializer);
   }
 
   @protected
@@ -3064,6 +3212,16 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  void sse_encode_opt_box_autoadd_u_8(int? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_u_8(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_list_String(
       List<String>? self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -3100,6 +3258,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   void sse_encode_u_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putUint32(self);
+  }
+
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putBigUint64(self);
   }
 
   @protected

--- a/bindings/flutter/lib/src/rust/frb_generated.io.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.io.dart
@@ -193,6 +193,9 @@ abstract class XybridRustLibApiImplPlatform
   int dco_decode_box_autoadd_u_32(dynamic raw);
 
   @protected
+  int dco_decode_box_autoadd_u_8(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
 
   @protected
@@ -205,7 +208,13 @@ abstract class XybridRustLibApiImplPlatform
   FfiLoadEvent dco_decode_ffi_load_event(dynamic raw);
 
   @protected
+  FfiMemoryPressure dco_decode_ffi_memory_pressure(dynamic raw);
+
+  @protected
   FfiMessageRole dco_decode_ffi_message_role(dynamic raw);
+
+  @protected
+  FfiResourceSnapshot dco_decode_ffi_resource_snapshot(dynamic raw);
 
   @protected
   FfiResult dco_decode_ffi_result(dynamic raw);
@@ -263,6 +272,9 @@ abstract class XybridRustLibApiImplPlatform
   int? dco_decode_opt_box_autoadd_u_32(dynamic raw);
 
   @protected
+  int? dco_decode_opt_box_autoadd_u_8(dynamic raw);
+
+  @protected
   List<String>? dco_decode_opt_list_String(dynamic raw);
 
   @protected
@@ -273,6 +285,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   int dco_decode_u_32(dynamic raw);
+
+  @protected
+  BigInt dco_decode_u_64(dynamic raw);
 
   @protected
   int dco_decode_u_8(dynamic raw);
@@ -423,6 +438,9 @@ abstract class XybridRustLibApiImplPlatform
   int sse_decode_box_autoadd_u_32(SseDeserializer deserializer);
 
   @protected
+  int sse_decode_box_autoadd_u_8(SseDeserializer deserializer);
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer);
 
   @protected
@@ -436,7 +454,15 @@ abstract class XybridRustLibApiImplPlatform
   FfiLoadEvent sse_decode_ffi_load_event(SseDeserializer deserializer);
 
   @protected
+  FfiMemoryPressure sse_decode_ffi_memory_pressure(
+      SseDeserializer deserializer);
+
+  @protected
   FfiMessageRole sse_decode_ffi_message_role(SseDeserializer deserializer);
+
+  @protected
+  FfiResourceSnapshot sse_decode_ffi_resource_snapshot(
+      SseDeserializer deserializer);
 
   @protected
   FfiResult sse_decode_ffi_result(SseDeserializer deserializer);
@@ -495,6 +521,9 @@ abstract class XybridRustLibApiImplPlatform
   int? sse_decode_opt_box_autoadd_u_32(SseDeserializer deserializer);
 
   @protected
+  int? sse_decode_opt_box_autoadd_u_8(SseDeserializer deserializer);
+
+  @protected
   List<String>? sse_decode_opt_list_String(SseDeserializer deserializer);
 
   @protected
@@ -506,6 +535,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
+
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_8(SseDeserializer deserializer);
@@ -659,6 +691,9 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_box_autoadd_u_32(int self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_u_8(int self, SseSerializer serializer);
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
 
   @protected
@@ -672,8 +707,16 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_ffi_load_event(FfiLoadEvent self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_memory_pressure(
+      FfiMemoryPressure self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_message_role(
       FfiMessageRole self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_ffi_resource_snapshot(
+      FfiResourceSnapshot self, SseSerializer serializer);
 
   @protected
   void sse_encode_ffi_result(FfiResult self, SseSerializer serializer);
@@ -739,6 +782,9 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_opt_box_autoadd_u_32(int? self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_u_8(int? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_list_String(List<String>? self, SseSerializer serializer);
 
   @protected
@@ -751,6 +797,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_8(int self, SseSerializer serializer);

--- a/bindings/flutter/lib/src/rust/frb_generated.web.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.web.dart
@@ -195,6 +195,9 @@ abstract class XybridRustLibApiImplPlatform
   int dco_decode_box_autoadd_u_32(dynamic raw);
 
   @protected
+  int dco_decode_box_autoadd_u_8(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
 
   @protected
@@ -207,7 +210,13 @@ abstract class XybridRustLibApiImplPlatform
   FfiLoadEvent dco_decode_ffi_load_event(dynamic raw);
 
   @protected
+  FfiMemoryPressure dco_decode_ffi_memory_pressure(dynamic raw);
+
+  @protected
   FfiMessageRole dco_decode_ffi_message_role(dynamic raw);
+
+  @protected
+  FfiResourceSnapshot dco_decode_ffi_resource_snapshot(dynamic raw);
 
   @protected
   FfiResult dco_decode_ffi_result(dynamic raw);
@@ -265,6 +274,9 @@ abstract class XybridRustLibApiImplPlatform
   int? dco_decode_opt_box_autoadd_u_32(dynamic raw);
 
   @protected
+  int? dco_decode_opt_box_autoadd_u_8(dynamic raw);
+
+  @protected
   List<String>? dco_decode_opt_list_String(dynamic raw);
 
   @protected
@@ -275,6 +287,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   int dco_decode_u_32(dynamic raw);
+
+  @protected
+  BigInt dco_decode_u_64(dynamic raw);
 
   @protected
   int dco_decode_u_8(dynamic raw);
@@ -425,6 +440,9 @@ abstract class XybridRustLibApiImplPlatform
   int sse_decode_box_autoadd_u_32(SseDeserializer deserializer);
 
   @protected
+  int sse_decode_box_autoadd_u_8(SseDeserializer deserializer);
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer);
 
   @protected
@@ -438,7 +456,15 @@ abstract class XybridRustLibApiImplPlatform
   FfiLoadEvent sse_decode_ffi_load_event(SseDeserializer deserializer);
 
   @protected
+  FfiMemoryPressure sse_decode_ffi_memory_pressure(
+      SseDeserializer deserializer);
+
+  @protected
   FfiMessageRole sse_decode_ffi_message_role(SseDeserializer deserializer);
+
+  @protected
+  FfiResourceSnapshot sse_decode_ffi_resource_snapshot(
+      SseDeserializer deserializer);
 
   @protected
   FfiResult sse_decode_ffi_result(SseDeserializer deserializer);
@@ -497,6 +523,9 @@ abstract class XybridRustLibApiImplPlatform
   int? sse_decode_opt_box_autoadd_u_32(SseDeserializer deserializer);
 
   @protected
+  int? sse_decode_opt_box_autoadd_u_8(SseDeserializer deserializer);
+
+  @protected
   List<String>? sse_decode_opt_list_String(SseDeserializer deserializer);
 
   @protected
@@ -508,6 +537,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
+
+  @protected
+  BigInt sse_decode_u_64(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_8(SseDeserializer deserializer);
@@ -661,6 +693,9 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_box_autoadd_u_32(int self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_u_8(int self, SseSerializer serializer);
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
 
   @protected
@@ -674,8 +709,16 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_ffi_load_event(FfiLoadEvent self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_memory_pressure(
+      FfiMemoryPressure self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_message_role(
       FfiMessageRole self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_ffi_resource_snapshot(
+      FfiResourceSnapshot self, SseSerializer serializer);
 
   @protected
   void sse_encode_ffi_result(FfiResult self, SseSerializer serializer);
@@ -741,6 +784,9 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_opt_box_autoadd_u_32(int? self, SseSerializer serializer);
 
   @protected
+  void sse_encode_opt_box_autoadd_u_8(int? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_list_String(List<String>? self, SseSerializer serializer);
 
   @protected
@@ -753,6 +799,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_64(BigInt self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_8(int self, SseSerializer serializer);

--- a/bindings/flutter/lib/src/xybrid.dart
+++ b/bindings/flutter/lib/src/xybrid.dart
@@ -14,6 +14,7 @@ import 'package:path_provider/path_provider.dart';
 import 'rust/frb_generated.dart';
 
 import '../xybrid.dart';
+import 'device_snapshot.dart';
 
 /// Main entry point for the Xybrid SDK.
 ///
@@ -136,6 +137,22 @@ class Xybrid {
     // TODO - Implement telemetry
     // XybridSdkClient.enableTelemetry();
     throw UnimplementedError();
+  }
+
+  /// Read the routing-engine's current view of device state.
+  ///
+  /// Returns the same [DeviceSnapshot] the engine reads internally on
+  /// each routing decision — battery + thermal from the platform
+  /// pollers / host pushes, CPU + memory from sysinfo. Force-refreshes
+  /// on every call so a diagnostics surface that polls at ~1 Hz sees
+  /// fresh data each tick. The refresh cost is bounded at `< 1 ms` on
+  /// a warm monitor.
+  ///
+  /// Intended for app-side diagnostics views ("what does the routing
+  /// engine see on this device right now?"). Production code should
+  /// not poll this — the engine reads it internally.
+  static DeviceSnapshot currentDeviceSnapshot() {
+    return DeviceSnapshot.fromFfi(XybridDevice.currentSnapshot());
   }
 
   /// Create a ModelLoader for the specified model.

--- a/bindings/flutter/lib/xybrid.dart
+++ b/bindings/flutter/lib/xybrid.dart
@@ -72,6 +72,7 @@
 library;
 
 export 'src/context.dart' show ConversationContext, MessageRole;
+export 'src/device_snapshot.dart' show DeviceSnapshot, MemoryPressure, ThermalState;
 export 'src/envelope.dart' show XybridEnvelope;
 export 'src/generation_config.dart' show GenerationConfig;
 export 'src/llm.dart' show StreamToken;

--- a/bindings/flutter/rust/src/api/device.rs
+++ b/bindings/flutter/rust/src/api/device.rs
@@ -14,6 +14,17 @@
 //! `DartFn` shape would re-enter Rust on every change, which is much
 //! more surface for marginal benefit when the host already gets these
 //! notifications routinely.
+//!
+//! The host can also *read* the routing-engine's current view of device
+//! state via [`XybridDevice::current_snapshot`]. This is the one-way
+//! mirror of the push surface: the host sees exactly what the routing
+//! engine sees, including signals that came from the in-Rust platform
+//! pollers (Linux sysfs, macOS / iOS NSProcessInfo) and from sysinfo
+//! (CPU + memory). Useful for diagnostics screens that need to verify
+//! signal coverage on a given platform without round-tripping through
+//! a telemetry event.
+
+use std::time::Duration;
 
 use flutter_rust_bridge::frb;
 
@@ -55,6 +66,63 @@ impl From<xybrid_sdk::ThermalState> for FfiThermalState {
             xybrid_sdk::ThermalState::Warm => FfiThermalState::Warm,
             xybrid_sdk::ThermalState::Hot => FfiThermalState::Hot,
             xybrid_sdk::ThermalState::Critical => FfiThermalState::Critical,
+        }
+    }
+}
+
+/// Derived memory-pressure classification mirrored onto the FFI surface.
+///
+/// Maps directly to [`xybrid_sdk::MemoryPressure`]. `Unknown` means the
+/// snapshot couldn't be computed (sysinfo refused to answer, or the
+/// host hasn't pushed an iOS / Android memory-warning observer yet).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FfiMemoryPressure {
+    Unknown,
+    Normal,
+    Warn,
+    Critical,
+}
+
+impl From<xybrid_sdk::MemoryPressure> for FfiMemoryPressure {
+    fn from(value: xybrid_sdk::MemoryPressure) -> Self {
+        match value {
+            xybrid_sdk::MemoryPressure::Unknown => FfiMemoryPressure::Unknown,
+            xybrid_sdk::MemoryPressure::Normal => FfiMemoryPressure::Normal,
+            xybrid_sdk::MemoryPressure::Warn => FfiMemoryPressure::Warn,
+            xybrid_sdk::MemoryPressure::Critical => FfiMemoryPressure::Critical,
+        }
+    }
+}
+
+/// Snapshot of routing-engine signals as the runtime currently sees them.
+///
+/// Field-for-field mirror of [`xybrid_sdk::ResourceSnapshot`]. `Option`
+/// fields are `None` when the underlying sensor isn't available on the
+/// running platform — a `None` here is what the routing engine reads as
+/// "no signal," which downstream gates treat as "do not penalize."
+#[derive(Clone, Debug)]
+pub struct FfiResourceSnapshot {
+    pub cpu_pct: Option<f32>,
+    pub process_rss_mb: Option<u32>,
+    pub available_mem_mb: Option<u32>,
+    pub total_mem_mb: Option<u32>,
+    pub memory_pressure: FfiMemoryPressure,
+    pub thermal_state: FfiThermalState,
+    pub battery_pct: Option<u8>,
+    pub captured_at_ms: u64,
+}
+
+impl From<xybrid_sdk::ResourceSnapshot> for FfiResourceSnapshot {
+    fn from(value: xybrid_sdk::ResourceSnapshot) -> Self {
+        Self {
+            cpu_pct: value.cpu_pct,
+            process_rss_mb: value.process_rss_mb,
+            available_mem_mb: value.available_mem_mb,
+            total_mem_mb: value.total_mem_mb,
+            memory_pressure: value.memory_pressure.into(),
+            thermal_state: value.thermal_state.into(),
+            battery_pct: value.battery_pct,
+            captured_at_ms: value.captured_at_ms,
         }
     }
 }
@@ -102,6 +170,28 @@ impl XybridDevice {
         xybrid_sdk::set_binding(FLUTTER_BINDING);
         xybrid_sdk::clear_thermal_state();
     }
+
+    /// Read the routing-engine's current device snapshot.
+    ///
+    /// Returns whatever the global [`xybrid_sdk::ResourceMonitor`] last
+    /// observed — battery + thermal from the platform pollers / host
+    /// pushes, CPU + memory from sysinfo. Force-refreshes on every
+    /// call (passes [`Duration::ZERO`]) so a diagnostics surface that
+    /// polls at ~1 Hz sees fresh data each tick. The refresh cost is
+    /// bounded; the contract is documented in `resource-telemetry.md`
+    /// at `< 1 ms` on a warm monitor.
+    ///
+    /// Intended for app-side diagnostics views ("what does the routing
+    /// engine see on this device right now?"). Production code should
+    /// not poll this — the engine reads it internally on each routing
+    /// decision.
+    #[frb(sync)]
+    pub fn current_snapshot() -> FfiResourceSnapshot {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
+        xybrid_sdk::ResourceMonitor::global()
+            .current_snapshot(Duration::ZERO)
+            .into()
+    }
 }
 
 #[cfg(test)]
@@ -125,6 +215,39 @@ mod tests {
             let back: FfiThermalState = sdk.into();
             assert_eq!(variant, back);
         }
+    }
+
+    #[test]
+    fn memory_pressure_maps_through_sdk_type() {
+        for variant in [
+            xybrid_sdk::MemoryPressure::Unknown,
+            xybrid_sdk::MemoryPressure::Normal,
+            xybrid_sdk::MemoryPressure::Warn,
+            xybrid_sdk::MemoryPressure::Critical,
+        ] {
+            let ffi: FfiMemoryPressure = variant.into();
+            // Round-trip is intentional via the SDK enum — we don't
+            // need a reverse `From` because the host never pushes
+            // memory pressure (Rust derives it). Just assert the
+            // mapping is total.
+            match (variant, ffi) {
+                (xybrid_sdk::MemoryPressure::Unknown, FfiMemoryPressure::Unknown) => {}
+                (xybrid_sdk::MemoryPressure::Normal, FfiMemoryPressure::Normal) => {}
+                (xybrid_sdk::MemoryPressure::Warn, FfiMemoryPressure::Warn) => {}
+                (xybrid_sdk::MemoryPressure::Critical, FfiMemoryPressure::Critical) => {}
+                other => panic!("unexpected mapping: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn current_snapshot_returns_finite_timestamp() {
+        // The reader is a thin wrapper around the global ResourceMonitor;
+        // we only need to assert it hands back a usable shape (timestamp
+        // populated, no panic). Actual sysinfo coverage lives in the
+        // xybrid-core resource tests.
+        let snap = XybridDevice::current_snapshot();
+        assert!(snap.captured_at_ms > 0, "captured_at_ms must be populated");
     }
 
     #[test]

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1487364937;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1942786553;
 
 // Section: executor
 
@@ -1690,6 +1690,36 @@ fn wire__crate__api__device__XybridDevice_clear_thermal_state_impl(
         },
     )
 }
+fn wire__crate__api__device__XybridDevice_current_snapshot_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridDevice_current_snapshot",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::device::XybridDevice::current_snapshot())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__device__XybridDevice_set_battery_level_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2181,6 +2211,20 @@ impl SseDecode for crate::api::model::FfiLoadEvent {
     }
 }
 
+impl SseDecode for crate::api::device::FfiMemoryPressure {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::device::FfiMemoryPressure::Unknown,
+            1 => crate::api::device::FfiMemoryPressure::Normal,
+            2 => crate::api::device::FfiMemoryPressure::Warn,
+            3 => crate::api::device::FfiMemoryPressure::Critical,
+            _ => unreachable!("Invalid variant for FfiMemoryPressure: {}", inner),
+        };
+    }
+}
+
 impl SseDecode for crate::api::context::FfiMessageRole {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2190,6 +2234,31 @@ impl SseDecode for crate::api::context::FfiMessageRole {
             1 => crate::api::context::FfiMessageRole::User,
             2 => crate::api::context::FfiMessageRole::Assistant,
             _ => unreachable!("Invalid variant for FfiMessageRole: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::device::FfiResourceSnapshot {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_cpuPct = <Option<f32>>::sse_decode(deserializer);
+        let mut var_processRssMb = <Option<u32>>::sse_decode(deserializer);
+        let mut var_availableMemMb = <Option<u32>>::sse_decode(deserializer);
+        let mut var_totalMemMb = <Option<u32>>::sse_decode(deserializer);
+        let mut var_memoryPressure =
+            <crate::api::device::FfiMemoryPressure>::sse_decode(deserializer);
+        let mut var_thermalState = <crate::api::device::FfiThermalState>::sse_decode(deserializer);
+        let mut var_batteryPct = <Option<u8>>::sse_decode(deserializer);
+        let mut var_capturedAtMs = <u64>::sse_decode(deserializer);
+        return crate::api::device::FfiResourceSnapshot {
+            cpu_pct: var_cpuPct,
+            process_rss_mb: var_processRssMb,
+            available_mem_mb: var_availableMemMb,
+            total_mem_mb: var_totalMemMb,
+            memory_pressure: var_memoryPressure,
+            thermal_state: var_thermalState,
+            battery_pct: var_batteryPct,
+            captured_at_ms: var_capturedAtMs,
         };
     }
 }
@@ -2399,6 +2468,17 @@ impl SseDecode for Option<u32> {
     }
 }
 
+impl SseDecode for Option<u8> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<u8>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<Vec<String>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2436,6 +2516,13 @@ impl SseDecode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_u32::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for u64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_u64::<NativeEndian>().unwrap()
     }
 }
 
@@ -2587,37 +2674,42 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__device__XybridDevice_set_battery_level_impl(
+        38 => wire__crate__api__device__XybridDevice_current_snapshot_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__device__XybridDevice_set_thermal_state_impl(
+        39 => wire__crate__api__device__XybridDevice_set_battery_level_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
+        40 => wire__crate__api__device__XybridDevice_set_thermal_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
+        41 => wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
+        42 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__model__ffi_generation_config_creative_impl(
+        43 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => {
+        44 => wire__crate__api__model__ffi_generation_config_creative_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        45 => {
             wire__crate__api__model__ffi_generation_config_greedy_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -2791,6 +2883,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::model::FfiLoadEvent>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::device::FfiMemoryPressure {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Unknown => 0.into_dart(),
+            Self::Normal => 1.into_dart(),
+            Self::Warn => 2.into_dart(),
+            Self::Critical => 3.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::device::FfiMemoryPressure
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::device::FfiMemoryPressure>
+    for crate::api::device::FfiMemoryPressure
+{
+    fn into_into_dart(self) -> crate::api::device::FfiMemoryPressure {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::context::FfiMessageRole {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -2809,6 +2924,33 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::context::FfiMessageRole>
     for crate::api::context::FfiMessageRole
 {
     fn into_into_dart(self) -> crate::api::context::FfiMessageRole {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::device::FfiResourceSnapshot {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.cpu_pct.into_into_dart().into_dart(),
+            self.process_rss_mb.into_into_dart().into_dart(),
+            self.available_mem_mb.into_into_dart().into_dart(),
+            self.total_mem_mb.into_into_dart().into_dart(),
+            self.memory_pressure.into_into_dart().into_dart(),
+            self.thermal_state.into_into_dart().into_dart(),
+            self.battery_pct.into_into_dart().into_dart(),
+            self.captured_at_ms.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::device::FfiResourceSnapshot
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::device::FfiResourceSnapshot>
+    for crate::api::device::FfiResourceSnapshot
+{
+    fn into_into_dart(self) -> crate::api::device::FfiResourceSnapshot {
         self
     }
 }
@@ -3132,6 +3274,24 @@ impl SseEncode for crate::api::model::FfiLoadEvent {
     }
 }
 
+impl SseEncode for crate::api::device::FfiMemoryPressure {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::device::FfiMemoryPressure::Unknown => 0,
+                crate::api::device::FfiMemoryPressure::Normal => 1,
+                crate::api::device::FfiMemoryPressure::Warn => 2,
+                crate::api::device::FfiMemoryPressure::Critical => 3,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for crate::api::context::FfiMessageRole {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3146,6 +3306,20 @@ impl SseEncode for crate::api::context::FfiMessageRole {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::device::FfiResourceSnapshot {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<f32>>::sse_encode(self.cpu_pct, serializer);
+        <Option<u32>>::sse_encode(self.process_rss_mb, serializer);
+        <Option<u32>>::sse_encode(self.available_mem_mb, serializer);
+        <Option<u32>>::sse_encode(self.total_mem_mb, serializer);
+        <crate::api::device::FfiMemoryPressure>::sse_encode(self.memory_pressure, serializer);
+        <crate::api::device::FfiThermalState>::sse_encode(self.thermal_state, serializer);
+        <Option<u8>>::sse_encode(self.battery_pct, serializer);
+        <u64>::sse_encode(self.captured_at_ms, serializer);
     }
 }
 
@@ -3326,6 +3500,16 @@ impl SseEncode for Option<u32> {
     }
 }
 
+impl SseEncode for Option<u8> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <u8>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<Vec<String>> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3360,6 +3544,13 @@ impl SseEncode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_u32::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for u64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_u64::<NativeEndian>(self).unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a one-line read path for routing-engine signals from Flutter:

\`\`\`dart
final snap = Xybrid.currentDeviceSnapshot();
print('cpu=${snap.cpuPct}, mem_avail=${snap.availableMemMb}, '
      'pressure=${snap.memoryPressure}, thermal=${snap.thermalState}, '
      'battery=${snap.batteryPct}');
\`\`\`

Counterpart to the existing push-state surface (\`setBatteryLevel\` / \`setThermalState\`). Both flow through the same \`ResourceMonitor\` cache, so a host that subscribes to OS notifications and reads back via \`currentDeviceSnapshot()\` sees its own pushes round-trip alongside the in-Rust sysinfo CPU/memory and platform pollers.

Force-refreshes on every call (\`Duration::ZERO\`) so a ~1 Hz diagnostics screen sees fresh data.

## Why

We suspect — but haven't verified — that sysinfo on iOS doesn't populate \`available_memory\` / \`global_cpu_usage\`. If true, the routing engine's memory-pressure (gate 4) and sustained-CPU (gate 5) cloud-fallback gates **never fire on iOS**. This SDK surface is what lets a host app render those values on screen and confirm.

The same surface is generally useful for app-side telemetry views, support tooling ("what does my user's device look like right now?"), and integration tests that assert the engine sees the signals it should.

## Layout

- \`bindings/flutter/rust/src/api/device.rs\` — FRB \`XybridDevice::current_snapshot()\` returning \`FfiResourceSnapshot\` + \`FfiMemoryPressure\` mirrors.
- \`bindings/flutter/lib/src/device_snapshot.dart\` — clean public Dart types (\`DeviceSnapshot\`, \`MemoryPressure\`, \`ThermalState\`), wrapping the FRB types so apps don't depend on generated symbols.
- \`bindings/flutter/lib/src/xybrid.dart\` — \`Xybrid.currentDeviceSnapshot()\` static.

## Test plan

- [x] \`cargo test -p xybrid_flutter --lib\` — 5/5 pass (existing 4 + 1 new \`current_snapshot_returns_finite_timestamp\`)
- [x] FRB codegen reruns cleanly
- [x] \`flutter analyze\` clean (verified against studio-flutter)
- [ ] Run a Flutter host on iOS, read the snapshot, confirm whether sysinfo populates the iOS fields — separate PR adds the studio-flutter diagnostics screen