### PR TITLE
feat(sdk): expose run options on pipeline APIs

### DIFF
--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -57,6 +57,7 @@ pub use result::{FfiPipelineExecutionResult, FfiStageExecutionResult};
 use crate::model::SdkError;
 use crate::registry_client::RegistryClient;
 use crate::result::OutputType;
+use crate::run_options::RunOptions;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -305,6 +306,38 @@ impl PipelineExecutionResult {
             _ => None,
         }
     }
+}
+
+fn pipeline_metrics(options: &RunOptions) -> DeviceMetrics {
+    options.device_metrics.as_ref().cloned().unwrap_or_default()
+}
+
+fn pipeline_complete_data(
+    stages: &[StageTiming],
+    output_type: &OutputType,
+    correlation_id: Option<&str>,
+) -> String {
+    let stage_data: Vec<serde_json::Value> = stages
+        .iter()
+        .map(|stage| {
+            serde_json::json!({
+                "name": stage.name,
+                "latency_ms": stage.latency_ms,
+                "target": stage.target,
+            })
+        })
+        .collect();
+
+    let mut data = serde_json::json!({
+        "stages": stage_data,
+        "output_type": format!("{:?}", output_type),
+    });
+
+    if let Some(correlation_id) = correlation_id {
+        data["correlation_id"] = serde_json::json!(correlation_id);
+    }
+
+    data.to_string()
 }
 
 // ============================================================================
