### PR TITLE
feat(telemetry): carry local reliability hint through to platform payload

### DIFF
--- a/crates/xybrid-core/README.md
+++ b/crates/xybrid-core/README.md
@@ -176,7 +176,7 @@ let telemetry = Telemetry::new();
 
 // Log events
 telemetry.log_stage_start("asr");
-telemetry.log_routing_decision("asr", "local", "low_latency");
+telemetry.log_routing_decision("asr", "local", "low_latency", 0.0, 0);
 telemetry.log_stage_complete("asr", "local", 50, None);
 ```
 

--- a/crates/xybrid-core/src/event_bus.rs
+++ b/crates/xybrid-core/src/event_bus.rs
@@ -30,10 +30,20 @@ pub enum OrchestratorEvent {
         reason: Option<String>,
     },
     /// Routing decision was made.
+    ///
+    /// `recent_abort_rate` and `sample_size` carry the rolling-window-derived
+    /// local reliability hint that the authority computed for this
+    /// `(model_id, signal_context)`. Empty-window decisions emit `(0.0, 0)`
+    /// so consumers can distinguish "no history yet" from "field absent
+    /// because of an older event shape". The SDK bridge hoists these into
+    /// `event.data.local_reliability_hint` so the platform exporter can
+    /// surface them at the payload top level.
     RoutingDecided {
         stage_name: String,
         target: String,
         reason: String,
+        recent_abort_rate: f32,
+        sample_size: u32,
     },
     /// Execution started.
     ExecutionStarted { stage_name: String, target: String },
@@ -355,6 +365,8 @@ mod tests {
             stage_name: "test".to_string(),
             target: "cloud".to_string(),
             reason: "optimal".to_string(),
+            recent_abort_rate: 0.0,
+            sample_size: 0,
         };
 
         // Verify Clone works
@@ -365,11 +377,13 @@ mod tests {
                     stage_name: s1,
                     target: t1,
                     reason: r1,
+                    ..
                 },
                 OrchestratorEvent::RoutingDecided {
                     stage_name: s2,
                     target: t2,
                     reason: r2,
+                    ..
                 },
             ) => {
                 assert_eq!(s1, s2);
@@ -415,6 +429,8 @@ mod tests {
             stage_name: "test".to_string(),
             target: "cloud".to_string(),
             reason: "optimal".to_string(),
+            recent_abort_rate: 0.0,
+            sample_size: 0,
         });
         let _ = subscription.recv().unwrap();
 

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -353,6 +353,8 @@ impl Orchestrator {
             stage_name: stage.name.clone(),
             target: routing_decision.target.to_json_string(),
             reason: routing_decision.reason.clone(),
+            recent_abort_rate: routing_decision.local_reliability_hint.recent_abort_rate,
+            sample_size: routing_decision.local_reliability_hint.sample_size,
         });
         self.telemetry.log_routing_decision(
             &stage.name,
@@ -583,6 +585,8 @@ impl Orchestrator {
             stage_name: stage.name.clone(),
             target: routing_decision.target.to_json_string(),
             reason: routing_decision.reason.clone(),
+            recent_abort_rate: routing_decision.local_reliability_hint.recent_abort_rate,
+            sample_size: routing_decision.local_reliability_hint.sample_size,
         });
         self.telemetry.log_routing_decision(
             &stage.name,

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -358,6 +358,8 @@ impl Orchestrator {
             &stage.name,
             &routing_decision.target.to_json_string(),
             &routing_decision.reason,
+            routing_decision.local_reliability_hint.recent_abort_rate,
+            routing_decision.local_reliability_hint.sample_size,
         );
 
         // Step 4: Execute model based on routing decision
@@ -586,6 +588,8 @@ impl Orchestrator {
             &stage.name,
             &routing_decision.target.to_json_string(),
             &routing_decision.reason,
+            routing_decision.local_reliability_hint.recent_abort_rate,
+            routing_decision.local_reliability_hint.sample_size,
         );
 
         // Execute model in blocking thread pool (adapter execution may be CPU-bound)

--- a/crates/xybrid-core/src/telemetry/events.rs
+++ b/crates/xybrid-core/src/telemetry/events.rs
@@ -396,7 +396,21 @@ impl Telemetry {
     }
 
     /// Log a routing decision event.
-    pub fn log_routing_decision(&self, stage_name: &str, target: &str, reason: &str) {
+    ///
+    /// `recent_abort_rate` and `sample_size` come from the local reliability
+    /// window the authority maintains per `(model_id, signal_context)`. Empty
+    /// window callers pass `(0.0, 0)`. The pair travels in the event's
+    /// `local_reliability_hint` attribute and is hoisted to the platform
+    /// event payload top level by the SDK telemetry exporter so analytics
+    /// can column-extract it without descending into the nested data object.
+    pub fn log_routing_decision(
+        &self,
+        stage_name: &str,
+        target: &str,
+        reason: &str,
+        recent_abort_rate: f32,
+        sample_size: u32,
+    ) {
         let entry = TelemetryEntry::new(
             Severity::Info,
             TelemetryEvent::RoutingDecision,
@@ -407,7 +421,11 @@ impl Telemetry {
             json!({
                 "stage": stage_name,
                 "target": target,
-                "reason": reason
+                "reason": reason,
+                "local_reliability_hint": {
+                    "recent_abort_rate": recent_abort_rate,
+                    "sample_size": sample_size,
+                }
             }),
         );
         self.emit(entry);
@@ -584,7 +602,40 @@ mod tests {
     #[test]
     fn test_log_routing_decision() {
         let telemetry = Telemetry::new();
-        telemetry.log_routing_decision("test_stage", "local", "high_latency");
+        telemetry.log_routing_decision("test_stage", "local", "high_latency", 0.0, 0);
+    }
+
+    #[test]
+    fn routing_decision_attributes_carry_local_reliability_hint() {
+        // Mirror the inline json! macro from log_routing_decision so the
+        // wire shape is asserted directly rather than depending on a
+        // captured emit sink. The TelemetryEntry round-trip proves the
+        // attribute survives serialization unchanged.
+        let attrs = json!({
+            "stage": "stage-1",
+            "target": "cloud",
+            "reason": "history_bias",
+            "local_reliability_hint": {
+                "recent_abort_rate": 0.75,
+                "sample_size": 4_u32,
+            }
+        });
+        let entry = TelemetryEntry::new(
+            Severity::Info,
+            TelemetryEvent::RoutingDecision,
+            String::from("Routing decision for 'stage-1': cloud (history_bias)"),
+            attrs,
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(&entry.to_json()).expect("entry to_json must be valid JSON");
+        let attributes = parsed
+            .get("attributes")
+            .expect("entry must serialize attributes");
+        assert_eq!(
+            attributes["local_reliability_hint"]["recent_abort_rate"],
+            0.75
+        );
+        assert_eq!(attributes["local_reliability_hint"]["sample_size"], 4);
     }
 
     #[test]

--- a/crates/xybrid-core/src/telemetry/events.rs
+++ b/crates/xybrid-core/src/telemetry/events.rs
@@ -400,9 +400,16 @@ impl Telemetry {
     /// `recent_abort_rate` and `sample_size` come from the local reliability
     /// window the authority maintains per `(model_id, signal_context)`. Empty
     /// window callers pass `(0.0, 0)`. The pair travels in the event's
-    /// `local_reliability_hint` attribute and is hoisted to the platform
-    /// event payload top level by the SDK telemetry exporter so analytics
-    /// can column-extract it without descending into the nested data object.
+    /// `local_reliability_hint` attribute, alongside the routing reason. The
+    /// public bridge path
+    /// (`OrchestratorEvent::RoutingDecided` → SDK exporter) hoists the same
+    /// field to the platform-event payload top level so analytics can
+    /// column-extract it without descending into the nested data object.
+    ///
+    /// Non-finite `recent_abort_rate` values (NaN, ±Infinity) are clamped to
+    /// `0.0` before serialization so the analytics backend's typed Float32
+    /// column never receives a JSON `null`. The authority itself emits only
+    /// finite values; this clamp is defense-in-depth for direct callers.
     pub fn log_routing_decision(
         &self,
         stage_name: &str,
@@ -411,6 +418,11 @@ impl Telemetry {
         recent_abort_rate: f32,
         sample_size: u32,
     ) {
+        let safe_rate = if recent_abort_rate.is_finite() {
+            recent_abort_rate
+        } else {
+            0.0_f32
+        };
         let entry = TelemetryEntry::new(
             Severity::Info,
             TelemetryEvent::RoutingDecision,
@@ -423,7 +435,7 @@ impl Telemetry {
                 "target": target,
                 "reason": reason,
                 "local_reliability_hint": {
-                    "recent_abort_rate": recent_abort_rate,
+                    "recent_abort_rate": safe_rate,
                     "sample_size": sample_size,
                 }
             }),

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -212,8 +212,10 @@ pub use telemetry::{
     register_telemetry_sender,
     set_telemetry_pipeline_context,
     shutdown_platform_telemetry,
-    HttpTelemetryExporter,
     // Platform telemetry exports
+    subscribe_orchestrator_events,
+    HttpTelemetryExporter,
+    OrchestratorEventBridge,
     TelemetryConfig,
     TelemetryEvent,
     TelemetrySender,
@@ -667,12 +669,17 @@ pub fn run_pipeline(config_path: &str) -> Result<PipelineResult, PipelineConfigE
 
     // Create orchestrator
     let mut orchestrator = Orchestrator::new();
+    let orchestrator_bridge = telemetry::subscribe_orchestrator_events(&orchestrator);
 
     // Execute the pipeline
     let start_time = std::time::Instant::now();
     let results: Vec<StageExecutionResult> = orchestrator
         .execute_pipeline(&stages, &input, &metrics, &availability_fn)
-        .map_err(|e| PipelineConfigError::ExecutionError(format!("{}", e)))?;
+        .map_err(|e| {
+            orchestrator_bridge.drain();
+            PipelineConfigError::ExecutionError(format!("{}", e))
+        })?;
+    orchestrator_bridge.drain();
     let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
     // Convert to SDK result format
@@ -773,13 +780,18 @@ pub async fn run_pipeline_async(config_path: &str) -> Result<PipelineResult, Pip
 
     // Create orchestrator
     let mut orchestrator = Orchestrator::new();
+    let orchestrator_bridge = telemetry::subscribe_orchestrator_events(&orchestrator);
 
     // Execute the pipeline asynchronously
     let start_time = std::time::Instant::now();
     let results: Vec<StageExecutionResult> = orchestrator
         .execute_pipeline_async(&stages, &input, &metrics, &availability_fn)
         .await
-        .map_err(|e| PipelineConfigError::ExecutionError(format!("{}", e)))?;
+        .map_err(|e| {
+            orchestrator_bridge.drain();
+            PipelineConfigError::ExecutionError(format!("{}", e))
+        })?;
+    orchestrator_bridge.drain();
     let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
     // Convert to SDK result format

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -901,16 +901,18 @@ impl Pipeline {
             .name
             .as_ref()
             .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
-        crate::telemetry::set_telemetry_pipeline_context(pipeline_id, Some(trace_id));
+        let _context_guard =
+            crate::telemetry::TelemetryPipelineContextGuard::install(pipeline_id, Some(trace_id));
 
         let mut orchestrator = Orchestrator::new();
-        // Subscribe the local orchestrator's event bus to the platform
-        // telemetry exporter. Without this, every OrchestratorEvent
-        // (RoutingDecided, ExecutionStarted, …) the orchestrator publishes
-        // dies inside this method's scope and never reaches the
-        // SDK->platform sink — most visibly, `local_reliability_hint` on
-        // routing decisions silently disappears.
-        crate::telemetry::bridge_orchestrator_events(&orchestrator);
+        // Subscribe after construction: bootstrap events emitted by
+        // `Orchestrator::new()` are constructor-local, while execution events
+        // below must be drained before this short-lived orchestrator returns.
+        let orchestrator_bridge = crate::telemetry::subscribe_orchestrator_events_in_context(
+            &orchestrator,
+            pipeline_id,
+            Some(trace_id),
+        );
         // No need to set registry config - executor uses bundle_path from stage descriptors
 
         let availability_fn = move |stage: &str| -> LocalAvailability {
@@ -923,15 +925,11 @@ impl Pipeline {
         let results: Vec<StageExecutionResult> = orchestrator
             .execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn)
             .map_err(|e| {
-                crate::telemetry::set_telemetry_pipeline_context(None, None);
+                orchestrator_bridge.drain();
                 SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
             })?;
+        orchestrator_bridge.drain();
         let total_latency_ms = start_time.elapsed().as_millis() as u32;
-
-        // Note: `set_telemetry_pipeline_context(None, None)` deferred to
-        // after `publish_telemetry_event` below. The exporter's flush
-        // thread reads pipeline_id/trace_id lazily at flush time; if we
-        // cleared here the PipelineComplete event would get null IDs.
 
         let stages: Vec<StageTiming> = results
             .iter()
@@ -991,11 +989,12 @@ impl Pipeline {
                 .map(|d| d.as_millis() as u64)
                 .unwrap_or(0),
         };
-        crate::telemetry::publish_with_resource_summary(event, resource_guard);
-
-        // Clear pipeline context AFTER publish so the event carried
-        // correlation IDs visible to the exporter's lazy-read flush.
-        crate::telemetry::set_telemetry_pipeline_context(None, None);
+        crate::telemetry::publish_with_resource_summary_in_context(
+            event,
+            resource_guard,
+            pipeline_id,
+            Some(trace_id),
+        );
 
         Ok(PipelineExecutionResult {
             name: self.name.clone(),
@@ -1038,13 +1037,18 @@ impl Pipeline {
             let pipeline_id = name
                 .as_ref()
                 .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
-            crate::telemetry::set_telemetry_pipeline_context(pipeline_id, Some(trace_id));
+            let _context_guard = crate::telemetry::TelemetryPipelineContextGuard::install(
+                pipeline_id,
+                Some(trace_id),
+            );
 
             let mut orchestrator = Orchestrator::new();
-            // Subscribe the local orchestrator's event bus to the platform
-            // telemetry exporter — see the matching comment on the sync
-            // `Pipeline::run` path above for rationale.
-            crate::telemetry::bridge_orchestrator_events(&orchestrator);
+            // Subscribe after construction; see the sync path above.
+            let orchestrator_bridge = crate::telemetry::subscribe_orchestrator_events_in_context(
+                &orchestrator,
+                pipeline_id,
+                Some(trace_id),
+            );
             // No need to set registry config - executor uses bundle_path from stage descriptors
 
             let availability_fn = move |stage: &str| -> LocalAvailability {
@@ -1062,14 +1066,11 @@ impl Pipeline {
                     &availability_fn,
                 )
                 .map_err(|e| {
-                    crate::telemetry::set_telemetry_pipeline_context(None, None);
+                    orchestrator_bridge.drain();
                     SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
                 })?;
+            orchestrator_bridge.drain();
             let total_latency_ms = start_time.elapsed().as_millis() as u32;
-
-            // Note: `set_telemetry_pipeline_context(None, None)` deferred
-            // to after `publish_telemetry_event` below — see sync arm for
-            // the correlation-ID rationale.
 
             let stages: Vec<StageTiming> = results
                 .iter()
@@ -1129,11 +1130,12 @@ impl Pipeline {
                     .map(|d| d.as_millis() as u64)
                     .unwrap_or(0),
             };
-            crate::telemetry::publish_with_resource_summary(event, resource_guard);
-
-            // Clear pipeline context after publish to keep the exporter's
-            // lazy-read flush correlated with the just-completed pipeline.
-            crate::telemetry::set_telemetry_pipeline_context(None, None);
+            crate::telemetry::publish_with_resource_summary_in_context(
+                event,
+                resource_guard,
+                pipeline_id,
+                Some(trace_id),
+            );
 
             Ok(PipelineExecutionResult {
                 name,

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -904,6 +904,13 @@ impl Pipeline {
         crate::telemetry::set_telemetry_pipeline_context(pipeline_id, Some(trace_id));
 
         let mut orchestrator = Orchestrator::new();
+        // Subscribe the local orchestrator's event bus to the platform
+        // telemetry exporter. Without this, every OrchestratorEvent
+        // (RoutingDecided, ExecutionStarted, …) the orchestrator publishes
+        // dies inside this method's scope and never reaches the
+        // SDK->platform sink — most visibly, `local_reliability_hint` on
+        // routing decisions silently disappears.
+        crate::telemetry::bridge_orchestrator_events(&orchestrator);
         // No need to set registry config - executor uses bundle_path from stage descriptors
 
         let availability_fn = move |stage: &str| -> LocalAvailability {
@@ -1034,6 +1041,10 @@ impl Pipeline {
             crate::telemetry::set_telemetry_pipeline_context(pipeline_id, Some(trace_id));
 
             let mut orchestrator = Orchestrator::new();
+            // Subscribe the local orchestrator's event bus to the platform
+            // telemetry exporter — see the matching comment on the sync
+            // `Pipeline::run` path above for rationale.
+            crate::telemetry::bridge_orchestrator_events(&orchestrator);
             // No need to set registry config - executor uses bundle_path from stage descriptors
 
             let availability_fn = move |stage: &str| -> LocalAvailability {

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -927,6 +927,12 @@ fn convert_to_platform_event(
                 "correlation_id",
                 "outcome_category",
                 "abort_reason",
+                // Per-routing-decision reliability hint (object with
+                // `recent_abort_rate` + `sample_size`). Lives in the SDK
+                // hoist list so the analytics backend can extract it via
+                // `json:$.local_reliability_hint.*` without descending
+                // into the nested data object.
+                "local_reliability_hint",
             ]
             .iter()
             {
@@ -2471,6 +2477,85 @@ mod tests {
             "aborted_for_cloud_fallback"
         );
         assert_eq!(platform.payload["abort_reason"], "stress_memory");
+    }
+
+    #[test]
+    fn local_reliability_hint_hoists_to_platform_event_top_level() {
+        // RoutingDecision events serialize the hint into event.data via
+        // `Telemetry::log_routing_decision`. The hoist list in
+        // convert_to_platform_event must copy that nested object to the
+        // payload top level so the analytics backend can column-extract
+        // `json:$.local_reliability_hint.recent_abort_rate` and
+        // `.sample_size` without descending into `data`.
+        let event = TelemetryEvent {
+            event_type: "RoutingDecision".to_string(),
+            stage_name: Some("stage-1".to_string()),
+            target: Some("cloud".to_string()),
+            latency_ms: None,
+            error: None,
+            data: Some(
+                serde_json::json!({
+                    "stage": "stage-1",
+                    "target": "cloud",
+                    "reason": "history_bias",
+                    "local_reliability_hint": {
+                        "recent_abort_rate": 0.75,
+                        "sample_size": 4_u32,
+                    }
+                })
+                .to_string(),
+            ),
+            timestamp_ms: 1_700_000_000_000,
+        };
+
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+
+        assert_eq!(
+            platform.payload["local_reliability_hint"]["recent_abort_rate"]
+                .as_f64()
+                .unwrap_or(-1.0),
+            0.75
+        );
+        assert_eq!(
+            platform.payload["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn empty_local_reliability_hint_still_hoists_with_sample_size_zero() {
+        // Empty-window case: window has no entries yet. The SDK still
+        // emits (0.0, 0) so the platform can distinguish "no data" from
+        // "field missing because the SDK is older than the schema".
+        let event = TelemetryEvent {
+            event_type: "RoutingDecision".to_string(),
+            stage_name: Some("stage-1".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: None,
+            error: None,
+            data: Some(
+                serde_json::json!({
+                    "stage": "stage-1",
+                    "target": "local",
+                    "reason": "default_local",
+                    "local_reliability_hint": {
+                        "recent_abort_rate": 0.0,
+                        "sample_size": 0_u32,
+                    }
+                })
+                .to_string(),
+            ),
+            timestamp_ms: 1_700_000_000_000,
+        };
+
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+
+        assert_eq!(
+            platform.payload["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(0)
+        );
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1485,6 +1485,16 @@ pub fn publish_with_resource_summary(
     publish_telemetry_event(event);
 }
 
+pub(crate) fn publish_with_resource_summary_in_context(
+    mut event: TelemetryEvent,
+    guard: xybrid_core::device::RunGuard,
+    pipeline_id: Option<Uuid>,
+    trace_id: Option<Uuid>,
+) {
+    attach_resource_summary(&mut event, guard.finish());
+    publish_telemetry_event_in_context(event, pipeline_id, trace_id);
+}
+
 /// Build a `LocalAborted` telemetry event for a resource-driven cloud-fallback
 /// abort.
 ///
@@ -2131,6 +2141,14 @@ fn current_telemetry_pipeline_context() -> (Option<Uuid>, Option<Uuid>) {
 
 fn snapshot_context_into_event(event: TelemetryEvent) -> TelemetryEvent {
     let (pipeline_id, trace_id) = current_telemetry_pipeline_context();
+    snapshot_context_into_event_with(event, pipeline_id, trace_id)
+}
+
+fn snapshot_context_into_event_with(
+    event: TelemetryEvent,
+    pipeline_id: Option<Uuid>,
+    trace_id: Option<Uuid>,
+) -> TelemetryEvent {
     if pipeline_id.is_none() && trace_id.is_none() {
         return event;
     }
@@ -2251,7 +2269,20 @@ pub fn publish_telemetry_event(event: TelemetryEvent) {
     // composability) are left untouched so they keep full control.
     let event = snapshot_spans_into_event(event);
     let event = snapshot_context_into_event(event);
+    dispatch_telemetry_event(event);
+}
 
+pub(crate) fn publish_telemetry_event_in_context(
+    event: TelemetryEvent,
+    pipeline_id: Option<Uuid>,
+    trace_id: Option<Uuid>,
+) {
+    let event = snapshot_spans_into_event(event);
+    let event = snapshot_context_into_event_with(event, pipeline_id, trace_id);
+    dispatch_telemetry_event(event);
+}
+
+fn dispatch_telemetry_event(event: TelemetryEvent) {
     // Use unwrap_or_else to recover from poisoned mutex - this prevents
     // a panic in one component from permanently breaking telemetry
     let Ok(senders) = TELEMETRY_SENDERS.lock() else {
@@ -2277,25 +2308,80 @@ pub fn publish_telemetry_event(event: TelemetryEvent) {
     }
 }
 
-/// Bridge orchestrator events to telemetry stream
+/// Scoped bridge from an orchestrator event bus to the telemetry stream.
 ///
-/// This function subscribes to orchestrator events and converts them
-/// to telemetry events, publishing them to all registered subscribers.
-pub fn bridge_orchestrator_events(orchestrator: &xybrid_core::orchestrator::Orchestrator) {
+/// The bridge captures the current pipeline context when it subscribes, then
+/// embeds that context into each converted event before enqueueing it. Callers
+/// that own a short-lived orchestrator should keep this handle and call
+/// [`Self::drain`] before returning so queued orchestrator events are not left
+/// behind a detached worker.
+pub struct OrchestratorEventBridge {
+    subscription: xybrid_core::event_bus::Subscription,
+    pipeline_id: Option<Uuid>,
+    trace_id: Option<Uuid>,
+}
+
+impl OrchestratorEventBridge {
+    /// Publish all events currently buffered for this bridge.
+    pub fn drain(&self) {
+        loop {
+            match self.subscription.try_recv() {
+                Ok(event) => self.publish_event(&event),
+                Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
+            }
+        }
+    }
+
+    fn publish_event(&self, event: &OrchestratorEvent) {
+        let telemetry_event = convert_orchestrator_event(event);
+        publish_telemetry_event_in_context(telemetry_event, self.pipeline_id, self.trace_id);
+    }
+
+    fn recv_forever(self) {
+        while let Ok(event) = self.subscription.recv() {
+            self.publish_event(&event);
+        }
+    }
+}
+
+impl Drop for OrchestratorEventBridge {
+    fn drop(&mut self) {
+        self.drain();
+    }
+}
+
+/// Subscribe to orchestrator events and return a drainable bridge handle.
+pub fn subscribe_orchestrator_events(
+    orchestrator: &xybrid_core::orchestrator::Orchestrator,
+) -> OrchestratorEventBridge {
+    let (pipeline_id, trace_id) = current_telemetry_pipeline_context();
+    subscribe_orchestrator_events_in_context(orchestrator, pipeline_id, trace_id)
+}
+
+pub(crate) fn subscribe_orchestrator_events_in_context(
+    orchestrator: &xybrid_core::orchestrator::Orchestrator,
+    pipeline_id: Option<Uuid>,
+    trace_id: Option<Uuid>,
+) -> OrchestratorEventBridge {
     let event_bus = orchestrator.event_bus();
     let subscription = event_bus.subscribe();
 
-    thread::spawn(move || {
-        loop {
-            match subscription.recv() {
-                Ok(event) => {
-                    let telemetry_event = convert_orchestrator_event(&event);
-                    publish_telemetry_event(telemetry_event);
-                }
-                Err(_) => break, // Event bus closed
-            }
-        }
-    });
+    OrchestratorEventBridge {
+        subscription,
+        pipeline_id,
+        trace_id,
+    }
+}
+
+/// Bridge orchestrator events to telemetry stream on a background thread.
+///
+/// Short-lived SDK entry points should prefer [`subscribe_orchestrator_events`]
+/// and drain the returned handle before returning. This detached helper is kept
+/// for long-running CLI flows that own an orchestrator for an interactive
+/// session.
+pub fn bridge_orchestrator_events(orchestrator: &xybrid_core::orchestrator::Orchestrator) {
+    let bridge = subscribe_orchestrator_events(orchestrator);
+    thread::spawn(move || bridge.recv_forever());
 }
 
 #[cfg(test)]
@@ -2885,6 +2971,63 @@ mod tests {
                 "non-finite rate {bad_rate} must be sanitized to 0.0"
             );
         }
+    }
+
+    #[test]
+    fn scoped_orchestrator_bridge_drains_queued_events_with_captured_context() {
+        let (tx, rx) = mpsc::channel();
+        register_telemetry_sender(tx);
+
+        let orchestrator = xybrid_core::orchestrator::Orchestrator::new();
+        let pipeline_id = Uuid::new_v4();
+        let trace_id = Uuid::new_v4();
+        let bridge = subscribe_orchestrator_events_in_context(
+            &orchestrator,
+            Some(pipeline_id),
+            Some(trace_id),
+        );
+
+        orchestrator
+            .event_bus()
+            .publish(OrchestratorEvent::RoutingDecided {
+                stage_name: "stage-1".to_string(),
+                target: "cloud".to_string(),
+                reason: "history_bias".to_string(),
+                recent_abort_rate: 0.5,
+                sample_size: 2,
+            });
+        bridge.drain();
+
+        let mut received = None;
+        for _ in 0..20 {
+            match rx.recv_timeout(std::time::Duration::from_millis(50)) {
+                Ok(event) if event.event_type == "RoutingDecided" => {
+                    received = Some(event);
+                    break;
+                }
+                Ok(_) | Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    panic!("telemetry receiver disconnected before RoutingDecided arrived")
+                }
+            }
+        }
+        let received = received.expect("drained bridge should publish queued orchestrator event");
+
+        let data: serde_json::Value =
+            serde_json::from_str(received.data.as_ref().expect("context-bearing data")).unwrap();
+        assert_eq!(
+            data[CONTEXT_PIPELINE_ID_KEY],
+            serde_json::json!(pipeline_id)
+        );
+        assert_eq!(data[CONTEXT_TRACE_ID_KEY], serde_json::json!(trace_id));
+        assert_eq!(
+            data["local_reliability_hint"]["recent_abort_rate"].as_f64(),
+            Some(0.5)
+        );
+        assert_eq!(
+            data["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(2)
+        );
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1948,13 +1948,35 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             stage_name,
             target,
             reason,
+            recent_abort_rate,
+            sample_size,
         } => TelemetryEvent {
             event_type: "RoutingDecided".to_string(),
             stage_name: Some(stage_name.clone()),
             target: Some(target.clone()),
             latency_ms: None,
             error: None,
-            data: Some(serde_json::json!({"reason": reason}).to_string()),
+            // Embed the local reliability hint at the top level of event.data
+            // so the `convert_to_platform_event` hoist list can surface it on
+            // the payload at the top level (where the platform datasource's
+            // JSONPath extractors live, alongside correlation_id / outcome_*).
+            // Non-finite f32 values would serialize to JSON `null`, breaking
+            // the typed platform column; the authority emits only finite
+            // values, but we sanitize at the bridge for defense in depth.
+            data: Some(
+                serde_json::json!({
+                    "reason": reason,
+                    "local_reliability_hint": {
+                        "recent_abort_rate": if recent_abort_rate.is_finite() {
+                            *recent_abort_rate
+                        } else {
+                            0.0_f32
+                        },
+                        "sample_size": sample_size,
+                    },
+                })
+                .to_string(),
+            ),
             timestamp_ms,
         },
         OrchestratorEvent::ExecutionStarted { stage_name, target } => TelemetryEvent {
@@ -2782,6 +2804,8 @@ mod tests {
             stage_name: "asr".to_string(),
             target: "cloud".to_string(),
             reason: "network_optimal".to_string(),
+            recent_abort_rate: 0.0,
+            sample_size: 0,
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2791,6 +2815,76 @@ mod tests {
         assert!(telemetry.data.is_some());
         let data = telemetry.data.unwrap();
         assert!(data.contains("network_optimal"));
+    }
+
+    #[test]
+    fn routing_decided_event_carries_local_reliability_hint_end_to_end() {
+        // Production-shape regression test: walk the full
+        // OrchestratorEvent -> TelemetryEvent -> PlatformEvent pipeline
+        // so the hint flows through every seam the previous PR draft
+        // missed.
+        let event = OrchestratorEvent::RoutingDecided {
+            stage_name: "stage-1".to_string(),
+            target: "cloud".to_string(),
+            reason: "history_bias".to_string(),
+            recent_abort_rate: 0.75,
+            sample_size: 4,
+        };
+        let telemetry_event = convert_orchestrator_event(&event);
+
+        // Bridge embeds the hint in event.data so the hoist list picks it up.
+        let data_str = telemetry_event.data.as_ref().expect("data must be present");
+        let parsed_data: serde_json::Value = serde_json::from_str(data_str).unwrap();
+        assert_eq!(
+            parsed_data["local_reliability_hint"]["recent_abort_rate"]
+                .as_f64()
+                .unwrap_or(-1.0),
+            0.75
+        );
+        assert_eq!(
+            parsed_data["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(4)
+        );
+
+        // And the platform-event payload surfaces the hint at the top level.
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&telemetry_event, &config, None, None, None);
+        assert_eq!(
+            platform.payload["local_reliability_hint"]["recent_abort_rate"]
+                .as_f64()
+                .unwrap_or(-1.0),
+            0.75
+        );
+        assert_eq!(
+            platform.payload["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn routing_decided_event_sanitizes_non_finite_recent_abort_rate() {
+        // Defense-in-depth: the authority emits only finite rates, but
+        // the bridge clamps NaN/Infinity to 0.0 so the platform's typed
+        // Float32 column never receives a JSON null. The clamp lives in
+        // the bridge so any future direct OrchestratorEvent caller (test,
+        // example, FFI) cannot poison the telemetry stream.
+        for bad_rate in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let event = OrchestratorEvent::RoutingDecided {
+                stage_name: "stage-1".to_string(),
+                target: "cloud".to_string(),
+                reason: "history_bias".to_string(),
+                recent_abort_rate: bad_rate,
+                sample_size: 1,
+            };
+            let telemetry_event = convert_orchestrator_event(&event);
+            let parsed_data: serde_json::Value =
+                serde_json::from_str(telemetry_event.data.as_ref().unwrap()).unwrap();
+            assert_eq!(
+                parsed_data["local_reliability_hint"]["recent_abort_rate"].as_f64(),
+                Some(0.0),
+                "non-finite rate {bad_rate} must be sanitized to 0.0"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Plumbs the `LocalReliabilityHint` (`recent_abort_rate` + `sample_size`) from `RoutingDecision` through `Telemetry::log_routing_decision` into the SDK→platform event payload, where it now lands at the top level next to `correlation_id` / `outcome_category` / `abort_reason`.
- Converts the short-lived SDK pipeline bridge from a detached, lossy handoff into a scoped drainable subscription. `Pipeline::run` and `Pipeline::run_async` now drain queued orchestrator events before returning, and those events carry the pipeline/trace context captured for that run instead of reading mutable exporter context later.
- Wires the legacy `xybrid_sdk::run_pipeline` and `run_pipeline_async` entry points through the same orchestrator-event bridge so function-form callers do not drop `RoutingDecided` telemetry.
- Rewords the pipeline subscription comment to avoid overclaiming bootstrap coverage: constructor bootstrap events still happen before pipeline-local subscription, while execution events are now drained deterministically.

## Known gap

- The single-stage streaming LLM fast path still bypasses the orchestrator and therefore does not emit `RoutingDecided` telemetry. That path needs a separate design decision because it intentionally avoids the orchestrator hot path.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p xybrid-core -p xybrid-sdk --features ort-download`
- [x] `cargo test -p xybrid-sdk --features ort-download --lib telemetry::tests::`
- [x] `cargo test -p xybrid-core --features ort-download --lib telemetry::events::tests`
- [x] `cargo test -p xybrid-core --features ort-download --lib event_bus`
- [x] `cargo clippy -p xybrid-core -p xybrid-sdk --all-targets --features ort-download -- -D warnings`
- [x] `cargo clippy --workspace -- -D warnings`
