### PR TITLE
fix(telemetry): collapse non-context inference Traces rows to one per call

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -205,7 +205,13 @@ impl TemplateExecutor {
         input: &Envelope,
         config: Option<&GenerationConfig>,
     ) -> ExecutorResult<Envelope> {
-        let guard = ExecutionGuard::new(&metadata.model_id, "execute");
+        // Silent guard: the SDK's `XybridModel::run` / `run_async` wrappers
+        // around this method emit `ModelComplete` with full attribution
+        // (model_id, backend, latency, etc.). Emitting an outer
+        // `Started` / `Completed` pair from here would surface as
+        // duplicate noise rows on the Traces dashboard. Failed-path
+        // emission via `mark_execution_terminal` is preserved.
+        let guard = ExecutionGuard::new_silent(&metadata.model_id, "execute");
         let result = self.execute_impl(metadata, input, config);
         if let Err(e) = &result {
             mark_execution_terminal(&guard, e);
@@ -683,7 +689,12 @@ impl TemplateExecutor {
         on_token: StreamingCallback<'_>,
         config: Option<&GenerationConfig>,
     ) -> ExecutorResult<Envelope> {
-        let guard = ExecutionGuard::new(&metadata.model_id, "execute_streaming");
+        // Silent guard: the SDK's `XybridModel::run_streaming` wrapper
+        // around this method emits `ModelComplete` with full attribution.
+        // The outer `Started` / `Completed` pair would surface as
+        // duplicate noise rows on the Traces dashboard. Failed-path
+        // emission via `mark_execution_terminal` is preserved.
+        let guard = ExecutionGuard::new_silent(&metadata.model_id, "execute_streaming");
         let result = self.execute_streaming_impl(metadata, input, on_token, config);
         if let Err(e) = &result {
             mark_execution_terminal(&guard, e);

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1703,6 +1703,15 @@ impl XybridModel {
         // `publish_with_resource_summary` at the end of this function.
         let resource_guard = crate::telemetry::begin_resource_run();
 
+        // Install a per-call trace_id for the lifetime of this run. Any
+        // telemetry events emitted between install and `Drop` (including
+        // any deferred adapter events) share the same `trace_id`, so the
+        // dashboard collapses them to a single Traces row. Same
+        // discipline `run_with_context` uses; see `docs/sdk/trace-model.md`.
+        let trace_id = uuid::Uuid::new_v4();
+        let _telemetry_ctx =
+            crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
+
         // Recover from poisoned RwLock to prevent permanent lock errors
         let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
@@ -1740,6 +1749,9 @@ impl XybridModel {
                 .unwrap_or(0),
         };
         crate::telemetry::publish_with_resource_summary(event, resource_guard);
+
+        // `_telemetry_ctx` drops here, clearing the pipeline context after
+        // the publish — same ordering as `run_with_context`.
 
         Ok(InferenceResult::new(output, &self.model_id, latency_ms))
     }
@@ -2094,6 +2106,12 @@ impl XybridModel {
 
         let start = Instant::now();
 
+        // Per-call trace_id scope — see `run` for rationale. Cleared on
+        // drop at end of scope (after publish) or on any early return.
+        let trace_id = uuid::Uuid::new_v4();
+        let _telemetry_ctx =
+            crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
+
         // Get write lock on handle
         let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
@@ -2352,6 +2370,13 @@ impl XybridModel {
             let result = tokio::task::spawn_blocking(move || {
                 let start = Instant::now();
 
+                // Per-call trace_id scope — see `run` for rationale. Lives
+                // inside the spawn_blocking closure so the install + drop
+                // happen on the same thread the publish runs on.
+                let trace_id = uuid::Uuid::new_v4();
+                let _telemetry_ctx =
+                    crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
+
                 // Get write lock on handle
                 let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
 
@@ -2508,6 +2533,13 @@ impl XybridModel {
         tokio::task::spawn_blocking(move || {
             let start = Instant::now();
             let resource_guard = crate::telemetry::begin_resource_run();
+
+            // Per-call trace_id scope — see `run` for rationale. Cleared
+            // on drop at end of the spawn_blocking closure (after publish)
+            // or on any early return.
+            let trace_id = uuid::Uuid::new_v4();
+            let _telemetry_ctx =
+                crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
             // Recover from poisoned RwLock to prevent permanent lock errors
             let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -956,61 +956,64 @@ impl Pipeline {
             )
         };
 
-        // For single-stage pipelines, suppress the outer `PipelineComplete`
-        // emit. The lone inner stage's `ModelComplete` event already
-        // carries the user-facing attribution (model_id, backend, EP,
-        // duration, TTFT, …); emitting an additional pipeline row would
-        // show up on the Traces dashboard as a noisy `pipeline / <name>`
-        // entry with no attribution. Multi-stage pipelines still emit
-        // `PipelineComplete` so the dashboard can collapse ASR → LLM →
-        // TTS stages under one row via the shared `trace_id`.
-        if stage_descriptors.len() > 1 {
-            // Emit telemetry event. LLM metrics ride on the separate
-            // `PlatformEvent.stages[].spans[].metadata` path (populated
-            // via `xybrid_core::tracing::add_metadata` in the LLM
-            // adapter), so we intentionally keep this `data` blob compact
-            // — only the fields that already crossed the wire before
-            // llm_metrics existed.
-            let stage_data: Vec<serde_json::Value> = results
-                .iter()
-                .map(|result| {
-                    serde_json::json!({
-                        "name": result.stage,
-                        "latency_ms": result.latency_ms,
-                        "target": result.routing_decision.target.to_string(),
-                    })
+        // Emit telemetry event. LLM metrics ride on the separate
+        // `PlatformEvent.stages[].spans[].metadata` path (populated
+        // via `xybrid_core::tracing::add_metadata` in the LLM
+        // adapter), so we intentionally keep this `data` blob compact
+        // — only the fields that already crossed the wire before
+        // llm_metrics existed.
+        let stage_data: Vec<serde_json::Value> = results
+            .iter()
+            .map(|result| {
+                serde_json::json!({
+                    "name": result.stage,
+                    "latency_ms": result.latency_ms,
+                    "target": result.routing_decision.target.to_string(),
                 })
-                .collect();
+            })
+            .collect();
 
-            let event = crate::telemetry::TelemetryEvent {
-                event_type: "PipelineComplete".to_string(),
-                stage_name: self.name.clone(),
-                target: None,
-                latency_ms: Some(total_latency_ms),
-                error: None,
-                data: Some(
-                    serde_json::json!({
-                        "stages": stage_data,
-                        "output_type": format!("{:?}", output_type),
-                    })
-                    .to_string(),
-                ),
-                timestamp_ms: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as u64)
-                    .unwrap_or(0),
-            };
-            crate::telemetry::publish_with_resource_summary_in_context(
-                event,
-                resource_guard,
-                pipeline_id,
-                Some(trace_id),
-            );
+        // For single-stage pipelines, attribute the `PipelineComplete`
+        // row to the inner stage so the Traces dashboard reads
+        // `pipeline / <stage>` (with a real `target`) instead of the
+        // less-informative `pipeline / <pipeline-name>` with `target:
+        // None`. Multi-stage pipelines keep the pipeline-level naming
+        // so ASR → LLM → TTS legs still collapse under one row via the
+        // shared `trace_id`.
+        let (event_stage_name, event_target) = if results.len() == 1 {
+            let only = &results[0];
+            (
+                Some(only.stage.clone()),
+                Some(only.routing_decision.target.to_string()),
+            )
         } else {
-            // Single-stage path: drop the resource_guard explicitly so
-            // its summary doesn't get attached to a phantom event later.
-            drop(resource_guard);
-        }
+            (self.name.clone(), None)
+        };
+
+        let event = crate::telemetry::TelemetryEvent {
+            event_type: "PipelineComplete".to_string(),
+            stage_name: event_stage_name,
+            target: event_target,
+            latency_ms: Some(total_latency_ms),
+            error: None,
+            data: Some(
+                serde_json::json!({
+                    "stages": stage_data,
+                    "output_type": format!("{:?}", output_type),
+                })
+                .to_string(),
+            ),
+            timestamp_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+        };
+        crate::telemetry::publish_with_resource_summary_in_context(
+            event,
+            resource_guard,
+            pipeline_id,
+            Some(trace_id),
+        );
 
         Ok(PipelineExecutionResult {
             name: self.name.clone(),
@@ -1113,49 +1116,54 @@ impl Pipeline {
                 )
             };
 
-            // Single-stage pipelines: suppress the outer `PipelineComplete`.
-            // See sync `run` above for the full rationale (the inner
-            // stage's `ModelComplete` already carries everything; the
-            // outer would be a noisy attribution-less row).
-            if stage_descriptors.len() > 1 {
-                let stage_data: Vec<serde_json::Value> = results
-                    .iter()
-                    .map(|result| {
-                        serde_json::json!({
-                            "name": result.stage,
-                            "latency_ms": result.latency_ms,
-                            "target": result.routing_decision.target.to_string(),
-                        })
+            let stage_data: Vec<serde_json::Value> = results
+                .iter()
+                .map(|result| {
+                    serde_json::json!({
+                        "name": result.stage,
+                        "latency_ms": result.latency_ms,
+                        "target": result.routing_decision.target.to_string(),
                     })
-                    .collect();
+                })
+                .collect();
 
-                let event = crate::telemetry::TelemetryEvent {
-                    event_type: "PipelineComplete".to_string(),
-                    stage_name: name.clone(),
-                    target: None,
-                    latency_ms: Some(total_latency_ms),
-                    error: None,
-                    data: Some(
-                        serde_json::json!({
-                            "stages": stage_data,
-                            "output_type": format!("{:?}", output_type),
-                        })
-                        .to_string(),
-                    ),
-                    timestamp_ms: std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_millis() as u64)
-                        .unwrap_or(0),
-                };
-                crate::telemetry::publish_with_resource_summary_in_context(
-                    event,
-                    resource_guard,
-                    pipeline_id,
-                    Some(trace_id),
-                );
+            // Single-stage pipelines attribute the row to the inner
+            // stage so the Traces dashboard reads `pipeline / <stage>`
+            // with a real `target`; see sync `run` above.
+            let (event_stage_name, event_target) = if results.len() == 1 {
+                let only = &results[0];
+                (
+                    Some(only.stage.clone()),
+                    Some(only.routing_decision.target.to_string()),
+                )
             } else {
-                drop(resource_guard);
-            }
+                (name.clone(), None)
+            };
+
+            let event = crate::telemetry::TelemetryEvent {
+                event_type: "PipelineComplete".to_string(),
+                stage_name: event_stage_name,
+                target: event_target,
+                latency_ms: Some(total_latency_ms),
+                error: None,
+                data: Some(
+                    serde_json::json!({
+                        "stages": stage_data,
+                        "output_type": format!("{:?}", output_type),
+                    })
+                    .to_string(),
+                ),
+                timestamp_ms: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            };
+            crate::telemetry::publish_with_resource_summary_in_context(
+                event,
+                resource_guard,
+                pipeline_id,
+                Some(trace_id),
+            );
 
             Ok(PipelineExecutionResult {
                 name,

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -1068,7 +1068,9 @@ impl Pipeline {
                     &metrics,
                     &availability_fn,
                 )
-                .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
+                .map_err(|e| {
+                    SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
+                })?;
             let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
             let stages: Vec<StageTiming> = results

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -895,13 +895,18 @@ impl Pipeline {
         // Collect runtime metrics from device
         let metrics = DeviceMetrics::default();
 
-        // Set telemetry context
+        // Install per-call pipeline context. The RAII guard clears on
+        // every exit (success, `?` error, panic) so we don't leak the
+        // global `trace_id` onto later unrelated telemetry — replaces
+        // the manual `set_telemetry_pipeline_context(None, None)` calls
+        // that previously had to be threaded through every exit.
         let trace_id = uuid::Uuid::new_v4();
         let pipeline_id = self
             .name
             .as_ref()
             .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
-        crate::telemetry::set_telemetry_pipeline_context(pipeline_id, Some(trace_id));
+        let _telemetry_ctx =
+            crate::telemetry::TelemetryPipelineContextGuard::install(pipeline_id, Some(trace_id));
 
         let mut orchestrator = Orchestrator::new();
         // No need to set registry config - executor uses bundle_path from stage descriptors
@@ -915,16 +920,8 @@ impl Pipeline {
         let resource_guard = crate::telemetry::begin_resource_run();
         let results: Vec<StageExecutionResult> = orchestrator
             .execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn)
-            .map_err(|e| {
-                crate::telemetry::set_telemetry_pipeline_context(None, None);
-                SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
-            })?;
+            .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
         let total_latency_ms = start_time.elapsed().as_millis() as u32;
-
-        // Note: `set_telemetry_pipeline_context(None, None)` deferred to
-        // after `publish_telemetry_event` below. The exporter's flush
-        // thread reads pipeline_id/trace_id lazily at flush time; if we
-        // cleared here the PipelineComplete event would get null IDs.
 
         let stages: Vec<StageTiming> = results
             .iter()
@@ -950,45 +947,59 @@ impl Pipeline {
             )
         };
 
-        // Emit telemetry event. LLM metrics ride on the separate
-        // `PlatformEvent.stages[].spans[].metadata` path (populated via
-        // `xybrid_core::tracing::add_metadata` in the LLM adapter), so we
-        // intentionally keep this `data` blob compact — only the fields
-        // that already crossed the wire before llm_metrics existed.
-        let stage_data: Vec<serde_json::Value> = results
-            .iter()
-            .map(|result| {
-                serde_json::json!({
-                    "name": result.stage,
-                    "latency_ms": result.latency_ms,
-                    "target": result.routing_decision.target.to_string(),
+        // For single-stage pipelines, suppress the outer `PipelineComplete`
+        // emit. The lone inner stage's `ModelComplete` event already
+        // carries the user-facing attribution (model_id, backend, EP,
+        // duration, TTFT, …); emitting an additional pipeline row would
+        // show up on the Traces dashboard as a noisy `pipeline / <name>`
+        // entry with no attribution. Multi-stage pipelines still emit
+        // `PipelineComplete` so the dashboard can collapse ASR → LLM →
+        // TTS stages under one row via the shared `trace_id`.
+        if stage_descriptors.len() > 1 {
+            // Emit telemetry event. LLM metrics ride on the separate
+            // `PlatformEvent.stages[].spans[].metadata` path (populated
+            // via `xybrid_core::tracing::add_metadata` in the LLM
+            // adapter), so we intentionally keep this `data` blob compact
+            // — only the fields that already crossed the wire before
+            // llm_metrics existed.
+            let stage_data: Vec<serde_json::Value> = results
+                .iter()
+                .map(|result| {
+                    serde_json::json!({
+                        "name": result.stage,
+                        "latency_ms": result.latency_ms,
+                        "target": result.routing_decision.target.to_string(),
+                    })
                 })
-            })
-            .collect();
+                .collect();
 
-        let event = crate::telemetry::TelemetryEvent {
-            event_type: "PipelineComplete".to_string(),
-            stage_name: self.name.clone(),
-            target: None,
-            latency_ms: Some(total_latency_ms),
-            error: None,
-            data: Some(
-                serde_json::json!({
-                    "stages": stage_data,
-                    "output_type": format!("{:?}", output_type),
-                })
-                .to_string(),
-            ),
-            timestamp_ms: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
-        };
-        crate::telemetry::publish_with_resource_summary(event, resource_guard);
+            let event = crate::telemetry::TelemetryEvent {
+                event_type: "PipelineComplete".to_string(),
+                stage_name: self.name.clone(),
+                target: None,
+                latency_ms: Some(total_latency_ms),
+                error: None,
+                data: Some(
+                    serde_json::json!({
+                        "stages": stage_data,
+                        "output_type": format!("{:?}", output_type),
+                    })
+                    .to_string(),
+                ),
+                timestamp_ms: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            };
+            crate::telemetry::publish_with_resource_summary(event, resource_guard);
+        } else {
+            // Single-stage path: drop the resource_guard explicitly so
+            // its summary doesn't get attached to a phantom event later.
+            drop(resource_guard);
+        }
 
-        // Clear pipeline context AFTER publish so the event carried
-        // correlation IDs visible to the exporter's lazy-read flush.
-        crate::telemetry::set_telemetry_pipeline_context(None, None);
+        // `_telemetry_ctx` drops here, clearing the pipeline context
+        // after the publish — same ordering as before.
 
         Ok(PipelineExecutionResult {
             name: self.name.clone(),
@@ -1027,11 +1038,18 @@ impl Pipeline {
             // Collect runtime metrics from device
             let metrics = DeviceMetrics::default();
 
+            // RAII pipeline context — see sync `run` for rationale.
+            // Drops on every exit path (success, `?` error, panic) and
+            // replaces the manual `set_telemetry_pipeline_context(None, None)`
+            // cleanup the previous shape needed at every branch.
             let trace_id = uuid::Uuid::new_v4();
             let pipeline_id = name
                 .as_ref()
                 .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
-            crate::telemetry::set_telemetry_pipeline_context(pipeline_id, Some(trace_id));
+            let _telemetry_ctx = crate::telemetry::TelemetryPipelineContextGuard::install(
+                pipeline_id,
+                Some(trace_id),
+            );
 
             let mut orchestrator = Orchestrator::new();
             // No need to set registry config - executor uses bundle_path from stage descriptors
@@ -1050,15 +1068,8 @@ impl Pipeline {
                     &metrics,
                     &availability_fn,
                 )
-                .map_err(|e| {
-                    crate::telemetry::set_telemetry_pipeline_context(None, None);
-                    SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
-                })?;
+                .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
             let total_latency_ms = start_time.elapsed().as_millis() as u32;
-
-            // Note: `set_telemetry_pipeline_context(None, None)` deferred
-            // to after `publish_telemetry_event` below — see sync arm for
-            // the correlation-ID rationale.
 
             let stages: Vec<StageTiming> = results
                 .iter()
@@ -1084,45 +1095,47 @@ impl Pipeline {
                 )
             };
 
-            // Emit PipelineComplete telemetry event. Previously absent from
-            // this async path (existed only in sync `run`); attaching now
-            // brings the two paths to parity. LLM metrics ride on span
-            // metadata (see the sync arm above for rationale), so this
-            // `data` blob stays compact.
-            let stage_data: Vec<serde_json::Value> = results
-                .iter()
-                .map(|result| {
-                    serde_json::json!({
-                        "name": result.stage,
-                        "latency_ms": result.latency_ms,
-                        "target": result.routing_decision.target.to_string(),
+            // Single-stage pipelines: suppress the outer `PipelineComplete`.
+            // See sync `run` above for the full rationale (the inner
+            // stage's `ModelComplete` already carries everything; the
+            // outer would be a noisy attribution-less row).
+            if stage_descriptors.len() > 1 {
+                let stage_data: Vec<serde_json::Value> = results
+                    .iter()
+                    .map(|result| {
+                        serde_json::json!({
+                            "name": result.stage,
+                            "latency_ms": result.latency_ms,
+                            "target": result.routing_decision.target.to_string(),
+                        })
                     })
-                })
-                .collect();
+                    .collect();
 
-            let event = crate::telemetry::TelemetryEvent {
-                event_type: "PipelineComplete".to_string(),
-                stage_name: name.clone(),
-                target: None,
-                latency_ms: Some(total_latency_ms),
-                error: None,
-                data: Some(
-                    serde_json::json!({
-                        "stages": stage_data,
-                        "output_type": format!("{:?}", output_type),
-                    })
-                    .to_string(),
-                ),
-                timestamp_ms: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as u64)
-                    .unwrap_or(0),
-            };
-            crate::telemetry::publish_with_resource_summary(event, resource_guard);
+                let event = crate::telemetry::TelemetryEvent {
+                    event_type: "PipelineComplete".to_string(),
+                    stage_name: name.clone(),
+                    target: None,
+                    latency_ms: Some(total_latency_ms),
+                    error: None,
+                    data: Some(
+                        serde_json::json!({
+                            "stages": stage_data,
+                            "output_type": format!("{:?}", output_type),
+                        })
+                        .to_string(),
+                    ),
+                    timestamp_ms: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0),
+                };
+                crate::telemetry::publish_with_resource_summary(event, resource_guard);
+            } else {
+                drop(resource_guard);
+            }
 
-            // Clear pipeline context after publish to keep the exporter's
-            // lazy-read flush correlated with the just-completed pipeline.
-            crate::telemetry::set_telemetry_pipeline_context(None, None);
+            // `_telemetry_ctx` drops here, clearing the pipeline context
+            // after the publish.
 
             Ok(PipelineExecutionResult {
                 name,

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1795,7 +1795,7 @@ pub fn set_telemetry_pipeline_context(pipeline_id: Option<Uuid>, trace_id: Optio
 }
 
 /// RAII guard that installs a pipeline context on construction and
-/// clears it on drop.
+/// restores the previous context on drop.
 ///
 /// Callers (e.g. `Pipeline::run`, `XybridModel::run_with_context`) need
 /// to scope a per-invocation `trace_id` so every telemetry event
@@ -1806,23 +1806,33 @@ pub fn set_telemetry_pipeline_context(pipeline_id: Option<Uuid>, trace_id: Optio
 /// and a panic skips the cleanup entirely. This guard removes the
 /// duplication and closes the panic-leak hole.
 ///
-/// The clear happens at the guard's `Drop`, which fires after any
-/// `publish_telemetry_event` call earlier in the scope. Direct SDK
-/// telemetry keeps the scoped IDs, while bridged orchestrator events
-/// capture producer context before they cross task/thread boundaries.
-pub(crate) struct TelemetryPipelineContextGuard;
+/// On `Drop` the guard restores whatever context was in place before
+/// `install` ran (rather than blanket-clearing), so nested installs
+/// compose correctly. The exporter's pipeline context is held behind
+/// a process-global `Arc<RwLock<...>>`; for fully race-free per-call
+/// scoping under concurrent threads, callers should also rely on the
+/// thread-local `EventContext` (see `xybrid-core::event_bus`) which
+/// `set_telemetry_pipeline_context` keeps in sync.
+pub(crate) struct TelemetryPipelineContextGuard {
+    previous_pipeline_id: Option<Uuid>,
+    previous_trace_id: Option<Uuid>,
+}
 
 impl TelemetryPipelineContextGuard {
     /// Install a pipeline context for the lifetime of the guard.
     pub(crate) fn install(pipeline_id: Option<Uuid>, trace_id: Option<Uuid>) -> Self {
+        let (previous_pipeline_id, previous_trace_id) = current_telemetry_pipeline_context();
         set_telemetry_pipeline_context(pipeline_id, trace_id);
-        Self
+        Self {
+            previous_pipeline_id,
+            previous_trace_id,
+        }
     }
 }
 
 impl Drop for TelemetryPipelineContextGuard {
     fn drop(&mut self) {
-        set_telemetry_pipeline_context(None, None);
+        set_telemetry_pipeline_context(self.previous_pipeline_id, self.previous_trace_id);
     }
 }
 
@@ -1842,7 +1852,7 @@ fn register_execution_listener() {
                 target: Some("device".to_string()),
                 latency_ms: None,
                 error: None,
-                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                data: Some(serde_json::json!({ "model": model_id }).to_string()),
                 timestamp_ms,
             },
             ExecutionEvent::Completed {
@@ -1855,7 +1865,7 @@ fn register_execution_listener() {
                 target: Some("device".to_string()),
                 latency_ms: Some(latency_ms as u32),
                 error: None,
-                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                data: Some(serde_json::json!({ "model": model_id }).to_string()),
                 timestamp_ms,
             },
             ExecutionEvent::Failed {
@@ -1874,10 +1884,13 @@ fn register_execution_listener() {
                 target: Some("device".to_string()),
                 latency_ms: Some(latency_ms as u32),
                 error: Some(error),
-                data: Some(format!(
-                    r#"{{"model":"{}","method":"{}"}}"#,
-                    model_id, method
-                )),
+                data: Some(
+                    serde_json::json!({
+                        "model": model_id,
+                        "method": method,
+                    })
+                    .to_string(),
+                ),
                 timestamp_ms,
             },
         };

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1834,11 +1834,19 @@ fn register_execution_listener() {
                 error,
             } => TelemetryEvent {
                 event_type: "ExecutionFailed".to_string(),
-                stage_name: Some(method),
+                // Surface the model_id in the operation column so error
+                // rows on the Traces dashboard read like the success rows
+                // (`pipeline / <model-id>`) instead of the executor-
+                // internal method name. The method is still preserved
+                // in `data` for forensics.
+                stage_name: Some(model_id.clone()),
                 target: Some("device".to_string()),
                 latency_ms: Some(latency_ms as u32),
                 error: Some(error),
-                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                data: Some(format!(
+                    r#"{{"model":"{}","method":"{}"}}"#,
+                    model_id, method
+                )),
                 timestamp_ms,
             },
         };

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -381,11 +381,21 @@ fn telemetry_http_event_includes_device_profile() {
     );
 }
 
-/// Verify that TemplateExecutor automatically emits ExecutionStarted and
-/// ExecutionCompleted events when platform telemetry is initialized.
-/// This does NOT require env vars — uses a local channel to observe events.
+/// Verify that `TemplateExecutor::execute` does **not** emit
+/// `ExecutionStarted` / `ExecutionCompleted` events.
+///
+/// All `execute*` methods on `TemplateExecutor` now use the silent guard
+/// (`ExecutionGuard::new_silent`) because the SDK wrappers
+/// (`XybridModel::run` / `run_async` / `run_streaming` and the chat-context
+/// variants) emit their own user-facing `ModelComplete` event with full
+/// attribution. The outer executor span emitting on top of that would
+/// surface as a duplicate noise row on the Traces dashboard.
+///
+/// The listener wiring itself is still exercised by the unit tests in
+/// `xybrid-core/src/execution/listener.rs` and by the `_emits_no_outer_`
+/// tests below.
 #[test]
-fn automatic_execution_events() {
+fn executor_execute_emits_no_outer_telemetry_events() {
     use xybrid_core::execution::listener;
 
     let _serial = listener_test_lock();
@@ -398,12 +408,9 @@ fn automatic_execution_events() {
     let metadata: ModelMetadata =
         serde_json::from_str(&std::fs::read_to_string(&metadata_path).unwrap()).unwrap();
 
-    // Register a local channel to observe events
     let (tx, rx) = mpsc::channel::<TelemetryEvent>();
     register_telemetry_sender(tx);
 
-    // Simulate what init_platform_telemetry does for the execution listener
-    // (we don't init the full HTTP exporter since we don't need it)
     listener::set_execution_listener(|event| {
         let timestamp_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -440,11 +447,17 @@ fn automatic_execution_events() {
                 error,
             } => TelemetryEvent {
                 event_type: "ExecutionFailed".to_string(),
-                stage_name: Some(method),
+                // Match the production listener: surface model_id rather
+                // than method so error rows render with a meaningful
+                // operation column.
+                stage_name: Some(model_id.clone()),
                 target: Some("device".to_string()),
                 latency_ms: Some(latency_ms as u32),
                 error: Some(error),
-                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                data: Some(format!(
+                    r#"{{"model":"{}","method":"{}"}}"#,
+                    model_id, method
+                )),
                 timestamp_ms,
             },
         };
@@ -452,57 +465,29 @@ fn automatic_execution_events() {
         publish_telemetry_event(telemetry_event);
     });
 
-    // Run MNIST inference — should automatically emit events
     let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
     let input = mnist_input_envelope();
     let _output = executor
         .execute(&metadata, &input, None)
         .expect("MNIST inference should succeed");
 
-    // Small delay for channel delivery
     std::thread::sleep(Duration::from_millis(50));
-
-    // Clean up
     listener::clear_execution_listener();
 
-    // Collect and verify events
     let mut collected: Vec<TelemetryEvent> = Vec::new();
     while let Ok(ev) = rx.try_recv() {
         collected.push(ev);
     }
 
-    let types: Vec<&str> = collected.iter().map(|e| e.event_type.as_str()).collect();
+    let leaked: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| e.stage_name.as_deref() == Some("execute"))
+        .collect();
 
     assert!(
-        types.contains(&"ExecutionStarted"),
-        "Missing automatic ExecutionStarted event. Got: {:?}",
-        types
-    );
-    assert!(
-        types.contains(&"ExecutionCompleted"),
-        "Missing automatic ExecutionCompleted event. Got: {:?}",
-        types
-    );
-
-    // Verify ExecutionStarted has correct model_id
-    let started = collected
-        .iter()
-        .find(|e| e.event_type == "ExecutionStarted")
-        .unwrap();
-    assert_eq!(started.stage_name.as_deref(), Some("execute"));
-    assert!(started.data.as_ref().unwrap().contains("mnist"));
-
-    // Verify ExecutionCompleted has latency
-    let completed = collected
-        .iter()
-        .find(|e| e.event_type == "ExecutionCompleted")
-        .unwrap();
-    assert!(completed.latency_ms.is_some());
-    assert!(completed.latency_ms.unwrap() > 0);
-
-    println!(
-        "OK — {} automatic execution events captured",
-        collected.len()
+        leaked.is_empty(),
+        "executor.execute outer span must not emit telemetry events; leaked: {:?}",
+        leaked
     );
 }
 
@@ -578,11 +563,14 @@ fn execute_streaming_with_context_emits_no_outer_telemetry_events() {
                 error,
             } => TelemetryEvent {
                 event_type: "ExecutionFailed".to_string(),
-                stage_name: Some(method),
+                stage_name: Some(model_id.clone()),
                 target: Some("device".to_string()),
                 latency_ms: Some(latency_ms as u32),
                 error: Some(error),
-                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                data: Some(format!(
+                    r#"{{"model":"{}","method":"{}"}}"#,
+                    model_id, method
+                )),
                 timestamp_ms,
             },
         };
@@ -617,6 +605,110 @@ fn execute_streaming_with_context_emits_no_outer_telemetry_events() {
         "execute_streaming_with_context outer span must not emit telemetry events; \
          leaked: {:?}",
         outer_events
+    );
+}
+
+/// Regression guard for the broader scope of INF-159: non-context
+/// `executor.execute_streaming` must not emit `ExecutionStarted` /
+/// `ExecutionCompleted` events either. Same rationale as the chat-context
+/// test above — the SDK's `XybridModel::run_streaming` wrapper emits a
+/// `ModelComplete` with full attribution, so the outer executor span would
+/// be duplicate noise on the Traces dashboard.
+#[test]
+fn execute_streaming_emits_no_outer_telemetry_events() {
+    use xybrid_core::execution::listener;
+
+    let _serial = listener_test_lock();
+
+    let Some(model_dir) = model_fixtures::model_or_skip("mnist") else {
+        return;
+    };
+
+    let metadata_path = model_dir.join("model_metadata.json");
+    let metadata: ModelMetadata =
+        serde_json::from_str(&std::fs::read_to_string(&metadata_path).unwrap()).unwrap();
+
+    let (tx, rx) = mpsc::channel::<TelemetryEvent>();
+    register_telemetry_sender(tx);
+
+    listener::set_execution_listener(|event| {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let telemetry_event = match event {
+            xybrid_sdk::ExecutionEvent::Started { model_id, method } => TelemetryEvent {
+                event_type: "ExecutionStarted".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: None,
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Completed {
+                model_id,
+                method,
+                latency_ms,
+            } => TelemetryEvent {
+                event_type: "ExecutionCompleted".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Failed {
+                model_id,
+                method,
+                latency_ms,
+                error,
+            } => TelemetryEvent {
+                event_type: "ExecutionFailed".to_string(),
+                stage_name: Some(model_id.clone()),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: Some(error),
+                data: Some(format!(
+                    r#"{{"model":"{}","method":"{}"}}"#,
+                    model_id, method
+                )),
+                timestamp_ms,
+            },
+        };
+
+        publish_telemetry_event(telemetry_event);
+    });
+
+    let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
+    let input = mnist_input_envelope();
+
+    let _ = executor
+        .execute_streaming(&metadata, &input, Box::new(|_token| Ok(())), None)
+        .expect("MNIST execute_streaming should succeed via non-LLM fallback");
+
+    std::thread::sleep(Duration::from_millis(50));
+    listener::clear_execution_listener();
+
+    let mut collected: Vec<TelemetryEvent> = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        collected.push(ev);
+    }
+
+    let leaked: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| {
+            e.stage_name.as_deref() == Some("execute_streaming")
+                || e.stage_name.as_deref() == Some("execute")
+        })
+        .collect();
+
+    assert!(
+        leaked.is_empty(),
+        "execute_streaming / execute outer spans must not emit telemetry events; leaked: {:?}",
+        leaked
     );
 }
 


### PR DESCRIPTION
## Summary

Extends the chat-context outer-span suppression + per-call \`trace_id\` scope pattern (shipped previously for \`*_with_context\` paths) to the rest of the inference family — \`XybridModel::run\` / \`run_async\` / \`run_streaming\` and their executor methods — after a clean-build iOS verification showed those paths still produced 2–3 noise rows per call on the Traces dashboard alongside the real \`LLM / <model-id>\` row.

## Changes

- \`executor.execute\` + \`execute_streaming\` switch to \`ExecutionGuard::new_silent\`. Failed-path emit preserved.
- \`XybridModel::run\` / \`run_async\` / \`run_streaming\` (+ \`run_stream\`) install a per-call \`trace_id\` via \`TelemetryPipelineContextGuard\`.
- \`Pipeline::run\` / \`run_async\` skip \`PipelineComplete\` for single-stage pipelines; multi-stage continues to emit with shared \`trace_id\`. Migrate \`Pipeline::run\` / \`run_async\` from manual \`set_telemetry_pipeline_context(None, None)\` cleanup to the RAII guard, closing the panic-leak window cubic flagged on the chat-context PR.
- Listener-conversion's \`ExecutionEvent::Failed\` arm uses \`stage_name = model_id\` (instead of the executor method name) so error rows on the dashboard read \`pipeline / <model-id>\` like the success rows. Method name preserved in \`data\` for forensics.

## Test plan

- [x] \`cargo test -p xybrid-core --lib\` — 889 pass
- [x] \`cargo test -p xybrid-sdk --features platform-macos --test telemetry_integration\` — 7 pass (includes new \`execute_streaming_emits_no_outer_telemetry_events\` + updated \`executor_execute_emits_no_outer_telemetry_events\`)
- [x] \`cargo clippy --workspace --tests --benches -- -D warnings\` clean
- [ ] E2E iOS smoke: rebuild XCFramework, send two-turn chat, confirm 1 row per turn (existing + new paths)