### PR TITLE
fix(telemetry): collapse chat-turn Traces rows and scope trace_id per turn

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -533,7 +533,13 @@ impl TemplateExecutor {
         context: &ConversationContext,
         config: Option<&GenerationConfig>,
     ) -> ExecutorResult<Envelope> {
-        let guard = ExecutionGuard::new(&metadata.model_id, "execute_with_context");
+        // Silent guard for the same reason as `execute_streaming_with_context`:
+        // the user-facing telemetry for a chat-context turn is the SDK's
+        // `ModelComplete` event from `XybridModel::run_with_context`. The
+        // outer executor span is an implementation detail and emitting
+        // `Started` / `Completed` from here surfaces as separate noise
+        // rows in the Traces dashboard. Error reporting is preserved.
+        let guard = ExecutionGuard::new_silent(&metadata.model_id, "execute_with_context");
         let result = self.execute_with_context_impl(metadata, input, context, config);
         if let Err(e) = &result {
             mark_execution_terminal(&guard, e);
@@ -772,7 +778,15 @@ impl TemplateExecutor {
         on_token: StreamingCallback<'_>,
         config: Option<&GenerationConfig>,
     ) -> ExecutorResult<Envelope> {
-        let guard = ExecutionGuard::new(&metadata.model_id, "execute_streaming_with_context");
+        // Silent guard: the user-facing telemetry for a chat-context
+        // turn is the SDK's `ModelComplete` event from
+        // `XybridModel::run_streaming_with_context`. Emitting an outer
+        // `Started`/`Completed` pair here surfaces as separate noise
+        // rows in the Traces dashboard with the executor-internal span
+        // name. Error reporting is preserved — `mark_execution_terminal`
+        // still flips the guard to emit `Failed` on the error path.
+        let guard =
+            ExecutionGuard::new_silent(&metadata.model_id, "execute_streaming_with_context");
         let result =
             self.execute_streaming_with_context_impl(metadata, input, context, on_token, config);
         if let Err(e) = &result {

--- a/crates/xybrid-core/src/execution/listener.rs
+++ b/crates/xybrid-core/src/execution/listener.rs
@@ -113,6 +113,27 @@ impl ExecutionGuard {
         }
     }
 
+    /// Create a guard that never emits `Started` or `Completed`, only
+    /// `Failed` when [`set_failed`](ExecutionGuard::set_failed) is
+    /// called.
+    ///
+    /// Used by outer-span methods whose user-facing telemetry is
+    /// already carried by an inner SDK-level event (e.g. `ModelComplete`
+    /// from `XybridModel::run_streaming_with_context`). Emitting a
+    /// `Started` / `Completed` pair from those paths produces
+    /// duplicate "phantom" rows in the Traces dashboard that don't
+    /// correspond to a user-facing operation. Error reporting is
+    /// preserved: `set_failed` still flips the terminal state so the
+    /// guard's `Drop` emits `Failed`.
+    pub(crate) fn new_silent(model_id: impl Into<String>, method: impl Into<String>) -> Self {
+        Self {
+            model_id: model_id.into(),
+            method: method.into(),
+            start: Instant::now(),
+            terminal: Mutex::new(ExecutionTerminal::Suppressed),
+        }
+    }
+
     /// Mark this execution as failed. The error message will be included
     /// in the `Failed` event emitted on drop.
     pub(crate) fn set_failed(&self, error: impl Into<String>) {
@@ -160,8 +181,19 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    // The execution listener and the events it fires are global, so the
+    // tests below must run serially — otherwise one test's listener
+    // captures another test's guard emits. `cargo test` parallelises by
+    // default; this lock pins them to one-at-a-time without pulling in
+    // the `serial_test` crate.
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn controlled_abort_suppresses_terminal_execution_event() {
+        let _serial = test_lock();
         clear_execution_listener();
         let events = Arc::new(Mutex::new(Vec::new()));
         let events_for_listener = events.clone();
@@ -182,6 +214,64 @@ mod tests {
             &events[0],
             ExecutionEvent::Started { model_id, method }
                 if model_id == "local-model" && method == "execute_streaming"
+        ));
+    }
+
+    #[test]
+    fn silent_guard_emits_nothing_on_success() {
+        let _serial = test_lock();
+        clear_execution_listener();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_listener = events.clone();
+
+        set_execution_listener(move |event| {
+            events_for_listener.lock().unwrap().push(event);
+        });
+
+        {
+            // Successful path: silent guard goes through new → drop with
+            // no `set_failed` call. Neither `Started` nor `Completed`
+            // should surface to the listener.
+            let _guard = ExecutionGuard::new_silent("local-model", "execute_streaming_with_context");
+        }
+
+        clear_execution_listener();
+        let events = events.lock().unwrap();
+        assert!(
+            events.is_empty(),
+            "silent guard on a success path must not emit any events; got: {:?}",
+            events
+        );
+    }
+
+    #[test]
+    fn silent_guard_still_emits_failed_on_error() {
+        let _serial = test_lock();
+        clear_execution_listener();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_listener = events.clone();
+
+        set_execution_listener(move |event| {
+            events_for_listener.lock().unwrap().push(event);
+        });
+
+        {
+            // Error path: `set_failed` flips the terminal state and the
+            // guard's `Drop` must emit `Failed` so error attribution is
+            // preserved even when `Started`/`Completed` are suppressed.
+            let guard = ExecutionGuard::new_silent("local-model", "execute_streaming_with_context");
+            guard.set_failed("boom");
+        }
+
+        clear_execution_listener();
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            ExecutionEvent::Failed { model_id, method, error, .. }
+                if model_id == "local-model"
+                    && method == "execute_streaming_with_context"
+                    && error == "boom"
         ));
     }
 }

