### PR TITLE
test(routing): cover reliability-window invariants and pin the resolver hint-drop gap

### DIFF
--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -139,6 +139,10 @@ harness = false
 name = "resource_telemetry"
 harness = false
 
+[[bench]]
+name = "routing_feedback"
+harness = false
+
 # Platform-specific ureq dependencies
 # Non-Android: Use default ureq with TLS
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/crates/xybrid-core/benches/routing_feedback.rs
+++ b/crates/xybrid-core/benches/routing_feedback.rs
@@ -1,0 +1,54 @@
+//! Criterion bench for local routing feedback.
+//!
+//! SLO defended:
+//!   * LocalAuthority::record_outcome write: <= 1 us
+//!
+//! Protects the bounded-window write path used by the local authority
+//! when the routing engine biases against repeatedly-failing local runs.
+//!
+//! Run with:
+//!   cargo bench -p xybrid-core --bench routing_feedback
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use xybrid_core::device::{MemoryPressure, ThermalState};
+use xybrid_core::orchestrator::authority::{
+    ExecutionOutcome, LocalAuthority, OrchestrationAuthority, OutcomeCategory, SignalContext,
+};
+use xybrid_core::orchestrator::ResolvedTarget;
+
+fn signal() -> SignalContext {
+    SignalContext {
+        memory_pressure: MemoryPressure::Warn,
+        thermal_state: ThermalState::Normal,
+        cpu_bucket: Some(5),
+    }
+}
+
+fn local_failure_outcome() -> ExecutionOutcome {
+    ExecutionOutcome {
+        stage_id: "stage".to_string(),
+        target: ResolvedTarget::Device,
+        latency_ms: 10,
+        success: false,
+        error: Some("local_failed".to_string()),
+        category: Some(OutcomeCategory::HardFail {
+            reason: "local_failed".to_string(),
+        }),
+        model_id: Some("model".to_string()),
+        signal_context: Some(signal()),
+    }
+}
+
+fn bench_record_outcome(c: &mut Criterion) {
+    let authority = LocalAuthority::default();
+    let outcome = local_failure_outcome();
+
+    c.bench_function("local_authority::record_outcome", |b| {
+        b.iter(|| {
+            authority.record_outcome(black_box(&outcome));
+        })
+    });
+}
+
+criterion_group!(benches, bench_record_outcome);
+criterion_main!(benches);

--- a/crates/xybrid-core/src/orchestrator/authority/local.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/local.rs
@@ -941,6 +941,157 @@ signature: "test-deny-all"
     }
 
     #[test]
