### PR TITLE
docs(readme): flatten Quick Start details into ### subheadings

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -139,9 +139,9 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 </details>
 
-<a id="flutter"></a>
 <details>
 <summary><b>Flutter</b> — iOS、Android、macOS、Linux、Windows</summary>
+<a id="flutter"></a>
 
 **インストール** `pubspec.yaml`:
 
@@ -160,9 +160,9 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 </details>
 
-<a id="kotlin"></a>
 <details>
 <summary><b>Kotlin</b> — Android</summary>
+<a id="kotlin"></a>
 
 **インストール** `build.gradle.kts`:
 
@@ -182,9 +182,9 @@ val result = model.run(Envelope.text("Hello world"))
 
 </details>
 
-<a id="swift"></a>
 <details>
 <summary><b>Swift</b> — iOS、macOS</summary>
+<a id="swift"></a>
 
 **インストール** `Package.swift`:
 
@@ -206,9 +206,9 @@ let result = try model.run(envelope: Envelope.text("Hello world"))
 
 </details>
 
-<a id="unity"></a>
 <details>
 <summary><b>Unity (C#)</b> — macOS、Windows、Linux、iOS、Android</summary>
+<a id="unity"></a>
 
 **インストール** Unity Package Managerを使用:
 
@@ -226,9 +226,9 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 </details>
 
-<a id="rust"></a>
 <details>
 <summary><b>Rust</b> — すべてのプラットフォーム</summary>
+<a id="rust"></a>
 
 **インストール** `Cargo.toml`:
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -116,8 +116,7 @@ Xybridは**Rustベースのランタイム**であり、すべての主要プラ
 
 お好みの言語でインストールしてモデルを実行できます。各セクションにはインストール手順と最小限のサンプルが含まれています。
 
-<details>
-<summary><b>CLI</b> — macOS、Linux、Windows</summary>
+### CLI
 
 **インストール:**
 
@@ -137,11 +136,7 @@ irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 ```
 
-</details>
-
-<details>
-<summary><b>Flutter</b> — iOS、Android、macOS、Linux、Windows</summary>
-<a id="flutter"></a>
+### Flutter
 
 **インストール** `pubspec.yaml`:
 
@@ -158,11 +153,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 // result → 24kHz WAVオーディオ
 ```
 
-</details>
-
-<details>
-<summary><b>Kotlin</b> — Android</summary>
-<a id="kotlin"></a>
+### Kotlin
 
 **インストール** `build.gradle.kts`:
 
@@ -180,11 +171,7 @@ val result = model.run(Envelope.text("Hello world"))
 // result → 24kHz WAVオーディオ
 ```
 
-</details>
-
-<details>
-<summary><b>Swift</b> — iOS、macOS</summary>
-<a id="swift"></a>
+### Swift
 
 **インストール** `Package.swift`:
 
@@ -204,11 +191,7 @@ let result = try model.run(envelope: Envelope.text("Hello world"))
 // result → 24kHz WAVオーディオ
 ```
 
-</details>
-
-<details>
-<summary><b>Unity (C#)</b> — macOS、Windows、Linux、iOS、Android</summary>
-<a id="unity"></a>
+### Unity
 
 **インストール** Unity Package Managerを使用:
 
@@ -224,11 +207,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 // result → 24kHz WAVオーディオ
 ```
 
-</details>
-
-<details>
-<summary><b>Rust</b> — すべてのプラットフォーム</summary>
-<a id="rust"></a>
+### Rust
 
 **インストール** `Cargo.toml`:
 
@@ -244,8 +223,6 @@ let model = Xybrid::model("kokoro-82m").load()?;
 let result = model.run(&Envelope::text("Hello world"))?;
 // result → 24kHz WAVオーディオ
 ```
-
-</details>
 
 すべてのオプション、ハードウェアアクセラレーション、CLIリファレンスについては、完全な[インストールガイド](docs/INSTALLATION.md)を参照してください。プラットフォーム固有のセットアップについては、各SDKのREADMEを参照してください: [Flutter](bindings/flutter/) · [Unity](bindings/unity/) · [Swift](bindings/apple/) · [Kotlin](bindings/kotlin/) · [Rust](crates/)。
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ Install and run a model in your language of choice. Each section includes the in
 
 See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) for all options.
 
-<details>
-<summary><b>Flutter</summary>
-<a id="flutter"></a>
+### Flutter
 
 **Install** in `pubspec.yaml`:
 
@@ -137,11 +135,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 // result → 24kHz WAV audio
 ```
 
-</details>
-
-<details>
-<summary><b>Kotlin</summary>
-<a id="kotlin"></a>
+### Kotlin
 
 **Install** in `build.gradle.kts`:
 
@@ -159,11 +153,7 @@ val result = model.run(Envelope.text("Hello world"))
 // result → 24kHz WAV audio
 ```
 
-</details>
-
-<details>
-<summary><b>Swift</summary>
-<a id="swift"></a>
+### Swift
 
 **Install** in `Package.swift`:
 
@@ -183,11 +173,7 @@ let result = try model.run(envelope: Envelope.text("Hello world"))
 // result → 24kHz WAV audio
 ```
 
-</details>
-
-<details>
-<summary><b>Unity/C#</summary>
-<a id="unity"></a>
+### Unity
 
 **Install** via Unity Package Manager:
 
@@ -203,11 +189,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 // result → 24kHz WAV audio
 ```
 
-</details>
-
-<details>
-<summary>Rust</summary>
-<a id="rust"></a>
+### Rust
 
 **Install** in `Cargo.toml`:
 
@@ -224,10 +206,7 @@ let result = model.run(&Envelope::text("Hello world"))?;
 // result → 24kHz WAV audio
 ```
 
-</details>
-
-<details>
-<summary><b>CLI</b> — macOS, Linux, Windows</summary>
+### CLI
 
 **Install:**
 
@@ -246,8 +225,6 @@ irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 ```sh
 xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 ```
-
-</details>
 
 For platform-specific setup, see each SDK's README: [Flutter](bindings/flutter/) · [Unity](bindings/unity/) · [Swift](bindings/apple/) · [Kotlin](bindings/kotlin/) · [Rust](crates/).
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Install and run a model in your language of choice. Each section includes the in
 
 See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) for all options.
 
-<a id="flutter"></a>
 <details>
 <summary><b>Flutter</summary>
+<a id="flutter"></a>
 
 **Install** in `pubspec.yaml`:
 
@@ -139,9 +139,9 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 </details>
 
-<a id="kotlin"></a>
 <details>
 <summary><b>Kotlin</summary>
+<a id="kotlin"></a>
 
 **Install** in `build.gradle.kts`:
 
@@ -161,9 +161,9 @@ val result = model.run(Envelope.text("Hello world"))
 
 </details>
 
-<a id="swift"></a>
 <details>
 <summary><b>Swift</summary>
+<a id="swift"></a>
 
 **Install** in `Package.swift`:
 
@@ -185,9 +185,9 @@ let result = try model.run(envelope: Envelope.text("Hello world"))
 
 </details>
 
-<a id="unity"></a>
 <details>
 <summary><b>Unity/C#</summary>
+<a id="unity"></a>
 
 **Install** via Unity Package Manager:
 
@@ -205,9 +205,9 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 </details>
 
-<a id="rust"></a>
 <details>
 <summary>Rust</summary>
+<a id="rust"></a>
 
 **Install** in `Cargo.toml`:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,9 +139,9 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 </details>
 
-<a id="flutter"></a>
 <details>
 <summary><b>Flutter</b> — iOS、Android、macOS、Linux、Windows</summary>
+<a id="flutter"></a>
 
 **安装** 在 `pubspec.yaml`：
 
@@ -160,9 +160,9 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 </details>
 
-<a id="kotlin"></a>
 <details>
 <summary><b>Kotlin</b> — Android</summary>
+<a id="kotlin"></a>
 
 **安装** 在 `build.gradle.kts`：
 
@@ -182,9 +182,9 @@ val result = model.run(Envelope.text("国破山河在，城春草木深"))
 
 </details>
 
-<a id="swift"></a>
 <details>
 <summary><b>Swift</b> — iOS、macOS</summary>
+<a id="swift"></a>
 
 **安装** 在 `Package.swift`：
 
@@ -206,9 +206,9 @@ let result = try model.run(envelope: Envelope.text("国破山河在，城春草�
 
 </details>
 
-<a id="unity"></a>
 <details>
 <summary><b>Unity (C#)</b> — macOS、Windows、Linux、iOS、Android</summary>
+<a id="unity"></a>
 
 **安装** 通过 Unity Package Manager：
 
@@ -226,9 +226,9 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 </details>
 
-<a id="rust"></a>
 <details>
 <summary><b>Rust</b> — 全平台</summary>
+<a id="rust"></a>
 
 **安装** 在 `Cargo.toml`：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -116,8 +116,7 @@ Xybrid 是一个 **Rust 驱动的运行时**，为所有主流平台提供原生
 
 选择你喜欢的语言，安装并运行模型。每个语言下都包含安装片段和最小示例。
 
-<details>
-<summary><b>CLI</b> — macOS、Linux、Windows</summary>
+### CLI
 
 **安装：**
 
@@ -137,11 +136,7 @@ irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -o output.wav
 ```
 
-</details>
-
-<details>
-<summary><b>Flutter</b> — iOS、Android、macOS、Linux、Windows</summary>
-<a id="flutter"></a>
+### Flutter
 
 **安装** 在 `pubspec.yaml`：
 
@@ -158,11 +153,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 // 输出 → 24kHz WAV 音频
 ```
 
-</details>
-
-<details>
-<summary><b>Kotlin</b> — Android</summary>
-<a id="kotlin"></a>
+### Kotlin
 
 **安装** 在 `build.gradle.kts`：
 
@@ -180,11 +171,7 @@ val result = model.run(Envelope.text("国破山河在，城春草木深"))
 // 输出 → 24kHz WAV 音频
 ```
 
-</details>
-
-<details>
-<summary><b>Swift</b> — iOS、macOS</summary>
-<a id="swift"></a>
+### Swift
 
 **安装** 在 `Package.swift`：
 
@@ -204,11 +191,7 @@ let result = try model.run(envelope: Envelope.text("国破山河在，城春草�
 // 输出 → 24kHz WAV 音频
 ```
 
-</details>
-
-<details>
-<summary><b>Unity (C#)</b> — macOS、Windows、Linux、iOS、Android</summary>
-<a id="unity"></a>
+### Unity
 
 **安装** 通过 Unity Package Manager：
 
@@ -224,11 +207,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 // 输出 → 24kHz WAV 音频
 ```
 
-</details>
-
-<details>
-<summary><b>Rust</b> — 全平台</summary>
-<a id="rust"></a>
+### Rust
 
 **安装** 在 `Cargo.toml`：
 
@@ -244,8 +223,6 @@ let model = Xybrid::model("kokoro-82m").load()?;
 let result = model.run(&Envelope::text("国破山河在，城春草木深"))?;
 // 输出 → 24kHz WAV 音频
 ```
-
-</details>
 
 完整安装选项、硬件加速与 CLI 参考请参阅 [Installation Guide](docs/INSTALLATION.md)。各平台的详细设置请参阅对应 SDK 的 README：[Flutter](bindings/flutter/) · [Unity](bindings/unity/) · [Swift](bindings/apple/) · [Kotlin](bindings/kotlin/) · [Rust](crates/)。
 


### PR DESCRIPTION
## Summary

Drops the collapsed `<details>` wrappers around each SDK in the README Quick Start and replaces them with plain `### Flutter / Kotlin / Swift / Unity / Rust / CLI` headings. The earlier follow-up — trying to auto-expand the `<details>` blocks when the header CTAs target their anchors — doesn't work on github.com (CSS/JS stripped, Chromium's fragment auto-expand doesn't fire there), so this flattens the content instead. Every SDK snippet is now visible without a click, and GitHub's heading-slug anchors keep the header CTAs (`#flutter`, `#swift`, `#kotlin`, `#unity`, `#rust`) working. Applied identically to `README.md`, `README.zh-CN.md`, and `README.ja-JP.md`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — docs-only change
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)