### PR TITLE
chore(release): pin XybridFFI checksum for v0.1.0-rc1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.1.0-rc1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "0000000000000000000000000000000000000000000000000000000000000000"
+let xybridFFIChecksum = "7a395ce792a136bec78a375b413ea76a62ad42854ccfd8100827088b59154772"
 
 let package = Package(
     name: "Xybrid",


### PR DESCRIPTION
## Summary

Replaces the placeholder `xybridFFIChecksum` in `Package.swift` with the SHA-256 of the `XybridFFI-v0.1.0-rc1.xcframework.zip` produced by the release workflow's first run on tag `v0.1.0-rc1` (CI run 25810835762, step "Compute XCFramework checksum"). The placeholder caused the release workflow's "Verify root Package.swift checksum" gate to fail, blocking artifact upload. With this committed on master, the tag can be moved to point at this commit and the release workflow will pass `--check` on the second run.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below)

Release-process change: pre-populates the SPM binary-target checksum for the v0.1.0-rc1 tag so SPM consumers can verify the published xcframework zip.

## Checklist

- [x] Tests pass (`cargo test`) — N/A, manifest-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No breaking changes (or breaking changes documented)