### PR TITLE
bump: 0.1.0-rc2

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -90,8 +90,12 @@ jobs:
             cargo-ndk-${{ runner.os }}-
 
       - name: Install cargo-ndk
-        if: steps.cache-cargo-ndk.outputs.cache-hit != 'true'
-        run: cargo install cargo-ndk
+        # actions/cache sets cache-hit only on EXACT key match; with
+        # restore-keys, a fallback can populate ~/.cargo/bin/cargo-ndk while
+        # leaving cache-hit empty, which made the previous `if:`-gated
+        # `cargo install` re-run and fail with "binary already exists".
+        # `which || install` is idempotent in both states.
+        run: which cargo-ndk || cargo install cargo-ndk
 
       - name: Build Android .so files
         run: cargo xtask build-android --release

--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -339,8 +339,12 @@ jobs:
             cargo-ndk-${{ runner.os }}-
 
       - name: Install cargo-ndk
-        if: steps.cache-cargo-ndk.outputs.cache-hit != 'true'
-        run: cargo install cargo-ndk
+        # actions/cache sets cache-hit only on EXACT key match; with
+        # restore-keys, a fallback can populate ~/.cargo/bin/cargo-ndk while
+        # leaving cache-hit empty, which made the previous `if:`-gated
+        # `cargo install` re-run and fail with "binary already exists".
+        # `which || install` is idempotent in both states.
+        run: which cargo-ndk || cargo install cargo-ndk
 
       - name: Build for aarch64-linux-android
         run: cargo xtask build-ffi --target aarch64-linux-android --deploy-unity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.0-rc2] - 2026-05-14
+
+### Fixed
+
+- **Apple device detection compile on non-Apple aarch64 targets** (#112): `detect_apple_device` in `xybrid-core` now compiles on `aarch64-linux-android` and `aarch64-unknown-linux-gnu`. The missing tail expression triggered E0317 on those targets, which silently blocked `Build Unity → Build Android Libraries` and the Release workflow's `Precompile Flutter (linux)` job in 0.1.0-rc1.
+
+### Release
+
+- **Flutter (pub.dev) and Unity (UPM)** ship for 0.1.0-rc2. Both were skipped in 0.1.0-rc1 because the aarch64 compile failure above blocked their upstream build jobs; no code/API changes in the Flutter or Unity bindings themselves.
+
+### Build / CI
+
+- **Release workflow self-patches the SPM manifest checksum** (#111): the XCFramework SHA computed by CI is now written into `xybridFFIChecksum` in `Package.swift`, committed, and the tag is force-moved to the patched commit. Removes the chicken-and-egg between the tag-time manifest and the CI-rebuilt zip bytes.
+
+---
+
 ## [0.1.0-rc1] - 2026-04-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -9603,7 +9603,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9618,7 +9618,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9645,7 +9645,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -9709,7 +9709,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -9720,7 +9720,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9729,7 +9729,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9755,7 +9755,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-uniffi"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 dependencies = [
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.1.0-rc1"
+let sdkVersion = "0.1.0-rc2"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0-rc2
+
+* Republishes 0.1.0-rc1 — the rc1 pub.dev publish was skipped due to an upstream compile failure in `xybrid-core` on `aarch64-linux-android` (fixed in xybrid-ai/xybrid#112). No API or behavior changes in the Flutter binding itself.
+
 ## 0.1.0-rc1
 
 * Registry calls now send the `X-Xybrid-Client` telemetry header identifying the Flutter binding, SDK / core versions, platform, and enabled backends; respects the `XYBRID_TELEMETRY_OPTOUT` env var

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.1.0-rc1
+version: 0.1.0-rc2
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.1.0-rc1",
+  "version": "0.1.0-rc2",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary

Version bump from `0.1.0-rc1` to `0.1.0-rc2` across every package manifest (Cargo workspace, Flutter pubspec, Kotlin Gradle, Unity package.json, Swift SPM manifest), plus rc2 entries in `CHANGELOG.md` and `bindings/flutter/CHANGELOG.md`. `version-sync.sh --check` reports all five manifests in sync.

rc2 is being cut to actually ship the **Flutter (pub.dev)** and **Unity (UPM)** SDKs, which `0.1.0-rc1` silently skipped: `Precompile Flutter (linux)` and `Build Unity → Build Android Libraries` both failed on rc1 due to a pre-existing `E0317` in `xybrid-core/device/apple.rs` on `aarch64-linux-android`/`aarch64-unknown-linux-gnu` (fixed in #112), which gated `publish-flutter` and the Unity Package + UPM publish steps. With the apple.rs fix on master and the release workflow's self-patch step from #111, rc2's tag-push should publish all five SDKs end-to-end on the first run.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below)

Release-prep version bump. No code changes outside manifest version literals and CHANGELOG entries.

## Checklist

- [x] Tests pass (`cargo test`) — N/A, version-bump only
- [x] Code follows project style
- [x] Documentation updated (if applicable) — both CHANGELOGs
- [x] No breaking changes (or breaking changes documented)

## Post-merge

\`\`\`bash
git fetch origin
git tag v0.1.0-rc2 origin/master
git push origin v0.1.0-rc2
\`\`\`