### PR TITLE
feat(telemetry): default GGUF backend label to llamacpp on unannotated bundles

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -73,6 +73,26 @@ fn stamp_llm_span_cost_attribution(metadata: &ModelMetadata) {
     }
 }
 
+/// Overwrite the currently-open span's `backend` cost-attribution
+/// metadata with the actual runtime's wire label.
+///
+/// `stamp_llm_span_cost_attribution` stamps the *template-derived*
+/// default first, but the runtime is selected by cargo feature (see
+/// `LlmRuntimeAdapter::new` precedence), so the template-derived
+/// label can disagree with the runtime that actually executes — for
+/// example, an `llm-mistral`-only build loading an unannotated GGUF
+/// bundle runs on mistral.rs but the template default says `llamacpp`.
+/// Calling this after the adapter is resolved replaces the default
+/// with ground truth (via [`LlmRuntimeAdapter::wire_label`]). Spans
+/// without a wire label (mock/test backends) leave the
+/// template-derived stamp in place.
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn stamp_llm_runtime_backend(adapter: &LlmRuntimeAdapter) {
+    if let Some(label) = adapter.wire_label() {
+        xybrid_trace::add_metadata("backend", label);
+    }
+}
+
 // Internal: ONNX-specific types needed for optimized execution paths
 // These are implementation details, not part of the public API
 use crate::execution::session_factory::OnnxSessionFactory;
