### PR TITLE
fix(telemetry): stamp backend + quantization on streaming and chat-context LLM spans

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -46,6 +46,29 @@ fn mark_execution_terminal(guard: &ExecutionGuard, error: &AdapterError) {
     }
 }
 
+/// Stamp cost-attribution metadata (`backend`, `quantization`) onto the
+/// currently-open span.
+///
+/// The outer `execute:<model_id>` span set up by `execute_impl` already
+/// carries these — but the chat-context entry points
+/// (`execute_with_context_impl`, `execute_streaming_with_context_impl`)
+/// dispatch directly to the inner `execute_llm*` methods without ever
+/// opening that outer span, so the inner LLM spans are the only place the
+/// SDK telemetry hoist can read these fields from on a chat-context call.
+/// Call this from each inner LLM span site immediately after `SpanGuard`
+/// so both the non-context and chat-context flows produce the same wire
+/// shape.
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn stamp_llm_span_cost_attribution(metadata: &ModelMetadata) {
+    let backend_hint = metadata.metadata.get("backend").and_then(|v| v.as_str());
+    if let Some(label) = backend_hint.and_then(normalize_llm_backend_hint) {
+        xybrid_trace::add_metadata("backend", label);
+    }
+    if let Some(quant) = quantization_label_from_metadata(metadata) {
+        xybrid_trace::add_metadata("quantization", quant);
+    }
+}
+
 // Internal: ONNX-specific types needed for optimized execution paths
 // These are implementation details, not part of the public API
 use crate::execution::session_factory::OnnxSessionFactory;
