### PR TITLE
fix(sdk): drain telemetry bridge with captured run context

### DIFF
--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -173,7 +173,7 @@ pub(crate) fn handle_repl_command(
     };
 
     let mut orchestrator = Orchestrator::new();
-    xybrid_sdk::bridge_orchestrator_events(&orchestrator);
+    let bridge = xybrid_sdk::bridge_orchestrator_events(&orchestrator);
 
     warmup_models(&mut orchestrator, &stages, &metrics, &availability_fn);
 
@@ -278,6 +278,11 @@ pub(crate) fn handle_repl_command(
             verbose,
         );
     }
+
+    drop(orchestrator);
+    bridge
+        .join()
+        .map_err(|e| anyhow::anyhow!("Orchestrator event bridge failed: {}", e))?;
 
     Ok(())
 }

--- a/crates/xybrid-cli/src/commands/run.rs
+++ b/crates/xybrid-cli/src/commands/run.rs
@@ -329,7 +329,6 @@ fn execute_pipeline(
     trace_export: Option<&PathBuf>,
 ) -> Result<()> {
     let mut orchestrator = Orchestrator::new();
-    xybrid_sdk::bridge_orchestrator_events(&orchestrator);
 
     if let Some(policy_file) = policy_path {
         ui::kv("Policy", &policy_file.display().to_string());
@@ -346,7 +345,14 @@ fn execute_pipeline(
 
     let sp = ui::spinner("Executing pipeline...");
 
-    match orchestrator.execute_pipeline(stages, input, metrics, availability_fn) {
+    let bridge = xybrid_sdk::bridge_orchestrator_events(&orchestrator);
+    let execution_result = orchestrator.execute_pipeline(stages, input, metrics, availability_fn);
+    drop(orchestrator);
+    bridge
+        .join()
+        .map_err(|e| anyhow::anyhow!("Orchestrator event bridge failed: {}", e))?;
+
+    match execution_result {
         Ok(results) => {
             sp.finish_and_clear();
             print_pipeline_results(&results, output_path)?;

--- a/crates/xybrid-core/src/event_bus.rs
+++ b/crates/xybrid-core/src/event_bus.rs
@@ -6,28 +6,157 @@
 //! For MVP, this implements a simple event enum with a synchronous broadcast channel.
 //! Future versions will support async channels (Tokio) and more sophisticated event routing.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use uuid::Uuid;
+
+thread_local! {
+    static CURRENT_EVENT_CONTEXT: RefCell<EventContext> = RefCell::new(EventContext::default());
+}
+
+/// Producer-side context attached to orchestrator events before they cross
+/// thread/task boundaries.
+///
+/// Consumers should read this struct from the event payload. They must not
+/// assume telemetry task-local or thread-local state is still available when
+/// a bridge drains the event later.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EventContext {
+    pub pipeline_id: Option<Uuid>,
+    pub trace_id: Option<Uuid>,
+    pub correlation_id: Option<String>,
+    pub request_id: Option<String>,
+    pub model_id: Option<String>,
+    pub span_id: Option<String>,
+}
+
+impl EventContext {
+    pub fn current() -> Self {
+        CURRENT_EVENT_CONTEXT.with(|context| context.borrow().clone())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pipeline_id.is_none()
+            && self.trace_id.is_none()
+            && self.correlation_id.is_none()
+            && self.request_id.is_none()
+            && self.model_id.is_none()
+            && self.span_id.is_none()
+    }
+
+    pub fn with_pipeline_id(mut self, pipeline_id: Uuid) -> Self {
+        self.pipeline_id = Some(pipeline_id);
+        self
+    }
+
+    pub fn with_trace_id(mut self, trace_id: Uuid) -> Self {
+        self.trace_id = Some(trace_id);
+        self
+    }
+
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<String>) -> Self {
+        self.correlation_id = Some(correlation_id.into());
+        self
+    }
+
+    pub fn with_request_id(mut self, request_id: impl Into<String>) -> Self {
+        self.request_id = Some(request_id.into());
+        self
+    }
+
+    pub fn with_model_id(mut self, model_id: impl Into<String>) -> Self {
+        self.model_id = Some(model_id.into());
+        self
+    }
+
+    pub fn with_span_id(mut self, span_id: impl Into<String>) -> Self {
+        self.span_id = Some(span_id.into());
+        self
+    }
+
+    fn merge_missing(mut self, fallback: EventContext) -> Self {
+        if self.pipeline_id.is_none() {
+            self.pipeline_id = fallback.pipeline_id;
+        }
+        if self.trace_id.is_none() {
+            self.trace_id = fallback.trace_id;
+        }
+        if self.correlation_id.is_none() {
+            self.correlation_id = fallback.correlation_id;
+        }
+        if self.request_id.is_none() {
+            self.request_id = fallback.request_id;
+        }
+        if self.model_id.is_none() {
+            self.model_id = fallback.model_id;
+        }
+        if self.span_id.is_none() {
+            self.span_id = fallback.span_id;
+        }
+        self
+    }
+}
+
+/// RAII guard for temporarily installing a producer event context.
+pub struct EventContextGuard {
+    previous: EventContext,
+}
+
+impl EventContextGuard {
+    pub fn install(context: EventContext) -> Self {
+        let previous = CURRENT_EVENT_CONTEXT.with(|slot| slot.replace(context));
+        Self { previous }
+    }
+}
+
+impl Drop for EventContextGuard {
+    fn drop(&mut self) {
+        CURRENT_EVENT_CONTEXT.with(|slot| {
+            slot.replace(self.previous.clone());
+        });
+    }
+}
+
+pub fn set_current_event_context(context: EventContext) {
+    CURRENT_EVENT_CONTEXT.with(|slot| {
+        slot.replace(context);
+    });
+}
+
+pub fn clear_current_event_context() {
+    set_current_event_context(EventContext::default());
+}
 
 /// Event types that can be published to the event bus.
 #[derive(Debug, Clone)]
 pub enum OrchestratorEvent {
     /// Stage execution started.
-    StageStart { stage_name: String },
+    StageStart {
+        stage_name: String,
+        context: EventContext,
+    },
     /// Stage execution completed.
     StageComplete {
         stage_name: String,
         target: String,
         latency_ms: u32,
+        context: EventContext,
     },
     /// Stage execution failed.
-    StageError { stage_name: String, error: String },
+    StageError {
+        stage_name: String,
+        error: String,
+        context: EventContext,
+    },
     /// Policy evaluation occurred.
     PolicyEvaluated {
         stage_name: String,
         allowed: bool,
         reason: Option<String>,
+        context: EventContext,
     },
     /// Routing decision was made.
     ///
@@ -44,20 +173,27 @@ pub enum OrchestratorEvent {
         reason: String,
         recent_abort_rate: f32,
         sample_size: u32,
+        context: EventContext,
     },
     /// Execution started.
-    ExecutionStarted { stage_name: String, target: String },
+    ExecutionStarted {
+        stage_name: String,
+        target: String,
+        context: EventContext,
+    },
     /// Execution completed.
     ExecutionCompleted {
         stage_name: String,
         target: String,
         execution_time_ms: u32,
+        context: EventContext,
     },
     /// Execution failed.
     ExecutionFailed {
         stage_name: String,
         target: String,
         error: String,
+        context: EventContext,
     },
     /// Local execution was cooperatively aborted (e.g. resource pressure
     /// triggered an `AbortPolicy`). Distinct from `ExecutionFailed` because
@@ -71,21 +207,81 @@ pub enum OrchestratorEvent {
         stage_name: String,
         target: String,
         reason: String,
+        context: EventContext,
     },
     /// Pipeline started.
-    PipelineStart { stages: Vec<String> },
+    PipelineStart {
+        stages: Vec<String>,
+        context: EventContext,
+    },
     /// Pipeline completed.
-    PipelineComplete { total_latency_ms: u32 },
+    PipelineComplete {
+        total_latency_ms: u32,
+        context: EventContext,
+    },
     /// Bootstrap process started.
-    BootstrapStart,
+    BootstrapStart { context: EventContext },
     /// Component initialized during bootstrap.
-    ComponentInitialized { component: String },
+    ComponentInitialized {
+        component: String,
+        context: EventContext,
+    },
     /// Adapter registered during bootstrap.
-    AdapterRegistered { name: String },
+    AdapterRegistered { name: String, context: EventContext },
     /// Executor is ready with registered adapters.
-    ExecutorReady,
+    ExecutorReady { context: EventContext },
     /// Orchestrator is fully initialized and ready.
-    OrchestratorReady,
+    OrchestratorReady { context: EventContext },
+}
+
+impl OrchestratorEvent {
+    pub fn context(&self) -> &EventContext {
+        match self {
+            Self::StageStart { context, .. }
+            | Self::StageComplete { context, .. }
+            | Self::StageError { context, .. }
+            | Self::PolicyEvaluated { context, .. }
+            | Self::RoutingDecided { context, .. }
+            | Self::ExecutionStarted { context, .. }
+            | Self::ExecutionCompleted { context, .. }
+            | Self::ExecutionFailed { context, .. }
+            | Self::LocalAborted { context, .. }
+            | Self::PipelineStart { context, .. }
+            | Self::PipelineComplete { context, .. }
+            | Self::BootstrapStart { context }
+            | Self::ComponentInitialized { context, .. }
+            | Self::AdapterRegistered { context, .. }
+            | Self::ExecutorReady { context }
+            | Self::OrchestratorReady { context } => context,
+        }
+    }
+
+    fn context_mut(&mut self) -> &mut EventContext {
+        match self {
+            Self::StageStart { context, .. }
+            | Self::StageComplete { context, .. }
+            | Self::StageError { context, .. }
+            | Self::PolicyEvaluated { context, .. }
+            | Self::RoutingDecided { context, .. }
+            | Self::ExecutionStarted { context, .. }
+            | Self::ExecutionCompleted { context, .. }
+            | Self::ExecutionFailed { context, .. }
+            | Self::LocalAborted { context, .. }
+            | Self::PipelineStart { context, .. }
+            | Self::PipelineComplete { context, .. }
+            | Self::BootstrapStart { context }
+            | Self::ComponentInitialized { context, .. }
+            | Self::AdapterRegistered { context, .. }
+            | Self::ExecutorReady { context }
+            | Self::OrchestratorReady { context } => context,
+        }
+    }
+
+    fn attach_context(mut self, context: EventContext) -> Self {
+        let merged = self.context().clone().merge_missing(context);
+        *self.context_mut() = merged;
+        self
+    }
 }
 
 /// Event subscription handle for managing subscriptions.
@@ -104,6 +300,14 @@ impl Subscription {
     /// Receive the next event, blocking until one is available.
     pub fn recv(&self) -> Result<OrchestratorEvent, mpsc::RecvError> {
         self.receiver.recv()
+    }
+
+    /// Receive the next event, blocking until one is available or timeout elapses.
+    pub fn recv_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<OrchestratorEvent, mpsc::RecvTimeoutError> {
+        self.receiver.recv_timeout(timeout)
     }
 
     /// Get the subscription ID.
@@ -126,6 +330,7 @@ struct Subscriber {
 pub struct EventBus {
     subscribers: Arc<Mutex<HashMap<usize, Subscriber>>>,
     next_id: Arc<Mutex<usize>>,
+    context: EventContext,
 }
 
 impl EventBus {
@@ -134,11 +339,19 @@ impl EventBus {
         Self {
             subscribers: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(Mutex::new(0)),
+            context: EventContext::current(),
         }
     }
 
     /// Publish an event to all subscribers.
     pub fn publish(&self, event: OrchestratorEvent) {
+        let current_context = EventContext::current();
+        let context = if current_context.is_empty() {
+            self.context.clone()
+        } else {
+            current_context.merge_missing(self.context.clone())
+        };
+        let event = event.attach_context(context);
         let subscribers = self.subscribers.lock().unwrap();
         let mut failed_ids = Vec::new();
 
@@ -244,6 +457,10 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
+    fn empty_context() -> EventContext {
+        EventContext::default()
+    }
+
     #[test]
     fn test_event_bus_creation() {
         let bus = EventBus::new();
@@ -257,11 +474,12 @@ mod tests {
 
         bus.publish(OrchestratorEvent::StageStart {
             stage_name: "test_stage".to_string(),
+            context: empty_context(),
         });
 
         let event = subscription.recv().unwrap();
         match event {
-            OrchestratorEvent::StageStart { stage_name } => {
+            OrchestratorEvent::StageStart { stage_name, .. } => {
                 assert_eq!(stage_name, "test_stage");
             }
             _ => panic!("Unexpected event type"),
@@ -276,6 +494,7 @@ mod tests {
 
         bus.publish(OrchestratorEvent::PipelineStart {
             stages: vec!["stage1".to_string(), "stage2".to_string()],
+            context: empty_context(),
         });
 
         let event1 = sub1.recv().unwrap();
@@ -283,8 +502,8 @@ mod tests {
 
         match (event1, event2) {
             (
-                OrchestratorEvent::PipelineStart { stages: s1 },
-                OrchestratorEvent::PipelineStart { stages: s2 },
+                OrchestratorEvent::PipelineStart { stages: s1, .. },
+                OrchestratorEvent::PipelineStart { stages: s2, .. },
             ) => {
                 assert_eq!(s1, s2);
                 assert_eq!(s1.len(), 2);
@@ -311,6 +530,7 @@ mod tests {
             stage_name: "test".to_string(),
             target: "local".to_string(),
             latency_ms: 100,
+            context: empty_context(),
         });
 
         // Give handler thread time to process
@@ -347,6 +567,7 @@ mod tests {
             stage_name: "test".to_string(),
             allowed: true,
             reason: None,
+            context: empty_context(),
         });
 
         // Should receive event now
@@ -367,6 +588,7 @@ mod tests {
             reason: "optimal".to_string(),
             recent_abort_rate: 0.0,
             sample_size: 0,
+            context: empty_context(),
         };
 
         // Verify Clone works
@@ -402,6 +624,7 @@ mod tests {
         // Test all event types
         bus.publish(OrchestratorEvent::StageStart {
             stage_name: "test".to_string(),
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
@@ -409,12 +632,14 @@ mod tests {
             stage_name: "test".to_string(),
             target: "local".to_string(),
             latency_ms: 100,
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
         bus.publish(OrchestratorEvent::StageError {
             stage_name: "test".to_string(),
             error: "test error".to_string(),
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
@@ -422,6 +647,7 @@ mod tests {
             stage_name: "test".to_string(),
             allowed: true,
             reason: Some("policy passed".to_string()),
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
@@ -431,12 +657,14 @@ mod tests {
             reason: "optimal".to_string(),
             recent_abort_rate: 0.0,
             sample_size: 0,
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
         bus.publish(OrchestratorEvent::ExecutionStarted {
             stage_name: "test".to_string(),
             target: "local".to_string(),
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
@@ -444,6 +672,7 @@ mod tests {
             stage_name: "test".to_string(),
             target: "local".to_string(),
             execution_time_ms: 50,
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
 
@@ -451,6 +680,7 @@ mod tests {
             stage_name: "test".to_string(),
             target: "cloud".to_string(),
             error: "execution error".to_string(),
+            context: empty_context(),
         });
         let _ = subscription.recv().unwrap();
     }

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -49,7 +49,7 @@ pub use authority::{
 use crate::context::{DeviceMetrics, StageDescriptor};
 use crate::control_sync::ControlSync;
 use crate::device::ResourceMonitor;
-use crate::event_bus::{EventBus, OrchestratorEvent};
+use crate::event_bus::{EventBus, EventContext, OrchestratorEvent};
 use crate::executor::{Executor, ExecutorError};
 use crate::ir::Envelope;
 use crate::streaming::manager::{StreamManager, StreamManagerConfig as StreamConfig};
@@ -141,6 +141,10 @@ pub struct Orchestrator {
 impl Orchestrator {
     fn effective_model_id(stage: &StageDescriptor) -> String {
         stage.model.clone().unwrap_or_else(|| stage.name.clone())
+    }
+
+    fn event_context_for_stage(stage: &StageDescriptor) -> EventContext {
+        EventContext::default().with_model_id(Self::effective_model_id(stage))
     }
 
     fn build_execution_outcome(
@@ -302,6 +306,7 @@ impl Orchestrator {
         // Emit stage start event
         self.event_bus.publish(OrchestratorEvent::StageStart {
             stage_name: stage.name.clone(),
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_stage_start(&stage.name);
 
@@ -320,6 +325,7 @@ impl Orchestrator {
             stage_name: stage.name.clone(),
             allowed: policy_allowed,
             reason: Some(policy_decision.reason.clone()),
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_policy_evaluation(
             &stage.name,
@@ -355,6 +361,7 @@ impl Orchestrator {
             reason: routing_decision.reason.clone(),
             recent_abort_rate: routing_decision.local_reliability_hint.recent_abort_rate,
             sample_size: routing_decision.local_reliability_hint.sample_size,
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_routing_decision(
             &stage.name,
@@ -368,6 +375,7 @@ impl Orchestrator {
         self.event_bus.publish(OrchestratorEvent::ExecutionStarted {
             stage_name: stage.name.clone(),
             target: routing_decision.target.to_json_string(),
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry
             .log_execution_start(&stage.name, &routing_decision.target.to_json_string());
@@ -390,12 +398,14 @@ impl Orchestrator {
                         stage_name: stage.name.clone(),
                         target: routing_decision.target.to_json_string(),
                         reason: reason.as_str().to_string(),
+                        context: Self::event_context_for_stage(stage),
                     });
                 } else {
                     self.event_bus.publish(OrchestratorEvent::ExecutionFailed {
                         stage_name: stage.name.clone(),
                         target: routing_decision.target.to_json_string(),
                         error: error_msg.clone(),
+                        context: Self::event_context_for_stage(stage),
                     });
                 }
                 // Record failure outcome
@@ -420,6 +430,7 @@ impl Orchestrator {
                 stage_name: stage.name.clone(),
                 target: routing_decision.target.to_json_string(),
                 execution_time_ms: latency_ms,
+                context: Self::event_context_for_stage(stage),
             });
         self.telemetry.log_execution_complete(
             &stage.name,
@@ -447,6 +458,7 @@ impl Orchestrator {
             stage_name: stage.name.clone(),
             target: routing_decision.target.to_json_string(),
             latency_ms,
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_stage_complete(
             &stage.name,
@@ -485,6 +497,7 @@ impl Orchestrator {
         // Emit pipeline start event
         self.event_bus.publish(OrchestratorEvent::PipelineStart {
             stages: stage_names.clone(),
+            context: Default::default(),
         });
 
         let mut results = Vec::new();
@@ -500,8 +513,10 @@ impl Orchestrator {
         let total_latency_ms = pipeline_start.elapsed().as_millis() as u32;
 
         // Emit pipeline complete event
-        self.event_bus
-            .publish(OrchestratorEvent::PipelineComplete { total_latency_ms });
+        self.event_bus.publish(OrchestratorEvent::PipelineComplete {
+            total_latency_ms,
+            context: Default::default(),
+        });
 
         Ok(results)
     }
@@ -534,6 +549,7 @@ impl Orchestrator {
         // Emit stage start event (consistent with sync execute_stage)
         self.event_bus.publish(OrchestratorEvent::StageStart {
             stage_name: stage.name.clone(),
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_stage_start(&stage.name);
 
@@ -552,6 +568,7 @@ impl Orchestrator {
             stage_name: stage.name.clone(),
             allowed: policy_allowed,
             reason: Some(policy_decision.reason.clone()),
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_policy_evaluation(
             &stage.name,
@@ -587,6 +604,7 @@ impl Orchestrator {
             reason: routing_decision.reason.clone(),
             recent_abort_rate: routing_decision.local_reliability_hint.recent_abort_rate,
             sample_size: routing_decision.local_reliability_hint.sample_size,
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_routing_decision(
             &stage.name,
@@ -604,6 +622,7 @@ impl Orchestrator {
         self.event_bus.publish(OrchestratorEvent::ExecutionStarted {
             stage_name: stage.name.clone(),
             target: routing_decision.target.to_json_string(),
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry
             .log_execution_start(&stage.name, &routing_decision.target.to_json_string());
@@ -629,12 +648,14 @@ impl Orchestrator {
                         stage_name: stage.name.clone(),
                         target: routing_decision.target.to_json_string(),
                         reason: reason.as_str().to_string(),
+                        context: Self::event_context_for_stage(stage),
                     });
                 } else {
                     self.event_bus.publish(OrchestratorEvent::ExecutionFailed {
                         stage_name: stage.name.clone(),
                         target: routing_decision.target.to_json_string(),
                         error: error_msg.clone(),
+                        context: Self::event_context_for_stage(stage),
                     });
                 }
                 // Record failure outcome
@@ -659,6 +680,7 @@ impl Orchestrator {
                 stage_name: stage.name.clone(),
                 target: routing_decision.target.to_json_string(),
                 execution_time_ms: latency_ms,
+                context: Self::event_context_for_stage(stage),
             });
         self.telemetry.log_execution_complete(
             &stage.name,
@@ -686,6 +708,7 @@ impl Orchestrator {
             stage_name: stage.name.clone(),
             target: routing_decision.target.to_json_string(),
             latency_ms,
+            context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_stage_complete(
             &stage.name,
@@ -735,6 +758,7 @@ impl Orchestrator {
         // Emit pipeline start event
         self.event_bus.publish(OrchestratorEvent::PipelineStart {
             stages: stage_names.clone(),
+            context: Default::default(),
         });
 
         let mut results = Vec::new();
@@ -753,8 +777,10 @@ impl Orchestrator {
         let total_latency_ms = pipeline_start.elapsed().as_millis() as u32;
 
         // Emit pipeline complete event
-        self.event_bus
-            .publish(OrchestratorEvent::PipelineComplete { total_latency_ms });
+        self.event_bus.publish(OrchestratorEvent::PipelineComplete {
+            total_latency_ms,
+            context: Default::default(),
+        });
 
         Ok(results)
     }

--- a/crates/xybrid-core/src/orchestrator/bootstrap.rs
+++ b/crates/xybrid-core/src/orchestrator/bootstrap.rs
@@ -103,7 +103,9 @@ impl Orchestrator {
     pub fn bootstrap(config_path: Option<&Path>) -> Result<Self, OrchestratorError> {
         // Emit bootstrap start event
         let event_bus = EventBus::new();
-        event_bus.publish(OrchestratorEvent::BootstrapStart);
+        event_bus.publish(OrchestratorEvent::BootstrapStart {
+            context: Default::default(),
+        });
 
         // Load configuration if provided
         let config = if let Some(path) = config_path {
@@ -120,12 +122,14 @@ impl Orchestrator {
         let policy_engine = Box::new(DefaultPolicyEngine::with_default_policy());
         event_bus.publish(OrchestratorEvent::ComponentInitialized {
             component: "policy_engine".to_string(),
+            context: Default::default(),
         });
 
         // Initialize routing engine
         let routing_engine = Box::new(DefaultRoutingEngine::new());
         event_bus.publish(OrchestratorEvent::ComponentInitialized {
             component: "routing_engine".to_string(),
+            context: Default::default(),
         });
 
         // Initialize executor
@@ -135,6 +139,7 @@ impl Orchestrator {
 
         event_bus.publish(OrchestratorEvent::ComponentInitialized {
             component: "executor".to_string(),
+            context: Default::default(),
         });
 
         // Register adapters based on configuration
@@ -157,6 +162,7 @@ impl Orchestrator {
                 executor.register_adapter(adapter);
                 event_bus.publish(OrchestratorEvent::AdapterRegistered {
                     name: "coreml".to_string(),
+                    context: Default::default(),
                 });
             }
 
@@ -167,6 +173,7 @@ impl Orchestrator {
                 executor.register_adapter(adapter);
                 event_bus.publish(OrchestratorEvent::AdapterRegistered {
                     name: "onnx-mobile".to_string(),
+                    context: Default::default(),
                 });
             }
 
@@ -177,6 +184,7 @@ impl Orchestrator {
                 executor.register_adapter(adapter);
                 event_bus.publish(OrchestratorEvent::AdapterRegistered {
                     name: "onnx".to_string(),
+                    context: Default::default(),
                 });
             }
 
@@ -187,6 +195,7 @@ impl Orchestrator {
                 executor.register_adapter(adapter);
                 event_bus.publish(OrchestratorEvent::AdapterRegistered {
                     name: "onnx".to_string(),
+                    context: Default::default(),
                 });
             }
 
@@ -197,6 +206,7 @@ impl Orchestrator {
                 executor.register_adapter(adapter);
                 event_bus.publish(OrchestratorEvent::AdapterRegistered {
                     name: "onnx".to_string(),
+                    context: Default::default(),
                 });
             }
         }
@@ -207,6 +217,7 @@ impl Orchestrator {
             executor.register_adapter(adapter);
             event_bus.publish(OrchestratorEvent::AdapterRegistered {
                 name: "cloud".to_string(),
+                context: Default::default(),
             });
         }
 
@@ -216,6 +227,7 @@ impl Orchestrator {
             executor.register_adapter(adapter);
             event_bus.publish(OrchestratorEvent::AdapterRegistered {
                 name: "mock".to_string(),
+                context: Default::default(),
             });
         }
 
@@ -263,10 +275,15 @@ impl Orchestrator {
         let authority: Box<dyn OrchestrationAuthority> = Box::new(LocalAuthority::new());
         event_bus.publish(OrchestratorEvent::ComponentInitialized {
             component: "authority".to_string(),
+            context: Default::default(),
         });
 
-        event_bus.publish(OrchestratorEvent::ExecutorReady);
-        event_bus.publish(OrchestratorEvent::OrchestratorReady);
+        event_bus.publish(OrchestratorEvent::ExecutorReady {
+            context: Default::default(),
+        });
+        event_bus.publish(OrchestratorEvent::OrchestratorReady {
+            context: Default::default(),
+        });
 
         // Create orchestrator instance
         let orchestrator = Orchestrator::with_all(

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -214,6 +214,8 @@ pub use telemetry::{
     shutdown_platform_telemetry,
     // Platform telemetry exports
     subscribe_orchestrator_events,
+    BridgeError,
+    BridgeHandle,
     HttpTelemetryExporter,
     OrchestratorEventBridge,
     TelemetryConfig,

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -908,11 +908,7 @@ impl Pipeline {
         // Subscribe after construction: bootstrap events emitted by
         // `Orchestrator::new()` are constructor-local, while execution events
         // below must be drained before this short-lived orchestrator returns.
-        let orchestrator_bridge = crate::telemetry::subscribe_orchestrator_events_in_context(
-            &orchestrator,
-            pipeline_id,
-            Some(trace_id),
-        );
+        let bridge = crate::telemetry::bridge_orchestrator_events(&orchestrator);
         // No need to set registry config - executor uses bundle_path from stage descriptors
 
         let availability_fn = move |stage: &str| -> LocalAvailability {
@@ -922,15 +918,18 @@ impl Pipeline {
 
         let start_time = std::time::Instant::now();
         let resource_guard = crate::telemetry::begin_resource_run();
-        let results: Vec<StageExecutionResult> = orchestrator
-            .execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn)
-            .map_err(|e| {
-                orchestrator_bridge.drain();
-                SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
-            })?;
-        orchestrator_bridge.drain();
+        let execution_result =
+            orchestrator.execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn);
+        drop(orchestrator);
+        bridge.join().map_err(|e| {
+            SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e))
+        })?;
+        let results: Vec<StageExecutionResult> = execution_result
+            .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
         let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
+        // Defer clearing context until after the PipelineComplete publish so
+        // direct SDK telemetry still carries this run's pipeline_id/trace_id.
         let stages: Vec<StageTiming> = results
             .iter()
             .map(|result| StageTiming {
@@ -1044,11 +1043,7 @@ impl Pipeline {
 
             let mut orchestrator = Orchestrator::new();
             // Subscribe after construction; see the sync path above.
-            let orchestrator_bridge = crate::telemetry::subscribe_orchestrator_events_in_context(
-                &orchestrator,
-                pipeline_id,
-                Some(trace_id),
-            );
+            let bridge = crate::telemetry::bridge_orchestrator_events(&orchestrator);
             // No need to set registry config - executor uses bundle_path from stage descriptors
 
             let availability_fn = move |stage: &str| -> LocalAvailability {
@@ -1058,20 +1053,23 @@ impl Pipeline {
 
             let start_time = std::time::Instant::now();
             let resource_guard = crate::telemetry::begin_resource_run();
-            let results: Vec<StageExecutionResult> = orchestrator
-                .execute_pipeline(
-                    &stage_descriptors,
-                    &envelope_clone,
-                    &metrics,
-                    &availability_fn,
-                )
-                .map_err(|e| {
-                    orchestrator_bridge.drain();
-                    SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
-                })?;
-            orchestrator_bridge.drain();
+            let execution_result = orchestrator.execute_pipeline(
+                &stage_descriptors,
+                &envelope_clone,
+                &metrics,
+                &availability_fn,
+            );
+            drop(orchestrator);
+            bridge.join().map_err(|e| {
+                SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e))
+            })?;
+            let results: Vec<StageExecutionResult> = execution_result.map_err(|e| {
+                SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
+            })?;
             let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
+            // Defer clearing context until after the PipelineComplete publish
+            // so direct SDK telemetry still carries this run's IDs.
             let stages: Vec<StageTiming> = results
                 .iter()
                 .map(|result| StageTiming {

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -16,6 +16,12 @@
 //! - **Circuit breaker**: Prevents hammering failing endpoints
 //! - **Automatic retry**: Exponential backoff with jitter for transient failures
 //! - **Failed event queue**: Retries failed events in the background
+//!
+//! # Orchestrator Bridge Context
+//!
+//! Producers attach context at orchestrator event publish time; bridge threads
+//! must not assume telemetry task-local or thread-local state is available when
+//! they drain events later.
 
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
@@ -27,7 +33,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 pub use xybrid_core::device::DeviceProfile;
 use xybrid_core::device::{ResourceMonitor, ResourceTelemetryMode, ResourceUsageSummary};
-use xybrid_core::event_bus::OrchestratorEvent;
+use xybrid_core::event_bus::{EventContext, OrchestratorEvent};
 use xybrid_core::execution::listener::{self as execution_listener, ExecutionEvent};
 use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy};
 use xybrid_core::tracing as core_tracing;
@@ -1772,6 +1778,15 @@ pub fn init_platform_telemetry_from_env() -> bool {
 
 /// Set pipeline context for event enrichment
 pub fn set_telemetry_pipeline_context(pipeline_id: Option<Uuid>, trace_id: Option<Uuid>) {
+    let mut event_context = xybrid_core::event_bus::EventContext::current();
+    event_context.pipeline_id = pipeline_id;
+    event_context.trace_id = trace_id;
+    if event_context.is_empty() {
+        xybrid_core::event_bus::clear_current_event_context();
+    } else {
+        xybrid_core::event_bus::set_current_event_context(event_context);
+    }
+
     if let Ok(exporter) = PLATFORM_EXPORTER.read() {
         if let Some(exp) = exporter.as_ref() {
             exp.set_pipeline_context(pipeline_id, trace_id);
@@ -1792,9 +1807,9 @@ pub fn set_telemetry_pipeline_context(pipeline_id: Option<Uuid>, trace_id: Optio
 /// duplication and closes the panic-leak hole.
 ///
 /// The clear happens at the guard's `Drop`, which fires after any
-/// `publish_telemetry_event` call earlier in the scope — preserving
-/// the existing "publish before clear" ordering the exporter's
-/// lazy-read flush relies on.
+/// `publish_telemetry_event` call earlier in the scope. Direct SDK
+/// telemetry keeps the scoped IDs, while bridged orchestrator events
+/// capture producer context before they cross task/thread boundaries.
 pub(crate) struct TelemetryPipelineContextGuard;
 
 impl TelemetryPipelineContextGuard {
@@ -1904,8 +1919,9 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
         .unwrap()
         .as_millis() as u64;
 
-    match event {
-        OrchestratorEvent::PipelineStart { stages } => TelemetryEvent {
+    let context = event.context().clone();
+    let telemetry_event = match event {
+        OrchestratorEvent::PipelineStart { stages, .. } => TelemetryEvent {
             event_type: "PipelineStart".to_string(),
             stage_name: None,
             target: None,
@@ -1914,7 +1930,9 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             data: Some(serde_json::json!({"stages": stages}).to_string()),
             timestamp_ms,
         },
-        OrchestratorEvent::PipelineComplete { total_latency_ms } => TelemetryEvent {
+        OrchestratorEvent::PipelineComplete {
+            total_latency_ms, ..
+        } => TelemetryEvent {
             event_type: "PipelineComplete".to_string(),
             stage_name: None,
             target: None,
@@ -1923,7 +1941,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             data: None,
             timestamp_ms,
         },
-        OrchestratorEvent::StageStart { stage_name } => TelemetryEvent {
+        OrchestratorEvent::StageStart { stage_name, .. } => TelemetryEvent {
             event_type: "StageStart".to_string(),
             stage_name: Some(stage_name.clone()),
             target: None,
@@ -1936,6 +1954,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             stage_name,
             target,
             latency_ms,
+            ..
         } => TelemetryEvent {
             event_type: "StageComplete".to_string(),
             stage_name: Some(stage_name.clone()),
@@ -1945,7 +1964,9 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             data: None,
             timestamp_ms,
         },
-        OrchestratorEvent::StageError { stage_name, error } => TelemetryEvent {
+        OrchestratorEvent::StageError {
+            stage_name, error, ..
+        } => TelemetryEvent {
             event_type: "StageError".to_string(),
             stage_name: Some(stage_name.clone()),
             target: None,
@@ -1960,6 +1981,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             reason,
             recent_abort_rate,
             sample_size,
+            ..
         } => TelemetryEvent {
             event_type: "RoutingDecided".to_string(),
             stage_name: Some(stage_name.clone()),
@@ -1989,7 +2011,9 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             ),
             timestamp_ms,
         },
-        OrchestratorEvent::ExecutionStarted { stage_name, target } => TelemetryEvent {
+        OrchestratorEvent::ExecutionStarted {
+            stage_name, target, ..
+        } => TelemetryEvent {
             event_type: "ExecutionStarted".to_string(),
             stage_name: Some(stage_name.clone()),
             target: Some(target.clone()),
@@ -2002,6 +2026,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             stage_name,
             target,
             execution_time_ms,
+            ..
         } => TelemetryEvent {
             event_type: "ExecutionCompleted".to_string(),
             stage_name: Some(stage_name.clone()),
@@ -2015,6 +2040,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             stage_name,
             target,
             error,
+            ..
         } => TelemetryEvent {
             event_type: "ExecutionFailed".to_string(),
             stage_name: Some(stage_name.clone()),
@@ -2028,6 +2054,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             stage_name,
             allowed,
             reason,
+            ..
         } => TelemetryEvent {
             event_type: "PolicyEvaluated".to_string(),
             stage_name: Some(stage_name.clone()),
@@ -2051,6 +2078,7 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             stage_name,
             target,
             reason,
+            ..
         } => TelemetryEvent {
             event_type: "LocalAborted".to_string(),
             stage_name: Some(stage_name.clone()),
@@ -2069,6 +2097,55 @@ pub fn convert_orchestrator_event(event: &OrchestratorEvent) -> TelemetryEvent {
             data: Some(format!("{:?}", event)),
             timestamp_ms,
         },
+    };
+
+    attach_event_context(telemetry_event, &context)
+}
+
+fn attach_event_context(event: TelemetryEvent, context: &EventContext) -> TelemetryEvent {
+    if context.is_empty() {
+        return event;
+    }
+
+    let mut data = match event.data.as_ref() {
+        Some(raw) => match serde_json::from_str::<serde_json::Value>(raw) {
+            Ok(value) if value.is_object() => value,
+            Ok(value) => serde_json::json!({ "value": value }),
+            Err(_) => serde_json::json!({ "value": raw }),
+        },
+        None => serde_json::json!({}),
+    };
+
+    if let Some(obj) = data.as_object_mut() {
+        if let Some(id) = context.pipeline_id {
+            obj.entry(CONTEXT_PIPELINE_ID_KEY.to_string())
+                .or_insert_with(|| serde_json::json!(id.to_string()));
+        }
+        if let Some(id) = context.trace_id {
+            obj.entry(CONTEXT_TRACE_ID_KEY.to_string())
+                .or_insert_with(|| serde_json::json!(id.to_string()));
+        }
+        if let Some(id) = context.correlation_id.as_ref() {
+            obj.entry("correlation_id".to_string())
+                .or_insert_with(|| serde_json::json!(id));
+        }
+        if let Some(id) = context.request_id.as_ref() {
+            obj.entry("request_id".to_string())
+                .or_insert_with(|| serde_json::json!(id));
+        }
+        if let Some(id) = context.model_id.as_ref() {
+            obj.entry("model_id".to_string())
+                .or_insert_with(|| serde_json::json!(id));
+        }
+        if let Some(id) = context.span_id.as_ref() {
+            obj.entry("span_id".to_string())
+                .or_insert_with(|| serde_json::json!(id));
+        }
+    }
+
+    TelemetryEvent {
+        data: Some(data.to_string()),
+        ..event
     }
 }
 
@@ -2308,85 +2385,148 @@ fn dispatch_telemetry_event(event: TelemetryEvent) {
     }
 }
 
-/// Scoped bridge from an orchestrator event bus to the telemetry stream.
-///
-/// The bridge captures the current pipeline context when it subscribes, then
-/// embeds that context into each converted event before enqueueing it. Callers
-/// that own a short-lived orchestrator should keep this handle and call
-/// [`Self::drain`] before returning so queued orchestrator events are not left
-/// behind a detached worker.
-pub struct OrchestratorEventBridge {
-    subscription: xybrid_core::event_bus::Subscription,
-    pipeline_id: Option<Uuid>,
-    trace_id: Option<Uuid>,
+#[derive(Debug, thiserror::Error)]
+pub enum BridgeError {
+    #[error("orchestrator event bridge is no longer running")]
+    Stopped,
+    #[error("orchestrator event bridge flush acknowledgement was dropped")]
+    FlushAckDropped,
+    #[error("orchestrator event bridge thread panicked")]
+    ThreadPanicked,
 }
 
-impl OrchestratorEventBridge {
-    /// Publish all events currently buffered for this bridge.
+enum BridgeCommand {
+    Flush(mpsc::Sender<()>),
+}
+
+/// Handle for a scoped orchestrator-to-telemetry event bridge.
+#[must_use = "BridgeHandle must be flushed or joined, otherwise queued orchestrator telemetry can be dropped"]
+pub struct BridgeHandle {
+    join_handle: thread::JoinHandle<()>,
+    command_tx: mpsc::Sender<BridgeCommand>,
+}
+
+impl BridgeHandle {
+    /// Block until all events queued before this call have been delivered to
+    /// the SDK telemetry stream.
+    pub fn flush(&self) -> Result<(), BridgeError> {
+        let (ack_tx, ack_rx) = mpsc::channel();
+        self.command_tx
+            .send(BridgeCommand::Flush(ack_tx))
+            .map_err(|_| BridgeError::Stopped)?;
+        ack_rx.recv().map_err(|_| BridgeError::FlushAckDropped)
+    }
+
+    /// Compatibility alias for callers that used the previous scoped bridge
+    /// drain API. New code should prefer [`Self::flush`] and handle errors.
     pub fn drain(&self) {
-        loop {
-            match self.subscription.try_recv() {
-                Ok(event) => self.publish_event(&event),
-                Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
-            }
-        }
+        let _ = self.flush();
     }
 
-    fn publish_event(&self, event: &OrchestratorEvent) {
-        let telemetry_event = convert_orchestrator_event(event);
-        publish_telemetry_event_in_context(telemetry_event, self.pipeline_id, self.trace_id);
-    }
-
-    fn recv_forever(self) {
-        while let Ok(event) = self.subscription.recv() {
-            self.publish_event(&event);
-        }
+    /// Wait for the bridge thread to finish draining after the orchestrator's
+    /// event bus has been dropped.
+    pub fn join(self) -> Result<(), BridgeError> {
+        let Self {
+            join_handle,
+            command_tx,
+        } = self;
+        drop(command_tx);
+        join_handle.join().map_err(|_| BridgeError::ThreadPanicked)
     }
 }
 
-impl Drop for OrchestratorEventBridge {
-    fn drop(&mut self) {
-        self.drain();
+pub type OrchestratorEventBridge = BridgeHandle;
+
+const BRIDGE_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Bridge orchestrator events to telemetry stream.
+///
+/// This function subscribes to orchestrator events and converts them to
+/// telemetry events. The returned handle must be joined after the orchestrator
+/// is dropped so queued events are drained before the caller tears down
+/// telemetry subscribers or the runtime.
+pub fn bridge_orchestrator_events(
+    orchestrator: &xybrid_core::orchestrator::Orchestrator,
+) -> BridgeHandle {
+    let event_bus = orchestrator.event_bus();
+    let subscription = event_bus.subscribe();
+    let (command_tx, command_rx) = mpsc::channel();
+
+    let join_handle = thread::spawn(move || bridge_loop(subscription, command_rx));
+
+    BridgeHandle {
+        join_handle,
+        command_tx,
     }
 }
 
 /// Subscribe to orchestrator events and return a drainable bridge handle.
 pub fn subscribe_orchestrator_events(
     orchestrator: &xybrid_core::orchestrator::Orchestrator,
-) -> OrchestratorEventBridge {
-    let (pipeline_id, trace_id) = current_telemetry_pipeline_context();
-    subscribe_orchestrator_events_in_context(orchestrator, pipeline_id, trace_id)
+) -> BridgeHandle {
+    bridge_orchestrator_events(orchestrator)
 }
 
 pub(crate) fn subscribe_orchestrator_events_in_context(
     orchestrator: &xybrid_core::orchestrator::Orchestrator,
-    pipeline_id: Option<Uuid>,
-    trace_id: Option<Uuid>,
-) -> OrchestratorEventBridge {
-    let event_bus = orchestrator.event_bus();
-    let subscription = event_bus.subscribe();
+    _pipeline_id: Option<Uuid>,
+    _trace_id: Option<Uuid>,
+) -> BridgeHandle {
+    bridge_orchestrator_events(orchestrator)
+}
 
-    OrchestratorEventBridge {
-        subscription,
-        pipeline_id,
-        trace_id,
+fn bridge_loop(
+    subscription: xybrid_core::event_bus::Subscription,
+    command_rx: mpsc::Receiver<BridgeCommand>,
+) {
+    loop {
+        drain_bridge_commands(&subscription, &command_rx);
+        match subscription.recv_timeout(BRIDGE_POLL_INTERVAL) {
+            Ok(event) => publish_orchestrator_event(event),
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                drain_available_orchestrator_events(&subscription);
+                drain_bridge_commands(&subscription, &command_rx);
+                break;
+            }
+        }
     }
 }
 
-/// Bridge orchestrator events to telemetry stream on a background thread.
-///
-/// Short-lived SDK entry points should prefer [`subscribe_orchestrator_events`]
-/// and drain the returned handle before returning. This detached helper is kept
-/// for long-running CLI flows that own an orchestrator for an interactive
-/// session.
-pub fn bridge_orchestrator_events(orchestrator: &xybrid_core::orchestrator::Orchestrator) {
-    let bridge = subscribe_orchestrator_events(orchestrator);
-    thread::spawn(move || bridge.recv_forever());
+fn drain_bridge_commands(
+    subscription: &xybrid_core::event_bus::Subscription,
+    command_rx: &mpsc::Receiver<BridgeCommand>,
+) {
+    while let Ok(command) = command_rx.try_recv() {
+        match command {
+            BridgeCommand::Flush(ack_tx) => {
+                drain_available_orchestrator_events(subscription);
+                let _ = ack_tx.send(());
+            }
+        }
+    }
+}
+
+fn drain_available_orchestrator_events(subscription: &xybrid_core::event_bus::Subscription) {
+    loop {
+        match subscription.try_recv() {
+            Ok(event) => publish_orchestrator_event(event),
+            Err(mpsc::TryRecvError::Empty | mpsc::TryRecvError::Disconnected) => break,
+        }
+    }
+}
+
+fn publish_orchestrator_event(event: OrchestratorEvent) {
+    let telemetry_event = convert_orchestrator_event(&event);
+    publish_telemetry_event(telemetry_event);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::MutexGuard;
+
+    static TELEMETRY_SENDER_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn platform_event_payload_has_no_legacy_cache_keys() {
@@ -2817,6 +2957,7 @@ mod tests {
     fn test_convert_stage_start_event() {
         let event = OrchestratorEvent::StageStart {
             stage_name: "asr".to_string(),
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2834,6 +2975,7 @@ mod tests {
             stage_name: "tts".to_string(),
             target: "local".to_string(),
             latency_ms: 150,
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2849,6 +2991,7 @@ mod tests {
         let event = OrchestratorEvent::StageError {
             stage_name: "asr".to_string(),
             error: "Model not found".to_string(),
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2861,6 +3004,7 @@ mod tests {
     fn test_convert_pipeline_start_event() {
         let event = OrchestratorEvent::PipelineStart {
             stages: vec!["asr".to_string(), "llm".to_string(), "tts".to_string()],
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2877,6 +3021,7 @@ mod tests {
     fn test_convert_pipeline_complete_event() {
         let event = OrchestratorEvent::PipelineComplete {
             total_latency_ms: 500,
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2892,6 +3037,7 @@ mod tests {
             reason: "network_optimal".to_string(),
             recent_abort_rate: 0.0,
             sample_size: 0,
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -2915,6 +3061,7 @@ mod tests {
             reason: "history_bias".to_string(),
             recent_abort_rate: 0.75,
             sample_size: 4,
+            context: Default::default(),
         };
         let telemetry_event = convert_orchestrator_event(&event);
 
@@ -2961,6 +3108,7 @@ mod tests {
                 reason: "history_bias".to_string(),
                 recent_abort_rate: bad_rate,
                 sample_size: 1,
+                context: Default::default(),
             };
             let telemetry_event = convert_orchestrator_event(&event);
             let parsed_data: serde_json::Value =
@@ -2978,14 +3126,15 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 
-        let orchestrator = xybrid_core::orchestrator::Orchestrator::new();
         let pipeline_id = Uuid::new_v4();
         let trace_id = Uuid::new_v4();
-        let bridge = subscribe_orchestrator_events_in_context(
-            &orchestrator,
-            Some(pipeline_id),
-            Some(trace_id),
+        let _event_context = xybrid_core::event_bus::EventContextGuard::install(
+            xybrid_core::event_bus::EventContext::default()
+                .with_pipeline_id(pipeline_id)
+                .with_trace_id(trace_id),
         );
+        let orchestrator = xybrid_core::orchestrator::Orchestrator::new();
+        let bridge = bridge_orchestrator_events(&orchestrator);
 
         orchestrator
             .event_bus()
@@ -2995,6 +3144,7 @@ mod tests {
                 reason: "history_bias".to_string(),
                 recent_abort_rate: 0.5,
                 sample_size: 2,
+                context: Default::default(),
             });
         bridge.drain();
 
@@ -3035,6 +3185,7 @@ mod tests {
         let event = OrchestratorEvent::ExecutionStarted {
             stage_name: "asr".to_string(),
             target: "local".to_string(),
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -3049,6 +3200,7 @@ mod tests {
             stage_name: "asr".to_string(),
             target: "local".to_string(),
             execution_time_ms: 75,
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -3064,6 +3216,7 @@ mod tests {
             stage_name: "tts".to_string(),
             target: "cloud".to_string(),
             error: "Timeout".to_string(),
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -3079,6 +3232,7 @@ mod tests {
             stage_name: "asr".to_string(),
             allowed: true,
             reason: Some("All conditions met".to_string()),
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -3094,6 +3248,7 @@ mod tests {
             stage_name: "llm".to_string(),
             allowed: false,
             reason: Some("Privacy policy violation".to_string()),
+            context: Default::default(),
         };
         let telemetry = convert_orchestrator_event(&event);
 
@@ -3103,6 +3258,164 @@ mod tests {
             telemetry.error,
             Some("Privacy policy violation".to_string())
         );
+    }
+
+    fn routing_decided_event(stage_name: impl Into<String>) -> OrchestratorEvent {
+        OrchestratorEvent::RoutingDecided {
+            stage_name: stage_name.into(),
+            target: "local".to_string(),
+            reason: "test_route".to_string(),
+            recent_abort_rate: 0.0,
+            sample_size: 0,
+            context: xybrid_core::event_bus::EventContext::default(),
+        }
+    }
+
+    fn clear_registered_telemetry_senders() {
+        TELEMETRY_SENDERS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+    }
+
+    fn telemetry_sender_test_lock() -> MutexGuard<'static, ()> {
+        TELEMETRY_SENDER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[test]
+    fn bridge_drains_all_events_on_orchestrator_drop() {
+        let _lock = telemetry_sender_test_lock();
+        clear_registered_telemetry_senders();
+        let (tx, rx) = mpsc::channel();
+        register_telemetry_sender(tx);
+
+        let orchestrator = xybrid_core::orchestrator::Orchestrator::new();
+        let bridge = bridge_orchestrator_events(&orchestrator);
+        for idx in 0..100 {
+            orchestrator
+                .event_bus()
+                .publish(routing_decided_event(format!("stage-{idx:03}")));
+        }
+
+        drop(orchestrator);
+        bridge.join().expect("bridge should drain cleanly");
+
+        let events: Vec<_> = rx
+            .try_iter()
+            .filter(|event| {
+                event.event_type == "RoutingDecided"
+                    && event
+                        .stage_name
+                        .as_deref()
+                        .is_some_and(|stage| stage.starts_with("stage-"))
+            })
+            .collect();
+        assert_eq!(events.len(), 100);
+        for idx in 0..100 {
+            assert!(
+                events
+                    .iter()
+                    .any(|event| event.stage_name.as_deref() == Some(&format!("stage-{idx:03}"))),
+                "missing routed event stage-{idx:03}; got {events:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn bridge_preserves_correlation_id_across_task_boundary() {
+        let _lock = telemetry_sender_test_lock();
+        clear_registered_telemetry_senders();
+        let (tx, rx) = mpsc::channel();
+        register_telemetry_sender(tx);
+
+        let publishers: Vec<_> = ["A", "B"]
+            .into_iter()
+            .map(|correlation_id| {
+                thread::spawn(move || {
+                    let _context = xybrid_core::event_bus::EventContextGuard::install(
+                        xybrid_core::event_bus::EventContext::default()
+                            .with_correlation_id(correlation_id),
+                    );
+                    let orchestrator = xybrid_core::orchestrator::Orchestrator::new();
+                    let bridge = bridge_orchestrator_events(&orchestrator);
+                    for idx in 0..10 {
+                        orchestrator
+                            .event_bus()
+                            .publish(routing_decided_event(format!("{correlation_id}-{idx}")));
+                        thread::yield_now();
+                    }
+                    drop(orchestrator);
+                    bridge.join().expect("bridge should drain cleanly");
+                })
+            })
+            .collect();
+
+        for publisher in publishers {
+            publisher.join().expect("publisher thread should not panic");
+        }
+
+        let events: Vec<_> = rx
+            .try_iter()
+            .filter(|event| {
+                event.event_type == "RoutingDecided"
+                    && event
+                        .stage_name
+                        .as_deref()
+                        .is_some_and(|stage| stage.starts_with("A-") || stage.starts_with("B-"))
+            })
+            .collect();
+        assert_eq!(events.len(), 20);
+        for event in events {
+            let stage = event.stage_name.as_deref().expect("stage name");
+            let data: serde_json::Value =
+                serde_json::from_str(event.data.as_deref().expect("event data")).unwrap();
+            let expected = stage.split('-').next().unwrap();
+            assert_eq!(
+                data["correlation_id"].as_str(),
+                Some(expected),
+                "event {stage} carried wrong context: {data}"
+            );
+        }
+    }
+
+    #[test]
+    fn flush_blocks_until_in_flight_events_delivered() {
+        let _lock = telemetry_sender_test_lock();
+        clear_registered_telemetry_senders();
+        let (tx, rx) = mpsc::channel();
+        register_telemetry_sender(tx);
+
+        let orchestrator = xybrid_core::orchestrator::Orchestrator::new();
+        let bridge = bridge_orchestrator_events(&orchestrator);
+        for idx in 0..5 {
+            orchestrator
+                .event_bus()
+                .publish(routing_decided_event(format!("flush-{idx}")));
+        }
+
+        bridge.flush().expect("flush should complete");
+
+        let mut delivered = Vec::new();
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while delivered.len() < 5 && std::time::Instant::now() < deadline {
+            let event = rx
+                .recv_timeout(Duration::from_millis(50))
+                .expect("flush should deliver event before returning");
+            if event.event_type == "RoutingDecided"
+                && event
+                    .stage_name
+                    .as_deref()
+                    .is_some_and(|stage| stage.starts_with("flush-"))
+            {
+                delivered.push(event);
+            }
+        }
+        assert_eq!(delivered.len(), 5);
+
+        drop(orchestrator);
+        bridge.join().expect("bridge should drain cleanly");
     }
 
     #[test]
@@ -3128,6 +3441,8 @@ mod tests {
 
     #[test]
     fn test_register_and_publish() {
+        let _lock = telemetry_sender_test_lock();
+        clear_registered_telemetry_senders();
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -3123,6 +3123,7 @@ mod tests {
 
     #[test]
     fn scoped_orchestrator_bridge_drains_queued_events_with_captured_context() {
+        let _guard = TelemetrySenderTestGuard::acquire();
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 
@@ -3139,7 +3140,7 @@ mod tests {
         orchestrator
             .event_bus()
             .publish(OrchestratorEvent::RoutingDecided {
-                stage_name: "stage-1".to_string(),
+                stage_name: "scoped-bridge-context".to_string(),
                 target: "cloud".to_string(),
                 reason: "history_bias".to_string(),
                 recent_abort_rate: 0.5,
@@ -3151,7 +3152,10 @@ mod tests {
         let mut received = None;
         for _ in 0..20 {
             match rx.recv_timeout(std::time::Duration::from_millis(50)) {
-                Ok(event) if event.event_type == "RoutingDecided" => {
+                Ok(event)
+                    if event.event_type == "RoutingDecided"
+                        && event.stage_name.as_deref() == Some("scoped-bridge-context") =>
+                {
                     received = Some(event);
                     break;
                 }
@@ -3278,16 +3282,29 @@ mod tests {
             .clear();
     }
 
-    fn telemetry_sender_test_lock() -> MutexGuard<'static, ()> {
-        TELEMETRY_SENDER_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    struct TelemetrySenderTestGuard {
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl TelemetrySenderTestGuard {
+        fn acquire() -> Self {
+            let guard = TELEMETRY_SENDER_TEST_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            clear_registered_telemetry_senders();
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for TelemetrySenderTestGuard {
+        fn drop(&mut self) {
+            clear_registered_telemetry_senders();
+        }
     }
 
     #[test]
     fn bridge_drains_all_events_on_orchestrator_drop() {
-        let _lock = telemetry_sender_test_lock();
-        clear_registered_telemetry_senders();
+        let _guard = TelemetrySenderTestGuard::acquire();
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 
@@ -3296,7 +3313,7 @@ mod tests {
         for idx in 0..100 {
             orchestrator
                 .event_bus()
-                .publish(routing_decided_event(format!("stage-{idx:03}")));
+                .publish(routing_decided_event(format!("bridge-drain-{idx:03}")));
         }
 
         drop(orchestrator);
@@ -3309,7 +3326,7 @@ mod tests {
                     && event
                         .stage_name
                         .as_deref()
-                        .is_some_and(|stage| stage.starts_with("stage-"))
+                        .is_some_and(|stage| stage.starts_with("bridge-drain-"))
             })
             .collect();
         assert_eq!(events.len(), 100);
@@ -3317,16 +3334,16 @@ mod tests {
             assert!(
                 events
                     .iter()
-                    .any(|event| event.stage_name.as_deref() == Some(&format!("stage-{idx:03}"))),
-                "missing routed event stage-{idx:03}; got {events:?}"
+                    .any(|event| event.stage_name.as_deref()
+                        == Some(&format!("bridge-drain-{idx:03}"))),
+                "missing routed event bridge-drain-{idx:03}; got {events:?}"
             );
         }
     }
 
     #[test]
     fn bridge_preserves_correlation_id_across_task_boundary() {
-        let _lock = telemetry_sender_test_lock();
-        clear_registered_telemetry_senders();
+        let _guard = TelemetrySenderTestGuard::acquire();
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 
@@ -3382,8 +3399,7 @@ mod tests {
 
     #[test]
     fn flush_blocks_until_in_flight_events_delivered() {
-        let _lock = telemetry_sender_test_lock();
-        clear_registered_telemetry_senders();
+        let _guard = TelemetrySenderTestGuard::acquire();
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 
@@ -3441,8 +3457,7 @@ mod tests {
 
     #[test]
     fn test_register_and_publish() {
-        let _lock = telemetry_sender_test_lock();
-        clear_registered_telemetry_senders();
+        let _guard = TelemetrySenderTestGuard::acquire();
         let (tx, rx) = mpsc::channel();
         register_telemetry_sender(tx);
 

--- a/crates/xybrid-sdk/tests/async_test.rs
+++ b/crates/xybrid-sdk/tests/async_test.rs
@@ -29,6 +29,7 @@ fn test_event_stream_subscription() {
         let event_bus = orchestrator.event_bus();
         event_bus.publish(OrchestratorEvent::StageStart {
             stage_name: "test_stage".to_string(),
+            context: Default::default(),
         });
 
         // Wait for the event to be received
@@ -37,7 +38,7 @@ fn test_event_stream_subscription() {
             if let Ok(event) = timeout(Duration::from_millis(200), event_stream.recv()).await {
                 if matches!(
                     event,
-                    Some(OrchestratorEvent::StageStart { stage_name }) if stage_name == "test_stage"
+                    Some(OrchestratorEvent::StageStart { stage_name, .. }) if stage_name == "test_stage"
                 ) {
                     found_stage_start = true;
                     break;


### PR DESCRIPTION
## Summary

This fixes a telemetry correctness gap in the orchestrator event bridge.

The bridge forwarded orchestrator events from a background thread, but callers did not have an explicit way to wait for it to drain before pipeline teardown. In short-lived runs, CLI commands, examples, or FFI-style calls, queued routing/execution events could be lost when the orchestrator or telemetry runtime was dropped.

The bridge also depended on task-local attribution at consumption time. Since bridge delivery happens outside the original pipeline task, events could lose or misattribute run context.

Changes:

- make bridge_orchestrator_events return a #[must_use] BridgeHandle
- add BridgeHandle::flush() and BridgeHandle::join()
- join the bridge before sync/async pipeline and CLI teardown
- attach producer-side event context to orchestrator events
- enrich SDK telemetry from event-carried context instead of bridge-thread task-local state
- preserve pipeline_id, trace_id, correlation_id, request_id, model_id, and span_id across task/thread boundaries
- add regressions for drain-on-drop, cross-task attribution, and flush ordering

## Verification

- cargo test -p xybrid-sdk bridge_drains_all_events_on_orchestrator_drop --features ort-download
- cargo test -p xybrid-sdk bridge_preserves_correlation_id_across_task_boundary --features ort-download
- cargo test -p xybrid-sdk flush_blocks_until_in_flight_events_delivered --features ort-download
- cargo fmt --all -- --check