--- a/crates/xybrid-core/src/execution/listener.rs
+++ b/crates/xybrid-core/src/execution/listener.rs
@@ -232,7 +232,8 @@ mod tests {
             // Successful path: silent guard goes through new → drop with
             // no `set_failed` call. Neither `Started` nor `Completed`
             // should surface to the listener.
-            let _guard = ExecutionGuard::new_silent("local-model", "execute_streaming_with_context");
+            let _guard =
+                ExecutionGuard::new_silent("local-model", "execute_streaming_with_context");
         }
 
         clear_execution_listener();

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1805,6 +1805,16 @@ impl XybridModel {
         let start = Instant::now();
         let resource_guard = crate::telemetry::begin_resource_run();
 
+        // Install a turn-scoped trace_id for the lifetime of this call.
+        // The guard's `Drop` clears the pipeline context on every exit —
+        // including the `?` error paths and panics below — so every
+        // telemetry event emitted between install and drop shares the
+        // same `trace_id` and the dashboard collapses the turn to one
+        // Traces row. Same discipline `Pipeline::run` uses for stages.
+        let trace_id = uuid::Uuid::new_v4();
+        let _telemetry_ctx =
+            crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
+
         // Recover from poisoned RwLock to prevent permanent lock errors
         let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
@@ -1843,6 +1853,9 @@ impl XybridModel {
                 .unwrap_or(0),
         };
         crate::telemetry::publish_with_resource_summary(event, resource_guard);
+
+        // `_telemetry_ctx` drops here (and on every early return / unwind
+        // above), clearing the pipeline context after the publish.
 
         Ok(InferenceResult::new(output, &self.model_id, latency_ms))
     }
@@ -1912,6 +1925,13 @@ impl XybridModel {
         use xybrid_core::runtime_adapter::types::PartialToken;
 
         let start = Instant::now();
+
+        // RAII pipeline context — see `run_with_context` for rationale.
+        // Cleared on drop at end of scope (after publish) or on any
+        // early return / unwind below.
+        let trace_id = uuid::Uuid::new_v4();
+        let _telemetry_ctx =
+            crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
         // Get write lock on handle
         let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
@@ -1985,6 +2005,9 @@ impl XybridModel {
                 .unwrap_or(0),
         };
         crate::telemetry::publish_telemetry_event(event);
+
+        // `_telemetry_ctx` drops here, clearing pipeline context after
+        // the publish — same ordering as before.
 
         Ok(InferenceResult::new(output, &self.model_id, latency_ms))
     }

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1763,6 +1763,38 @@ pub fn set_telemetry_pipeline_context(pipeline_id: Option<Uuid>, trace_id: Optio
     }
 }
 