@@ -1049,6 +1069,11 @@ impl TemplateExecutor {
         // local-cache-hit count to the wire payload.
         let (output, backend_name, cached_prefix) =
             if let Some((_, adapter)) = &self.llm_adapter_cache {
+                // Overwrite the template-derived `backend` stamp with
+                // the runtime that actually executes (mistral.rs vs
+                // llama.cpp, selected by cargo feature, not by the
+                // bundle metadata).
+                stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
                 let out = backend.generate_streaming(&messages, &gen_config, on_token)?;
                 let name = backend.name().to_string();
@@ -1141,6 +1166,11 @@ impl TemplateExecutor {
         // Capture backend name + cached-prefix length for the metric mirror.
         let (output, backend_name, cached_prefix) =
             if let Some((_, adapter)) = &self.llm_adapter_cache {
+                // Overwrite the template-derived `backend` stamp with
+                // the runtime that actually executes (mistral.rs vs
+                // llama.cpp, selected by cargo feature, not by the
+                // bundle metadata).
+                stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
                 let out = backend.generate(messages, &gen_config)?;
                 let name = backend.name().to_string();
@@ -1236,6 +1266,11 @@ impl TemplateExecutor {
         // Capture backend name + cached-prefix length for the metric mirror.
         let (output, backend_name, cached_prefix) =
             if let Some((_, adapter)) = &self.llm_adapter_cache {
+                // Overwrite the template-derived `backend` stamp with
+                // the runtime that actually executes (mistral.rs vs
+                // llama.cpp, selected by cargo feature, not by the
+                // bundle metadata).
+                stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
                 let out = backend.generate_streaming(messages, &gen_config, on_token)?;
                 let name = backend.name().to_string();
@@ -1395,6 +1430,11 @@ impl TemplateExecutor {
         // Capture backend name + cached-prefix length for the metric mirror.
         let (output, backend_name, cached_prefix) =
             if let Some((_, adapter)) = &self.llm_adapter_cache {
+                // Overwrite the template-derived `backend` stamp with
+                // the runtime that actually executes (mistral.rs vs
+                // llama.cpp, selected by cargo feature, not by the
+                // bundle metadata).
+                stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
                 let out = backend.generate(&messages, &gen_config)?;
                 let name = backend.name().to_string();
@@ -3001,6 +3041,119 @@ mod tests {
                 captured.get("quantization").map(String::as_str),
                 Some("q4_k_m"),
                 "stamp must surface the filename-inferred quantization alongside backend"
+            );
+        }
+
+        // A backend stub that lets a test pick the wire label so we can
+        // verify `stamp_llm_runtime_backend` overwrites the
+        // template-derived default with the runtime's identity. Needed
+        // because the runtime is chosen by cargo feature, so the
+        // template-derived label can disagree with the runtime that
+        // actually executes (e.g. mistralrs on an `llm-mistral`-only
+        // build loading an unannotated GGUF bundle).
+        struct WireLabelStub(Option<&'static str>);
+
+        impl crate::runtime_adapter::llm::LlmBackend for WireLabelStub {
+            fn name(&self) -> &str {
+                "wire-label-stub"
+            }
+            fn wire_label(&self) -> Option<&'static str> {
+                self.0
+            }
+            fn supported_formats(&self) -> Vec<&'static str> {
+                vec!["gguf"]
+            }
+            fn load(
+                &mut self,
+                _config: &crate::runtime_adapter::llm::LlmConfig,
+            ) -> crate::runtime_adapter::llm::LlmResult<()> {
+                Ok(())
+            }
+            fn is_loaded(&self) -> bool {
+                true
+            }
+            fn unload(&mut self) -> crate::runtime_adapter::llm::LlmResult<()> {
+                Ok(())
+            }
+            fn generate(
+                &self,
+                _messages: &[crate::runtime_adapter::llm::ChatMessage],
+                _config: &crate::runtime_adapter::llm::GenerationConfig,
+            ) -> crate::runtime_adapter::llm::LlmResult<crate::runtime_adapter::llm::GenerationOutput>
+            {
+                unreachable!("stub backend should not be invoked for inference in this test")
+            }
+            fn generate_raw(
+                &self,
+                _prompt: &str,
+                _config: &crate::runtime_adapter::llm::GenerationConfig,
+            ) -> crate::runtime_adapter::llm::LlmResult<crate::runtime_adapter::llm::GenerationOutput>
+            {
+                unreachable!("stub backend should not be invoked for inference in this test")
+            }
+        }
+
+        fn capture_with_runtime_overwrite(
+            metadata: &ModelMetadata,
+            wire_label: Option<&'static str>,
+        ) -> HashMap<String, String> {
+            let adapter = crate::runtime_adapter::llm::LlmRuntimeAdapter::with_backend(Box::new(
+                WireLabelStub(wire_label),
+            ));
+            tracing::init_tracing(true);
+            tracing::reset_tracing();
+            {
+                let _guard = tracing::SpanGuard::new("execute:test");
+                stamp_llm_span_cost_attribution(metadata);
+                stamp_llm_runtime_backend(&adapter);
+            }
+            let json = tracing::get_stages_json();
+            tracing::reset_tracing();
+
+            let span = json["spans"]
+                .as_array()
+                .and_then(|spans| {
+                    spans
+                        .iter()
+                        .find(|s| s["name"].as_str() == Some("execute:test"))
+                })
+                .expect("span recorded by SpanGuard must be present in stages json");
+            span["metadata"]
+                .as_object()
+                .map(|obj| {
+                    obj.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+
+        #[test]
+        fn runtime_wire_label_overwrites_template_default() {
+            let _lock = GLOBAL_TRACE_LOCK.lock().unwrap();
+            // Template default for unannotated GGUF is `llamacpp`, but
+            // the runtime selected by cargo feature is mistral.rs. The
+            // overwrite must flip the stamp to ground truth so the
+            // dashboard reflects the runtime that actually executed.
+            let captured = capture_with_runtime_overwrite(&gguf_metadata(None), Some("mistralrs"));
+            assert_eq!(
+                captured.get("backend").map(String::as_str),
+                Some("mistralrs"),
+                "runtime wire label must overwrite the template-derived default"
+            );
+        }
+
+        #[test]
+        fn runtime_overwrite_preserves_template_default_when_label_absent() {
+            let _lock = GLOBAL_TRACE_LOCK.lock().unwrap();
+            // Mock/test backends return None from wire_label so the
+            // template-derived stamp survives — anything else would
+            // erase ground truth that the template *did* carry.
+            let captured = capture_with_runtime_overwrite(&gguf_metadata(None), None);
+            assert_eq!(
+                captured.get("backend").map(String::as_str),
+                Some("llamacpp"),
+                "stub backends without a wire label must not erase the template-derived stamp"
             );
         }
     }

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -2881,4 +2881,127 @@ mod tests {
             );
         }
     }
+
+    // ============================================================================
+    // stamp_llm_span_cost_attribution Tests
+    // ============================================================================
+    //
+    // These cases pin the chat-context cost-attribution path: the wire `backend`
+    // label that lands on the currently-open span when
+    // `execute_with_context_impl` / `execute_streaming_with_context_impl` bypass
+    // the outer `execute:<model_id>` span. They share state with the global
+    // span collector, so a process-wide mutex serialises them — `cargo test`
+    // parallelises within a binary and these would otherwise stomp each other's
+    // reset/measure window.
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    mod stamp_llm_span {
+        use super::*;
+        use crate::tracing;
+        use std::sync::Mutex;
+
+        static GLOBAL_TRACE_LOCK: Mutex<()> = Mutex::new(());
+
+        fn gguf_metadata(backend_hint: Option<&str>) -> ModelMetadata {
+            let mut bundle_metadata = HashMap::new();
+            if let Some(hint) = backend_hint {
+                bundle_metadata.insert("backend".to_string(), serde_json::json!(hint));
+            }
+            ModelMetadata {
+                model_id: "test-gguf".into(),
+                version: "1".into(),
+                execution_template: ExecutionTemplate::Gguf {
+                    model_file: "test.gguf".into(),
+                    chat_template: None,
+                    context_length: 2048,
+                    generation_params: None,
+                },
+                preprocessing: Vec::new(),
+                postprocessing: Vec::new(),
+                files: Vec::new(),
+                description: None,
+                metadata: bundle_metadata,
+                voices: None,
+                max_chunk_chars: None,
+                trim_trailing_samples: None,
+            }
+        }
+
+        fn capture_span_metadata(
+            span_name: &str,
+            metadata: &ModelMetadata,
+        ) -> HashMap<String, String> {
+            tracing::init_tracing(true);
+            tracing::reset_tracing();
+            {
+                let _guard = tracing::SpanGuard::new(span_name);
+                stamp_llm_span_cost_attribution(metadata);
+            }
+            let json = tracing::get_stages_json();
+            tracing::reset_tracing();
+
+            let span = json["spans"]
+                .as_array()
+                .and_then(|spans| spans.iter().find(|s| s["name"].as_str() == Some(span_name)))
+                .expect("span recorded by SpanGuard must be present in stages json");
+            span["metadata"]
+                .as_object()
+                .map(|obj| {
+                    obj.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+
+        #[test]
+        fn unannotated_gguf_stamps_llamacpp_default() {
+            let _lock = GLOBAL_TRACE_LOCK.lock().unwrap();
+            let captured = capture_span_metadata("execute:test", &gguf_metadata(None));
+            assert_eq!(
+                captured.get("backend").map(String::as_str),
+                Some("llamacpp"),
+                "chat-context flow must default unannotated GGUF bundles to llamacpp so PlatformEvent.backend is non-empty"
+            );
+        }
+
+        #[test]
+        fn mistralrs_hint_wins_on_gguf() {
+            let _lock = GLOBAL_TRACE_LOCK.lock().unwrap();
+            let captured = capture_span_metadata("execute:test", &gguf_metadata(Some("mistralrs")));
+            assert_eq!(
+                captured.get("backend").map(String::as_str),
+                Some("mistralrs")
+            );
+        }
+
+        #[test]
+        fn legacy_mistral_alias_normalises_to_mistralrs() {
+            let _lock = GLOBAL_TRACE_LOCK.lock().unwrap();
+            let captured = capture_span_metadata("execute:test", &gguf_metadata(Some("mistral")));
+            assert_eq!(
+                captured.get("backend").map(String::as_str),
+                Some("mistralrs"),
+                "the legacy `mistral` bundle alias must canonicalise to the wire label"
+            );
+        }
+
+        #[test]
+        fn quantization_stamped_from_gguf_filename() {
+            let _lock = GLOBAL_TRACE_LOCK.lock().unwrap();
+            let mut metadata = gguf_metadata(None);
+            metadata.execution_template = ExecutionTemplate::Gguf {
+                model_file: "tinyllama-1.1b-chat-q4_k_m.gguf".into(),
+                chat_template: None,
+                context_length: 2048,
+                generation_params: None,
+            };
+            let captured = capture_span_metadata("execute:test", &metadata);
+            assert_eq!(
+                captured.get("quantization").map(String::as_str),
+                Some("q4_k_m"),
+                "stamp must surface the filename-inferred quantization alongside backend"
+            );
+        }
+    }
 }

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -20,12 +20,12 @@
 
 use log::{debug, info, warn};
 
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+use super::template::PostprocessingStep;
 use super::template::{
     backend_label_from_template, quantization_label_from_metadata, span_kind_from_template,
     stage_kind_from_task, ExecutionMode, ExecutionTemplate, ModelMetadata, PipelineStage,
 };
-#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-use super::template::PostprocessingStep;
 use crate::conversation::ConversationContext;
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 use crate::ir::EnvelopeKind;

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -25,7 +25,7 @@ use super::template::{
     stage_kind_from_task, ExecutionMode, ExecutionTemplate, ModelMetadata, PipelineStage,
 };
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-use super::template::{normalize_llm_backend_hint, PostprocessingStep};
+use super::template::PostprocessingStep;
 use crate::conversation::ConversationContext;
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 use crate::ir::EnvelopeKind;
@@ -60,8 +60,12 @@ fn mark_execution_terminal(guard: &ExecutionGuard, error: &AdapterError) {
 /// shape.
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 fn stamp_llm_span_cost_attribution(metadata: &ModelMetadata) {
+    // Reuse the same resolver the outer `execute:<model_id>` span uses
+    // so both spans agree on the canonical wire label — including the
+    // GGUF-defaults-to-llamacpp behaviour that lights up unannotated
+    // bundles in the registry.
     let backend_hint = metadata.metadata.get("backend").and_then(|v| v.as_str());
-    if let Some(label) = backend_hint.and_then(normalize_llm_backend_hint) {
+    if let Some(label) = backend_label_from_template(&metadata.execution_template, backend_hint) {
         xybrid_trace::add_metadata("backend", label);
     }
     if let Some(quant) = quantization_label_from_metadata(metadata) {

--- a/crates/xybrid-core/src/execution/strategies/llm.rs
+++ b/crates/xybrid-core/src/execution/strategies/llm.rs
@@ -11,7 +11,7 @@ use log::{debug, info};
 use std::path::Path;
 
 use super::{ExecutionContext, ExecutionStrategy};
-use crate::execution::template::{normalize_llm_backend_hint, ExecutionTemplate, ModelMetadata};
+use crate::execution::template::{ExecutionTemplate, ModelMetadata};
 use crate::execution::types::ExecutorResult;
 use crate::ir::{Envelope, EnvelopeKind};
 use crate::runtime_adapter::AdapterError;
@@ -250,6 +250,18 @@ pub trait LlmInference: Send + Sync {
 
     /// Get the name of this backend for logging.
     fn backend_name(&self) -> &str;
+
+    /// Canonical wire label of the actual runtime that will execute
+    /// inference (`Some("llamacpp")` / `Some("mistralrs")`), or `None`
+    /// for mock/test backends that shouldn't claim a real identity.
+    ///
+    /// Used by the inner LLM span site to overwrite the
+    /// template-derived `backend` stamp with the runtime that was
+    /// actually selected by cargo feature — see
+    /// `runtime_adapter::llm::LlmBackend::wire_label`.
+    fn wire_label(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 // ============================================================================
@@ -387,6 +399,10 @@ impl LlmInference for DefaultLlmInference {
 
     fn backend_name(&self) -> &str {
         self.backend_hint.as_deref().unwrap_or("default")
+    }
+
+    fn wire_label(&self) -> Option<&'static str> {
+        self.adapter.as_ref().and_then(|a| a.wire_label())
     }
 }
 
@@ -548,17 +564,6 @@ impl<I: LlmInference + 'static> ExecutionStrategy for LlmStrategy<I> {
         );
 
         xybrid_trace::add_metadata("model", &config.model_path);
-        // Emit the canonical wire label (`mistralrs` / `llamacpp`) onto the
-        // inner LLM span so the SDK telemetry hoist surfaces a closed-set
-        // value on `PlatformEvent.backend`. The raw `metadata.backend`
-        // string can still be the legacy `mistral` alias on older bundles.
-        if let Some(hint) = config
-            .backend_hint
-            .as_deref()
-            .and_then(normalize_llm_backend_hint)
-        {
-            xybrid_trace::add_metadata("backend", hint);
-        }
 
         // Load model if needed
         let mut inference = self
@@ -569,6 +574,17 @@ impl<I: LlmInference + 'static> ExecutionStrategy for LlmStrategy<I> {
         if !inference.is_loaded() {
             debug!(target: "xybrid_core", "Loading LLM model: {}", config.model_path);
             inference.load_model(&config)?;
+        }
+
+        // Stamp the canonical wire label (`mistralrs` / `llamacpp`) on
+        // the inner LLM span so the SDK telemetry hoist surfaces a
+        // closed-set value on `PlatformEvent.backend`. Read it from
+        // the loaded backend rather than the bundle hint: the runtime
+        // is selected by cargo feature, so the hint can disagree with
+        // the runtime that actually executes (e.g. unannotated GGUF
+        // on an `llm-mistral`-only build).
+        if let Some(label) = inference.wire_label() {
+            xybrid_trace::add_metadata("backend", label);
         }
 
         // Extract prompt

--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -446,6 +446,16 @@ pub fn normalize_llm_backend_hint(hint: &str) -> Option<&'static str> {
 /// (e.g. CoreML, TFLite, ModelGraph) — the contract is "additive, omit
 /// when unknown" so unrecognised templates simply leave the field absent.
 ///
+/// **GGUF templates** default to `llamacpp` when no recognised hint is
+/// supplied. llama.cpp is the universal GGUF runtime in this checkout
+/// (the only one with platform-android support and the platform-wide
+/// preset on macOS / iOS / desktop); the `metadata.backend` hint is
+/// reserved for the opt-out path that selects `mistralrs` instead. This
+/// is a deliberate departure from the "omit when unknown" rule above:
+/// for GGUF the runtime is *known* (the template fixes it), so the
+/// dashboard column is more useful populated than silent on every
+/// unannotated old bundle.
+///
 /// `cloud` is intentionally not represented here: the cloud adapter
 /// emits the label from its own span site (see
 /// `runtime_adapter::cloud::CloudRuntimeAdapter::execute`) where the
@@ -462,7 +472,13 @@ pub fn backend_label_from_template(
         ExecutionTemplate::SafeTensors { .. } => {
             hint.and_then(normalize_llm_backend_hint).or(Some("candle"))
         }
-        ExecutionTemplate::Gguf { .. } => hint.and_then(normalize_llm_backend_hint),
+        // GGUF: llama.cpp is the universal runtime in this checkout,
+        // so fall back to it when the hint is absent or unrecognised.
+        // Unannotated bundles in the registry then surface `llamacpp`
+        // on the dashboard instead of a blank column.
+        ExecutionTemplate::Gguf { .. } => hint
+            .and_then(normalize_llm_backend_hint)
+            .or(Some("llamacpp")),
         ExecutionTemplate::CoreMl { .. }
         | ExecutionTemplate::TfLite { .. }
         | ExecutionTemplate::ModelGraph { .. } => None,
@@ -641,21 +657,31 @@ mod tests {
             "deferred mlx hints must not claim an unavailable runtime"
         );
 
-        // GGUF: hint required to disambiguate llama.cpp vs mistral.rs;
-        // omit when the bundle didn't pin a backend so downstream can
-        // tell "we don't know" from "we know it's X".
+        // GGUF: llama.cpp is the universal runtime in this checkout
+        // (the only one with Android support, the macOS/iOS/desktop
+        // platform-preset backend, and the runtime that executes any
+        // bundle the registry serves today). When the bundle didn't
+        // pin a `metadata.backend` hint, default to `llamacpp` rather
+        // than emitting nothing — the runtime is known from the
+        // template itself, and a populated column is more useful than
+        // a silent one on every old / unannotated bundle in the registry.
         let gguf = ExecutionTemplate::Gguf {
             model_file: "m.gguf".into(),
             chat_template: None,
             context_length: 2048,
             generation_params: None,
         };
-        assert_eq!(backend_label_from_template(&gguf, None), None);
+        assert_eq!(
+            backend_label_from_template(&gguf, None),
+            Some("llamacpp"),
+            "unannotated GGUF bundles must default to the universal llama.cpp runtime"
+        );
         assert_eq!(
             backend_label_from_template(&gguf, Some("llamacpp")),
             Some("llamacpp")
         );
-        // Accept both the bundle-file alias and the canonical name.
+        // The `mistralrs` opt-out still wins: bundles that explicitly
+        // hint at the alternative runtime select it.
         assert_eq!(
             backend_label_from_template(&gguf, Some("mistral")),
             Some("mistralrs")
@@ -664,9 +690,14 @@ mod tests {
             backend_label_from_template(&gguf, Some("mistralrs")),
             Some("mistralrs")
         );
-        // MLX is deferred in this checkout, so the hint path must not
-        // emit an unavailable runtime label.
-        assert_eq!(backend_label_from_template(&gguf, Some("mlx")), None);
+        // MLX is deferred in this checkout, so an mlx hint falls
+        // through to the GGUF default — the model will actually run
+        // on llama.cpp, which is what the dashboard should reflect.
+        assert_eq!(
+            backend_label_from_template(&gguf, Some("mlx")),
+            Some("llamacpp"),
+            "deferred mlx hints must reflect the runtime that actually executes the model"
+        );
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -316,6 +316,10 @@ impl LlmBackend for LlamaCppBackend {
         "llama-cpp"
     }
 
+    fn wire_label(&self) -> Option<&'static str> {
+        Some("llamacpp")
+    }
+
     fn supported_formats(&self) -> Vec<&'static str> {
         vec!["gguf"]
     }

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -238,6 +238,27 @@ pub trait LlmBackend: Send + Sync {
     fn last_cached_prefix_len(&self) -> Option<usize> {
         None
     }
+
+    /// Canonical wire label for cost-attribution telemetry.
+    ///
+    /// Returns the closed-set `backend` value the inner `llm_inference`
+    /// span should carry on the wire (`"llamacpp"` / `"mistralrs"` /
+    /// future additions). Defaults to `None` so mock and test backends
+    /// don't claim a real runtime identity.
+    ///
+    /// Real LLM backends override this and the inner-span sites call
+    /// it *after* backend selection so the wire label reflects the
+    /// runtime that actually executes the model — not the
+    /// template-derived default produced by
+    /// `backend_label_from_template`. This matters because the runtime
+    /// is chosen by cargo feature (see [`Self::new`] precedence), so
+    /// non-default-features builds (e.g. `llm-mistral` only, or
+    /// `llm-mistral` + `llm-llamacpp` where the mistral arm wins) would
+    /// otherwise mislabel unannotated GGUF bundles as `"llamacpp"`
+    /// when mistral.rs is the executing backend.
+    fn wire_label(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 /// Factory function type for creating LLM backends.
@@ -350,6 +371,14 @@ impl LlmRuntimeAdapter {
     /// Get the context length of the loaded model.
     pub fn context_length(&self) -> Option<usize> {
         self.backend.context_length()
+    }
+
+    /// Canonical wire label of the underlying backend (see
+    /// [`LlmBackend::wire_label`]). Inner LLM span sites call this to
+    /// stamp the runtime that actually executed, overwriting the
+    /// template-derived default from `backend_label_from_template`.
+    pub fn wire_label(&self) -> Option<&'static str> {
+        self.backend.wire_label()
     }
 
     /// Get a reference to the underlying backend.

--- a/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
@@ -317,6 +317,10 @@ impl LlmBackend for MistralBackend {
         "mistral"
     }
 
+    fn wire_label(&self) -> Option<&'static str> {
+        Some("mistralrs")
+    }
+
     fn supported_formats(&self) -> Vec<&'static str> {
         vec!["gguf"]
     }


### PR DESCRIPTION
## Summary

- `backend_label_from_template` previously required a `metadata.backend` hint on every GGUF bundle to populate the wire label, returning `None` otherwise. The hint was originally for llama.cpp vs mistral.rs disambiguation — but mistral.rs has SIGILL on Android and is no longer the universal-runtime path. llama.cpp is the only GGUF runtime in this checkout's `platform-android` / `platform-ios` / `platform-macos` / `platform-desktop` presets. Old / unannotated registry bundles all actually run on llama.cpp, so a blank `backend` column on the dashboard is strictly less informative than the known runtime label.
- GGUF templates now fall back to `llamacpp` when the hint is absent or unrecognised. Bundles that explicitly hint `mistral` / `mistralrs` still get `mistralrs` — the hint becomes the opt-out path rather than a hard precondition.
- Deliberate departure from the "additive, omit when unknown" rule that applies to CoreML / TFLite / ModelGraph: for GGUF the runtime is *known* (the template fixes it), so a default is honest. Documented inline.
- Consolidates `stamp_llm_span_cost_attribution` (introduced in the preceding PR) onto `backend_label_from_template` so the outer `execute:<model_id>` span and every inner `llm_inference*` span agree on the canonical label — including the new default.

## Why

Surfaced when verifying the preceding PR on the CLI streaming flow: gemma-3-1b traces show `q4_k_m` + `metal` (outer span's quant stamp + EP from the LLM backend) but a blank `backend` column, because the gemma bundle didn't declare `metadata.backend`. The two ways to fix it are (a) re-pack every affected bundle in the registry, or (b) make the default match reality at the resolver. (b) is one line and covers every existing bundle without a republish.

## Test plan

- [x] `cargo test -p xybrid-core --features llm-llamacpp --lib` — 903 pass, including the updated `backend_label_covers_canonical_runtimes` test that now asserts `Some("llamacpp")` for GGUF + None hint and GGUF + deferred `mlx` hint.
- [x] `cargo test -p xybrid-sdk --features platform-macos` — 317 lib + 33 doctest + 8 integration tests pass.
- [x] `cargo clippy --workspace --tests --benches --features platform-macos -- -D warnings` — clean.
- [ ] On-device verify: chat on gemma-3-1b and any other unannotated GGUF bundle — `backend` column should read `llamacpp` on the Traces dashboard.

## Notes

- Builds on #118 (just merged). The inner-LLM-span stamp from that PR now uses the same resolver as the outer span, so the GGUF default propagates everywhere.
- mistral.rs opt-out via `metadata.backend = "mistralrs"` (or the legacy `"mistral"` alias) is preserved; the dashboard still distinguishes the two runtimes when a bundle is explicit.