### PR TITLE
fix(routing): plumb resolver reliability hint

### DIFF
--- a/crates/xybrid-core/src/pipeline/resolver.rs
+++ b/crates/xybrid-core/src/pipeline/resolver.rs
@@ -12,7 +12,9 @@ use super::target::ExecutionTarget;
 use crate::context::DeviceMetrics;
 use crate::device::capabilities::HardwareCapabilities;
 use crate::device::MemoryPressure;
-use crate::orchestrator::routing_engine::{LocalAvailability, RouteTarget, RoutingDecision};
+use crate::orchestrator::routing_engine::{
+    LocalAvailability, LocalReliabilityHint, RouteTarget, RoutingDecision,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Resolution context containing all information needed to resolve execution targets.
@@ -140,14 +142,17 @@ impl ResolvedTarget {
     }
 
     /// Convert to a RoutingDecision for telemetry.
-    pub fn to_routing_decision(&self, stage: &str) -> RoutingDecision {
+    pub fn to_routing_decision(
+        &self,
+        stage: &str,
+        local_reliability_hint: LocalReliabilityHint,
+    ) -> RoutingDecision {
         RoutingDecision {
             stage: stage.to_string(),
             target: self.target.clone(),
             reason: self.reason.clone(),
             timestamp_ms: current_timestamp_ms(),
-            local_reliability_hint:
-                crate::orchestrator::routing_engine::LocalReliabilityHint::EMPTY,
+            local_reliability_hint,
         }
     }
 }
@@ -563,7 +568,10 @@ mod tests {
     #[test]
     fn test_resolved_target_to_routing_decision() {
         let resolved = ResolvedTarget::local("wav2vec2", Some("1.0"), "test reason");
-        let decision = resolved.to_routing_decision("asr");
+        let decision = resolved.to_routing_decision(
+            "asr",
+            crate::orchestrator::routing_engine::LocalReliabilityHint::EMPTY,
+        );
 
         assert_eq!(decision.stage, "asr");
         assert_eq!(decision.target, RouteTarget::Local);
@@ -572,32 +580,14 @@ mod tests {
     }
 
     #[test]
-    fn resolved_target_to_routing_decision_currently_drops_local_reliability_hint() {
-        // REGRESSION-PIN for a KNOWN GAP at `ResolvedTarget::to_routing_decision`
-        // (above in this file): the function hardcodes
-        // `LocalReliabilityHint::EMPTY` because it has no access to the
-        // `LocalAuthority`'s reliability history. Every routing decision
-        // emitted through this path carries `sample_size=0` and
-        // `recent_abort_rate=0.0`, regardless of the device's actual
-        // local-failure history.
-        //
-        // The main routing path (`DefaultRoutingEngine::decide`) populates
-        // the hint correctly via `LocalAuthority::history_hint`. This
-        // second emission seam was missed.
-        //
-        // When this gap is closed (the resolver gains access to an
-        // authority or accepts a pre-computed hint), this test will start
-        // failing. Update it to assert that the real hint flows through.
+    fn resolved_target_to_routing_decision_carries_local_reliability_hint() {
         let resolved = ResolvedTarget::local("wav2vec2", Some("1.0"), "test reason");
-        let decision = resolved.to_routing_decision("asr");
+        let hint = crate::orchestrator::routing_engine::LocalReliabilityHint {
+            recent_abort_rate: 0.75,
+            sample_size: 4,
+        };
+        let decision = resolved.to_routing_decision("asr", hint);
 
-        assert_eq!(
-            decision.local_reliability_hint.recent_abort_rate, 0.0,
-            "regression-pin: see comment above — resolver drops the hint"
-        );
-        assert_eq!(
-            decision.local_reliability_hint.sample_size, 0,
-            "regression-pin: see comment above — resolver drops the hint"
-        );
+        assert_eq!(decision.local_reliability_hint, hint);
     }
 }


### PR DESCRIPTION
## Summary

- Thread `LocalReliabilityHint` through `ResolvedTarget::to_routing_decision` instead of hardcoding `EMPTY`.
- Replace the xybrid#103 regression-pin test with a positive assertion that a populated hint survives resolver emission.

## Why

`ResolvedTarget::to_routing_decision` was a secondary telemetry emission path that dropped local reliability history. Callers can now pass the same precomputed hint used by the routing-authority path.

Linear: INF-161

## Validation

- `cargo test -p xybrid-core resolved_target_to_routing_decision --lib`
- `cargo test -p xybrid-core routing_decision_json --lib`
- `cargo test -p xybrid-core reliability --lib`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download`
