### PR TITLE
fix(device): cover aarch64 non-Apple targets in detect_apple_device

### DIFF
--- a/crates/xybrid-core/src/device/apple.rs
+++ b/crates/xybrid-core/src/device/apple.rs
@@ -130,6 +130,21 @@ pub fn detect_apple_device() -> AppleDeviceInfo {
             confidence: DetectionConfidence::High,
         }
     }
+    // Non-Apple aarch64 hosts (Linux aarch64, Android aarch64). The
+    // function isn't *expected* to run here — these hosts can't actually
+    // host an Apple device — but the file is compiled for every target
+    // in the workspace, so this branch is needed to keep the function
+    // a `-> AppleDeviceInfo` rather than `-> ()`. Env-var hints above
+    // are the only signal that could have produced a real value; if we
+    // reached this point, we had none.
+    #[cfg(all(target_arch = "aarch64", not(any(target_os = "macos", target_os = "ios"))))]
+    {
+        AppleDeviceInfo {
+            device_model: None,
+            has_neural_engine: false,
+            confidence: DetectionConfidence::Unknown,
+        }
+    }
 }
 
 /// Read the hardware-model identifier via `sysctlbyname`. Returns the

--- a/crates/xybrid-core/src/device/apple.rs
+++ b/crates/xybrid-core/src/device/apple.rs
@@ -137,7 +137,10 @@ pub fn detect_apple_device() -> AppleDeviceInfo {
     // a `-> AppleDeviceInfo` rather than `-> ()`. Env-var hints above
     // are the only signal that could have produced a real value; if we
     // reached this point, we had none.
-    #[cfg(all(target_arch = "aarch64", not(any(target_os = "macos", target_os = "ios"))))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        not(any(target_os = "macos", target_os = "ios"))
+    ))]
     {
         AppleDeviceInfo {
             device_model: None,


### PR DESCRIPTION
## Summary

On `aarch64-linux-android` and `aarch64-unknown-linux-gnu`, none of the existing cfg-gated tail blocks in `detect_apple_device` compile in (per-OS aarch64 blocks gate on macos/ios; the "Intel Mac" fallback gates on `not(target_arch = "aarch64")`), so the function reduces to a bare `if let Some(_) = env_model { ... }` which evaluates to `()` and triggers `E0317` against the `-> AppleDeviceInfo` return type. Adds a fallback for `aarch64 && !macos && !ios` returning an Unknown `AppleDeviceInfo`, matching the conservative posture used for aarch64-ios when no model identifier is available. Unblocks Build Unity → Build Android Libraries and Release → Precompile Flutter (linux) without changing behavior on any target that previously compiled.

## Reproduction

No cross C toolchain needed — `cargo check` fails on dep build scripts because aarch64-linux-gnu-gcc isn't installed, but `rustc` alone is enough since this is a type-level error in the crate's own source:

```bash
rustc --target aarch64-unknown-linux-gnu --crate-type lib \
      --emit=metadata -o /tmp/x.rmeta crates/xybrid-core/src/device/apple.rs
```

Before this change: `E0317` on `detect_apple_device`. After: clean.

Verified locally on `aarch64-unknown-linux-gnu`, `aarch64-linux-android`, `aarch64-apple-darwin` (host), and `x86_64-unknown-linux-gnu` with a minimal reproducer mirroring the cfg shape. `cargo check -p xybrid-core --lib` passes on the host.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — host check verified; the new branch is a static return, no test coverage needed
- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No breaking changes (or breaking changes documented)