### PR TITLE
fix(llama-cpp): also gate prefix-reuse on hybrid architectures (LFM2 etc.)

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -223,17 +223,24 @@ impl LlamaCppBackend {
             .lock()
             .map_err(|_| AdapterError::RuntimeError("KV state mutex poisoned".to_string()))?;
 
-        // Recurrent / hybrid architectures (Mamba, RWKV, LFM, …) can't
-        // safely have their cache truncated by position — the recurrence
-        // accumulates state across positions, so `llama_kv_cache_seq_rm`
-        // leaves the residual state inconsistent with the new prefix
-        // length and `llama_decode` fails on the diverging tail (wrapper
-        // error code -3, surfaced on LFM 2.5 second-turn chat). Skip the
-        // optimisation entirely on these models and fall back to the
-        // pre-prefix-reuse full-clear path. The cost is per-turn
-        // re-prefill of the full conversation, which is the engine's
-        // pre-INF-99 behaviour.
-        if sys::llama_model_is_recurrent(model) {
+        // Models with recurrent state — fully recurrent (Mamba, RWKV)
+        // OR hybrid (LFM2 / LFM2MOE, Qwen35 / Qwen35MOE, Granite-hybrid,
+        // …) — can't safely have their cache truncated by position.
+        // Their recurrent layers accumulate state across positions, so
+        // `llama_kv_cache_seq_rm` leaves the residual state inconsistent
+        // with the new prefix length and `llama_decode` fails on the
+        // diverging tail (wrapper error code -3; surfaced on LFM 2.5
+        // second-turn chat).
+        //
+        // Gating on `has_recurrent_state` (which combines the upstream
+        // `is_recurrent` and `is_hybrid` predicates) instead of
+        // `is_recurrent` alone is important: LFM2 is classified hybrid,
+        // not fully recurrent, so a narrower check missed it the first
+        // time round. Skip prefix-reuse entirely on these models and
+        // fall back to the pre-INF-99 full-clear path. The cost is
+        // per-turn re-prefill of the full conversation — correct, just
+        // not the prefix-reuse optimisation.
+        if sys::llama_model_has_recurrent_state(model) {
             sys::llama_kv_cache_clear(context);
             state.cached_tokens = new_tokens.to_vec();
             state.last_prefix_hit = Some(0);

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/sys.rs
@@ -145,15 +145,24 @@ extern "C" {
     fn llama_n_vocab_c(model: *const c_void) -> c_int;
     fn llama_n_ctx_c(ctx: *const c_void) -> c_int;
 
-    // Recurrent / hybrid architecture detection. Returns true for Mamba,
-    // RWKV, LFM, and similar models whose state can't be safely
-    // truncated by position (the recurrence accumulates state). Callers
-    // must skip the KV-cache prefix-reuse optimisation on these models —
-    // truncate-then-prefill-tail leaves the residual recurrent state
-    // inconsistent with the new prefix length and `llama_decode` fails
+    // Fully recurrent architecture (Mamba, RWKV). Distinct from
+    // hybrid models — see `llama_model_has_recurrent_state_c`.
+    fn llama_model_is_recurrent_c(model: *const c_void) -> bool;
+
+    // Recurrent OR hybrid architecture (Mamba, RWKV, LFM2, LFM2MOE,
+    // Qwen35, Qwen35MOE, Granite-hybrid, …). This is the predicate
+    // the KV-cache prefix-reuse path gates on: any model with
+    // recurrent state cannot have its cache safely truncated by
+    // position via `llama_kv_cache_seq_rm`, because the recurrence
+    // accumulates across positions and the residual state ends up
+    // inconsistent with the new prefix length. `llama_decode` fails
     // on the diverging tail (returns non-zero, surfaces as wrapper
     // error code -3).
-    fn llama_model_is_recurrent_c(model: *const c_void) -> bool;
+    //
+    // Wraps two upstream predicates (`llama_model_is_recurrent` +
+    // `llama_model_is_hybrid`) so the Rust caller doesn't need to
+    // know which bucket each architecture falls into.
+    fn llama_model_has_recurrent_state_c(model: *const c_void) -> bool;
 
     // Generation (low-level)
     fn llama_decode_c(ctx: *mut c_void, batch: *const c_void) -> c_int;
@@ -417,17 +426,28 @@ pub fn llama_n_ctx(ctx: &LlamaContext) -> usize {
     unsafe { llama_n_ctx_c(ctx.ptr) as usize }
 }
 
-/// Returns true for recurrent / hybrid-state architectures (Mamba,
-/// RWKV, LFM, etc.). Callers that manipulate the KV cache by position —
-/// in particular the multi-turn prefix-reuse path in
-/// `LlamaCppBackend::prepare_kv_cache_and_get_tail` — must skip those
-/// optimisations on these models and full-clear the cache between
-/// turns instead. Truncating a recurrent state mid-sequence leaves the
-/// residual state inconsistent with the new prefix length and
-/// `llama_decode` fails on the diverging tail.
+/// Returns true for fully recurrent architectures (Mamba, RWKV).
+/// Most callers want [`llama_model_has_recurrent_state`] instead,
+/// which also covers hybrid models (LFM2, Qwen35, Granite-hybrid, …)
+/// — they have the same cache-truncation hazard.
 #[cfg(feature = "llm-llamacpp")]
 pub fn llama_model_is_recurrent(model: &LlamaModel) -> bool {
     unsafe { llama_model_is_recurrent_c(model.ptr) }
+}
+
+/// Returns true for any model with recurrent state — fully recurrent
+/// (Mamba, RWKV) or hybrid (LFM2 / LFM2MOE, Qwen35 / Qwen35MOE,
+/// Granite-hybrid, …). Callers that manipulate the KV cache by
+/// position — in particular the multi-turn prefix-reuse path in
+/// `LlamaCppBackend::prepare_kv_cache_and_get_tail` — must skip
+/// those optimisations on these models and full-clear the cache
+/// between turns instead. Truncating recurrent state mid-sequence
+/// leaves the residual state inconsistent with the new prefix length
+/// and `llama_decode` fails on the diverging tail (wrapper error
+/// code -3).
+#[cfg(feature = "llm-llamacpp")]
+pub fn llama_model_has_recurrent_state(model: &LlamaModel) -> bool {
+    unsafe { llama_model_has_recurrent_state_c(model.ptr) }
 }
 
 /// Get the model's chat template string from GGUF metadata.

--- a/crates/xybrid-core/vendor/llama_wrapper.cpp
+++ b/crates/xybrid-core/vendor/llama_wrapper.cpp
@@ -257,26 +257,37 @@ int llama_n_ctx_c(const llama_context* ctx) {
     return static_cast<int>(llama_n_ctx(ctx));
 }
 
-// Returns true if the model uses a recurrent / hybrid-state architecture
-// (Mamba, RWKV, LFM, etc.) rather than a pure attention KV cache.
-//
-// The multi-turn prefix-reuse path in the Rust adapter
-// (`prepare_kv_cache_and_get_tail`) calls `llama_kv_cache_seq_rm` to
-// truncate the cache to a shared prefix, then re-prefills the
-// diverging tail at `n_past_in`. That dance is safe for pure attention
-// caches but corrupts the recurrent state of hybrid models — the
-// recurrence accumulates across positions, so dropping a contiguous
-// suffix leaves the residual state inconsistent with the truncated
-// position. `llama_decode` then fails on the first batch of the new
-// tail.
-//
-// Callers should skip prefix-reuse and full-clear the cache between
-// turns when this returns true.
+// Returns true if the model uses a fully recurrent architecture
+// (Mamba, RWKV, etc.). See `llama_model_has_recurrent_state_c` for
+// the predicate the KV-cache prefix-reuse path should actually gate
+// on — that one also covers hybrid architectures (LFM, Qwen35,
+// Granite-hybrid) which mix attention + recurrent layers and have the
+// same cache-truncation hazard.
 bool llama_model_is_recurrent_c(const llama_model* model) {
     if (!model) {
         return false;
     }
     return llama_model_is_recurrent(model);
+}
+
+// Returns true if the model has any recurrent state — either fully
+// recurrent (Mamba, RWKV) or hybrid (LFM2, LFM2MOE, Qwen35,
+// Qwen35MOE, Granite-hybrid, etc.). Hybrid models interleave
+// attention and recurrent layers; the recurrent layers accumulate
+// state across positions, so truncating the cache by position via
+// `llama_kv_cache_seq_rm` leaves the residual state inconsistent
+// with the new prefix length and `llama_decode` fails on the
+// diverging tail.
+//
+// The Rust adapter's `prepare_kv_cache_and_get_tail` must skip
+// prefix-reuse and full-clear the cache between turns when this
+// returns true. Wraps the two upstream predicates in one call so
+// callers don't need to know the recurrent / hybrid distinction.
+bool llama_model_has_recurrent_state_c(const llama_model* model) {
+    if (!model) {
+        return false;
+    }
+    return llama_model_is_recurrent(model) || llama_model_is_hybrid(model);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #109. On-device LFM 2.5 verification after #109 merged showed the gate still didn't fire — turn-2 chat continued to fail with \`error -3 (n_past_in=13)\`. Root cause: \`llama_model_is_recurrent\` (the predicate #109 gated on) only covers fully recurrent architectures (Mamba, RWKV). LFM 2.5 is classified \`LLM_ARCH_LFM2\` → \`is_hybrid\` in upstream llama.cpp, which #109's narrower check missed.

## Fix

Wrap both upstream predicates (\`llama_model_is_recurrent\` + \`llama_model_is_hybrid\`) in one \`llama_model_has_recurrent_state_c\` helper. Gate prefix-reuse on the combined check. Now catches: Mamba, RWKV, LFM2 / LFM2MOE, Qwen35 / Qwen35MOE, Granite-hybrid — anything llama.cpp classifies as having recurrent state. Callers don't need to know which upstream bucket each arch lives in.

## Why the previous fix missed it

I read the upstream classification too narrowly — \`is_recurrent\` and \`is_hybrid\` are distinct predicates in llama.cpp (`src/llama-arch.h:636-637`). The fix shape was right; the predicate was wrong. The enriched \`-3\` error message from #109 (\`n_past_in=13\` in the user-facing string) is what surfaced this in one turn of on-device testing — that diagnostic earned its keep.

## Test plan

- [x] \`cargo test -p xybrid-core --features llm-llamacpp --lib\` — 903 pass
- [x] \`cargo clippy --workspace --tests --benches -- -D warnings\` clean
- [ ] On-device LFM 2.5 two-turn chat: verify the second turn now succeeds (the case that motivated this PR)
- [ ] Gemma-3-1b regression: prefix-reuse should still work on pure-attention models