@@ -873,6 +906,20 @@ impl Pipeline {
     ///
     /// If models aren't loaded yet, this will automatically download them first.
     pub fn run(&self, envelope: &Envelope) -> PipelineResult<PipelineExecutionResult> {
+        self.run_with_options(envelope, &RunOptions::default())
+    }
+
+    /// Run inference on the pipeline with per-run controls.
+    ///
+    /// `RunOptions::correlation_id` is copied into the pipeline completion
+    /// telemetry payload. `RunOptions::device_metrics`, when present, supplies
+    /// the metrics passed into routing; otherwise the existing default metrics
+    /// behavior is preserved.
+    pub fn run_with_options(
+        &self,
+        envelope: &Envelope,
+        options: &RunOptions,
+    ) -> PipelineResult<PipelineExecutionResult> {
         if !self.is_ready() {
             self.load_models()?;
         }
@@ -892,8 +939,8 @@ impl Pipeline {
         let availability_map = handle.availability_map.clone();
         drop(handle);
 
-        // Collect runtime metrics from device
-        let metrics = DeviceMetrics::default();
+        // Collect runtime metrics from caller options when provided.
+        let metrics = pipeline_metrics(options);
 
         // Install per-call pipeline context. The RAII guard clears on
         // every exit (success, `?` error, panic) so we don't leak the
@@ -962,17 +1009,6 @@ impl Pipeline {
         // adapter), so we intentionally keep this `data` blob compact
         // — only the fields that already crossed the wire before
         // llm_metrics existed.
-        let stage_data: Vec<serde_json::Value> = results
-            .iter()
-            .map(|result| {
-                serde_json::json!({
-                    "name": result.stage,
-                    "latency_ms": result.latency_ms,
-                    "target": result.routing_decision.target.to_string(),
-                })
-            })
-            .collect();
-
         // For single-stage pipelines, attribute the `PipelineComplete`
         // row to the inner stage so the Traces dashboard reads
         // `pipeline / <stage>` (with a real `target`) instead of the
@@ -989,20 +1025,17 @@ impl Pipeline {
         } else {
             (self.name.clone(), None)
         };
-
         let event = crate::telemetry::TelemetryEvent {
             event_type: "PipelineComplete".to_string(),
             stage_name: event_stage_name,
             target: event_target,
             latency_ms: Some(total_latency_ms),
             error: None,
-            data: Some(
-                serde_json::json!({
-                    "stages": stage_data,
-                    "output_type": format!("{:?}", output_type),
-                })
-                .to_string(),
-            ),
+            data: Some(pipeline_complete_data(
+                &stages,
+                &output_type,
+                options.correlation_id.as_deref(),
+            )),
             timestamp_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as u64)
@@ -1026,6 +1059,16 @@ impl Pipeline {
 
     /// Run inference asynchronously.
     pub async fn run_async(&self, envelope: &Envelope) -> PipelineResult<PipelineExecutionResult> {
+        self.run_async_with_options(envelope, &RunOptions::default())
+            .await
+    }
+
+    /// Run inference asynchronously with per-run controls.
+    pub async fn run_async_with_options(
+        &self,
+        envelope: &Envelope,
+        options: &RunOptions,
+    ) -> PipelineResult<PipelineExecutionResult> {
         if !self.is_ready() {
             self.load_models()?;
         }
@@ -1047,10 +1090,11 @@ impl Pipeline {
 
         let envelope_clone = envelope.clone();
         let name = self.name.clone();
+        let options = options.clone();
 
         tokio::task::spawn_blocking(move || {
-            // Collect runtime metrics from device
-            let metrics = DeviceMetrics::default();
+            // Collect runtime metrics from caller options when provided.
+            let metrics = pipeline_metrics(&options);
 
             // RAII pipeline context — see sync `run` for rationale.
             // Drops on every exit path (success, `?` error, panic) and
@@ -1116,17 +1160,11 @@ impl Pipeline {
                 )
             };
 
-            let stage_data: Vec<serde_json::Value> = results
-                .iter()
-                .map(|result| {
-                    serde_json::json!({
-                        "name": result.stage,
-                        "latency_ms": result.latency_ms,
-                        "target": result.routing_decision.target.to_string(),
-                    })
-                })
-                .collect();
-
+            // Emit PipelineComplete telemetry event. Previously absent from
+            // this async path (existed only in sync `run`); attaching now
+            // brings the two paths to parity. LLM metrics ride on span
+            // metadata (see the sync arm above for rationale), so this
+            // `data` blob stays compact.
             // Single-stage pipelines attribute the row to the inner
             // stage so the Traces dashboard reads `pipeline / <stage>`
             // with a real `target`; see sync `run` above.
@@ -1139,20 +1177,17 @@ impl Pipeline {
             } else {
                 (name.clone(), None)
             };
-
             let event = crate::telemetry::TelemetryEvent {
                 event_type: "PipelineComplete".to_string(),
                 stage_name: event_stage_name,
                 target: event_target,
                 latency_ms: Some(total_latency_ms),
                 error: None,
-                data: Some(
-                    serde_json::json!({
-                        "stages": stage_data,
-                        "output_type": format!("{:?}", output_type),
-                    })
-                    .to_string(),
-                ),
+                data: Some(pipeline_complete_data(
+                    &stages,
+                    &output_type,
+                    options.correlation_id.as_deref(),
+                )),
                 timestamp_ms: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_millis() as u64)
@@ -1215,8 +1250,17 @@ impl Xybrid {
         yaml: &str,
         envelope: &Envelope,
     ) -> PipelineResult<PipelineExecutionResult> {
+        Self::run_pipeline_with_options(yaml, envelope, &RunOptions::default())
+    }
+
+    /// Run a pipeline from YAML in one call with per-run controls.
+    pub fn run_pipeline_with_options(
+        yaml: &str,
+        envelope: &Envelope,
+        options: &RunOptions,
+    ) -> PipelineResult<PipelineExecutionResult> {
         let pipeline = PipelineRef::from_yaml(yaml)?.load()?;
-        pipeline.run(envelope)
+        pipeline.run_with_options(envelope, options)
     }
 
     /// Create a pipeline reference from YAML.
@@ -1374,6 +1418,51 @@ stages:
         let ref_ = PipelineRef::from_yaml(yaml).unwrap();
         assert_eq!(ref_.name(), Some("Test Pipeline"));
         assert_eq!(ref_.stage_count(), 1);
+    }
+
+    #[test]
+    fn pipeline_complete_data_includes_correlation_id_when_options_set() {
+        let stages = vec![StageTiming {
+            name: "llm".to_string(),
+            latency_ms: 12,
+            target: "local".to_string(),
+            reason: "local_available".to_string(),
+        }];
+
+        let json = pipeline_complete_data(&stages, &OutputType::Text, Some("run-abc"));
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["correlation_id"], "run-abc");
+        assert_eq!(value["output_type"], "Text");
+        assert_eq!(value["stages"][0]["name"], "llm");
+        assert_eq!(value["stages"][0]["latency_ms"], 12);
+        assert_eq!(value["stages"][0]["target"], "local");
+    }
+
+    #[test]
+    fn pipeline_complete_data_omits_correlation_id_when_options_unset() {
+        let stages = vec![StageTiming {
+            name: "asr".to_string(),
+            latency_ms: 7,
+            target: "device".to_string(),
+            reason: "local_available".to_string(),
+        }];
+
+        let json = pipeline_complete_data(&stages, &OutputType::Audio, None);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert!(value.get("correlation_id").is_none());
+        assert_eq!(value["output_type"], "Audio");
+        assert_eq!(value["stages"][0]["target"], "device");
+    }
+
+    #[test]
+    fn xybrid_run_pipeline_with_options_is_public_api() {
+        let _method: fn(
+            &str,
+            &Envelope,
+            &RunOptions,
+        ) -> PipelineResult<PipelineExecutionResult> = Xybrid::run_pipeline_with_options;
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -1458,11 +1458,8 @@ stages:
 
     #[test]
     fn xybrid_run_pipeline_with_options_is_public_api() {
-        let _method: fn(
-            &str,
-            &Envelope,
-            &RunOptions,
-        ) -> PipelineResult<PipelineExecutionResult> = Xybrid::run_pipeline_with_options;
+        let _method: fn(&str, &Envelope, &RunOptions) -> PipelineResult<PipelineExecutionResult> =
+            Xybrid::run_pipeline_with_options;
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/run_options.rs
+++ b/crates/xybrid-sdk/src/run_options.rs
@@ -440,6 +440,22 @@ mod tests {
     }
 
     #[test]
+    fn abort_policy_and_run_options_defaults_match_documented_contract() {
+        let policy = AbortPolicy::default();
+        assert!(policy.stop_on.is_empty());
+        assert!(!policy.fallback_to_cloud);
+        assert_eq!(policy.max_grace_tokens, 0);
+
+        let options = RunOptions::default();
+        assert!(options.generation_config.is_none());
+        assert_eq!(options.abort_policy, policy);
+        assert!(options.cancellation_token.is_none());
+        assert!(options.correlation_id.is_none());
+        assert!(options.resource_provider.is_none());
+        assert!(options.device_metrics.is_none());
+    }
+
+    #[test]
     fn abort_state_respects_grace_tokens() {
         let token = CancellationToken::new();
         let options = RunOptions::new()

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -442,6 +442,32 @@ class XybridPipeline {
 }
 ```
 
+### Rust
+
+```rust
+impl Pipeline {
+    pub fn run_with_options(
+        &self,
+        envelope: &Envelope,
+        options: &RunOptions,
+    ) -> PipelineResult<PipelineExecutionResult>;
+
+    pub async fn run_async_with_options(
+        &self,
+        envelope: &Envelope,
+        options: &RunOptions,
+    ) -> PipelineResult<PipelineExecutionResult>;
+}
+
+impl Xybrid {
+    pub fn run_pipeline_with_options(
+        yaml: &str,
+        envelope: &Envelope,
+        options: &RunOptions,
+    ) -> PipelineResult<PipelineExecutionResult>;
+}
+```
+
 ### Implementation Status
 
 | Method | Dart | Kotlin | Swift | C# |
@@ -455,6 +481,7 @@ class XybridPipeline {
 | `stageNames` | ✅ | — | — | — |
 | `load()` | ✅ | — | — | — |
 | `run()` | ✅ | — | — | — |
+| `runWithOptions()` / `run_with_options()` | Rust ✅ | planned | planned | planned |
 
 > **Note**: The Dart SDK currently uses a single `XybridPipeline` class (no separate `PipelineRef`).
 > The Kotlin spec shows the two-step `PipelineRef` → `Pipeline` pattern which is the target design.
@@ -816,9 +843,10 @@ final stream = model.runStreaming(
 ### RunOptions and AbortPolicy
 
 Per-run controls for cooperative cancellation and resource-driven local abort.
-Rust SDK methods with options are available as `run_with_options`,
+Rust SDK methods with options are available as model-level `run_with_options`,
 `run_with_context_options`, `run_streaming_with_options`, and
-`run_streaming_with_context_options`.
+`run_streaming_with_context_options`, plus pipeline-level `run_with_options`,
+`run_async_with_options`, and `Xybrid::run_pipeline_with_options`.
 
 ```rust
 let token = CancellationToken::new();

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -199,6 +199,12 @@ classes:
         async: true
         params: [{ name: envelope, type: Envelope }]
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
+      runWithOptions:
+        async: true
+        params:
+          - { name: envelope, type: Envelope }
+          - { name: options, type: RunOptions }
+        status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
     properties:
       name:
         type: "String?"


### PR DESCRIPTION
## Summary
- Add backward-compatible pipeline `RunOptions` entrypoints for `Pipeline` and `Xybrid` convenience execution.
- Carry caller-provided correlation IDs into pipeline completion telemetry and allow caller-provided device metrics for routing.
- Add explicit default-contract coverage for `AbortPolicy` and `RunOptions`, then document the Rust SDK API surface.

## Validation
- `cargo test -p xybrid-sdk --features platform-macos --lib`
- `cargo clippy -p xybrid-sdk --features platform-macos --lib --tests -- -D warnings`
- `./tools/scripts/api-contract-check.sh --check` exits 0; existing binding-status warning drift remains.