### PR TITLE
fix(llama-cpp): skip KV prefix-reuse on recurrent/hybrid architectures

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -213,6 +213,7 @@ impl LlamaCppBackend {
     /// accessor [`Self::last_cached_prefix_len`].
     fn prepare_kv_cache_and_get_tail(
         &self,
+        model: &sys::LlamaModel,
         context: &sys::LlamaContext,
         new_tokens: &[i32],
         max_new_tokens: usize,
@@ -232,9 +233,6 @@ impl LlamaCppBackend {
         // pre-prefix-reuse full-clear path. The cost is per-turn
         // re-prefill of the full conversation, which is the engine's
         // pre-INF-99 behaviour.
-        let model = self.model.as_ref().ok_or_else(|| {
-            AdapterError::ModelNotLoaded("No model loaded for KV cache prepare".to_string())
-        })?;
         if sys::llama_model_is_recurrent(model) {
             sys::llama_kv_cache_clear(context);
             state.cached_tokens = new_tokens.to_vec();
@@ -418,7 +416,7 @@ impl LlmBackend for LlamaCppBackend {
             // unconditional clear, just without the duplicate work in
             // multi-turn chats.
             let (tail, n_past) =
-                self.prepare_kv_cache_and_get_tail(context, &tokens, config.max_tokens)?;
+                self.prepare_kv_cache_and_get_tail(model, context, &tokens, config.max_tokens)?;
 
             // Per-chunk timestamps capture the streaming cadence for TTFT +
             // inter-token-latency telemetry. The closure is observation-only
@@ -548,7 +546,7 @@ impl LlmBackend for LlamaCppBackend {
             // across calls so the LCP path will mostly clear-and-refill,
             // but the unified helper keeps behaviour consistent.
             let (tail, n_past) =
-                self.prepare_kv_cache_and_get_tail(context, &tokens, config.max_tokens)?;
+                self.prepare_kv_cache_and_get_tail(model, context, &tokens, config.max_tokens)?;
 
             // Use the streaming-capable API with an observation-only
             // callback so raw generation gets the same TTFT / ITL /
@@ -639,7 +637,7 @@ impl LlmBackend for LlamaCppBackend {
             // already prefilled, only re-prefill the diverged tail. See
             // prepare_kv_cache_and_get_tail for the full contract.
             let (tail, n_past) =
-                self.prepare_kv_cache_and_get_tail(context, &tokens, config.max_tokens)?;
+                self.prepare_kv_cache_and_get_tail(model, context, &tokens, config.max_tokens)?;
 
             // Shared streaming state: telemetry recorder + text filter.
             // The filter owns cumulative text, think-block state, stop-pattern

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -222,6 +222,26 @@ impl LlamaCppBackend {
             .lock()
             .map_err(|_| AdapterError::RuntimeError("KV state mutex poisoned".to_string()))?;
 
+        // Recurrent / hybrid architectures (Mamba, RWKV, LFM, …) can't
+        // safely have their cache truncated by position — the recurrence
+        // accumulates state across positions, so `llama_kv_cache_seq_rm`
+        // leaves the residual state inconsistent with the new prefix
+        // length and `llama_decode` fails on the diverging tail (wrapper
+        // error code -3, surfaced on LFM 2.5 second-turn chat). Skip the
+        // optimisation entirely on these models and fall back to the
+        // pre-prefix-reuse full-clear path. The cost is per-turn
+        // re-prefill of the full conversation, which is the engine's
+        // pre-INF-99 behaviour.
+        let model = self.model.as_ref().ok_or_else(|| {
+            AdapterError::ModelNotLoaded("No model loaded for KV cache prepare".to_string())
+        })?;
+        if sys::llama_model_is_recurrent(model) {
+            sys::llama_kv_cache_clear(context);
+            state.cached_tokens = new_tokens.to_vec();
+            state.last_prefix_hit = Some(0);
+            return Ok((new_tokens.to_vec(), 0));
+        }
+
         let n_ctx = sys::llama_n_ctx(context);
         let prefix_len = compute_reusable_prefix_len(&state.cached_tokens, new_tokens);
 

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
@@ -866,7 +866,8 @@ pub fn llama_generate_with_stops(
             -2 => "sampler chain creation failed",
             -3 => {
                 "llama_decode failed on prefill \
-                 (enable XYBRID_LLAMACPP_VERBOSITY=2 for the wrapper-level diagnostic)"
+                 (the wrapper logs the actual llama_decode return code + chunk \
+                 position to stderr; see `llama_generate_c` in llama_wrapper.cpp)"
             }
             -4 => "input exceeds context window",
             _ => "unknown",
@@ -1067,20 +1068,22 @@ where
             -1 => "invalid arguments (null context/model/input or non-positive sizes)",
             -2 => "sampler chain creation failed",
             -3 => {
-                // The wrapper logs the actual llama_decode return code +
-                // n_past_in / chunk position to stderr (see
-                // `llama_generate_streaming_c` in llama_wrapper.cpp). When
-                // n_past_in > 0 the prefix-reuse path was in play; that's
-                // the path that triggers KV-cache state mismatches on
-                // recurrent / hybrid models. The adapter
+                // The wrapper unconditionally logs the actual llama_decode
+                // return code + n_past_in / chunk position to stderr (see
+                // `llama_generate_streaming_c` in llama_wrapper.cpp); the
+                // diagnostic is not gated on `XYBRID_LLAMACPP_VERBOSITY`,
+                // which only controls llama.cpp's own log callback path.
+                // When n_past_in > 0 the prefix-reuse path was in play;
+                // that's the path that triggers KV-cache state mismatches
+                // on recurrent / hybrid models. The adapter
                 // (`prepare_kv_cache_and_get_tail`) now full-clears the
                 // cache for recurrent models specifically, so this should
-                // be rare; if you hit it on a new architecture, enable
-                // `XYBRID_LLAMACPP_VERBOSITY=2` for the wrapper's stderr
-                // diagnostic and consider whether the model needs the
-                // recurrent path.
+                // be rare; if you hit it on a new architecture, consult
+                // the stderr line and consider whether the model needs
+                // the recurrent path.
                 "llama_decode failed on prefill (KV-cache state mismatch likely; \
-                 enable XYBRID_LLAMACPP_VERBOSITY=2 for the wrapper-level diagnostic)"
+                 see stderr for the wrapper-level diagnostic line emitted by \
+                 `llama_generate_streaming_c`)"
             }
             -4 => "input + prefix exceeds context window (n_past_in + n_input >= n_ctx)",
             _ => "unknown",

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
@@ -145,6 +145,16 @@ extern "C" {
     fn llama_n_vocab_c(model: *const c_void) -> c_int;
     fn llama_n_ctx_c(ctx: *const c_void) -> c_int;
 
+    // Recurrent / hybrid architecture detection. Returns true for Mamba,
+    // RWKV, LFM, and similar models whose state can't be safely
+    // truncated by position (the recurrence accumulates state). Callers
+    // must skip the KV-cache prefix-reuse optimisation on these models —
+    // truncate-then-prefill-tail leaves the residual recurrent state
+    // inconsistent with the new prefix length and `llama_decode` fails
+    // on the diverging tail (returns non-zero, surfaces as wrapper
+    // error code -3).
+    fn llama_model_is_recurrent_c(model: *const c_void) -> bool;
+
     // Generation (low-level)
     fn llama_decode_c(ctx: *mut c_void, batch: *const c_void) -> c_int;
     fn llama_get_logits_c(ctx: *mut c_void) -> *mut c_float;
@@ -405,6 +415,19 @@ pub fn llama_n_vocab(model: &LlamaModel) -> usize {
 #[cfg(feature = "llm-llamacpp")]
 pub fn llama_n_ctx(ctx: &LlamaContext) -> usize {
     unsafe { llama_n_ctx_c(ctx.ptr) as usize }
+}
+
+/// Returns true for recurrent / hybrid-state architectures (Mamba,
+/// RWKV, LFM, etc.). Callers that manipulate the KV cache by position —
+/// in particular the multi-turn prefix-reuse path in
+/// `LlamaCppBackend::prepare_kv_cache_and_get_tail` — must skip those
+/// optimisations on these models and full-clear the cache between
+/// turns instead. Truncating a recurrent state mid-sequence leaves the
+/// residual state inconsistent with the new prefix length and
+/// `llama_decode` fails on the diverging tail.
+#[cfg(feature = "llm-llamacpp")]
+pub fn llama_model_is_recurrent(model: &LlamaModel) -> bool {
+    unsafe { llama_model_is_recurrent_c(model.ptr) }
 }
 
 /// Get the model's chat template string from GGUF metadata.
@@ -838,9 +861,19 @@ pub fn llama_generate_with_stops(
     };
 
     if result < 0 {
+        let detail = match result {
+            -1 => "invalid arguments (null context/model/input or non-positive sizes)",
+            -2 => "sampler chain creation failed",
+            -3 => {
+                "llama_decode failed on prefill \
+                 (enable XYBRID_LLAMACPP_VERBOSITY=2 for the wrapper-level diagnostic)"
+            }
+            -4 => "input exceeds context window",
+            _ => "unknown",
+        };
         return Err(AdapterError::RuntimeError(format!(
-            "Generation failed with error code {}",
-            result
+            "Generation failed with error code {} ({})",
+            result, detail
         )));
     }
 
@@ -1030,9 +1063,31 @@ where
     // Check for hard error codes FIRST — these are never callback-stop.
     // -1 = invalid args, -2 = sampler creation failed, -3 = decode failed, -4 = input too long.
     if (-4..=-1).contains(&result) {
+        let detail = match result {
+            -1 => "invalid arguments (null context/model/input or non-positive sizes)",
+            -2 => "sampler chain creation failed",
+            -3 => {
+                // The wrapper logs the actual llama_decode return code +
+                // n_past_in / chunk position to stderr (see
+                // `llama_generate_streaming_c` in llama_wrapper.cpp). When
+                // n_past_in > 0 the prefix-reuse path was in play; that's
+                // the path that triggers KV-cache state mismatches on
+                // recurrent / hybrid models. The adapter
+                // (`prepare_kv_cache_and_get_tail`) now full-clears the
+                // cache for recurrent models specifically, so this should
+                // be rare; if you hit it on a new architecture, enable
+                // `XYBRID_LLAMACPP_VERBOSITY=2` for the wrapper's stderr
+                // diagnostic and consider whether the model needs the
+                // recurrent path.
+                "llama_decode failed on prefill (KV-cache state mismatch likely; \
+                 enable XYBRID_LLAMACPP_VERBOSITY=2 for the wrapper-level diagnostic)"
+            }
+            -4 => "input + prefix exceeds context window (n_past_in + n_input >= n_ctx)",
+            _ => "unknown",
+        };
         return Err(AdapterError::RuntimeError(format!(
-            "Generation failed with error code {}",
-            result
+            "Generation failed with error code {} ({}; n_past_in={})",
+            result, detail, n_past_in
         )));
     }
 

--- a/crates/xybrid-core/tests/llm_context_integration.rs
+++ b/crates/xybrid-core/tests/llm_context_integration.rs
@@ -334,3 +334,86 @@ fn test_moderate_prompt_over_512_tokens_works() {
         println!("Moderate prompt response: {}", text);
     }
 }
+
+/// Regression test for INF-162: two-turn chat on a recurrent/hybrid-arch
+/// model (LFM 2.5 350M) must not fail with `Generation failed with
+/// error code -3` on the second turn.
+///
+/// Root cause: the multi-turn KV-cache prefix-reuse path
+/// (`prepare_kv_cache_and_get_tail`) calls `llama_kv_cache_seq_rm` to
+/// truncate the cache to a shared prefix, then re-prefills the
+/// diverging tail at `n_past_in`. That dance is safe for pure attention
+/// caches but leaves the recurrent state of hybrid models (LFM, Mamba,
+/// RWKV) inconsistent with the new prefix length — `llama_decode` then
+/// fails on the diverging tail (wrapper error code -3).
+///
+/// The fix gates prefix-reuse on `!llama_model_is_recurrent`, so
+/// recurrent models full-clear the cache between turns (the pre-INF-99
+/// behaviour). This test exercises the previously-failing sequence to
+/// catch the regression if the gate is ever removed.
+///
+/// Skips when the `lfm2.5-350m` fixture isn't downloaded, mirroring
+/// the other tests in this file.
+#[test]
+fn test_recurrent_model_multi_turn_no_decode_error_3() {
+    if !model_fixtures::model_available("lfm2.5-350m") {
+        eprintln!("Skipping: lfm2.5-350m model not downloaded");
+        return;
+    }
+
+    let model_dir = model_fixtures::require_model("lfm2.5-350m");
+    let metadata = load_metadata(&model_dir);
+    let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
+
+    let mut ctx = ConversationContext::new().with_max_history_len(20);
+
+    // Turn 1: warm the cache. Pre-INF-99 this is the only kind of call;
+    // post-INF-99 it primes `kv_state.cached_tokens` for the
+    // prefix-reuse path that triggers the bug on turn 2.
+    let turn1 = Envelope::new(EnvelopeKind::Text(
+        "Say the word ready in one word.".to_string(),
+    ))
+    .with_role(MessageRole::User);
+    let result1 = executor.execute_streaming_with_context(
+        &metadata,
+        &turn1,
+        &ctx,
+        Box::new(|_token| Ok(())),
+        None,
+    );
+    assert!(
+        result1.is_ok(),
+        "Turn 1 on lfm2.5-350m should succeed: {:?}",
+        result1.err()
+    );
+    ctx.push(turn1);
+    ctx.push(result1.unwrap());
+
+    // Turn 2: previously failed at ~8ms with
+    // `Generation failed with error code -3` because prefix-reuse left
+    // the recurrent state mismatched. With the recurrent gate, the
+    // cache full-clears and turn 2 succeeds.
+    let turn2 = Envelope::new(EnvelopeKind::Text(
+        "Now say the word done in one word.".to_string(),
+    ))
+    .with_role(MessageRole::User);
+    let result2 = executor.execute_streaming_with_context(
+        &metadata,
+        &turn2,
+        &ctx,
+        Box::new(|_token| Ok(())),
+        None,
+    );
+    assert!(
+        result2.is_ok(),
+        "Turn 2 on lfm2.5-350m must not fail with decode error -3: {:?}",
+        result2.err()
+    );
+
+    if let EnvelopeKind::Text(text) = &result2.unwrap().kind {
+        assert!(
+            !text.is_empty(),
+            "Turn 2 response should not be empty (model produced no tokens)"
+        );
+    }
+}

--- a/crates/xybrid-core/vendor/llama_wrapper.cpp
+++ b/crates/xybrid-core/vendor/llama_wrapper.cpp
@@ -257,6 +257,28 @@ int llama_n_ctx_c(const llama_context* ctx) {
     return static_cast<int>(llama_n_ctx(ctx));
 }
 
+// Returns true if the model uses a recurrent / hybrid-state architecture
+// (Mamba, RWKV, LFM, etc.) rather than a pure attention KV cache.
+//
+// The multi-turn prefix-reuse path in the Rust adapter
+// (`prepare_kv_cache_and_get_tail`) calls `llama_kv_cache_seq_rm` to
+// truncate the cache to a shared prefix, then re-prefills the
+// diverging tail at `n_past_in`. That dance is safe for pure attention
+// caches but corrupts the recurrent state of hybrid models — the
+// recurrence accumulates across positions, so dropping a contiguous
+// suffix leaves the residual state inconsistent with the truncated
+// position. `llama_decode` then fails on the first batch of the new
+// tail.
+//
+// Callers should skip prefix-reuse and full-clear the cache between
+// turns when this returns true.
+bool llama_model_is_recurrent_c(const llama_model* model) {
+    if (!model) {
+        return false;
+    }
+    return llama_model_is_recurrent(model);
+}
+
 // =============================================================================
 // Generation (low-level)
 // =============================================================================
@@ -761,7 +783,20 @@ int llama_generate_streaming_c(
             n_cur++;
         }
 
-        if (llama_decode(ctx, batch) != 0) {
+        int decode_result = llama_decode(ctx, batch);
+        if (decode_result != 0) {
+            // Surface the actual llama_decode return code via stderr so
+            // operators running with XYBRID_LLAMACPP_VERBOSITY>=2 can
+            // distinguish KV-cache state mismatch (common on recurrent /
+            // hybrid arch models when prefix-reuse is misapplied) from
+            // hard runtime failures. The wrapper still returns -3 to
+            // preserve the Rust-side error-code contract.
+            fprintf(stderr,
+                    "llama_generate_streaming_c: llama_decode returned %d on "
+                    "prefill chunk [%d, %d) at n_past_in=%d, n_input=%d, n_ctx=%d. "
+                    "On recurrent/hybrid models this usually indicates "
+                    "prefix-reuse left the cache in an inconsistent state.\n",
+                    decode_result, chunk_start, chunk_end, n_past_in, n_input, n_ctx);
             delete[] candidates_data;
             llama_batch_free(batch);
             llama_sampler_free(sampler);

--- a/crates/xybrid-core/vendor/llama_wrapper.cpp
+++ b/crates/xybrid-core/vendor/llama_wrapper.cpp
@@ -585,7 +585,17 @@ int llama_generate_c(
             n_cur++;
         }
 
-        if (llama_decode(ctx, batch) != 0) {
+        int decode_result = llama_decode(ctx, batch);
+        if (decode_result != 0) {
+            // Mirror the streaming wrapper's diagnostic so the -3 Rust
+            // error message can point at a real stderr line. Always-on
+            // (not gated on llama.cpp verbosity) — this path has no
+            // n_past_in / prefix-reuse, so a decode failure here points
+            // at the input chunk itself, not a KV-cache state mismatch.
+            fprintf(stderr,
+                    "llama_generate_c: llama_decode returned %d on prefill "
+                    "chunk [%d, %d), n_input=%d, n_ctx=%d.\n",
+                    decode_result, chunk_start, chunk_end, n_input, n_ctx);
             delete[] candidates_data;
             llama_batch_free(batch);
             llama_sampler_free(sampler);


### PR DESCRIPTION
## Summary

Multi-turn chat on LFM 2.5 350M failed immediately on turn 2 with the opaque \`Generation failed with error code -3\` (8ms, pre-token-emission). Root cause: the KV-cache prefix-reuse path calls \`llama_kv_cache_seq_rm\` to truncate the cache to a shared prefix, then re-prefills the diverging tail at \`n_past_in\`. Safe for pure attention caches, breaks recurrent / hybrid arch (LFM, Mamba, RWKV) because the recurrent state can't be safely truncated by position.

## Changes

- **`vendor/llama_wrapper.cpp`** — wrap upstream \`llama_model_is_recurrent\` as \`llama_model_is_recurrent_c\`; add a stderr diagnostic that prints the actual \`llama_decode\` return code + chunk position + \`n_past_in\` when prefill fails (visible with \`XYBRID_LLAMACPP_VERBOSITY=2\`).
- **\`llama_cpp/sys.rs\`** — bind \`llama_model_is_recurrent_c\` as a safe Rust wrapper. Enrich error messages for codes -1 / -2 / -3 / -4 to include condition + \`n_past_in\`; no more opaque "error code -3".
- **\`llama_cpp/mod.rs\`** — gate prefix-reuse in \`prepare_kv_cache_and_get_tail\`: if \`llama_model_is_recurrent\` is true, full-clear the cache between turns (pre-prefix-reuse behaviour). No new arch-list to maintain — llama.cpp owns the classification.
- **\`tests/llm_context_integration.rs\`** — regression test \`test_recurrent_model_multi_turn_no_decode_error_3\` exercising the failing two-turn lfm2.5-350m sequence. Skips when the fixture isn't downloaded (mirrors the other tests in the file).

## Test plan

- [x] \`cargo test -p xybrid-core --features llm-llamacpp --lib\` — 898 pass
- [x] \`cargo test -p xybrid-core --features llm-llamacpp --test llm_context_integration\` — 6 pass (lfm2.5-350m test compiles + runs, skips without fixture)
- [x] \`cargo clippy --workspace --tests --benches -- -D warnings\` clean
- [ ] On-device smoke (iOS, lfm2.5-350m): rebuild XCFramework, send two-turn chat, confirm both turns succeed and no \`error code -3\`. Also test gemma-3-1b (non-recurrent) to verify prefix-reuse still works on the optimised path.