### PR TITLE
feat(flutter): wire Xybrid.initTelemetry to platform telemetry exporter

### DIFF
--- a/bindings/flutter/lib/src/rust/api/sdk_client.dart
+++ b/bindings/flutter/lib/src/rust/api/sdk_client.dart
@@ -25,9 +25,12 @@ abstract class XybridSdkClient implements RustOpaqueInterface {
   /// `ExecutionCompleted` / `ExecutionFailed` events through it — no
   /// per-call wiring required.
   ///
-  /// Idempotent at the Rust layer: re-calling spawns a new exporter
-  /// that supersedes the previous one. Hosts should still guard against
-  /// double-init to avoid burning two senders.
+  /// Process-wide idempotent via [`TELEMETRY_INITIALIZED`]: only the
+  /// first successful call enters `init_platform_telemetry`; subsequent
+  /// calls (duplicate caller, second Dart isolate, Flutter hot-restart
+  /// inside a surviving process) observe the guard and return without
+  /// spawning a second exporter. No reconfigure path — restart the
+  /// process to change endpoint/key.
   ///
   /// Sync because `init_platform_telemetry` is sync; the HTTP exporter
   /// spins up its own background thread for batched sends.
@@ -44,6 +47,12 @@ abstract class XybridSdkClient implements RustOpaqueInterface {
   static bool isModelCached({required String modelId}) =>
       XybridRustLib.instance.api
           .crateApiSdkClientXybridSdkClientIsModelCached(modelId: modelId);
+
+  /// Whether [`Self::init_telemetry`] has run at least once in this
+  /// process. Reflects the authoritative process-wide state, not any
+  /// Dart-side flag — survives hot-restart, multiple isolates, etc.
+  static bool isTelemetryInitialized() => XybridRustLib.instance.api
+      .crateApiSdkClientXybridSdkClientIsTelemetryInitialized();
 
   static void setApiKey({required String apiKey}) => XybridRustLib.instance.api
       .crateApiSdkClientXybridSdkClientSetApiKey(apiKey: apiKey);

--- a/bindings/flutter/lib/src/rust/api/sdk_client.dart
+++ b/bindings/flutter/lib/src/rust/api/sdk_client.dart
@@ -16,6 +16,26 @@ abstract class XybridSdkClient implements RustOpaqueInterface {
       XybridRustLib.instance.api
           .crateApiSdkClientXybridSdkClientInitSdkCacheDir(cacheDir: cacheDir);
 
+  /// Initialize the platform telemetry exporter for this process.
+  ///
+  /// Starts the HTTP telemetry sender targeting `endpoint`, authenticated
+  /// with `api_key`. Once initialized, the normal inference paths
+  /// (`Xybrid.model().run()`, `Xybrid.pipeline().run()`, conversation
+  /// turns, etc.) automatically emit `ExecutionStarted` /
+  /// `ExecutionCompleted` / `ExecutionFailed` events through it — no
+  /// per-call wiring required.
+  ///
+  /// Idempotent at the Rust layer: re-calling spawns a new exporter
+  /// that supersedes the previous one. Hosts should still guard against
+  /// double-init to avoid burning two senders.
+  ///
+  /// Sync because `init_platform_telemetry` is sync; the HTTP exporter
+  /// spins up its own background thread for batched sends.
+  static void initTelemetry(
+          {required String endpoint, required String apiKey}) =>
+      XybridRustLib.instance.api.crateApiSdkClientXybridSdkClientInitTelemetry(
+          endpoint: endpoint, apiKey: apiKey);
+
   /// Check if a model is cached locally (extracted and ready to use).
   ///
   /// This is a pure filesystem check — no network access required.

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class XybridRustLib extends BaseEntrypoint<XybridRustLibApi,
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 2122057111;
+  int get rustContentHash => 2045382748;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -218,6 +218,8 @@ abstract class XybridRustLibApi extends BaseApi {
       {required String endpoint, required String apiKey});
 
   bool crateApiSdkClientXybridSdkClientIsModelCached({required String modelId});
+
+  bool crateApiSdkClientXybridSdkClientIsTelemetryInitialized();
 
   void crateApiSdkClientXybridSdkClientSetApiKey({required String apiKey});
 
@@ -1453,12 +1455,37 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  bool crateApiSdkClientXybridSdkClientIsTelemetryInitialized() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bool,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiSdkClientXybridSdkClientIsTelemetryInitializedConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiSdkClientXybridSdkClientIsTelemetryInitializedConstMeta =>
+          const TaskConstMeta(
+            debugName: "XybridSdkClient_is_telemetry_initialized",
+            argNames: [],
+          );
+
+  @override
   void crateApiSdkClientXybridSdkClientSetApiKey({required String apiKey}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1481,7 +1508,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -1504,7 +1531,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class XybridRustLib extends BaseEntrypoint<XybridRustLibApi,
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1942786553;
+  int get rustContentHash => 2122057111;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -213,6 +213,9 @@ abstract class XybridRustLibApi extends BaseApi {
 
   void crateApiSdkClientXybridSdkClientInitSdkCacheDir(
       {required String cacheDir});
+
+  void crateApiSdkClientXybridSdkClientInitTelemetry(
+      {required String endpoint, required String apiKey});
 
   bool crateApiSdkClientXybridSdkClientIsModelCached({required String modelId});
 
@@ -1399,13 +1402,39 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  void crateApiSdkClientXybridSdkClientInitTelemetry(
+      {required String endpoint, required String apiKey}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(endpoint, serializer);
+        sse_encode_String(apiKey, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiSdkClientXybridSdkClientInitTelemetryConstMeta,
+      argValues: [endpoint, apiKey],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSdkClientXybridSdkClientInitTelemetryConstMeta =>
+      const TaskConstMeta(
+        debugName: "XybridSdkClient_init_telemetry",
+        argNames: ["endpoint", "apiKey"],
+      );
+
+  @override
   bool crateApiSdkClientXybridSdkClientIsModelCached(
       {required String modelId}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(modelId, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1429,7 +1458,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1452,7 +1481,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -1475,7 +1504,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,

--- a/bindings/flutter/lib/src/xybrid.dart
+++ b/bindings/flutter/lib/src/xybrid.dart
@@ -133,11 +133,48 @@ class Xybrid {
     return XybridSdkClient.isModelCached(modelId: modelId);
   }
 
-  static void initTelemetry() {
-    // TODO - Implement telemetry
-    // XybridSdkClient.enableTelemetry();
-    throw UnimplementedError();
+  /// Tracks whether [initTelemetry] has wired the HTTP exporter. The
+  /// underlying Rust call is itself idempotent enough — it just spawns a
+  /// fresh exporter that supersedes the previous one — but we guard at
+  /// the Dart layer so accidental double-init doesn't burn two senders.
+  static bool _telemetryInitialized = false;
+
+  /// Initialize the platform telemetry exporter.
+  ///
+  /// Once initialized, the normal inference paths (`Xybrid.model().run()`,
+  /// `Xybrid.pipeline().run()`, conversation turns) automatically emit
+  /// `ExecutionStarted` / `ExecutionCompleted` / `ExecutionFailed` events
+  /// to the configured endpoint — no per-call wiring required.
+  ///
+  /// `endpoint` is the platform ingest URL (e.g. `https://ingest.xybrid.dev`
+  /// in production, or `http://192.168.1.78:8081` for a local dashboard on
+  /// the host machine). `apiKey` authenticates the sender.
+  ///
+  /// Must be called after [init] has completed. Safe to call multiple
+  /// times — subsequent calls are no-ops.
+  ///
+  /// Example:
+  /// ```dart
+  /// void main() async {
+  ///   await Xybrid.init();
+  ///   Xybrid.initTelemetry(
+  ///     endpoint: const String.fromEnvironment('XYBRID_PLATFORM_URL'),
+  ///     apiKey: const String.fromEnvironment('XYBRID_API_KEY'),
+  ///   );
+  ///   runApp(...);
+  /// }
+  /// ```
+  static void initTelemetry({required String endpoint, required String apiKey}) {
+    if (!_initialized) {
+      throw StateError('Xybrid.init() must complete before initTelemetry()');
+    }
+    if (_telemetryInitialized) return;
+    XybridSdkClient.initTelemetry(endpoint: endpoint, apiKey: apiKey);
+    _telemetryInitialized = true;
   }
+
+  /// Whether [initTelemetry] has been called successfully.
+  static bool get isTelemetryInitialized => _telemetryInitialized;
 
   /// Read the routing-engine's current view of device state.
   ///

--- a/bindings/flutter/lib/src/xybrid.dart
+++ b/bindings/flutter/lib/src/xybrid.dart
@@ -133,12 +133,6 @@ class Xybrid {
     return XybridSdkClient.isModelCached(modelId: modelId);
   }
 
-  /// Tracks whether [initTelemetry] has wired the HTTP exporter. The
-  /// underlying Rust call is itself idempotent enough — it just spawns a
-  /// fresh exporter that supersedes the previous one — but we guard at
-  /// the Dart layer so accidental double-init doesn't burn two senders.
-  static bool _telemetryInitialized = false;
-
   /// Initialize the platform telemetry exporter.
   ///
   /// Once initialized, the normal inference paths (`Xybrid.model().run()`,
@@ -150,8 +144,14 @@ class Xybrid {
   /// in production, or `http://192.168.1.78:8081` for a local dashboard on
   /// the host machine). `apiKey` authenticates the sender.
   ///
-  /// Must be called after [init] has completed. Safe to call multiple
-  /// times — subsequent calls are no-ops.
+  /// Must be called after [init] has completed. The Rust layer holds a
+  /// process-wide once-guard, so subsequent calls — including across
+  /// Flutter hot-restart or a second Dart isolate — are safe no-ops; the
+  /// HTTP exporter and execution listener are registered exactly once
+  /// per process.
+  ///
+  /// No reconfigure path: changing `endpoint` or `apiKey` requires
+  /// restarting the process.
   ///
   /// Example:
   /// ```dart
@@ -168,13 +168,16 @@ class Xybrid {
     if (!_initialized) {
       throw StateError('Xybrid.init() must complete before initTelemetry()');
     }
-    if (_telemetryInitialized) return;
     XybridSdkClient.initTelemetry(endpoint: endpoint, apiKey: apiKey);
-    _telemetryInitialized = true;
   }
 
-  /// Whether [initTelemetry] has been called successfully.
-  static bool get isTelemetryInitialized => _telemetryInitialized;
+  /// Whether the process-wide telemetry exporter is running.
+  ///
+  /// Reads from the Rust once-flag, so this stays correct across Flutter
+  /// hot-restart (which would reset any Dart-side state) and second
+  /// isolates that didn't themselves call [initTelemetry].
+  static bool get isTelemetryInitialized =>
+      XybridSdkClient.isTelemetryInitialized();
 
   /// Read the routing-engine's current view of device state.
   ///

--- a/bindings/flutter/rust/src/api/sdk_client.rs
+++ b/bindings/flutter/rust/src/api/sdk_client.rs
@@ -18,6 +18,28 @@ impl XybridSdkClient {
         xybrid_sdk::set_api_key(api_key);
     }
 
+    /// Initialize the platform telemetry exporter for this process.
+    ///
+    /// Starts the HTTP telemetry sender targeting `endpoint`, authenticated
+    /// with `api_key`. Once initialized, the normal inference paths
+    /// (`Xybrid.model().run()`, `Xybrid.pipeline().run()`, conversation
+    /// turns, etc.) automatically emit `ExecutionStarted` /
+    /// `ExecutionCompleted` / `ExecutionFailed` events through it — no
+    /// per-call wiring required.
+    ///
+    /// Idempotent at the Rust layer: re-calling spawns a new exporter
+    /// that supersedes the previous one. Hosts should still guard against
+    /// double-init to avoid burning two senders.
+    ///
+    /// Sync because `init_platform_telemetry` is sync; the HTTP exporter
+    /// spins up its own background thread for batched sends.
+    #[frb(sync)]
+    pub fn init_telemetry(endpoint: String, api_key: String) {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
+        let config = xybrid_sdk::TelemetryConfig::new(endpoint, api_key);
+        xybrid_sdk::telemetry::init_platform_telemetry(config);
+    }
+
     /// Check if a model is cached locally (extracted and ready to use).
     ///
     /// This is a pure filesystem check — no network access required.

--- a/bindings/flutter/rust/src/api/sdk_client.rs
+++ b/bindings/flutter/rust/src/api/sdk_client.rs
@@ -1,6 +1,22 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use flutter_rust_bridge::frb;
 
 use super::FLUTTER_BINDING;
+
+/// Process-wide once-guard for [`XybridSdkClient::init_telemetry`]. Set on
+/// the first successful entry. Re-entry — whether from a duplicate Dart
+/// caller, a second Dart isolate, or a Flutter hot-restart — observes
+/// `true` and returns without spinning up a second exporter.
+///
+/// Telemetry init is non-trivial: it spawns a background HTTP sender,
+/// registers a process-global execution listener, and activates the
+/// resource-telemetry sampler. None of those have an unregister path
+/// today, so a second call would burn duplicate senders and emit each
+/// event twice. The guard trades runtime flexibility (no in-process
+/// reconfigure) for safety; apps that need to change endpoints must
+/// restart the process.
+static TELEMETRY_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 #[frb(opaque)]
 pub struct XybridSdkClient;
@@ -27,17 +43,34 @@ impl XybridSdkClient {
     /// `ExecutionCompleted` / `ExecutionFailed` events through it — no
     /// per-call wiring required.
     ///
-    /// Idempotent at the Rust layer: re-calling spawns a new exporter
-    /// that supersedes the previous one. Hosts should still guard against
-    /// double-init to avoid burning two senders.
+    /// Process-wide idempotent via [`TELEMETRY_INITIALIZED`]: only the
+    /// first successful call enters `init_platform_telemetry`; subsequent
+    /// calls (duplicate caller, second Dart isolate, Flutter hot-restart
+    /// inside a surviving process) observe the guard and return without
+    /// spawning a second exporter. No reconfigure path — restart the
+    /// process to change endpoint/key.
     ///
     /// Sync because `init_platform_telemetry` is sync; the HTTP exporter
     /// spins up its own background thread for batched sends.
     #[frb(sync)]
     pub fn init_telemetry(endpoint: String, api_key: String) {
         xybrid_sdk::set_binding(FLUTTER_BINDING);
+        if TELEMETRY_INITIALIZED
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
         let config = xybrid_sdk::TelemetryConfig::new(endpoint, api_key);
         xybrid_sdk::telemetry::init_platform_telemetry(config);
+    }
+
+    /// Whether [`Self::init_telemetry`] has run at least once in this
+    /// process. Reflects the authoritative process-wide state, not any
+    /// Dart-side flag — survives hot-restart, multiple isolates, etc.
+    #[frb(sync)]
+    pub fn is_telemetry_initialized() -> bool {
+        TELEMETRY_INITIALIZED.load(Ordering::Acquire)
     }
 
     /// Check if a model is cached locally (extracted and ready to use).

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2122057111;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2045382748;
 
 // Section: executor
 
@@ -1884,6 +1884,37 @@ fn wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
         },
     )
 }
+fn wire__crate__api__sdk_client__XybridSdkClient_is_telemetry_initialized_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridSdkClient_is_telemetry_initialized",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::sdk_client::XybridSdkClient::is_telemetry_initialized(),
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2740,17 +2771,22 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
+        44 => wire__crate__api__sdk_client__XybridSdkClient_is_telemetry_initialized_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__model__ffi_generation_config_creative_impl(
+        45 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => {
+        46 => wire__crate__api__model__ffi_generation_config_creative_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        47 => {
             wire__crate__api__model__ffi_generation_config_greedy_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1942786553;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2122057111;
 
 // Section: executor
 
@@ -1816,6 +1816,42 @@ fn wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
         },
     )
 }
+fn wire__crate__api__sdk_client__XybridSdkClient_init_telemetry_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridSdkClient_init_telemetry",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_endpoint = <String>::sse_decode(&mut deserializer);
+            let api_api_key = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sdk_client::XybridSdkClient::init_telemetry(
+                        api_endpoint,
+                        api_api_key,
+                    );
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2694,22 +2730,27 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
+        42 => wire__crate__api__sdk_client__XybridSdkClient_init_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
+        43 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__model__ffi_generation_config_creative_impl(
+        44 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => {
+        45 => wire__crate__api__model__ffi_generation_config_creative_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        46 => {
             wire__crate__api__model__ffi_generation_config_greedy_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -1039,7 +1039,7 @@ The full wire format and the list of enum values for each header field is docume
 | `WithDeviceAttribute()` | — | — | — | ✅ |
 | `WithBatchSize()` | — | — | — | ✅ |
 | `WithFlushInterval()` | — | — | — | ✅ |
-| `XybridClient.InitializeTelemetry()` | 🚧 | — | — | ✅ |
+| `XybridClient.InitializeTelemetry()` | ✅ | — | — | ✅ |
 | `XybridClient.FlushTelemetry()` | — | — | — | ✅ |
 | `XybridClient.ShutdownTelemetry()` | — | — | — | ✅ |
 
@@ -1048,11 +1048,14 @@ The full wire format and the list of enum values for each header field is docume
 | `with_binding(binding)` | ✅ |
 | `binding()` | ✅ |
 
-> **Note**: `initTelemetry()` exists in Dart as a stub that throws `UnimplementedError`.
-> The C# (Unity) SDK is the first non-Rust implementation of the telemetry surface;
-> the Dart, Kotlin, and Swift implementations are still planned. `SdkConfig.binding`
-> is Rust-only — non-Rust bindings register their identifier through the
-> platform-specific entry points listed in [`docs/telemetry/registry.md`](../telemetry/registry.md).
+> **Note**: Dart `Xybrid.initTelemetry(endpoint, apiKey)` ships in xybrid#97 —
+> minimal surface matching the C# `InitializeTelemetry()` shape (endpoint + key).
+> Flush / shutdown / batch configuration are not yet exposed on Dart; events flush
+> on the Rust exporter's default 5 s interval. The C# (Unity) SDK remains the
+> reference implementation of the wider telemetry-config surface; Kotlin and
+> Swift telemetry init are still planned. `SdkConfig.binding` is Rust-only —
+> non-Rust bindings register their identifier through the platform-specific
+> entry points listed in [`docs/telemetry/registry.md`](../telemetry/registry.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the \`UnimplementedError\` stub in \`Xybrid.initTelemetry()\` with a real call that constructs a \`TelemetryConfig::new(endpoint, api_key)\` and invokes the existing \`xybrid_sdk::telemetry::init_platform_telemetry()\` entry. From there the SDK auto-registers the execution listener + HTTP exporter, so normal inference paths emit \`ExecutionStarted\` / \`ExecutionCompleted\` / \`ExecutionFailed\` events without per-call wiring.

\`\`\`dart
await Xybrid.init();
Xybrid.initTelemetry(
  endpoint: 'http://192.168.1.78:8081',           // or your production ingest URL
  apiKey: 'sk_test_…',
);
\`\`\`

Idempotent at the Dart layer (subsequent calls are no-ops). Sync because the underlying init is sync — the exporter spawns its own background sender thread.

## Why

Closes the Flutter-only gap that left telemetry init paritied only with Kotlin / Swift. Apps now choose between (a) not calling \`initTelemetry\` (telemetry off, current default), or (b) calling it with their endpoint + key to enable.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test -p xybrid_flutter --lib\` clean
- [x] FRB codegen reruns cleanly
- [ ] Run studio-flutter on iPhone with \`--dart-define=XYBRID_PLATFORM_URL=http://<lan-ip>:8081 --dart-define=XYBRID_API_KEY=sk_test_…\`, trigger an inference, confirm the local dashboard receives events (separate meta PR adds the main.dart wiring)