@@ -369,6 +392,7 @@ impl TemplateExecutor {
 
                 // LLM execution via LlmRuntimeAdapter
                 return self.execute_llm(
+                    metadata,
                     model_file,
                     chat_template.as_deref(),
                     *context_length,
@@ -630,6 +654,7 @@ impl TemplateExecutor {
             let backend_hint = metadata.metadata.get("backend").and_then(|v| v.as_str());
 
             let mut result = self.execute_llm_with_messages(
+                metadata,
                 model_file,
                 *context_length,
                 &chat_messages,
@@ -723,6 +748,7 @@ impl TemplateExecutor {
                 let backend_hint = metadata.metadata.get("backend").and_then(|v| v.as_str());
 
                 return self.execute_llm_streaming(
+                    metadata,
                     model_file,
                     chat_template.as_deref(),
                     *context_length,
@@ -884,6 +910,7 @@ impl TemplateExecutor {
                 let backend_hint = metadata.metadata.get("backend").and_then(|v| v.as_str());
 
                 let result = self.execute_llm_streaming_with_messages(
+                    metadata,
                     model_file,
                     *context_length,
                     &chat_messages,
@@ -924,6 +951,7 @@ impl TemplateExecutor {
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
     fn execute_llm_streaming(
         &mut self,
+        metadata: &ModelMetadata,
         model_file: &str,
         chat_template: Option<&str>,
         context_length: usize,
@@ -944,6 +972,7 @@ impl TemplateExecutor {
         let _llm_span = xybrid_trace::SpanGuard::new("llm_inference_streaming");
         xybrid_trace::add_metadata("model", model_file);
         xybrid_trace::add_metadata("streaming", "true");
+        stamp_llm_span_cost_attribution(metadata);
 
         // Build full model path
         let model_path = Path::new(&self.base_path).join(model_file);
@@ -1062,6 +1091,7 @@ impl TemplateExecutor {
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
     fn execute_llm_with_messages(
         &mut self,
+        metadata: &ModelMetadata,
         model_file: &str,
         context_length: usize,
         messages: &[ChatMessage],
@@ -1079,6 +1109,7 @@ impl TemplateExecutor {
         let _llm_span = xybrid_trace::SpanGuard::new("llm_inference_with_messages");
         xybrid_trace::add_metadata("model", model_file);
         xybrid_trace::add_metadata("message_count", messages.len().to_string());
+        stamp_llm_span_cost_attribution(metadata);
 
         // Build full model path
         let model_path = Path::new(&self.base_path).join(model_file);
@@ -1152,6 +1183,7 @@ impl TemplateExecutor {
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
     fn execute_llm_streaming_with_messages(
         &mut self,
+        metadata: &ModelMetadata,
         model_file: &str,
         context_length: usize,
         messages: &[ChatMessage],
@@ -1172,6 +1204,7 @@ impl TemplateExecutor {
         let _llm_span = xybrid_trace::SpanGuard::new("llm_inference_streaming_with_messages");
         xybrid_trace::add_metadata("model", model_file);
         xybrid_trace::add_metadata("message_count", messages.len().to_string());
+        stamp_llm_span_cost_attribution(metadata);
 
         // Build full model path
         let model_path = Path::new(&self.base_path).join(model_file);
@@ -1245,6 +1278,7 @@ impl TemplateExecutor {
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
     fn execute_llm(
         &mut self,
+        metadata: &ModelMetadata,
         model_file: &str,
         chat_template: Option<&str>,
         context_length: usize,
@@ -1261,13 +1295,14 @@ impl TemplateExecutor {
 
         let _llm_span = xybrid_trace::SpanGuard::new("llm_inference");
         xybrid_trace::add_metadata("model", model_file);
-        // Normalise the legacy `mistral` alias to the canonical wire label
-        // before annotating the span: the SDK telemetry hoist reads this
-        // span for the `backend` field on `PlatformEvent`, which must be
-        // in the closed set `{llamacpp, mistralrs, ...}`.
-        if let Some(hint) = backend_hint.and_then(normalize_llm_backend_hint) {
-            xybrid_trace::add_metadata("backend", hint);
-        }
+        // Stamp the canonical `backend` + `quantization` labels onto the
+        // inner LLM span. The SDK telemetry hoist reads from any span in
+        // the trace; the outer `execute:<model_id>` span set up by
+        // `execute_impl` also carries these, but the chat-context
+        // dispatch path bypasses that outer span entirely, so stamping
+        // here is what makes the wire shape consistent across both
+        // entry points.
+        stamp_llm_span_cost_attribution(metadata);
 
         // Build full model path
         let model_path = Path::new(&self.base_path).join(model_file);

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -48,16 +48,16 @@ onnx-inspect = ["dep:ort", "ort/download-binaries", "ort/tls-native"]
 # PLATFORM PRESETS (SINGLE SOURCE OF TRUTH)
 
 # Android: Dynamic ORT loading + Candle + llama.cpp (mistral.rs has SIGILL issues on ARM)
-platform-android = ["xybrid-core/ort-dynamic", "xybrid-core/llm-llamacpp", "xybrid-core/candle"]
+platform-android = ["xybrid-core/ort-dynamic", "xybrid-core/llm-llamacpp", "xybrid-core/candle", "llm-llamacpp"]
 
 # iOS: CoreML + Metal acceleration + llama.cpp
-platform-ios = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "xybrid-core/llm-llamacpp"]
+platform-ios = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "xybrid-core/llm-llamacpp", "llm-llamacpp"]
 
 # macOS: CoreML + Metal + llama.cpp
-platform-macos = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "xybrid-core/llm-llamacpp"]
+platform-macos = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "xybrid-core/llm-llamacpp", "llm-llamacpp"]
 
 # Desktop (Linux/Windows): CPU with llama.cpp
-platform-desktop = ["xybrid-core/ort-download", "xybrid-core/llm-llamacpp"]
+platform-desktop = ["xybrid-core/ort-download", "xybrid-core/llm-llamacpp", "llm-llamacpp"]
 
 # INDIVIDUAL FEATURE FORWARDING (for custom builds)
 

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -712,6 +712,106 @@ fn execute_streaming_emits_no_outer_telemetry_events() {
     );
 }
 
+/// Regression guard: a chat-context LLM call must carry the `backend` and
+/// `quantization` cost-attribution labels somewhere in its captured span
+/// tree. The SDK's downstream `convert_to_platform_event` hoist reads
+/// from any span via `extract_string_attr_from_any_span`, so as long as
+/// at least one span in the trace carries each key the Traces dashboard
+/// renders the columns.
+///
+/// The subtle thing this is protecting against: the chat-context family
+/// in `execute_with_context_impl` / `execute_streaming_with_context_impl`
+/// dispatches directly to `execute_llm_with_messages` /
+/// `execute_llm_streaming_with_messages` without ever opening the outer
+/// `execute:<model>` span where the original cost-attribution stamps
+/// live. If a future refactor reroutes either of those inner functions
+/// off the helper that stamps `backend` + `quantization`, both columns
+/// blank out on every local LLM chat — the symptom is silent at the
+/// wire layer because the events still publish; the dashboard just
+/// shows two empty cells.
+///
+/// Skips gracefully when the GGUF fixture isn't downloaded so CI without
+/// `--features llm-llamacpp` and developers without the model on disk
+/// don't see spurious failures.
+#[cfg(feature = "llm-llamacpp")]
+#[test]
+fn chat_context_llm_call_carries_backend_and_quantization_on_spans() {
+    use xybrid_core::conversation::ConversationContext;
+    use xybrid_core::ir::MessageRole;
+    use xybrid_core::runtime_adapter::types::GenerationConfig;
+    use xybrid_core::tracing as core_tracing;
+
+    let _serial = listener_test_lock();
+
+    let Some(model_dir) = model_fixtures::model_or_skip("qwen2.5-0.5b-instruct") else {
+        return; // fixture not downloaded — skip gracefully
+    };
+
+    let metadata_path = model_dir.join("model_metadata.json");
+    let mut metadata: ModelMetadata =
+        serde_json::from_str(&std::fs::read_to_string(&metadata_path).unwrap()).unwrap();
+
+    // Pin the backend hint so the test asserts the SDK plumbing rather
+    // than whether the published bundle metadata happened to carry it.
+    // A separate concern (bundle hygiene) tracks getting every GGUF
+    // bundle's `metadata.backend` populated at pack time.
+    metadata
+        .metadata
+        .insert("backend".to_string(), serde_json::json!("llamacpp"));
+
+    // Enable + clear the global tracing collector so we read only the
+    // spans this test produced. Other tests that touch tracing share the
+    // collector — the listener_test_lock above serialises them.
+    core_tracing::init_tracing(true);
+    core_tracing::reset_tracing();
+
+    let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
+    let input = Envelope::new(EnvelopeKind::Text("hi".to_string())).with_role(MessageRole::User);
+    let ctx = ConversationContext::new();
+
+    // Keep generation tiny — we only need the call to exit cleanly so
+    // the LLM span closes and its metadata flushes into the collector.
+    let gen_config = GenerationConfig {
+        max_tokens: 4,
+        ..GenerationConfig::default()
+    };
+
+    let _ = executor
+        .execute_with_context(&metadata, &input, &ctx, Some(&gen_config))
+        .expect("chat-context LLM call should succeed");
+
+    let stages = core_tracing::get_stages_json();
+    let spans = stages
+        .get("spans")
+        .and_then(|v| v.as_array())
+        .expect("stages should have a spans array");
+
+    let any_span_carries = |key: &str| -> bool {
+        spans.iter().any(|s| {
+            s.get("metadata")
+                .and_then(|m| m.get(key))
+                .and_then(|v| v.as_str())
+                .is_some()
+        })
+    };
+
+    assert!(
+        any_span_carries("backend"),
+        "chat-context LLM call must stamp `backend` onto some span — the chat-context \
+         dispatch bypasses the outer `execute:<model>` span, so the inner LLM span has \
+         to carry it. Spans captured: {:#}",
+        stages
+    );
+    assert!(
+        any_span_carries("quantization"),
+        "chat-context LLM call must stamp `quantization` onto some span — same \
+         rationale as `backend`. Spans captured: {:#}",
+        stages
+    );
+
+    core_tracing::reset_tracing();
+}
+
 /// Smoke test: MNIST inference works without telemetry (no env vars needed).
 /// Ensures the model fixture is valid and the execution pipeline doesn't panic.
 #[test]


### PR DESCRIPTION
## Summary

- Cost-attribution labels (`backend`, `quantization`) were only stamped on the outer `execute:<model>` span (in `execute_impl`) and the basic `llm_inference` span — the three streaming / chat-context siblings (`llm_inference_streaming`, `llm_inference_with_messages`, `llm_inference_streaming_with_messages`) were never instrumented.
- Invisible for non-context CLI runs (they exercise the outer span), but every on-device chat call routes through `execute_with_context_impl` / `execute_streaming_with_context_impl`, which dispatch directly to the `_with_messages` family for GGUF templates without ever opening the outer span. Result: both Traces dashboard columns blank for every local LLM chat across gemma-3-1b, lfm2.5-350m, qwen3.5-*, …
- New `stamp_llm_span_cost_attribution(&ModelMetadata)` helper applies the existing label resolvers and emits onto the current span; called from all four inner LLM dispatch methods right after their `SpanGuard`.
- The four method signatures gain a leading `metadata: &ModelMetadata` so the helper can reach template + bundle hints without separate plumbing.

## Why

The original cost-attribution stamps assumed every LLM dispatch eventually reaches the outer `execute:<model>` span. Chat-context dispatches don't — they fork to `_with_messages` siblings that never had the stamping wired in. Adding it on the inner spans is consistent with the SDK telemetry hoist's `read from any span` design (which is what makes both non-context and chat-context flows produce the same wire shape after this fix).

## Test plan

- [x] `cargo test -p xybrid-sdk --features platform-macos` — 317 lib + 33 doctest + 8 integration tests pass, including the new `chat_context_llm_call_carries_backend_and_quantization_on_spans`. New test skips gracefully when the `qwen2.5-0.5b-instruct` fixture isn't downloaded.
- [x] `cargo test -p xybrid-core --features llm-llamacpp --lib` — 903 pass.
- [x] `cargo clippy --workspace --tests --benches --features platform-macos -- -D warnings` — clean.
- [ ] On-device verify chat on `gemma-3-1b` and `lfm2.5-350m`: both rows should now render `backend` (`llamacpp`) and `quantization` (`q4_k_m` etc) columns on the Traces dashboard.

## Notes

- `xybrid-sdk/Cargo.toml` platform presets now also enable the sdk-side `llm-llamacpp` feature (in addition to `xybrid-core/llm-llamacpp`) so the new integration test runs under the documented `cargo test -p xybrid-sdk --features platform-macos` invocation without an extra flag. xybrid-sdk has no source-level cfg on `feature = "llm-llamacpp"` today — change is purely additive.
- The new test pins `metadata.backend = "llamacpp"` on the loaded `ModelMetadata` before dispatch so it asserts the SDK plumbing rather than whether the published fixture bundle happened to declare the hint. Hardening pack-time bundle hygiene (every GGUF bundle should ship `metadata.backend`) is a separate follow-up.