### PR TITLE
ci(release): inline publish-flutter to dodge checkout@v6 ref-moved guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,18 +482,41 @@ jobs:
 
   #
   # Publish Flutter SDK to pub.dev (OIDC -- zero secrets)
-  # Uses dart-lang/setup-dart reusable workflow for automatic OIDC token exchange.
-  # Requires trusted publisher configured on pub.dev for xybrid-ai/xybrid + release.yml.
-  # This job does NOT block the GitHub Release -- failure only affects pub.dev publishing.
+  #
+  # Inlines the same steps the dart-lang/setup-dart publish.yml reusable
+  # workflow runs, but pins actions/checkout to v4 instead of v6. v6 added
+  # a safety check that aborts when the workflow's ref has been updated
+  # since the run was triggered. Our build-apple-all job force-moves the
+  # tag (self-patches xybridFFIChecksum into Package.swift), which trips
+  # that check and skipped Flutter from pub.dev on 0.1.0-rc2. v4 doesn't
+  # enforce the check; everything else under release.yml already pins v4.
+  #
+  # pub.dev's trusted-publisher config matches on `workflow_ref` (the
+  # caller's workflow path), so inlining preserves the existing trust
+  # binding to xybrid-ai/xybrid/.github/workflows/release.yml.
+  #
+  # This job does NOT block the GitHub Release -- failure only affects
+  # pub.dev publishing.
   #
   publish-flutter:
     name: Publish Flutter to pub.dev
     needs: [build-apple-all, precompile-flutter-linux, precompile-flutter-windows]
+    runs-on: ubuntu-latest
     permissions:
       id-token: write   # Required for OIDC authentication with pub.dev
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      working-directory: bindings/flutter
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+      - uses: flutter-actions/setup-flutter@18c66a64fb6f6d3338c63cabbc5cd6da395e7f1d
+      - name: Install dependencies
+        run: dart pub get
+        working-directory: bindings/flutter
+      - name: Publish - dry run
+        run: dart pub publish --dry-run
+        working-directory: bindings/flutter
+      - name: Publish to pub.dev
+        run: dart pub publish -f
+        working-directory: bindings/flutter
 
   #
   # CLI builds (Linux + Windows only; macOS is built in build-apple-all)


### PR DESCRIPTION
## Summary

The \`dart-lang/setup-dart/.github/workflows/publish.yml@v1\` reusable workflow pins \`actions/checkout\` to v6, which enforces a "ref may have been updated since trigger" guard. Our \`build-apple-all\` job force-moves the tag (so the tagged commit has the freshly-built XCFramework's SHA in \`xybridFFIChecksum\`), and \`publish-flutter\` runs after that step — so \`checkout@v6\` refuses to fetch and Flutter is silently skipped from pub.dev (what happened on 0.1.0-rc2, which was published manually as a workaround). Inline the three publish steps under \`release.yml\` using \`actions/checkout@v4\` (the SHA the rest of \`release.yml\` already pins) — v4 doesn't enforce that check. pub.dev's trusted-publisher claim is validated against \`workflow_ref\` (the caller's workflow path), not \`job_workflow_ref\`, so the existing trust binding to \`xybrid-ai/xybrid/.github/workflows/release.yml\` is preserved; no pub.dev config change required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

CI/release-workflow fix.

## Checklist

- [x] Tests pass (\`cargo test\`) — N/A, workflow-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No breaking changes (or breaking changes documented)

## Will need verification on the next tag push

There's no way to exercise this change without cutting a new release tag (the workflow only runs on \`push.tags: v*\`). The diff matches the reusable workflow's steps 1:1 apart from the checkout pin, and the comment in the workflow walks through the rationale, so the next \`v*\` tag — whether rc3 or 0.1.0 final — will be the validation event.