+    fn reliability_window_evicts_oldest_after_32_entries() {
+        // Pin the exact retained FIFO sequence: writing failure-0..32 must
+        // leave failure-1..32 in oldest-to-newest order. Asserting length
+        // alone (or just the absence of failure-0) would silently accept
+        // reversed eviction, duplicate retention, or stable-non-FIFO bugs.
+        let authority = LocalAuthority::with_cache_provider(Arc::new(CachedProvider));
+        for idx in 0..33 {
+            authority.record_outcome(&ExecutionOutcome {
+                stage_id: "test-stage".to_string(),
+                target: ResolvedTarget::Device,
+                latency_ms: 10,
+                success: false,
+                error: Some(format!("failure-{idx}")),
+                category: Some(OutcomeCategory::HardFail {
+                    reason: format!("failure-{idx}"),
+                }),
+                model_id: Some("test-model".to_string()),
+                signal_context: Some(signal()),
+            });
+        }
+
+        let history = authority.history_snapshot("test-model", signal());
+
+        assert_eq!(history.len(), RELIABILITY_WINDOW);
+        let actual_reasons: Vec<String> = history
+            .iter()
+            .map(|c| match c {
+                OutcomeCategory::HardFail { reason } => reason.clone(),
+                other => panic!("expected HardFail, got {other:?}"),
+            })
+            .collect();
+        let expected_reasons: Vec<String> = (1..=RELIABILITY_WINDOW)
+            .map(|i| format!("failure-{i}"))
+            .collect();
+        assert_eq!(
+            actual_reasons, expected_reasons,
+            "history must contain failure-1..failure-{RELIABILITY_WINDOW} in FIFO order (oldest first)"
+        );
+    }
+
+    // Helper: record one HardFail under `(model, sig)` and return the
+    // resulting snapshot. Keeps the per-dimension isolation tests compact.
+    fn record_hard_fail_and_snapshot(
+        authority: &LocalAuthority,
+        model: &str,
+        sig: SignalContext,
+        reason: &str,
+    ) -> std::collections::VecDeque<OutcomeCategory> {
+        authority.record_outcome(&ExecutionOutcome {
+            stage_id: "test-stage".to_string(),
+            target: ResolvedTarget::Device,
+            latency_ms: 10,
+            success: false,
+            error: Some(reason.to_string()),
+            category: Some(OutcomeCategory::HardFail {
+                reason: reason.to_string(),
+            }),
+            model_id: Some(model.to_string()),
+            signal_context: Some(sig),
+        });
+        authority.history_snapshot(model, sig)
+    }
+
+    #[test]
+    fn reliability_history_is_scoped_by_memory_pressure() {
+        // Memory-pressure isolation: same (model, thermal, cpu_bucket) but
+        // different memory_pressure must keep histories separate.
+        let authority = LocalAuthority::with_cache_provider(Arc::new(CachedProvider));
+        let mut warn_signal = signal();
+        warn_signal.memory_pressure = MemoryPressure::Warn;
+        let mut critical_signal = signal();
+        critical_signal.memory_pressure = MemoryPressure::Critical;
+
+        let warn_history =
+            record_hard_fail_and_snapshot(&authority, "test-model", warn_signal, "warn-failure");
+        let critical_history = record_hard_fail_and_snapshot(
+            &authority,
+            "test-model",
+            critical_signal,
+            "critical-failure",
+        );
+
+        assert_eq!(warn_history.len(), 1);
+        assert_eq!(critical_history.len(), 1);
+        assert_ne!(warn_history, critical_history);
+    }
+
+    #[test]
+    fn reliability_history_is_scoped_by_thermal_state() {
+        // Thermal-state isolation: same (model, memory_pressure, cpu_bucket)
+        // but different thermal_state must keep histories separate. Without
+        // this, a `Normal` device's hot history would leak into a `Hot`
+        // device's bias decision.
+        let authority = LocalAuthority::with_cache_provider(Arc::new(CachedProvider));
+        let mut normal_signal = signal();
+        normal_signal.thermal_state = ThermalState::Normal;
+        let mut hot_signal = signal();
+        hot_signal.thermal_state = ThermalState::Hot;
+
+        let normal_history =
+            record_hard_fail_and_snapshot(&authority, "test-model", normal_signal, "normal-fail");
+        let hot_history =
+            record_hard_fail_and_snapshot(&authority, "test-model", hot_signal, "hot-fail");
+
+        assert_eq!(normal_history.len(), 1);
+        assert_eq!(hot_history.len(), 1);
+        assert_ne!(normal_history, hot_history);
+    }
+
+    #[test]
+    fn reliability_history_is_scoped_by_cpu_bucket() {
+        // cpu_bucket isolation: same (model, memory, thermal) but different
+        // quantized CPU bucket must keep histories separate. The bucket is
+        // the only continuous dimension in SignalContext, so a coarse
+        // quantization regression would manifest here.
+        let authority = LocalAuthority::with_cache_provider(Arc::new(CachedProvider));
+        let mut low_cpu_signal = signal();
+        low_cpu_signal.cpu_bucket = Some(2);
+        let mut high_cpu_signal = signal();
+        high_cpu_signal.cpu_bucket = Some(9);
+
+        let low_history =
+            record_hard_fail_and_snapshot(&authority, "test-model", low_cpu_signal, "low-cpu-fail");
+        let high_history = record_hard_fail_and_snapshot(
+            &authority,
+            "test-model",
+            high_cpu_signal,
+            "high-cpu-fail",
+        );
+
+        assert_eq!(low_history.len(), 1);
+        assert_eq!(high_history.len(), 1);
+        assert_ne!(low_history, high_history);
+    }
+
+    #[test]
+    fn reliability_history_is_scoped_by_model_id() {
+        // model_id isolation: identical SignalContext but different model
+        // IDs must keep histories separate. If the key ever collapsed to
+        // SignalContext alone, this would conflate per-model reliability.
+        let authority = LocalAuthority::with_cache_provider(Arc::new(CachedProvider));
+
+        let history_a = record_hard_fail_and_snapshot(&authority, "model-a", signal(), "a-fail");
+        let history_b = record_hard_fail_and_snapshot(&authority, "model-b", signal(), "b-fail");
+
+        assert_eq!(history_a.len(), 1);
+        assert_eq!(history_b.len(), 1);
+        assert_ne!(history_a, history_b);
+    }
+
+    #[test]
     fn reliability_history_bias_routes_cloud_with_hint() {
         let authority =
             LocalAuthority::with_cache_provider(Arc::new(CachedProvider)).with_history_bias_k(3);

--- a/crates/xybrid-core/src/orchestrator/routing_engine.rs
+++ b/crates/xybrid-core/src/orchestrator/routing_engine.rs
@@ -524,6 +524,62 @@ mod tests {
     }
 
     #[test]
+    fn routing_decision_json_includes_local_reliability_hint() {
+        let decision = RoutingDecision {
+            stage: "stage-1".to_string(),
+            target: RouteTarget::Cloud,
+            reason: "history_bias".to_string(),
+            timestamp_ms: 1730559412312,
+            local_reliability_hint: LocalReliabilityHint {
+                recent_abort_rate: 1.0,
+                sample_size: 3,
+            },
+        };
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&decision.to_json()).expect("to_json output must be valid JSON");
+
+        let hint = parsed
+            .get("local_reliability_hint")
+            .expect("hint must be present at the payload top level");
+        assert_eq!(hint["recent_abort_rate"].as_f64(), Some(1.0));
+        assert_eq!(hint["sample_size"].as_u64(), Some(3));
+        // sample_size must serialize as an integer, not a float. The
+        // platform datasource binds the column as UInt32 and a float
+        // value (e.g. `3.0`) would fail JSONPath extraction.
+        assert!(
+            hint["sample_size"].is_u64(),
+            "sample_size must serialize as integer (got {:?})",
+            hint["sample_size"]
+        );
+    }
+
+    #[test]
+    fn routing_decision_json_emits_empty_local_reliability_hint() {
+        // Empty-window case: when the authority has no history yet, the
+        // serialized hint must still be present with sample_size=0 and
+        // recent_abort_rate=0.0. The platform datasource needs the field
+        // populated (even at zero) to distinguish "no history yet" from
+        // "field absent because the SDK is older than the schema".
+        let decision = RoutingDecision {
+            stage: "stage-1".to_string(),
+            target: RouteTarget::Local,
+            reason: "default_local".to_string(),
+            timestamp_ms: 1730559412312,
+            local_reliability_hint: LocalReliabilityHint::EMPTY,
+        };
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&decision.to_json()).expect("to_json output must be valid JSON");
+
+        let hint = parsed
+            .get("local_reliability_hint")
+            .expect("hint must be present even when EMPTY");
+        assert_eq!(hint["recent_abort_rate"].as_f64(), Some(0.0));
+        assert_eq!(hint["sample_size"].as_u64(), Some(0));
+    }
+
+    #[test]
     fn routing_decision_json_escapes_special_characters_in_reason() {
         // Pre-fix, the hand-rolled format!() template would emit a quote
         // verbatim, producing a malformed JSON line whenever a model_id

--- a/crates/xybrid-core/src/pipeline/resolver.rs
+++ b/crates/xybrid-core/src/pipeline/resolver.rs
@@ -570,4 +570,34 @@ mod tests {
         assert_eq!(decision.reason, "test reason");
         assert!(decision.timestamp_ms > 0);
     }
+
+    #[test]
+    fn resolved_target_to_routing_decision_currently_drops_local_reliability_hint() {
+        // REGRESSION-PIN for a KNOWN GAP at `ResolvedTarget::to_routing_decision`
+        // (above in this file): the function hardcodes
+        // `LocalReliabilityHint::EMPTY` because it has no access to the
+        // `LocalAuthority`'s reliability history. Every routing decision
+        // emitted through this path carries `sample_size=0` and
+        // `recent_abort_rate=0.0`, regardless of the device's actual
+        // local-failure history.
+        //
+        // The main routing path (`DefaultRoutingEngine::decide`) populates
+        // the hint correctly via `LocalAuthority::history_hint`. This
+        // second emission seam was missed.
+        //
+        // When this gap is closed (the resolver gains access to an
+        // authority or accepts a pre-computed hint), this test will start
+        // failing. Update it to assert that the real hint flows through.
+        let resolved = ResolvedTarget::local("wav2vec2", Some("1.0"), "test reason");
+        let decision = resolved.to_routing_decision("asr");
+
+        assert_eq!(
+            decision.local_reliability_hint.recent_abort_rate, 0.0,
+            "regression-pin: see comment above — resolver drops the hint"
+        );
+        assert_eq!(
+            decision.local_reliability_hint.sample_size, 0,
+            "regression-pin: see comment above — resolver drops the hint"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Three test additions covering the bounded per-(model_id, signal_context) local reliability window: exact FIFO eviction sequence (failure-1..32), per-dimension key isolation across memory_pressure / thermal_state / cpu_bucket / model_id, and the empty-window case for LocalReliabilityHint JSON serialization.
- New regression-pin test documenting a second LocalReliabilityHint drop seam at `crates/xybrid-core/src/pipeline/resolver.rs:144`: `TargetResolution::to_routing_decision` hardcodes `LocalReliabilityHint::EMPTY` because it has no `LocalAuthority` access. The main routing path populates the hint correctly; this seam was missed. The test asserts current EMPTY behavior so a future fix forces an intentional update.
- Wires up the `routing_feedback` Criterion bench measuring per-write overhead for `LocalAuthority::record_outcome` (72 ns on Apple Silicon; the `<= 1 us` target is informational — CI does not run `cargo bench`). A follow-up will promote the bench to a CI-gated SLO with realistic workloads (new-key insertion, cap eviction, contention).

## Test plan

- [x] `cargo test -p xybrid-core --features ort-download --lib` — 10 `reliability_*` + 4 `routing_decision_json` + 1 resolver-drop regression-pin all pass
- [x] `cargo clippy -p xybrid-core --all-targets --features ort-download -- -D warnings` — clean
- [x] `cargo bench -p xybrid-core --bench routing_feedback` — `local_authority::record_outcome` mean 72 ns