+/// RAII guard that installs a pipeline context on construction and
+/// clears it on drop.
+///
+/// Callers (e.g. `Pipeline::run`, `XybridModel::run_with_context`) need
+/// to scope a per-invocation `trace_id` so every telemetry event
+/// emitted during the call shares it. Pairing the install with a manual
+/// `set_telemetry_pipeline_context(None, None)` on every exit path is
+/// error-prone — any `?` between install and clear leaks the
+/// `trace_id` onto subsequent unrelated telemetry on the same thread,
+/// and a panic skips the cleanup entirely. This guard removes the
+/// duplication and closes the panic-leak hole.
+///
+/// The clear happens at the guard's `Drop`, which fires after any
+/// `publish_telemetry_event` call earlier in the scope — preserving
+/// the existing "publish before clear" ordering the exporter's
+/// lazy-read flush relies on.
+pub(crate) struct TelemetryPipelineContextGuard;
+
+impl TelemetryPipelineContextGuard {
+    /// Install a pipeline context for the lifetime of the guard.
+    pub(crate) fn install(pipeline_id: Option<Uuid>, trace_id: Option<Uuid>) -> Self {
+        set_telemetry_pipeline_context(pipeline_id, trace_id);
+        Self
+    }
+}
+
+impl Drop for TelemetryPipelineContextGuard {
+    fn drop(&mut self) {
+        set_telemetry_pipeline_context(None, None);
+    }
+}
+
 /// Register the execution listener that converts `ExecutionEvent`s from
 /// xybrid-core's `TemplateExecutor` into `TelemetryEvent`s and publishes them.
 fn register_execution_listener() {

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -52,6 +52,16 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Serial lock for tests that touch the global execution listener or
+/// telemetry-sender registry. `cargo test` parallelises by default and
+/// one test's listener install would otherwise capture another test's
+/// emitted events, masking real regressions as vacuous passes. Mirrors
+/// the same discipline `xybrid-core::execution::listener::tests` uses.
+fn listener_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 fn event(event_type: &str) -> TelemetryEvent {
     TelemetryEvent {
         event_type: event_type.to_string(),
@@ -378,6 +388,8 @@ fn telemetry_http_event_includes_device_profile() {
 fn automatic_execution_events() {
     use xybrid_core::execution::listener;
 
+    let _serial = listener_test_lock();
+
     let Some(model_dir) = model_fixtures::model_or_skip("mnist") else {
         return; // model not downloaded — skip gracefully
     };
@@ -491,6 +503,120 @@ fn automatic_execution_events() {
     println!(
         "OK — {} automatic execution events captured",
         collected.len()
+    );
+}
+
+/// Regression guard: `execute_streaming_with_context` must not emit
+/// `ExecutionStarted` / `ExecutionCompleted` events for its outer span.
+///
+/// A chat-context turn produced three Traces rows on the dashboard
+/// (outer `pipeline` / `execute_streaming_with_context`, inner LLM,
+/// and a phantom duplicate) because the outer executor span emitted
+/// its own `Started` / `Completed` events on top of the SDK's
+/// `ModelComplete`. The user-facing telemetry is the SDK event; the
+/// outer span is an executor implementation detail and must stay
+/// silent so the dashboard collapses each chat turn to one row.
+///
+/// Uses MNIST so the test doesn't require an LLM fixture — on a
+/// non-LLM model `execute_streaming_with_context` routes through the
+/// non-LLM streaming fallback, which has no inner `ExecutionGuard`
+/// either, so the captured event count is the cleanest possible
+/// signal for the outer-span suppression.
+#[test]
+fn execute_streaming_with_context_emits_no_outer_telemetry_events() {
+    use xybrid_core::conversation::ConversationContext;
+    use xybrid_core::execution::listener;
+
+    let _serial = listener_test_lock();
+
+    let Some(model_dir) = model_fixtures::model_or_skip("mnist") else {
+        return;
+    };
+
+    let metadata_path = model_dir.join("model_metadata.json");
+    let metadata: ModelMetadata =
+        serde_json::from_str(&std::fs::read_to_string(&metadata_path).unwrap()).unwrap();
+
+    // Observe TelemetryEvents over a local channel — same pattern as
+    // `automatic_execution_events` above.
+    let (tx, rx) = mpsc::channel::<TelemetryEvent>();
+    register_telemetry_sender(tx);
+
+    listener::set_execution_listener(|event| {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let telemetry_event = match event {
+            xybrid_sdk::ExecutionEvent::Started { model_id, method } => TelemetryEvent {
+                event_type: "ExecutionStarted".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: None,
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Completed {
+                model_id,
+                method,
+                latency_ms,
+            } => TelemetryEvent {
+                event_type: "ExecutionCompleted".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Failed {
+                model_id,
+                method,
+                latency_ms,
+                error,
+            } => TelemetryEvent {
+                event_type: "ExecutionFailed".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: Some(error),
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+        };
+
+        publish_telemetry_event(telemetry_event);
+    });
+
+    let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
+    let input = mnist_input_envelope();
+    let ctx = ConversationContext::new();
+
+    let _ = executor
+        .execute_streaming_with_context(&metadata, &input, &ctx, Box::new(|_token| Ok(())), None)
+        .expect("MNIST execute_streaming_with_context should succeed via non-LLM fallback");
+
+    // Brief delay for channel delivery, then drain.
+    std::thread::sleep(Duration::from_millis(50));
+    listener::clear_execution_listener();
+
+    let mut collected: Vec<TelemetryEvent> = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        collected.push(ev);
+    }
+
+    let outer_events: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| e.stage_name.as_deref() == Some("execute_streaming_with_context"))
+        .collect();
+
+    assert!(
+        outer_events.is_empty(),
+        "execute_streaming_with_context outer span must not emit telemetry events; \
+         leaked: {:?}",
+        outer_events
     );
 }
 


### PR DESCRIPTION
## Summary

Chat-context turns produced three Traces rows on the dashboard because the outer executor spans (`execute_with_context` / `execute_streaming_with_context`) emitted their own `Started` / `Completed` events on top of the SDK's `ModelComplete`. This silences those outer spans via a new `ExecutionGuard::new_silent` (error reporting via `Failed` is preserved) and installs a per-turn `trace_id` in `XybridModel::run_with_context` / `run_streaming_with_context` through a `TelemetryPipelineContextGuard` RAII so cleanup survives early returns and unwinds. Adds unit tests for the silent guard, an integration regression test for the outer-span suppression, and a serial lock for tests that touch the global execution listener / telemetry-sender registry so they don't mask each other's events.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)