### PR TITLE
fix(device): real GPU/NPU/Metal probes; drop silent-true stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,20 +753,11 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
-dependencies = [
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.4",
+ "objc2",
 ]
 
 [[package]]
@@ -951,7 +942,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-metal",
  "rand 0.9.4",
  "rand_distr 0.5.1",
@@ -1000,8 +991,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
 dependencies = [
  "half",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
+ "objc2",
+ "objc2-foundation",
  "objc2-metal",
  "once_cell",
  "thiserror 2.0.18",
@@ -2044,8 +2035,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2 0.6.2",
- "objc2 0.6.4",
+ "block2",
+ "objc2",
 ]
 
 [[package]]
@@ -4666,7 +4657,7 @@ dependencies = [
  "dispatch2",
  "float8",
  "half",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-metal",
  "thiserror 2.0.18",
 ]
@@ -4687,7 +4678,7 @@ dependencies = [
  "hf-hub 0.4.3",
  "lazy_static",
  "memmap2",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
  "objc2-metal",
  "paste",
  "rayon",
@@ -5047,22 +5038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,10 +5053,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
- "block2 0.6.2",
+ "block2",
  "dispatch2",
  "libc",
- "objc2 0.6.4",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-ml"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201b055e6acfa0f9f15568255d3f03ce2b54bc86d1814442dc69138e36813e18"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -5092,26 +5086,14 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
-dependencies = [
- "bitflags 2.11.1",
- "block2 0.5.1",
- "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "block2 0.6.2",
+ "block2",
  "libc",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -5122,10 +5104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "bitflags 2.11.1",
- "block2 0.6.2",
+ "block2",
  "dispatch2",
  "libc",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -5136,11 +5118,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.1",
- "block2 0.6.2",
+ "block2",
  "dispatch2",
- "objc2 0.6.4",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -9762,6 +9744,7 @@ dependencies = [
  "hound",
  "image 0.25.10",
  "lazy_static",
+ "libc",
  "log",
  "mel_spec",
  "mistralrs",
@@ -9769,10 +9752,13 @@ dependencies = [
  "ndarray-npy 0.10.0",
  "num-complex",
  "num-traits",
- "objc2 0.5.2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.2.2",
+ "objc2-core-graphics",
+ "objc2-core-ml",
+ "objc2-foundation",
  "objc2-io-kit",
+ "objc2-metal",
  "ort",
  "regex",
  "rustfft",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -155,8 +155,32 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 # Foundation crates work cross-platform under the same target_os check
 # clang's apple compilation matrix uses.
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-objc2 = "0.5"
-objc2-foundation = { version = "0.2", features = ["NSProcessInfo", "NSString"] }
+# objc2 + objc2-foundation pinned at 0.6 / 0.3 so the direct deps unify with
+# the transitive 0.6/0.3 versions pulled by objc2-metal/-core-graphics/-core-ml.
+# Mixing 0.5 + 0.6 in the same dep graph splits NSObjectProtocol/AnyObject
+# types and breaks isKindOfClass-style checks across them.
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString"] }
+# Real Metal probe via MTLCreateSystemDefaultDevice.
+objc2-metal = { version = "0.3", default-features = false, features = ["std", "MTLDevice"] }
+# Sibling dep to satisfy the CoreGraphics framework link objc2-metal documents
+# as a build requirement. 0.2 does not exist on crates.io — must be 0.3.
+objc2-core-graphics = { version = "0.3", default-features = false, features = ["std"] }
+# Real Apple Neural Engine probe via Core ML compute-device enumeration.
+# Note: we deliberately do NOT enable the `MLAllComputeDevices` feature.
+# That feature's generated wrapper emits a strong extern reference to the
+# `MLAllComputeDevices` C symbol — which would re-introduce the bind-at-load
+# risk on macOS 13 / iOS 16 that our libc::dlsym lookup in apple.rs avoids.
+# We need only the type bindings here; the function itself is resolved at
+# runtime via dlsym in detect_neural_engine_with_confidence.
+objc2-core-ml = { version = "0.3", default-features = false, features = [
+    "std",
+    "MLComputeDeviceProtocol",
+    "MLNeuralEngineComputeDevice",
+] }
+# libc for dlsym(RTLD_DEFAULT, ...) to resolve MLAllComputeDevices at runtime
+# instead of through the objc2-core-ml generated wrapper.
+libc = "0.2"
 
 # macOS-only battery poller: IOKit IOPSCopyPowerSourcesInfo. The IOPS
 # APIs are gated behind a private entitlement on iOS; the public
@@ -186,4 +210,6 @@ windows = { version = "0.61", features = [
     "Win32_System_Ole",
     "Win32_System_Variant",
     "Win32_System_Wmi",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Dxgi_Common",
 ] }

--- a/crates/xybrid-core/examples/caps_dump.rs
+++ b/crates/xybrid-core/examples/caps_dump.rs
@@ -1,0 +1,7 @@
+//! Prints `detect_capabilities()` output. Useful for sanity-checking the
+//! probes return sensible values on the host machine.
+
+fn main() {
+    let caps = xybrid_core::device::capabilities::detect_capabilities();
+    println!("{caps:#?}");
+}

--- a/crates/xybrid-core/src/device/apple.rs
+++ b/crates/xybrid-core/src/device/apple.rs
@@ -202,9 +202,8 @@ fn read_hw_machine() -> Option<String> {
 /// `MLAllComputeDevices` and looks for an `MLNeuralEngineComputeDevice`
 /// in the result — confidence is High. On older OS where the class
 /// doesn't exist in the Objective-C runtime, falls through to the
-/// arch-based heuristic at Medium confidence (the heuristic is correct
-/// on most modern Apple hardware but wrong on older arm64 iPhones/iPads
-/// without ANE). Off Apple, returns `(false, Unknown)`.
+/// device-model/sysctl path and preserves that fallback's confidence.
+/// Off Apple, returns `(false, Unknown)`.
 pub fn detect_neural_engine_with_confidence() -> (bool, DetectionConfidence) {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
@@ -223,7 +222,7 @@ pub fn detect_neural_engine_with_confidence() -> (bool, DetectionConfidence) {
         // over the `CStr::from_bytes_with_nul` alternative.
         let Some(ne_class) = AnyClass::get(c"MLNeuralEngineComputeDevice") else {
             let info = detect_apple_device();
-            return (info.has_neural_engine, DetectionConfidence::Medium);
+            return (info.has_neural_engine, info.confidence);
         };
 
         // Second gate: resolve MLAllComputeDevices at runtime via dlsym
@@ -255,7 +254,7 @@ pub fn detect_neural_engine_with_confidence() -> (bool, DetectionConfidence) {
         };
         if raw.is_null() {
             let info = detect_apple_device();
-            return (info.has_neural_engine, DetectionConfidence::Medium);
+            return (info.has_neural_engine, info.confidence);
         }
 
         // SAFETY: `raw` is non-null (checked above). The transmute
@@ -269,10 +268,10 @@ pub fn detect_neural_engine_with_confidence() -> (bool, DetectionConfidence) {
         // SAFETY: `retain_autoreleased` balances the autorelease and
         // gives us a `Retained<...>` we own. It returns `None` if the
         // pointer is null, which we treat as "Apple gave us nothing"
-        // and fall back to the arch heuristic.
+        // and fall back to the device-model/sysctl path.
         let Some(devices) = (unsafe { Retained::retain_autoreleased(raw_array) }) else {
             let info = detect_apple_device();
-            return (info.has_neural_engine, DetectionConfidence::Medium);
+            return (info.has_neural_engine, info.confidence);
         };
 
         // `isKindOfClass:` is exposed as safe in objc2-foundation 0.3.
@@ -426,10 +425,10 @@ mod tests {
                 "Class present → real Core ML probe ran → High confidence",
             );
         } else {
+            let fallback = detect_apple_device();
             assert_eq!(
-                confidence,
-                DetectionConfidence::Medium,
-                "Class absent → arch fallback → Medium confidence",
+                confidence, fallback.confidence,
+                "Class absent → fallback confidence should be preserved",
             );
         }
     }

--- a/crates/xybrid-core/src/device/apple.rs
+++ b/crates/xybrid-core/src/device/apple.rs
@@ -5,6 +5,19 @@
 
 use super::types::DetectionConfidence;
 
+// Pull the CoreGraphics framework link into xybrid-core. `objc2-metal`
+// documents `MTLCreateSystemDefaultDevice` as requiring CoreGraphics at
+// link time, and `objc2-core-graphics` declares `#[link(name =
+// "CoreGraphics", kind = "framework")]` for that purpose. Without
+// referencing the crate from code, the linker can GC the directive
+// because nothing in xybrid-core uses any symbol from
+// objc2-core-graphics — which would leave the binary missing the
+// framework on builds that don't transitively pull it in (release,
+// stripped, LTO). The unused-import suppression is intentional and
+// load-bearing.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use objc2_core_graphics as _;
+
 /// iOS/macOS device family detection result.
 #[derive(Debug, Clone)]
 pub struct AppleDeviceInfo {
@@ -16,20 +29,33 @@ pub struct AppleDeviceInfo {
     pub confidence: DetectionConfidence,
 }
 
-/// Detects Metal framework availability (macOS/iOS only).
-pub fn detect_metal_availability() -> bool {
-    // Stub: Always return true on Apple platforms
-    // TODO: Real implementation would check:
-    // - MTLCreateSystemDefaultDevice() != nil
-    // - Device supports compute shaders
+/// Real Metal probe via MTLCreateSystemDefaultDevice.
+///
+/// Returns `(present, confidence)`. On Apple platforms this is a real
+/// runtime device probe — confidence is High. Off Apple, returns
+/// `(false, Unknown)`.
+pub fn detect_metal_with_confidence() -> (bool, DetectionConfidence) {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
-        true
+        // MTLCreateSystemDefaultDevice in objc2-metal 0.3 is:
+        //   pub extern "C-unwind" fn MTLCreateSystemDefaultDevice()
+        //       -> Option<Retained<ProtocolObject<dyn MTLDevice>>>
+        // It is NOT `unsafe fn` — no unsafe block needed. The
+        // objc2-core-graphics sibling dep is in tree to satisfy the
+        // CoreGraphics framework link this call requires.
+        let device = objc2_metal::MTLCreateSystemDefaultDevice();
+        (device.is_some(), DetectionConfidence::High)
     }
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     {
-        false
+        (false, DetectionConfidence::Unknown)
     }
+}
+
+/// Compatibility wrapper. Existing callers consuming a bare bool stay working;
+/// new code should prefer `detect_metal_with_confidence`.
+pub fn detect_metal_availability() -> bool {
+    detect_metal_with_confidence().0
 }
 
 /// Detect Apple device model from environment variables.
@@ -40,13 +66,15 @@ pub fn detect_metal_availability() -> bool {
 ///
 /// Returns device info with Neural Engine availability inference.
 pub fn detect_apple_device() -> AppleDeviceInfo {
-    // Try environment variables that might be set by the runtime
-    let model = std::env::var("DEVICE_MODEL")
+    // 1) Env-var hint from the host runtime (Flutter sets DEVICE_MODEL,
+    //    Xcode sets SIMULATOR_MODEL_IDENTIFIER). Medium confidence — we
+    //    can't verify the variable wasn't lying.
+    let env_model = std::env::var("DEVICE_MODEL")
         .or_else(|_| std::env::var("SIMULATOR_MODEL_IDENTIFIER"))
         .or_else(|_| std::env::var("APPLE_DEVICE_MODEL"))
         .ok();
 
-    if let Some(ref model_str) = model {
+    if let Some(ref model_str) = env_model {
         let has_ne = has_neural_engine_by_model(model_str);
         return AppleDeviceInfo {
             device_model: Some(model_str.clone()),
@@ -55,28 +83,205 @@ pub fn detect_apple_device() -> AppleDeviceInfo {
         };
     }
 
-    // No model detected - use architecture-based fallback
-    #[cfg(target_arch = "aarch64")]
+    // 2) sysctl `hw.machine` — reads the hardware identifier straight
+    //    from the kernel (e.g. "iPhone10,3", "iPad8,1", "Mac15,3").
+    //    Pure Rust, no JNI / no host bridge, allowed by Apple's App
+    //    Store review guidelines. This is the authoritative path.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    if let Some(model) = read_hw_machine() {
+        let has_ne = has_neural_engine_by_model(&model);
+        return AppleDeviceInfo {
+            device_model: Some(model),
+            has_neural_engine: has_ne,
+            confidence: DetectionConfidence::High,
+        };
+    }
+
+    // 3) Final fallback. Reached only if sysctl is unavailable, which
+    //    is an exotic environment. Branch carefully — aarch64 alone
+    //    is NOT a guarantee of Neural Engine on iOS (A9..A10X lack
+    //    ANE; only A11+ have it).
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     {
-        // ARM64 Apple devices generally have Neural Engine:
-        // - All Apple Silicon Macs (M1/M2/M3/M4)
-        // - All iPhones since iPhone 8/X (A11+)
-        // - All iPads since iPad Pro 2018 (A12X+)
-        // Conservative: assume available on ARM64
+        // Every aarch64 Mac is Apple Silicon → ANE present.
         AppleDeviceInfo {
             device_model: None,
             has_neural_engine: true,
-            confidence: DetectionConfidence::Medium,
+            confidence: DetectionConfidence::High,
+        }
+    }
+    #[cfg(all(target_arch = "aarch64", target_os = "ios"))]
+    {
+        // aarch64 iOS spans A9 through A17; ANE only on A11+. Without
+        // a model identifier we cannot tell — signal Unknown honestly
+        // rather than fabricating a value the routing engine could act on.
+        AppleDeviceInfo {
+            device_model: None,
+            has_neural_engine: false,
+            confidence: DetectionConfidence::Unknown,
         }
     }
     #[cfg(not(target_arch = "aarch64"))]
     {
-        // Intel Macs don't have Neural Engine
+        // Intel Mac — no Apple device has ANE on x86_64.
         AppleDeviceInfo {
             device_model: None,
             has_neural_engine: false,
-            confidence: DetectionConfidence::High, // We know Intel has no NE
+            confidence: DetectionConfidence::High,
         }
+    }
+}
+
+/// Read the hardware-model identifier via `sysctlbyname`. Returns the
+/// kernel's identifier — `"iPhone10,3"` on iOS, `"Mac15,3"` on macOS.
+///
+/// Apple's sysctl keys are platform-specific:
+/// - **iOS / iPadOS / tvOS / watchOS**: `hw.machine` returns the
+///   device identifier (`"iPhone15,2"`).
+/// - **macOS**: `hw.machine` returns the architecture (`"arm64"`),
+///   not the model. The model lives under `hw.model` (`"Mac15,3"`).
+///
+/// In the iOS Simulator the kernel returns the host Mac's architecture
+/// rather than the simulated device's identifier;
+/// `has_neural_engine_by_model("arm64")` falls through to the
+/// conservative "unknown device" default. The env-var path
+/// (`SIMULATOR_MODEL_IDENTIFIER`) catches the simulated model first
+/// when Xcode sets it.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn read_hw_machine() -> Option<String> {
+    use std::ffi::CStr;
+
+    #[cfg(target_os = "macos")]
+    let key: &CStr = c"hw.model";
+    #[cfg(target_os = "ios")]
+    let key: &CStr = c"hw.machine";
+
+    // First call: query the required buffer size.
+    let mut size: libc::size_t = 0;
+    // SAFETY: passing a null oldp with a valid oldlenp asks sysctl to
+    // write the required size into oldlenp without writing data. Name
+    // is a NUL-terminated string literal.
+    let ret = unsafe {
+        libc::sysctlbyname(
+            key.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 || size == 0 {
+        return None;
+    }
+
+    let mut buf = vec![0u8; size];
+    // SAFETY: buf is sized exactly to `size` from the previous query.
+    let ret = unsafe {
+        libc::sysctlbyname(
+            key.as_ptr(),
+            buf.as_mut_ptr() as *mut _,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 {
+        return None;
+    }
+
+    CStr::from_bytes_until_nul(&buf)
+        .ok()?
+        .to_str()
+        .ok()
+        .map(String::from)
+}
+
+/// Real Neural Engine probe via Core ML's MLAllComputeDevices.
+///
+/// Returns `(present, confidence)`. On macOS 14+ / iOS 17+ this calls
+/// `MLAllComputeDevices` and looks for an `MLNeuralEngineComputeDevice`
+/// in the result — confidence is High. On older OS where the class
+/// doesn't exist in the Objective-C runtime, falls through to the
+/// arch-based heuristic at Medium confidence (the heuristic is correct
+/// on most modern Apple hardware but wrong on older arm64 iPhones/iPads
+/// without ANE). Off Apple, returns `(false, Unknown)`.
+pub fn detect_neural_engine_with_confidence() -> (bool, DetectionConfidence) {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        use objc2::rc::Retained;
+        use objc2::runtime::{AnyClass, NSObjectProtocol, ProtocolObject};
+        use objc2_core_ml::MLComputeDeviceProtocol;
+        use objc2_foundation::NSArray;
+
+        // First gate (cheap): MLNeuralEngineComputeDevice was added in
+        // macOS 14 / iOS 17. AnyClass::get returns None if the class
+        // isn't registered with the Objective-C runtime.
+        // c-string literals (`c"..."`) require Rust 1.77+. The
+        // workspace has no pinned MSRV (xybrid-core/Cargo.toml) and
+        // CI uses `dtolnay/rust-toolchain@stable`, so this is fine;
+        // clippy's `manual_c_str_literals` lint also prefers this form
+        // over the `CStr::from_bytes_with_nul` alternative.
+        let Some(ne_class) = AnyClass::get(c"MLNeuralEngineComputeDevice") else {
+            let info = detect_apple_device();
+            return (info.has_neural_engine, DetectionConfidence::Medium);
+        };
+
+        // Second gate: resolve MLAllComputeDevices at runtime via dlsym
+        // rather than through the `objc2-core-ml` generated wrapper. The
+        // wrapper emits a strong extern reference to the C symbol, which
+        // can cause dyld to refuse loading the binary on macOS 13 / iOS
+        // 16 where the symbol doesn't exist. We deliberately do NOT
+        // enable the `MLAllComputeDevices` feature in Cargo.toml; this
+        // dlsym path is the only entry point.
+        //
+        // Type the function pointer with a RAW *mut NSArray return,
+        // matching the underlying C ABI. Wrapping the return in
+        // `Retained<...>` directly would skip the autorelease retain
+        // handoff that the generated wrapper performs, causing
+        // ownership corruption on the returned object.
+        type AllComputeDevicesFn = unsafe extern "C-unwind" fn() -> *mut NSArray<
+            ProtocolObject<dyn MLComputeDeviceProtocol>,
+        >;
+
+        // SAFETY: dlsym with RTLD_DEFAULT searches the process's loaded
+        // libraries for the named symbol. The call has no caller-side
+        // preconditions; the return is either a valid function pointer
+        // or null. We only invoke the pointer after a null check.
+        let raw = unsafe {
+            libc::dlsym(
+                libc::RTLD_DEFAULT,
+                c"MLAllComputeDevices".as_ptr() as *const _,
+            )
+        };
+        if raw.is_null() {
+            let info = detect_apple_device();
+            return (info.has_neural_engine, DetectionConfidence::Medium);
+        }
+
+        // SAFETY: `raw` is non-null (checked above). The transmute
+        // matches the C symbol's documented ABI: no arguments, returns
+        // an autoreleased `*mut NSArray<id<MLComputeDeviceProtocol>>`.
+        let all_compute_devices: AllComputeDevicesFn = unsafe { std::mem::transmute(raw) };
+        // SAFETY: the function has no preconditions per Apple's docs.
+        // The returned pointer is autoreleased (+0 ownership).
+        let raw_array = unsafe { all_compute_devices() };
+
+        // SAFETY: `retain_autoreleased` balances the autorelease and
+        // gives us a `Retained<...>` we own. It returns `None` if the
+        // pointer is null, which we treat as "Apple gave us nothing"
+        // and fall back to the arch heuristic.
+        let Some(devices) = (unsafe { Retained::retain_autoreleased(raw_array) }) else {
+            let info = detect_apple_device();
+            return (info.has_neural_engine, DetectionConfidence::Medium);
+        };
+
+        // `isKindOfClass:` is exposed as safe in objc2-foundation 0.3.
+        let has_ne = devices.iter().any(|device| device.isKindOfClass(ne_class));
+        (has_ne, DetectionConfidence::High)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    {
+        (false, DetectionConfidence::Unknown)
     }
 }
 
@@ -182,19 +387,50 @@ pub fn has_neural_engine_by_model(model: &str) -> bool {
 
 /// Detects CoreML Neural Engine availability (macOS/iOS only).
 ///
-/// - Detects device model from environment variables
-/// - Infers Neural Engine availability by device family
-/// - iPhone 8/X (A11+) and iPad Pro 2018 (A12X+) have Neural Engine
-/// - All Apple Silicon Macs have Neural Engine
-/// - Intel Macs do NOT have Neural Engine
+/// Compatibility wrapper. New code should prefer
+/// `detect_neural_engine_with_confidence`.
 pub fn detect_coreml_availability() -> bool {
+    detect_neural_engine_with_confidence().0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::types::DetectionConfidence;
+
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    {
-        let device_info = detect_apple_device();
-        device_info.has_neural_engine
+    #[test]
+    fn test_metal_probe_returns_high_on_apple() {
+        let (_present, confidence) = detect_metal_with_confidence();
+        assert_eq!(confidence, DetectionConfidence::High);
     }
+
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    {
-        false
+    #[test]
+    fn test_metal_probe_returns_unknown_off_apple() {
+        let (present, confidence) = detect_metal_with_confidence();
+        assert!(!present);
+        assert_eq!(confidence, DetectionConfidence::Unknown);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_neural_engine_probe_uses_runtime_class_lookup() {
+        use objc2::runtime::AnyClass;
+        let class_present = AnyClass::get(c"MLNeuralEngineComputeDevice").is_some();
+        let (_has_ne, confidence) = detect_neural_engine_with_confidence();
+        if class_present {
+            assert_eq!(
+                confidence,
+                DetectionConfidence::High,
+                "Class present → real Core ML probe ran → High confidence",
+            );
+        } else {
+            assert_eq!(
+                confidence,
+                DetectionConfidence::Medium,
+                "Class absent → arch fallback → Medium confidence",
+            );
+        }
     }
 }

--- a/crates/xybrid-core/src/device/capabilities.rs
+++ b/crates/xybrid-core/src/device/capabilities.rs
@@ -42,7 +42,7 @@ pub use super::types::{
 use super::common::{detect_cpu, detect_memory};
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-use super::apple::{detect_coreml_availability, detect_metal_availability};
+use super::apple::{detect_metal_with_confidence, detect_neural_engine_with_confidence};
 
 #[cfg(target_os = "android")]
 use super::android::detect_nnapi_availability;
@@ -53,10 +53,47 @@ use super::android::detect_nnapi_availability;
 /// detection (memory, CPU cores) and platform-specific accelerator probes
 /// (Metal/CoreML on Apple, NNAPI on Android, Vulkan/DirectX stubs elsewhere).
 ///
+/// **Cache scope:** only static fields are cached after the first call —
+/// accelerator presence (`has_gpu`, `has_metal`, `has_npu`, `has_nnapi`),
+/// accelerator types, confidence levels, CPU core count, and total memory.
+/// Dynamic fields (`memory_available_mb`, `cpu_usage_percent`) are refreshed
+/// on every call because they vary over the process lifetime. The cache
+/// exists to skip the ~1-second cold-init cost of `MLAllComputeDevices`
+/// on first Core ML access — not to freeze live system state.
+///
 /// `battery_level` and `thermal_state` are NOT populated here — they live on
 /// the live `ResourceSnapshot` and are overlaid onto a `HardwareCapabilities`
 /// view at routing time via [`crate::context::DeviceMetrics::with_live_snapshot`].
 pub fn detect_capabilities() -> HardwareCapabilities {
+    use std::sync::OnceLock;
+    static STATIC_CACHE: OnceLock<HardwareCapabilities> = OnceLock::new();
+    let mut caps = STATIC_CACHE
+        .get_or_init(detect_capabilities_uncached)
+        .clone();
+    // Refresh dynamic fields on each call — sysinfo handles these cheaply
+    // (< 1ms) so there's no reason to cache stale values.
+    let memory_info = detect_memory();
+    caps.memory_available_mb = memory_info.available_mb;
+    let cpu_info = detect_cpu();
+    caps.cpu_usage_percent = cpu_info.usage_percent;
+    caps
+}
+
+/// Prewarm the capability cache.
+///
+/// Triggers `detect_capabilities` (synchronously populating the OnceLock
+/// static-fields cache) if it hasn't been called yet. Cheap no-op after
+/// the first call. Call this from long-lived construction paths — e.g.
+/// `LocalAuthority::new` — to keep the cold-init cost (~1s on first
+/// `MLAllComputeDevices` invocation when Core ML lazy-loads on macOS/iOS)
+/// out of latency-sensitive hot paths like routing decisions. The refresh
+/// of dynamic memory/CPU fields on each `detect_capabilities` call is
+/// unaffected by this prewarm.
+pub fn prewarm() {
+    let _ = detect_capabilities();
+}
+
+fn detect_capabilities_uncached() -> HardwareCapabilities {
     let mut capabilities = HardwareCapabilities::new();
 
     // Detect memory using sysinfo
@@ -73,58 +110,58 @@ pub fn detect_capabilities() -> HardwareCapabilities {
     // Platform-specific detection
     #[cfg(target_os = "macos")]
     {
-        capabilities.has_metal = detect_metal_availability();
-        capabilities.has_gpu = capabilities.has_metal;
-        capabilities.gpu_type = if capabilities.has_metal {
+        let (metal_present, metal_conf) = detect_metal_with_confidence();
+        capabilities.has_metal = metal_present;
+        capabilities.has_gpu = metal_present;
+        capabilities.gpu_type = if metal_present {
             GpuType::Metal
         } else {
             GpuType::None
         };
-        // GPU confidence: Medium (compile-time check, not runtime validation)
-        capabilities.gpu_confidence = DetectionConfidence::Medium;
+        capabilities.gpu_confidence = metal_conf;
 
-        // CoreML Neural Engine detection (stub based on arch)
-        capabilities.has_npu = detect_coreml_availability();
-        capabilities.npu_type = if capabilities.has_npu {
+        let (ne_present, ne_conf) = detect_neural_engine_with_confidence();
+        capabilities.has_npu = ne_present;
+        capabilities.npu_type = if ne_present {
             NpuType::CoreML
         } else {
             NpuType::None
         };
-        // NPU confidence: Medium (arch-based, not actual detection)
-        capabilities.npu_confidence = DetectionConfidence::Medium;
+        capabilities.npu_confidence = ne_conf;
     }
 
     #[cfg(target_os = "ios")]
     {
-        capabilities.has_metal = detect_metal_availability();
-        capabilities.has_gpu = capabilities.has_metal;
-        capabilities.gpu_type = if capabilities.has_metal {
+        let (metal_present, metal_conf) = detect_metal_with_confidence();
+        capabilities.has_metal = metal_present;
+        capabilities.has_gpu = metal_present;
+        capabilities.gpu_type = if metal_present {
             GpuType::Metal
         } else {
             GpuType::None
         };
-        capabilities.gpu_confidence = DetectionConfidence::Medium;
+        capabilities.gpu_confidence = metal_conf;
 
-        capabilities.has_npu = detect_coreml_availability();
-        capabilities.npu_type = if capabilities.has_npu {
+        let (ne_present, ne_conf) = detect_neural_engine_with_confidence();
+        capabilities.has_npu = ne_present;
+        capabilities.npu_type = if ne_present {
             NpuType::CoreML
         } else {
             NpuType::None
         };
-        capabilities.npu_confidence = DetectionConfidence::Medium;
+        capabilities.npu_confidence = ne_conf;
     }
 
     #[cfg(target_os = "android")]
     {
         capabilities.has_nnapi = detect_nnapi_availability();
-        capabilities.has_gpu = detect_gpu_availability_stub();
-        capabilities.gpu_type = if capabilities.has_gpu {
-            GpuType::Vulkan
-        } else {
-            GpuType::None
-        };
-        // GPU confidence: Low (stubbed, always true)
-        capabilities.gpu_confidence = DetectionConfidence::Low;
+
+        // Android GPU probe via the NDK Vulkan loader requires a JNI
+        // bridge; deferred. Returning Unknown is more honest than the
+        // silent `true` v1 had.
+        capabilities.has_gpu = false;
+        capabilities.gpu_type = GpuType::None;
+        capabilities.gpu_confidence = DetectionConfidence::Unknown;
 
         // NNAPI can use NPU accelerators
         capabilities.has_npu = capabilities.has_nnapi;
@@ -140,33 +177,52 @@ pub fn detect_capabilities() -> HardwareCapabilities {
 
     #[cfg(target_os = "windows")]
     {
-        capabilities.has_gpu = detect_gpu_availability_stub();
-        capabilities.gpu_type = if capabilities.has_gpu {
+        let (gpu_present, gpu_conf) = super::windows::detect_gpu_with_confidence();
+        capabilities.has_gpu = gpu_present;
+        capabilities.gpu_type = if gpu_present {
             GpuType::DirectX
         } else {
             GpuType::None
         };
-        capabilities.gpu_confidence = DetectionConfidence::Low;
+        capabilities.gpu_confidence = gpu_conf;
 
-        // DirectML NPU (stub)
+        // DirectML NPU detection not implemented; mark Unknown rather than
+        // the v1 hardcoded false which read as a confident negative.
         capabilities.has_npu = false;
         capabilities.npu_type = NpuType::None;
-        capabilities.npu_confidence = DetectionConfidence::Low;
+        capabilities.npu_confidence = DetectionConfidence::Unknown;
     }
 
     #[cfg(target_os = "linux")]
     {
-        capabilities.has_gpu = detect_gpu_availability_stub();
-        capabilities.gpu_type = if capabilities.has_gpu {
+        // Cheap probe: /dev/dri/renderD* files exist when the kernel has
+        // exposed a DRM render node. Catches NVIDIA/AMD/Intel/Mesa — any
+        // userspace-visible GPU surface. Does NOT catch WSL2 (/dev/dxg)
+        // or sandboxed containers where /dev/dri is denied; those return
+        // (false, Unknown).
+        let has_render_node = std::fs::read_dir("/dev/dri/")
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .any(|e| e.file_name().to_string_lossy().starts_with("renderD"))
+            })
+            .unwrap_or(false);
+
+        capabilities.has_gpu = has_render_node;
+        capabilities.gpu_type = if has_render_node {
             GpuType::Vulkan
         } else {
             GpuType::None
         };
-        capabilities.gpu_confidence = DetectionConfidence::Low;
+        capabilities.gpu_confidence = if has_render_node {
+            DetectionConfidence::Medium
+        } else {
+            DetectionConfidence::Unknown
+        };
 
         capabilities.has_npu = false;
         capabilities.npu_type = NpuType::None;
-        capabilities.npu_confidence = DetectionConfidence::Low;
+        capabilities.npu_confidence = DetectionConfidence::Unknown;
     }
 
     #[cfg(not(any(
@@ -177,25 +233,16 @@ pub fn detect_capabilities() -> HardwareCapabilities {
         target_os = "linux"
     )))]
     {
-        capabilities.has_gpu = detect_gpu_availability_stub();
+        // Unknown platform — nothing to probe.
+        capabilities.has_gpu = false;
         capabilities.gpu_type = GpuType::None;
-        capabilities.gpu_confidence = DetectionConfidence::Low;
+        capabilities.gpu_confidence = DetectionConfidence::Unknown;
         capabilities.has_npu = false;
         capabilities.npu_type = NpuType::None;
-        capabilities.npu_confidence = DetectionConfidence::Low;
+        capabilities.npu_confidence = DetectionConfidence::Unknown;
     }
 
     capabilities
-}
-
-/// Stub GPU detection for platforms without specific detection.
-#[allow(dead_code)]
-fn detect_gpu_availability_stub() -> bool {
-    // Stub: Always return true for now
-    // TODO: Real implementation would check:
-    // - Vulkan device availability
-    // - GPU compute shader support
-    true
 }
 
 #[cfg(test)]
@@ -420,6 +467,8 @@ mod tests {
             caps.gpu_confidence == DetectionConfidence::High
                 || caps.gpu_confidence == DetectionConfidence::Medium
                 || caps.gpu_confidence == DetectionConfidence::Low
+                || caps.gpu_confidence == DetectionConfidence::Unknown,
+            "gpu_confidence must be one of the four documented variants",
         );
     }
 
@@ -430,5 +479,71 @@ mod tests {
         assert!(caps.cpu_cores >= 1, "Should detect at least 1 CPU core");
         // Memory should be detected
         assert!(caps.memory_total_mb > 0, "Should detect total memory");
+    }
+
+    #[test]
+    fn test_detection_confidence_unknown_added() {
+        assert_eq!(DetectionConfidence::Unknown.as_str(), "unknown");
+        let default: DetectionConfidence = Default::default();
+        assert_eq!(default, DetectionConfidence::Low);
+    }
+
+    #[test]
+    fn test_detection_confidence_wire_format_stays_capitalized() {
+        let json = serde_json::to_string(&DetectionConfidence::Unknown).unwrap();
+        assert_eq!(
+            json, "\"Unknown\"",
+            "wire format must stay capitalized — no rename_all"
+        );
+        let parsed: DetectionConfidence = serde_json::from_str("\"High\"").unwrap();
+        assert_eq!(parsed, DetectionConfidence::High);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn test_capabilities_apple_uses_real_probes() {
+        let caps = detect_capabilities();
+        assert_eq!(caps.gpu_confidence, DetectionConfidence::High);
+        assert!(matches!(
+            caps.npu_confidence,
+            DetectionConfidence::High | DetectionConfidence::Medium,
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_gpu_no_silent_true() {
+        let caps = detect_capabilities();
+        if caps.has_gpu {
+            assert!(
+                matches!(
+                    caps.gpu_confidence,
+                    DetectionConfidence::Medium | DetectionConfidence::High
+                ),
+                "has_gpu=true must come with Medium+ confidence",
+            );
+            assert_eq!(caps.gpu_type, GpuType::Vulkan);
+        } else {
+            assert_eq!(caps.gpu_confidence, DetectionConfidence::Unknown);
+            assert_eq!(caps.gpu_type, GpuType::None);
+        }
+    }
+
+    #[cfg(target_os = "android")]
+    #[test]
+    fn test_android_gpu_unknown() {
+        let caps = detect_capabilities();
+        assert!(!caps.has_gpu);
+        assert_eq!(caps.gpu_confidence, DetectionConfidence::Unknown);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_windows_real_dxgi_probe() {
+        let caps = detect_capabilities();
+        assert!(matches!(
+            caps.gpu_confidence,
+            DetectionConfidence::High | DetectionConfidence::Unknown,
+        ));
     }
 }

--- a/crates/xybrid-core/src/device/common.rs
+++ b/crates/xybrid-core/src/device/common.rs
@@ -83,16 +83,3 @@ pub fn detect_cpu() -> CpuInfo {
         }
     }
 }
-
-/// Detects GPU/Vulkan acceleration availability.
-///
-/// This is a stub implementation that returns true.
-/// Real implementation would check Vulkan device availability.
-#[allow(dead_code)]
-pub fn detect_gpu_availability() -> bool {
-    // Stub: Always return true for now
-    // TODO: Real implementation would check:
-    // - Vulkan device availability
-    // - GPU compute shader support
-    true
-}

--- a/crates/xybrid-core/src/device/mod.rs
+++ b/crates/xybrid-core/src/device/mod.rs
@@ -35,6 +35,9 @@ pub mod common;
 pub mod android;
 pub mod apple;
 
+#[cfg(target_os = "windows")]
+pub mod windows;
+
 // Main detection logic
 pub mod capabilities;
 

--- a/crates/xybrid-core/src/device/platform_state.rs
+++ b/crates/xybrid-core/src/device/platform_state.rs
@@ -278,10 +278,10 @@ mod apple {
         // thread-safe and never null on every macOS we support — there
         // is no precondition the caller can violate.
         let info = NSProcessInfo::processInfo();
-        // SAFETY: see comment above — `thermalState` is thread-safe and
-        // has no caller-side preconditions; the cast to i64 is widening
-        // from NSInteger and lossless.
-        let raw = unsafe { info.thermalState() }.0 as i64;
+        // `thermalState` is exposed as safe in objc2-foundation 0.3 —
+        // the binding wraps the Objective-C call which has no caller-
+        // side preconditions and is documented thread-safe.
+        let raw = info.thermalState().0 as i64;
         thermal_from_nsprocessinfo(raw)
     }
 

--- a/crates/xybrid-core/src/device/tests.rs
+++ b/crates/xybrid-core/src/device/tests.rs
@@ -73,7 +73,7 @@ mod apple_tests {
         #[cfg(target_arch = "aarch64")]
         {
             assert!(info.has_neural_engine);
-            assert_eq!(info.confidence, DetectionConfidence::Medium);
+            assert_eq!(info.confidence, DetectionConfidence::High);
         }
 
         // On Intel, should NOT detect Neural Engine
@@ -100,6 +100,52 @@ mod android_tests {
         // (unless running in an Android environment)
         if info.api_level.is_none() {
             assert_eq!(info.confidence, DetectionConfidence::Low);
+        }
+    }
+}
+
+#[cfg(test)]
+mod cross_cutting_tests {
+    #[test]
+    fn test_unknown_serializes_capitalized() {
+        use crate::device::types::{DetectionConfidence, HardwareCapabilities};
+        let mut caps = HardwareCapabilities::new();
+        caps.gpu_confidence = DetectionConfidence::Unknown;
+        let json = caps.to_json();
+        assert!(
+            json.contains("\"gpu_confidence\":\"Unknown\""),
+            "no rename_all → capitalized; got: {json}",
+        );
+        let parsed = HardwareCapabilities::from_json(&json).expect("round-trip");
+        assert_eq!(parsed.gpu_confidence, DetectionConfidence::Unknown);
+    }
+
+    #[test]
+    fn test_legacy_capitalized_json_still_deserializes() {
+        use crate::device::types::HardwareCapabilities;
+        let legacy = r#"{
+            "has_gpu":true,"gpu_type":"Metal","has_nnapi":false,"has_metal":true,
+            "has_npu":false,"npu_type":"None","memory_available_mb":8192,
+            "memory_total_mb":16384,"cpu_usage_percent":0.0,"cpu_cores":8,
+            "battery_level":100,"thermal_state":"normal","platform":"MacOS",
+            "memory_confidence":"High","gpu_confidence":"High","npu_confidence":"Low"
+        }"#;
+        let parsed = HardwareCapabilities::from_json(legacy).expect("legacy must parse");
+        assert_eq!(
+            parsed.gpu_confidence,
+            crate::device::types::DetectionConfidence::High,
+        );
+    }
+
+    #[test]
+    fn test_no_silent_true_with_low_confidence() {
+        let caps = crate::device::capabilities::detect_capabilities();
+        if caps.has_gpu {
+            assert_ne!(
+                caps.gpu_confidence,
+                crate::device::types::DetectionConfidence::Low,
+                "has_gpu=true with Low confidence is the exact bug this PR fixed",
+            );
         }
     }
 }

--- a/crates/xybrid-core/src/device/types.rs
+++ b/crates/xybrid-core/src/device/types.rs
@@ -145,6 +145,8 @@ pub enum DetectionConfidence {
     /// Hardcoded default or estimate
     #[default]
     Low,
+    /// No probe was performed; the field value should not be trusted
+    Unknown,
 }
 
 impl DetectionConfidence {
@@ -153,6 +155,7 @@ impl DetectionConfidence {
             DetectionConfidence::High => "high",
             DetectionConfidence::Medium => "medium",
             DetectionConfidence::Low => "low",
+            DetectionConfidence::Unknown => "unknown",
         }
     }
 }

--- a/crates/xybrid-core/src/device/windows.rs
+++ b/crates/xybrid-core/src/device/windows.rs
@@ -1,0 +1,69 @@
+//! Windows platform detection.
+//!
+//! DXGI adapter enumeration via the `windows` crate. Software adapters
+//! (WARP) are filtered out — the routing engine wants a real hardware
+//! accelerator before preferring local execution (see
+//! pipeline/resolver.rs:336 comment).
+
+use super::types::DetectionConfidence;
+use windows::Win32::Graphics::Dxgi::{
+    CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory1, DXGI_ADAPTER_FLAG, DXGI_ADAPTER_FLAG_SOFTWARE,
+};
+
+/// Returns `(hardware_gpu_present, confidence)`.
+///
+/// Confidence is `High` whenever `CreateDXGIFactory1` succeeds —
+/// including a result where the only adapter is WARP, which we
+/// filter to `(false, High)`. Confidence is `Unknown` only when
+/// DXGI itself cannot be loaded.
+pub fn detect_gpu_with_confidence() -> (bool, DetectionConfidence) {
+    // SAFETY: CreateDXGIFactory1 is a COM constructor with no
+    // preconditions; the `windows` crate's Drop releases the COM ref.
+    let factory_result: windows::core::Result<IDXGIFactory1> = unsafe { CreateDXGIFactory1() };
+    let Ok(factory) = factory_result else {
+        return (false, DetectionConfidence::Unknown);
+    };
+
+    let mut index: u32 = 0;
+    loop {
+        // SAFETY: EnumAdapters1 on a valid factory is safe to call with
+        // any u32 index; out-of-range returns DXGI_ERROR_NOT_FOUND
+        // which becomes Err in the windows crate's binding.
+        let adapter_result: windows::core::Result<IDXGIAdapter1> =
+            unsafe { factory.EnumAdapters1(index) };
+        let Ok(adapter) = adapter_result else {
+            // Walked all adapters; none were hardware.
+            return (false, DetectionConfidence::High);
+        };
+
+        // SAFETY: GetDesc1 on a valid adapter has no preconditions. In
+        // `windows` 0.61 it returns `Result<DXGI_ADAPTER_DESC1>` (the
+        // struct is the Ok value; there is no out-pointer parameter).
+        if let Ok(desc) = unsafe { adapter.GetDesc1() } {
+            let is_software =
+                (DXGI_ADAPTER_FLAG(desc.Flags as i32).0 & DXGI_ADAPTER_FLAG_SOFTWARE.0) != 0;
+            if !is_software {
+                return (true, DetectionConfidence::High);
+            }
+        }
+        index += 1;
+        // Sanity bound — DXGI on any real machine returns < 16 adapters.
+        if index > 16 {
+            return (false, DetectionConfidence::High);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_probe_returns_one_of_two_documented_states() {
+        let (_present, confidence) = detect_gpu_with_confidence();
+        assert!(matches!(
+            confidence,
+            DetectionConfidence::High | DetectionConfidence::Unknown,
+        ));
+    }
+}

--- a/crates/xybrid-core/src/orchestrator/authority/local.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/local.rs
@@ -80,6 +80,12 @@ pub struct LocalAuthority {
 impl LocalAuthority {
     /// Create a new LocalAuthority with default policy, routing, and cache provider.
     pub fn new() -> Self {
+        // Prewarm the static-capability cache. First call to
+        // `detect_capabilities()` can take ~1s on macOS/iOS because
+        // `MLAllComputeDevices` lazy-loads Core ML. Doing it here keeps
+        // that cost out of latency-sensitive routing paths (e.g. the
+        // hysteresis check measured in tens of ms).
+        crate::device::capabilities::prewarm();
         Self {
             policy_engine: DefaultPolicyEngine::with_default_policy(),
             routing_engine: Mutex::new(DefaultRoutingEngine::new()),
@@ -93,6 +99,7 @@ impl LocalAuthority {
 
     /// Create a LocalAuthority with a custom cache provider.
     pub fn with_cache_provider(cache_provider: Arc<dyn CacheProvider>) -> Self {
+        crate::device::capabilities::prewarm();
         Self {
             policy_engine: DefaultPolicyEngine::with_default_policy(),
             routing_engine: Mutex::new(DefaultRoutingEngine::new()),
@@ -106,6 +113,7 @@ impl LocalAuthority {
 
     /// Create a LocalAuthority with a custom policy engine.
     pub fn with_policy_engine(policy_engine: DefaultPolicyEngine) -> Self {
+        crate::device::capabilities::prewarm();
         Self {
             policy_engine,
             routing_engine: Mutex::new(DefaultRoutingEngine::new()),
@@ -122,6 +130,7 @@ impl LocalAuthority {
         policy_engine: DefaultPolicyEngine,
         cache_provider: Arc<dyn CacheProvider>,
     ) -> Self {
+        crate::device::capabilities::prewarm();
         Self {
             policy_engine,
             routing_engine: Mutex::new(DefaultRoutingEngine::new()),

--- a/crates/xybrid-core/src/runtime_adapter/onnx/mobile.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/mobile.rs
@@ -20,7 +20,7 @@
 
 use super::execution_provider::ExecutionProviderKind;
 use super::session::{ONNXSession, SessionOptions};
-use crate::device::capabilities::ThermalState;
+use crate::device::capabilities::{detect_capabilities, ThermalState};
 use crate::ir::{Envelope, EnvelopeKind};
 use crate::runtime_adapter::tensor_utils::{envelope_to_tensors, tensors_to_envelope};
 use crate::runtime_adapter::{
@@ -50,9 +50,9 @@ pub struct ONNXMobileRuntimeAdapter {
     sessions: HashMap<String, ONNXSession>,
     /// Currently active model (for simple single-model execution)
     current_model: Option<String>,
-    /// NNAPI availability (stub: always true for now)
+    /// NNAPI availability (resolved from centralized hardware capability detection)
     nnapi_available: bool,
-    /// GPU/Vulkan availability (stub: always true for now)
+    /// GPU/Vulkan availability (resolved from centralized hardware capability detection)
     gpu_available: bool,
     /// Current battery level (0-100)
     battery_level: u8,
@@ -63,12 +63,13 @@ pub struct ONNXMobileRuntimeAdapter {
 impl ONNXMobileRuntimeAdapter {
     /// Creates a new ONNX Mobile Runtime Adapter instance.
     pub fn new() -> Self {
+        let caps = detect_capabilities();
         Self {
             models: HashMap::new(),
             sessions: HashMap::new(),
             current_model: None,
-            nnapi_available: Self::detect_nnapi_availability(),
-            gpu_available: Self::detect_gpu_availability(),
+            nnapi_available: caps.has_nnapi,
+            gpu_available: caps.has_gpu,
             battery_level: 100, // Default to full battery
             thermal_state: ThermalState::Normal,
         }
@@ -78,54 +79,16 @@ impl ONNXMobileRuntimeAdapter {
     ///
     /// Useful for testing mobile-specific scenarios.
     pub fn with_conditions(battery_level: u8, thermal_state: ThermalState) -> Self {
+        let caps = detect_capabilities();
         Self {
             models: HashMap::new(),
             sessions: HashMap::new(),
             current_model: None,
-            nnapi_available: Self::detect_nnapi_availability(),
-            gpu_available: Self::detect_gpu_availability(),
+            nnapi_available: caps.has_nnapi,
+            gpu_available: caps.has_gpu,
             battery_level,
             thermal_state,
         }
-    }
-
-    /// Detects NNAPI (Android Neural Networks API) availability.
-    ///
-    /// For MVP, this is a stub that returns true.
-    /// Real implementation would check:
-    /// - Android API level >= 27 (Android 8.1)
-    /// - NNAPI runtime availability via JNI
-    /// - Hardware accelerator support (DSP, NPU, GPU)
-    fn detect_nnapi_availability() -> bool {
-        // Stub: Always return true for now
-        // TODO: Real implementation would check:
-        // - Android API level
-        // - NNAPI runtime via JNI calls
-        // - Available accelerators
-        #[cfg(target_os = "android")]
-        {
-            true
-        }
-        #[cfg(not(target_os = "android"))]
-        {
-            false // NNAPI is Android-specific
-        }
-    }
-
-    /// Detects GPU/Vulkan acceleration availability.
-    ///
-    /// For MVP, this is a stub that returns true.
-    /// Real implementation would check:
-    /// - Vulkan API availability
-    /// - GPU compute capability
-    /// - Memory constraints
-    fn detect_gpu_availability() -> bool {
-        // Stub: Always return true for now
-        // TODO: Real implementation would check:
-        // - Vulkan device availability
-        // - GPU compute shader support
-        // - Sufficient memory available
-        true
     }
 
     /// Returns whether NNAPI is available.
@@ -452,18 +415,23 @@ mod tests {
     #[test]
     fn test_nnapi_detection() {
         let adapter = ONNXMobileRuntimeAdapter::new();
-        // NNAPI should be false on non-Android platforms
-        #[cfg(not(target_os = "android"))]
-        assert!(!adapter.has_nnapi());
-        #[cfg(target_os = "android")]
-        assert!(adapter.has_nnapi());
+        // Adapter's NNAPI availability must mirror centralized capability
+        // detection rather than a private stub.
+        assert_eq!(
+            adapter.has_nnapi(),
+            crate::device::capabilities::detect_capabilities().has_nnapi
+        );
     }
 
     #[test]
     fn test_gpu_detection() {
         let adapter = ONNXMobileRuntimeAdapter::new();
-        // Stub always returns true
-        assert!(adapter.has_gpu());
+        // Adapter's GPU availability must mirror centralized capability
+        // detection rather than a private stub.
+        assert_eq!(
+            adapter.has_gpu(),
+            crate::device::capabilities::detect_capabilities().has_gpu
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replaces `xybrid-core::device`'s partly-stubbed GPU/NPU/Metal detection with real platform probes (Metal via `objc2-metal`, Apple Neural Engine via `objc2-core-ml::MLAllComputeDevices` resolved at runtime via dlsym, Linux via `/dev/dri/renderD*` sysfs, Windows via DXGI with software-adapter filter).
- Introduces `DetectionConfidence::Unknown` so platforms still without a probe (Android GPU, DirectML NPU) signal "not asked" honestly instead of fabricating a boolean the routing engine then acts on.
- Cleans up two duplicate silent-true bug patterns (`common::detect_gpu_availability`, `onnx::mobile::ONNXMobileRuntimeAdapter::detect_gpu_availability` / `detect_nnapi_availability`); both now route through the centralized `detect_capabilities()`.

## What changed

### Apple
- `detect_metal_with_confidence` calls `MTLCreateSystemDefaultDevice`. `objc2-core-graphics` pulled in via `use ... as _;` so the CoreGraphics framework link directive survives release/stripped builds.
- `detect_neural_engine_with_confidence` resolves `MLAllComputeDevices` at runtime via `libc::dlsym(RTLD_DEFAULT, ...)` with `Retained::retain_autoreleased` for the ARC autorelease handoff. The `MLAllComputeDevices` feature on `objc2-core-ml` is deliberately NOT enabled — its wrapper emits a strong extern that can cause dyld to refuse loading on macOS 13 / iOS 16. Two runtime gates: `AnyClass::get` for class registration + non-null dlsym result. Older OS falls through to the arch heuristic at Medium confidence. `nm -gU` on the test binary confirms the symbol is absent from the bind table.

### Linux / Android / Windows
- **Linux:** `/dev/dri/renderD*` sysfs probe. No new deps. Medium confidence when a render node is present, Unknown otherwise.
- **Android:** `(has_gpu=false, Unknown)`. Real Vulkan probe needs a JNI bridge, deferred — documented in `src/device/NOTE.md`.
- **Windows:** new `device::windows` module enumerates DXGI adapters via `windows` 0.61's `IDXGIFactory1::EnumAdapters1` and filters out `DXGI_ADAPTER_FLAG_SOFTWARE` so WARP isn't reported as a real accelerator.

### Cross-cutting
- `DetectionConfidence::Unknown` variant added. **No `rename_all`** — wire format stays capitalized so persisted JSON deserializes unchanged; a legacy-JSON test guards this.
- `detect_capabilities()` cached via `OnceLock` for **static** fields only (accelerator presence/types, core count, total memory). Dynamic fields (`memory_available_mb`, `cpu_usage_percent`) refresh every call. The cache exists to skip the ~1s cold-init of `MLAllComputeDevices` on first Core ML access — not to freeze live system state.
- `LocalAuthority::{new, with_cache_provider, with_policy_engine, with_policy_and_cache}` call `capabilities::prewarm()` so the Core ML cold-init is paid at authority construction, not on latency-sensitive routing paths (the 20ms-TTL `hysteresis_is_model_scoped_and_expires` test would otherwise flake).
- `objc2` family unified to 0.6 / 0.3 — direct deps were 0.5 / 0.2, splitting from the 0.6 transitives pulled by `objc2-metal` / `objc2-core-ml`. `platform_state.rs` drops one `unsafe { }` block that's no longer needed.

## Test plan

- [x] CI: macOS / Linux test job passes
- [x] CI: Windows / Ubuntu feature-matrix `check` jobs pass (Windows test runner not in the matrix — cfg-gated bodies are compile-checked only)
- [x] CI: clippy --workspace --all-targets -- -D warnings clean
- [x] CI: fmt clean
- [x] On a macOS dev box: `cargo test -p xybrid-core --features ort-download` passes (esp. `device::*` and `orchestrator::authority::local::tests::hysteresis_is_model_scoped_and_expires`)
- [x] On a macOS dev box: `nm -gU $(find target/debug/deps -name 'xybrid_core-*' -type f -perm -u+x | head -1) | grep MLAllComputeDevices` → empty
- [x] On a macOS dev box: `otool -L` on the same test binary lists Metal, MetalKit, **and CoreGraphics**
- [ ] If reviewer has a Linux box with NVIDIA / AMD / Intel GPU: `cargo test -p xybrid-core --features ort-download device::capabilities::tests::test_linux_gpu_no_silent_true` passes
- [ ] If reviewer has a Windows box: `cargo build --target x86_64-pc-windows-msvc` succeeds

## Out of scope / follow-ups

- Android Vulkan probe (requires JNI bridge)
- Routing engine consuming raw `has_gpu` boolean without checking `gpu_confidence` (`pipeline/resolver.rs:336`)
- Forward-only `Unknown` wire compatibility (pre-rebuild binaries will reject new `"Unknown"` JSON)
- Snap/flatpak/seccomp Linux container behavior (graceful — falls to Unknown)