### PR TITLE
refactor(onnx): consolidate ONNXSession construction behind single build entry

### DIFF
--- a/crates/xybrid-core/benches/inference_backends.rs
+++ b/crates/xybrid-core/benches/inference_backends.rs
@@ -34,7 +34,7 @@ use ort::value::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
-use xybrid_core::runtime_adapter::onnx::{ExecutionProviderKind, ONNXSession};
+use xybrid_core::runtime_adapter::onnx::{ExecutionProviderKind, ONNXSession, SessionOptions};
 
 // ============================================================================
 // Model Configurations
@@ -272,9 +272,10 @@ fn benchmark_cpu(c: &mut Criterion) {
         };
 
         // Create session with CPU provider
-        let session = match ONNXSession::with_provider(
+        let session = match ONNXSession::build(
             model_path.to_str().unwrap(),
             ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
         ) {
             Ok(s) => s,
             Err(e) => {
@@ -327,13 +328,14 @@ fn benchmark_coreml_ane(c: &mut Criterion) {
         };
 
         // Create session with CoreML Neural Engine provider
-        let session = match ONNXSession::with_provider(
+        let session = match ONNXSession::build(
             model_path.to_str().unwrap(),
             ExecutionProviderKind::CoreML(CoreMLConfig {
                 compute_units: CoreMLComputeUnits::CpuAndNeuralEngine,
                 use_subgraphs: true,
                 require_static_shapes: false,
             }),
+            SessionOptions::default(),
         ) {
             Ok(s) => s,
             Err(e) => {
@@ -381,13 +383,14 @@ fn benchmark_coreml_gpu(c: &mut Criterion) {
         };
 
         // Create session with CoreML GPU provider
-        let session = match ONNXSession::with_provider(
+        let session = match ONNXSession::build(
             model_path.to_str().unwrap(),
             ExecutionProviderKind::CoreML(CoreMLConfig {
                 compute_units: CoreMLComputeUnits::CpuAndGpu,
                 use_subgraphs: true,
                 require_static_shapes: false,
             }),
+            SessionOptions::default(),
         ) {
             Ok(s) => s,
             Err(e) => {

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -49,7 +49,9 @@ fn mark_execution_terminal(guard: &ExecutionGuard, error: &AdapterError) {
 // Internal: ONNX-specific types needed for optimized execution paths
 // These are implementation details, not part of the public API
 use crate::execution::session_factory::OnnxSessionFactory;
-use crate::runtime_adapter::onnx::{ExecutionProviderKind, ONNXSession, OnnxRuntime, SessionOptions};
+use crate::runtime_adapter::onnx::{
+    ExecutionProviderKind, ONNXSession, OnnxRuntime, SessionOptions,
+};
 
 #[cfg(feature = "candle")]
 use crate::runtime_adapter::candle::CandleRuntime;

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -48,7 +48,8 @@ fn mark_execution_terminal(guard: &ExecutionGuard, error: &AdapterError) {
 
 // Internal: ONNX-specific types needed for optimized execution paths
 // These are implementation details, not part of the public API
-use crate::runtime_adapter::onnx::{ONNXSession, OnnxRuntime};
+use crate::execution::session_factory::OnnxSessionFactory;
+use crate::runtime_adapter::onnx::{ExecutionProviderKind, ONNXSession, OnnxRuntime, SessionOptions};
 
 #[cfg(feature = "candle")]
 use crate::runtime_adapter::candle::CandleRuntime;
@@ -410,8 +411,12 @@ impl TemplateExecutor {
                 .as_token_ids()
                 .ok_or_else(|| AdapterError::InvalidInput("Expected token IDs".to_string()))?;
 
-            // Create and run BERT session directly
-            let session = ONNXSession::new(model_full_path.to_str().unwrap(), false, false)?;
+            // Create and run BERT session through the shared factory entry.
+            let session = OnnxSessionFactory::create_session(
+                &model_full_path,
+                ExecutionProviderKind::Cpu,
+                SessionOptions::default(),
+            )?;
             let raw_outputs =
                 execute_bert_inference(&session, ids, attention_mask, token_type_ids)?;
 
@@ -1871,7 +1876,11 @@ impl TemplateExecutor {
         const CROSSFADE_SAMPLES: usize = 480;
 
         let mut audio_chunks: Vec<Vec<f32>> = Vec::new();
-        let session = ONNXSession::new(model_path.to_str().unwrap(), false, false)?;
+        let session = OnnxSessionFactory::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )?;
         let speed = extract_tts_speed(input);
 
         for (i, chunk) in chunks.iter().enumerate() {
@@ -1970,8 +1979,12 @@ impl TemplateExecutor {
         let voice_loader = TtsVoiceLoader::new(&self.base_path);
         let voice_embedding = voice_loader.load(metadata, input)?;
 
-        // Create and run TTS session
-        let session = ONNXSession::new(model_path.to_str().unwrap(), false, false)?;
+        // Create and run TTS session through the shared factory entry.
+        let session = OnnxSessionFactory::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )?;
         let speed = extract_tts_speed(input);
         let mut raw_outputs = execute_tts_inference(&session, phoneme_ids, voice_embedding, speed)?;
 

--- a/crates/xybrid-core/src/execution/session_factory.rs
+++ b/crates/xybrid-core/src/execution/session_factory.rs
@@ -63,7 +63,7 @@ pub trait SessionFactory: Send + Sync {
 // ONNX Implementation
 // ============================================================================
 
-use crate::runtime_adapter::onnx::ONNXSession;
+use crate::runtime_adapter::onnx::{ExecutionProviderKind, ONNXSession, SessionOptions};
 
 /// Wrapper to implement InferenceSession for ONNXSession.
 pub struct OnnxInferenceSession {
@@ -88,18 +88,56 @@ impl InferenceSession for OnnxInferenceSession {
 }
 
 /// Default session factory that creates real ONNX sessions.
+///
+/// Acts as the single construction point for raw `ONNXSession` instances
+/// used inside `xybrid-core` strategies, executor, and the inference
+/// backend. Routing through here keeps the expensive resolved-EP
+/// capture opt-in — every call site picks its own [`SessionOptions`]
+/// but goes through the same builder, so we never re-introduce the
+/// bypass that hid EP attribution on the TTS/ASR paths.
+///
+/// The runtime adapters (`OnnxRuntimeAdapter::load_model`,
+/// `ONNXMobileRuntimeAdapter::load_model`) construct sessions via
+/// `ONNXSession::build` directly: they own a per-model session cache
+/// and want explicit control over the EP-capture flag (the desktop
+/// adapter opts in to capture so its `real_inference` can read the
+/// resolved EP back; the mobile adapter stays on the cheap path).
+/// Every other ONNX session in this crate goes through the factory.
 #[derive(Default)]
 pub struct OnnxSessionFactory;
+
+impl OnnxSessionFactory {
+    /// Build a raw [`ONNXSession`] with explicit execution-provider and
+    /// option control.
+    ///
+    /// This is the helper that strategies, the executor, and the
+    /// inference backend share — they need the concrete `ONNXSession`
+    /// (for `run_with_values`, `input_dtypes`, etc.), but no longer
+    /// construct it inline. Pass [`SessionOptions::default`] for the
+    /// cheap, capture-off path; opt in to `capture_resolved_ep` only
+    /// when a caller actually reads `resolved_providers()`.
+    pub fn create_session(
+        model_path: &Path,
+        execution_provider: ExecutionProviderKind,
+        options: SessionOptions,
+    ) -> ExecutorResult<ONNXSession> {
+        let path_str = model_path
+            .to_str()
+            .ok_or_else(|| AdapterError::InvalidInput("Invalid model path encoding".to_string()))?;
+        let session = ONNXSession::build(path_str, execution_provider, options)?;
+        Ok(session)
+    }
+}
 
 impl SessionFactory for OnnxSessionFactory {
     type Session = OnnxInferenceSession;
 
     fn create(&self, model_path: &Path) -> ExecutorResult<Self::Session> {
-        let path_str = model_path
-            .to_str()
-            .ok_or_else(|| AdapterError::InvalidInput("Invalid model path encoding".to_string()))?;
-
-        let session = ONNXSession::new(path_str, false, false)?;
+        let session = Self::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )?;
         Ok(OnnxInferenceSession { session })
     }
 }

--- a/crates/xybrid-core/src/execution/strategies/standard.rs
+++ b/crates/xybrid-core/src/execution/strategies/standard.rs
@@ -7,11 +7,11 @@ use log::{debug, info};
 
 use super::{ExecutionContext, ExecutionStrategy};
 use crate::execution::modes::execute_bert_inference;
+use crate::execution::session_factory::OnnxSessionFactory;
 use crate::execution::template::{ExecutionTemplate, ModelMetadata, PreprocessingStep};
 use crate::execution::types::{ExecutorResult, PreprocessedData, RawOutputs};
 use crate::execution::{postprocessing, preprocessing};
 use crate::ir::Envelope;
-use crate::execution::session_factory::OnnxSessionFactory;
 use crate::runtime_adapter::onnx::{ExecutionProviderKind, SessionOptions};
 use crate::runtime_adapter::AdapterError;
 use crate::tracing as xybrid_trace;

--- a/crates/xybrid-core/src/execution/strategies/standard.rs
+++ b/crates/xybrid-core/src/execution/strategies/standard.rs
@@ -11,7 +11,8 @@ use crate::execution::template::{ExecutionTemplate, ModelMetadata, Preprocessing
 use crate::execution::types::{ExecutorResult, PreprocessedData, RawOutputs};
 use crate::execution::{postprocessing, preprocessing};
 use crate::ir::Envelope;
-use crate::runtime_adapter::onnx::ONNXSession;
+use crate::execution::session_factory::OnnxSessionFactory;
+use crate::runtime_adapter::onnx::{ExecutionProviderKind, SessionOptions};
 use crate::runtime_adapter::AdapterError;
 use crate::tracing as xybrid_trace;
 
@@ -153,8 +154,14 @@ impl StandardStrategy {
             .as_token_ids()
             .ok_or_else(|| AdapterError::InvalidInput("Expected token IDs".to_string()))?;
 
-        // Create and run BERT session directly
-        let session = ONNXSession::new(model_path.to_str().unwrap(), false, false)?;
+        // Build through the shared factory entry. BERT goes through this
+        // path on the cheap (no profiling, no resolved-EP capture);
+        // attribution is the adapter's responsibility, not the strategy's.
+        let session = OnnxSessionFactory::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )?;
         let raw_outputs = execute_bert_inference(&session, ids, attention_mask, token_type_ids)?;
 
         // Convert outputs to envelope

--- a/crates/xybrid-core/src/execution/strategies/tts.rs
+++ b/crates/xybrid-core/src/execution/strategies/tts.rs
@@ -20,7 +20,8 @@ use crate::execution::types::{ExecutorResult, PreprocessedData, RawOutputs};
 use crate::execution::voice_loader::TtsVoiceLoader;
 use crate::execution::{postprocessing, preprocessing};
 use crate::ir::{Envelope, EnvelopeKind};
-use crate::runtime_adapter::onnx::ONNXSession;
+use crate::execution::session_factory::OnnxSessionFactory;
+use crate::runtime_adapter::onnx::{ExecutionProviderKind, SessionOptions};
 use crate::runtime_adapter::AdapterError;
 use crate::tracing as xybrid_trace;
 
@@ -141,8 +142,15 @@ impl TtsStrategy {
         let voice_embedding =
             voice_loader.load_for_token_count(metadata, input, Some(phoneme_ids.len()))?;
 
-        // Create and run TTS session
-        let session = ONNXSession::new(model_path.to_str().unwrap(), false, false)?;
+        // Build through the shared factory entry. TTS is the path that
+        // surfaced the original "EP = —" gap; centralising construction
+        // here is what lets a future change opt this site into capture
+        // without revisiting four inline sites.
+        let session = OnnxSessionFactory::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )?;
         let speed = extract_tts_speed(input);
         let mut raw_outputs = execute_tts_inference(&session, phoneme_ids, voice_embedding, speed)?;
 
@@ -202,7 +210,11 @@ impl TtsStrategy {
 
         // Process each chunk and collect audio
         let mut all_audio: Vec<f32> = Vec::new();
-        let session = ONNXSession::new(model_path.to_str().unwrap(), false, false)?;
+        let session = OnnxSessionFactory::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )?;
         let speed = extract_tts_speed(input);
 
         // Compute inter-chunk silence (e.g. 200ms at 24kHz = 4800 zero samples)

--- a/crates/xybrid-core/src/execution/strategies/tts.rs
+++ b/crates/xybrid-core/src/execution/strategies/tts.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use super::{ExecutionContext, ExecutionStrategy};
 use crate::execution::executor::extract_tts_speed;
 use crate::execution::modes::execute_tts_inference;
+use crate::execution::session_factory::OnnxSessionFactory;
 use crate::execution::template::{
     ExecutionTemplate, ModelMetadata, PostprocessingStep, PreprocessingStep,
 };
@@ -20,7 +21,6 @@ use crate::execution::types::{ExecutorResult, PreprocessedData, RawOutputs};
 use crate::execution::voice_loader::TtsVoiceLoader;
 use crate::execution::{postprocessing, preprocessing};
 use crate::ir::{Envelope, EnvelopeKind};
-use crate::execution::session_factory::OnnxSessionFactory;
 use crate::runtime_adapter::onnx::{ExecutionProviderKind, SessionOptions};
 use crate::runtime_adapter::AdapterError;
 use crate::tracing as xybrid_trace;

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -92,7 +92,7 @@ pub mod llama_cpp;
 // Re-exports from runtime backends
 pub use cloud::{CloudRuntimeAdapter, CloudStreaming};
 pub use metadata_driven::MetadataDrivenAdapter;
-pub use onnx::ONNXSession;
+pub use onnx::{ExecutionProviderKind, ONNXSession, SessionOptions};
 pub use onnx::OnnxBackend;
 pub use onnx::OnnxRuntimeAdapter;
 

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -92,9 +92,9 @@ pub mod llama_cpp;
 // Re-exports from runtime backends
 pub use cloud::{CloudRuntimeAdapter, CloudStreaming};
 pub use metadata_driven::MetadataDrivenAdapter;
-pub use onnx::{ExecutionProviderKind, ONNXSession, SessionOptions};
 pub use onnx::OnnxBackend;
 pub use onnx::OnnxRuntimeAdapter;
+pub use onnx::{ExecutionProviderKind, ONNXSession, SessionOptions};
 
 #[cfg(any(target_os = "android", test))]
 pub use onnx::ONNXMobileRuntimeAdapter;

--- a/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
@@ -22,7 +22,7 @@
 //! ```
 
 use super::execution_provider::ExecutionProviderKind;
-use super::session::ONNXSession;
+use super::session::{ONNXSession, SessionOptions};
 use crate::ir::Envelope;
 use crate::runtime_adapter::tensor_utils::{envelope_to_tensors, tensors_to_envelope};
 use crate::runtime_adapter::{
@@ -336,7 +336,13 @@ impl RuntimeAdapter for OnnxRuntimeAdapter {
         // single biggest reason latency varies on the same chip + model.
         // The capture costs ~10-15% on the first inference (the warm-up
         // call) and zero on every subsequent call.
-        let session = ONNXSession::with_resolved_ep_capture(path, self.execution_provider)?;
+        let session = ONNXSession::build(
+            path,
+            self.execution_provider,
+            SessionOptions {
+                capture_resolved_ep: true,
+            },
+        )?;
 
         log::info!(
             "Loaded model '{}' with {} execution provider",

--- a/crates/xybrid-core/src/runtime_adapter/onnx/backend.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/backend.rs
@@ -4,7 +4,9 @@
 //! It wraps the existing ONNXSession implementation to conform to the
 //! InferenceBackend trait.
 
-use super::session::ONNXSession;
+use super::execution_provider::ExecutionProviderKind;
+use super::session::{ONNXSession, SessionOptions};
+use crate::execution::session_factory::OnnxSessionFactory;
 use crate::runtime_adapter::inference_backend::{
     BackendError, BackendResult, InferenceBackend, RuntimeType,
 };
@@ -43,14 +45,17 @@ impl InferenceBackend for OnnxBackend {
     }
 
     fn load_model(&mut self, model_path: &Path, _config_path: Option<&Path>) -> BackendResult<()> {
-        // Load ONNX model using existing ONNXSession
-        let model_path_str = model_path
-            .to_str()
-            .ok_or_else(|| BackendError::LoadFailed("Invalid model path".to_string()))?;
-
-        // Create session with hardware acceleration hints (auto-detected by ort)
-        let session = ONNXSession::new(model_path_str, false, false)
-            .map_err(|e| BackendError::LoadFailed(format!("Failed to load ONNX model: {}", e)))?;
+        // Cheap path — this backend doesn't consume the resolved-EP
+        // signal, so we don't pay the profiling cost or require a
+        // writable tempdir on sandboxed targets. Routed through the
+        // shared factory entry so any future change to ONNX session
+        // construction picks this site up automatically.
+        let session = OnnxSessionFactory::create_session(
+            model_path,
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )
+        .map_err(|e| BackendError::LoadFailed(format!("Failed to load ONNX model: {}", e)))?;
 
         self.session = Some(session);
         Ok(())

--- a/crates/xybrid-core/src/runtime_adapter/onnx/mobile.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/mobile.rs
@@ -18,7 +18,8 @@
 //! adapter.load_model("/path/to/model.onnx")?;
 //! ```
 
-use super::session::ONNXSession;
+use super::execution_provider::ExecutionProviderKind;
+use super::session::{ONNXSession, SessionOptions};
 use crate::device::capabilities::ThermalState;
 use crate::ir::{Envelope, EnvelopeKind};
 use crate::runtime_adapter::tensor_utils::{envelope_to_tensors, tensors_to_envelope};
@@ -304,12 +305,14 @@ impl RuntimeAdapter for ONNXMobileRuntimeAdapter {
             return Ok(());
         }
 
-        // Create ONNX Runtime session
-        // Use NNAPI on Android if available and battery is sufficient
-        let use_nnapi = self.nnapi_available && self.battery_level > 20;
-        let use_metal = false; // Metal is for macOS/iOS, not Android
-
-        let session = ONNXSession::new(path, use_nnapi, use_metal)?;
+        // Create ONNX Runtime session. The legacy `new(path, use_nnapi,
+        // use_metal)` API silently dropped those flags, so this adapter
+        // has always loaded onto the CPU EP regardless of the captured
+        // `nnapi_available` / `battery_level` state. The unified `build`
+        // entry point keeps that behaviour explicit; wiring real
+        // NNAPI/Metal selection is a separate (overdue) change.
+        let session =
+            ONNXSession::build(path, ExecutionProviderKind::Cpu, SessionOptions::default())?;
 
         // Extract real input/output shapes from session
         let input_shapes = session.input_shapes();

--- a/crates/xybrid-core/src/runtime_adapter/onnx/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/mod.rs
@@ -28,7 +28,7 @@ pub use execution_provider::{
 pub use execution_provider::{CoreMLComputeUnits, CoreMLConfig};
 pub use profiling::ResolvedExecutionProviders;
 pub use runtime::OnnxRuntime;
-pub use session::ONNXSession;
+pub use session::{ONNXSession, SessionOptions};
 
 #[cfg(any(target_os = "android", test))]
 pub use mobile::ONNXMobileRuntimeAdapter;

--- a/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
@@ -6,19 +6,32 @@
 //! - Handles execution provider selection (CPU, CoreML, etc.)
 //! - Provides a clean interface for running inference
 //!
+//! Construction goes through a single entry point — [`ONNXSession::build`] —
+//! taking the model path, the requested [`ExecutionProviderKind`], and a
+//! [`SessionOptions`] flag bag. The default options keep the session on
+//! the cheap path; opting in to `capture_resolved_ep` enables ORT
+//! profiling so the *actual* execution provider that ran each op can be
+//! harvested after the first inference (see
+//! [`ONNXSession::resolved_providers`]).
+//!
 //! # Example
 //!
 //! ```rust,ignore
-//! use xybrid_core::runtime_adapter::onnx::{ONNXSession, ExecutionProviderKind};
+//! use xybrid_core::runtime_adapter::onnx::{ONNXSession, ExecutionProviderKind, SessionOptions};
 //!
-//! // CPU execution (default)
-//! let session = ONNXSession::with_provider("/path/to/model.onnx", ExecutionProviderKind::Cpu)?;
-//!
-//! // CoreML execution (requires ort-coreml feature)
-//! #[cfg(feature = "ort-coreml")]
-//! let session = ONNXSession::with_provider(
+//! // CPU execution, no profiling overhead
+//! let session = ONNXSession::build(
 //!     "/path/to/model.onnx",
-//!     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine())
+//!     ExecutionProviderKind::Cpu,
+//!     SessionOptions::default(),
+//! )?;
+//!
+//! // CoreML execution with resolved-EP capture (requires ort-coreml feature)
+//! #[cfg(feature = "ort-coreml")]
+//! let session = ONNXSession::build(
+//!     "/path/to/model.onnx",
+//!     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine()),
+//!     SessionOptions { capture_resolved_ep: true },
 //! )?;
 //!
 //! let inputs = /* prepare inputs */;
@@ -40,15 +53,44 @@ use tempfile::TempDir;
 /// Metadata extracted from ONNX model inputs: (names, shapes, element types).
 type InputMetadata = (Vec<String>, Vec<Vec<i64>>, Vec<Option<TensorElementType>>);
 
+/// Construction-time options for [`ONNXSession::build`].
+///
+/// Every field defaults to the cheap behaviour — opting in costs
+/// something measurable, so the burden is on the caller to ask for it.
+///
+/// Marked `#[non_exhaustive]` so adding new flags later isn't a
+/// breaking change for external struct-literal callers. Construct with
+/// [`SessionOptions::default`] (cheap path), or build the literal with
+/// `..Default::default()` when only a subset of flags need to be set.
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SessionOptions {
+    /// When `true`, the session is built with ORT profiling enabled so
+    /// the *resolved* execution provider (the EP that actually ran each
+    /// op) can be harvested after the first inference via
+    /// [`ONNXSession::resolved_providers`].
+    ///
+    /// Profiling adds roughly 10-15 % wall-clock overhead to the first
+    /// inference; subsequent inferences run at normal cost once the
+    /// harvest finalises the profile file. Profiling also requires a
+    /// writable tempdir at construction — sandboxed targets (iOS,
+    /// restricted Android, hermetic CI runners) where
+    /// `tempfile::tempdir()` can fail will refuse to construct the
+    /// session, so leave this `false` on any path that doesn't actually
+    /// read the resolved EP.
+    pub capture_resolved_ep: bool,
+}
+
 /// Lifecycle state for the resolved-EP capture.
 ///
-/// `Disabled` is the legacy default and what every caller of
-/// [`ONNXSession::with_provider`] sees. `Pending` means profiling was
-/// enabled at construction and we're waiting for the first inference to
-/// produce a profile we can harvest. `Harvested` carries the parsed
-/// summary. `Failed` records the error string so callers can decide
-/// whether to retry or fall back to the requested EP — we don't poison
-/// the whole session over a profile-parse failure.
+/// `Disabled` is what every caller of [`ONNXSession::build`] with the
+/// default [`SessionOptions`] sees. `Pending` means profiling was
+/// enabled at construction (via `SessionOptions { capture_resolved_ep:
+/// true, .. }`) and we're waiting for the first inference to produce a
+/// profile we can harvest. `Harvested` carries the parsed summary.
+/// `Failed` records the error string so callers can decide whether to
+/// retry or fall back to the requested EP — we don't poison the whole
+/// session over a profile-parse failure.
 ///
 /// The `TempDir` keeps the profile file alive until harvest succeeds and
 /// drops it (with the file inside) automatically afterwards. ORT's
@@ -88,71 +130,62 @@ pub struct ONNXSession {
     input_dtypes: Vec<Option<TensorElementType>>,
     /// The execution provider used for this session
     execution_provider: ExecutionProviderKind,
-    /// Resolved-EP capture state. `Disabled` for sessions built via
-    /// [`ONNXSession::with_provider`]; `Pending → Harvested/Failed`
-    /// for sessions built via [`ONNXSession::with_resolved_ep_capture`].
-    /// Wrapped in [`Mutex`] so the auto-harvest path inside
+    /// Resolved-EP capture state. `Disabled` for sessions built with the
+    /// default [`SessionOptions`]; `Pending → Harvested/Failed` for
+    /// sessions built with `SessionOptions { capture_resolved_ep: true,
+    /// .. }`. Wrapped in [`Mutex`] so the auto-harvest path inside
     /// [`run_with_values`] (which only has `&self`) can mutate it.
     resolved_state: Mutex<ResolvedEpState>,
 }
 
 impl ONNXSession {
-    /// Creates a new ONNX session from a model file (legacy API).
+    /// Builds a new ONNX session.
     ///
-    /// This method is kept for backwards compatibility. For new code,
-    /// prefer using `with_provider()` which gives explicit control over
-    /// the execution provider.
-    ///
-    /// # Arguments
-    ///
-    /// * `model_path` - Path to the ONNX model file
-    /// * `_use_nnapi` - Deprecated: use `with_provider()` instead
-    /// * `_use_metal` - Deprecated: use `with_provider()` instead
-    ///
-    /// # Returns
-    ///
-    /// A new `ONNXSession` instance using CPU execution
-    pub fn new(model_path: &str, _use_nnapi: bool, _use_metal: bool) -> AdapterResult<Self> {
-        Self::with_provider(model_path, ExecutionProviderKind::Cpu)
-    }
-
-    /// Creates a new ONNX session with the specified execution provider.
+    /// This is the single construction entry point on `ONNXSession`. It
+    /// loads the model file, configures the requested execution
+    /// provider, extracts input/output metadata, and — when
+    /// `options.capture_resolved_ep` is set — turns on ORT profiling so
+    /// the resolved EP can be harvested after the first inference.
     ///
     /// # Arguments
     ///
-    /// * `model_path` - Path to the ONNX model file
-    /// * `execution_provider` - The execution provider to use (CPU, CoreML, etc.)
-    ///
-    /// # Returns
-    ///
-    /// A new `ONNXSession` instance
+    /// * `model_path` — Path to the ONNX model file
+    /// * `execution_provider` — The execution provider to request (CPU, CoreML, …)
+    /// * `options` — [`SessionOptions`]; default leaves the session on
+    ///   the cheap path (no profiling, no tempdir requirement)
     ///
     /// # Errors
     ///
     /// Returns an error if:
-    /// - Model file doesn't exist
-    /// - Model loading fails
-    /// - Execution provider initialization fails
-    /// - Metadata extraction fails
+    /// - the model file doesn't exist or fails to load
+    /// - the execution provider fails to initialise
+    /// - metadata extraction fails
+    /// - `options.capture_resolved_ep` is set and a tempdir cannot be
+    ///   created (sandboxed targets — opt out of capture on those paths)
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// use xybrid_core::runtime_adapter::onnx::{ONNXSession, ExecutionProviderKind};
+    /// use xybrid_core::runtime_adapter::onnx::{ONNXSession, ExecutionProviderKind, SessionOptions};
     ///
-    /// // CPU execution
-    /// let session = ONNXSession::with_provider("model.onnx", ExecutionProviderKind::Cpu)?;
-    ///
-    /// // CoreML with Neural Engine (requires ort-coreml feature)
-    /// #[cfg(feature = "ort-coreml")]
-    /// let session = ONNXSession::with_provider(
+    /// // Cheap path — no profiling overhead, no tempdir
+    /// let session = ONNXSession::build(
     ///     "model.onnx",
-    ///     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine())
+    ///     ExecutionProviderKind::Cpu,
+    ///     SessionOptions::default(),
+    /// )?;
+    ///
+    /// // Opt in to resolved-EP capture for telemetry callers
+    /// let session = ONNXSession::build(
+    ///     "model.onnx",
+    ///     ExecutionProviderKind::Cpu,
+    ///     SessionOptions { capture_resolved_ep: true },
     /// )?;
     /// ```
-    pub fn with_provider(
+    pub fn build(
         model_path: &str,
         execution_provider: ExecutionProviderKind,
+        options: SessionOptions,
     ) -> AdapterResult<Self> {
         let path = Path::new(model_path);
         if !path.exists() {
@@ -165,7 +198,10 @@ impl ONNXSession {
         // Initialize ONNX Runtime environment (singleton, safe to call multiple times)
         let _ = ort::init().commit();
 
-        // Create session builder with optimization
+        // Build the session-builder up front; the profiling branch adds
+        // a tempdir and a `with_profiling` call, the default branch
+        // skips both. Keeping the two paths visibly separate is what
+        // lets sandboxed targets stay on the no-tempdir path safely.
         let mut builder = Session::builder()
             .map_err(|e| {
                 AdapterError::RuntimeError(format!("Failed to create session builder: {}", e))
@@ -175,95 +211,26 @@ impl ONNXSession {
                 AdapterError::RuntimeError(format!("Failed to set optimization level: {}", e))
             })?;
 
-        // Configure execution provider
-        builder = Self::configure_execution_provider(builder, &execution_provider)?;
-
-        // Load model
-        let session = builder
-            .commit_from_file(model_path)
-            .map_err(|e| AdapterError::RuntimeError(format!("Failed to load ONNX model: {}", e)))?;
-
-        // Extract input/output metadata from session
-        let (input_names, input_shapes, input_dtypes) = Self::extract_input_metadata(&session)?;
-        let (output_names, output_shapes) = Self::extract_output_metadata(&session)?;
-
-        log::info!(
-            "Created ONNX session with {} execution provider for model: {}",
-            execution_provider,
-            model_path
-        );
-
-        Ok(Self {
-            session: Mutex::new(session),
-            input_names,
-            output_names,
-            input_shapes,
-            output_shapes,
-            input_dtypes,
-            execution_provider,
-            resolved_state: Mutex::new(ResolvedEpState::Disabled),
-        })
-    }
-
-    /// Creates an ONNX session with profiling enabled so the *resolved*
-    /// execution provider (the one that actually ran each op) can be
-    /// captured after the first inference.
-    ///
-    /// Same arguments + behaviour as [`ONNXSession::with_provider`], plus:
-    /// - profiling is turned on at session-build time, writing to a
-    ///   tempfile that's cleaned up on drop;
-    /// - the first call to [`ONNXSession::run_with_values`] (or
-    ///   [`ONNXSession::run`]) triggers a one-shot harvest that ends
-    ///   profiling, parses the JSON, and stores a
-    ///   [`ResolvedExecutionProviders`] summary readable via
-    ///   [`ONNXSession::resolved_providers`].
-    /// - subsequent calls run at normal cost (profiling is finalised
-    ///   after the first run, so there's no per-call overhead).
-    ///
-    /// ORT's profiling adds roughly 10-15 % wall-clock overhead, but
-    /// that hits exactly one inference — typically the warm-up call
-    /// telemetry already discards. Use this constructor only for
-    /// sessions that need the resolved EP for telemetry; the default
-    /// path stays on [`ONNXSession::with_provider`] with no regression.
-    pub fn with_resolved_ep_capture(
-        model_path: &str,
-        execution_provider: ExecutionProviderKind,
-    ) -> AdapterResult<Self> {
-        let path = Path::new(model_path);
-        if !path.exists() {
-            return Err(AdapterError::ModelNotFound(format!(
-                "Model file not found: {}",
-                model_path
-            )));
-        }
-
-        let _ = ort::init().commit();
-
-        let tempdir = tempfile::tempdir().map_err(|e| {
-            AdapterError::RuntimeError(format!(
-                "Failed to create profile tempdir for resolved-EP capture: {}",
-                e
-            ))
-        })?;
-        // ORT appends `_<timestamp>.json` to whatever prefix we pass; this
-        // gives us a stable subpath inside the tempdir we own.
-        let profile_prefix: PathBuf = tempdir.path().join("xybrid-profile");
-
-        let mut builder = Session::builder()
-            .map_err(|e| {
-                AdapterError::RuntimeError(format!("Failed to create session builder: {}", e))
-            })?
-            .with_optimization_level(GraphOptimizationLevel::Level3)
-            .map_err(|e| {
-                AdapterError::RuntimeError(format!("Failed to set optimization level: {}", e))
-            })?
-            .with_profiling(&profile_prefix)
-            .map_err(|e| {
+        let resolved_state = if options.capture_resolved_ep {
+            let tempdir = tempfile::tempdir().map_err(|e| {
+                AdapterError::RuntimeError(format!(
+                    "Failed to create profile tempdir for resolved-EP capture: {}",
+                    e
+                ))
+            })?;
+            // ORT appends `_<timestamp>.json` to whatever prefix we pass;
+            // this gives us a stable subpath inside the tempdir we own.
+            let profile_prefix: PathBuf = tempdir.path().join("xybrid-profile");
+            builder = builder.with_profiling(&profile_prefix).map_err(|e| {
                 AdapterError::RuntimeError(format!(
                     "Failed to enable profiling for resolved-EP capture: {}",
                     e
                 ))
             })?;
+            ResolvedEpState::Pending { _tempdir: tempdir }
+        } else {
+            ResolvedEpState::Disabled
+        };
 
         builder = Self::configure_execution_provider(builder, &execution_provider)?;
 
@@ -275,9 +242,10 @@ impl ONNXSession {
         let (output_names, output_shapes) = Self::extract_output_metadata(&session)?;
 
         log::info!(
-            "Created ONNX session with {} EP and resolved-EP profiling enabled for model: {}",
+            "Created ONNX session with {} execution provider for model: {} (capture_resolved_ep={})",
             execution_provider,
-            model_path
+            model_path,
+            options.capture_resolved_ep,
         );
 
         Ok(Self {
@@ -288,7 +256,7 @@ impl ONNXSession {
             output_shapes,
             input_dtypes,
             execution_provider,
-            resolved_state: Mutex::new(ResolvedEpState::Pending { _tempdir: tempdir }),
+            resolved_state: Mutex::new(resolved_state),
         })
     }
 
@@ -567,8 +535,8 @@ impl ONNXSession {
 
     /// Returns the resolved-EP summary from the first inference's
     /// profile output, if and only if the session was built with
-    /// [`ONNXSession::with_resolved_ep_capture`] **and** at least one
-    /// inference has completed since.
+    /// `SessionOptions { capture_resolved_ep: true, .. }` **and** at
+    /// least one inference has completed since.
     ///
     /// Returns `None` for sessions without capture enabled, sessions
     /// where capture is still pending, or sessions where harvest
@@ -658,7 +626,11 @@ mod tests {
 
     #[test]
     fn test_session_creation_fails_on_nonexistent_file() {
-        let result = ONNXSession::new("/nonexistent/model.onnx", false, false);
+        let result = ONNXSession::build(
+            "/nonexistent/model.onnx",
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        );
         assert!(matches!(result, Err(AdapterError::ModelNotFound(_))));
     }
 
@@ -674,7 +646,11 @@ mod tests {
         fs::write(&model_path, b"fake onnx data").unwrap();
 
         // This will fail at ort initialization or model loading, but we can test the structure
-        let result = ONNXSession::new(model_path.to_str().unwrap(), false, false);
+        let result = ONNXSession::build(
+            model_path.to_str().unwrap(),
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        );
 
         // The session creation might fail due to invalid ONNX format,
         // but we've at least tested that the file existence check passes
@@ -717,7 +693,11 @@ mod tests {
             }
         };
 
-        let result = ONNXSession::new(model_path.to_str().unwrap(), false, false);
+        let result = ONNXSession::build(
+            model_path.to_str().unwrap(),
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        );
         assert!(
             result.is_ok(),
             "Failed to load MNIST model: {:?}",
@@ -773,8 +753,12 @@ mod tests {
             }
         };
 
-        let session = ONNXSession::new(model_path.to_str().unwrap(), false, false)
-            .expect("Failed to load MNIST model");
+        let session = ONNXSession::build(
+            model_path.to_str().unwrap(),
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        )
+        .expect("Failed to load MNIST model");
 
         // Get real input name from session
         let input_names = session.input_names();
@@ -826,23 +810,26 @@ mod tests {
 
     #[test]
     fn resolved_providers_returns_none_when_capture_disabled() {
-        // Default `with_provider` path must leave the resolved-EP API
-        // dormant — capture is opt-in and the legacy code path is
-        // unaffected. Uses a nonexistent model so we
-        // never have to load the runtime; constructor errors before the
-        // accessor is reachable, so we skip the assertion when ort fails
-        // to initialise (e.g. in environments without the binary).
-        let result =
-            ONNXSession::with_provider("/nonexistent/model.onnx", ExecutionProviderKind::Cpu);
+        // Default-options path must leave the resolved-EP API dormant —
+        // capture is opt-in and the cheap code path is unaffected. Uses
+        // a nonexistent model so we never have to load the runtime; the
+        // constructor errors before the accessor is reachable, so we
+        // skip the assertion when ort fails to initialise (e.g. in
+        // environments without the binary).
+        let result = ONNXSession::build(
+            "/nonexistent/model.onnx",
+            ExecutionProviderKind::Cpu,
+            SessionOptions::default(),
+        );
         assert!(matches!(result, Err(AdapterError::ModelNotFound(_))));
     }
 
     #[test]
     fn resolved_providers_populates_after_first_inference() {
-        // End-to-end: build with `with_resolved_ep_capture`, run one
-        // inference, expect `resolved_providers()` to surface a primary
-        // EP. Skips when the MNIST fixture isn't present so CI without
-        // the model still passes.
+        // End-to-end: build with capture enabled, run one inference,
+        // expect `resolved_providers()` to surface a primary EP. Skips
+        // when the MNIST fixture isn't present so CI without the model
+        // still passes.
         let possible_paths = [
             PathBuf::from("test_models/mnist-12.onnx"),
             PathBuf::from("../test_models/mnist-12.onnx"),
@@ -856,9 +843,12 @@ mod tests {
             }
         };
 
-        let session = ONNXSession::with_resolved_ep_capture(
+        let session = ONNXSession::build(
             model_path.to_str().unwrap(),
             ExecutionProviderKind::Cpu,
+            SessionOptions {
+                capture_resolved_ep: true,
+            },
         )
         .expect("Failed to load MNIST model with resolved-EP capture enabled");
 


### PR DESCRIPTION
## Summary

Replace the trio of `ONNXSession::new` / `with_provider` / `with_resolved_ep_capture` constructors with a single `ONNXSession::build(path, provider, SessionOptions)` entry. Profiling for resolved-EP capture becomes an opt-in `capture_resolved_ep` flag on `SessionOptions` instead of a parallel constructor, keeping default callers on the cheap (no-tempdir, no-profiling) path. Strategy, executor, and `OnnxBackend` session construction now route through `OnnxSessionFactory::create_session` so future ONNX setup changes have one chokepoint; `OnnxRuntimeAdapter::load_model` opts in to capture explicitly. Mobile adapter and `inference_backends` benches updated to the new API.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)