### PR TITLE
feat(sdk): add typed InferenceMetrics on result types (INF-15 PR-A)

### DIFF
--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -196,7 +196,7 @@ pub use pipeline::{
     TextInputConfig,
     Xybrid,
 };
-pub use result::{InferenceResult, OutputType};
+pub use result::{InferenceMetrics, InferenceResult, OutputType, StageLatency};
 pub use source::ModelSource;
 pub use stream::{PartialResult, StreamState, StreamStats, TranscriptionResult, XybridStream};
 // FFI streaming types for platform bindings (Flutter, Kotlin, Swift)

--- a/crates/xybrid-sdk/src/pipeline/result.rs
+++ b/crates/xybrid-sdk/src/pipeline/result.rs
@@ -25,7 +25,9 @@
 //! assert_eq!(error_result.error, Some("Model not found".to_string()));
 //! ```
 
+use crate::result::{InferenceMetrics, StageLatency};
 use serde::{Deserialize, Serialize};
+use xybrid_core::ir::Envelope;
 
 // ============================================================================
 // Stage Execution Result (FFI-safe)
@@ -158,6 +160,12 @@ pub struct FfiPipelineExecutionResult {
     pub stages_executed: u32,
     /// Stages skipped (due to conditions)
     pub stages_skipped: u32,
+    /// Typed metrics (TTFT, tok/s, per-stage latencies).
+    ///
+    /// `stage_latencies_ms` is populated from `stages` by `with_stages`.
+    /// LLM-specific fields are populated by `populate_metrics_from_envelope`.
+    #[serde(default)]
+    pub metrics: InferenceMetrics,
 }
 
 impl FfiPipelineExecutionResult {
@@ -213,6 +221,10 @@ impl FfiPipelineExecutionResult {
             stages: Vec::new(),
             stages_executed: 1,
             stages_skipped: 0,
+            metrics: InferenceMetrics {
+                total_ms: latency_ms,
+                ..InferenceMetrics::default()
+            },
         }
     }
 
@@ -246,6 +258,10 @@ impl FfiPipelineExecutionResult {
             stages: Vec::new(),
             stages_executed: 1,
             stages_skipped: 0,
+            metrics: InferenceMetrics {
+                total_ms: latency_ms,
+                ..InferenceMetrics::default()
+            },
         }
     }
 
@@ -281,6 +297,7 @@ impl FfiPipelineExecutionResult {
             stages: Vec::new(),
             stages_executed: 0,
             stages_skipped: 0,
+            metrics: InferenceMetrics::default(),
         }
     }
 
@@ -313,7 +330,29 @@ impl FfiPipelineExecutionResult {
     pub fn with_stages(&mut self, stages: Vec<FfiStageExecutionResult>) {
         self.stages_executed = stages.iter().filter(|s| s.executed).count() as u32;
         self.stages_skipped = stages.iter().filter(|s| !s.executed).count() as u32;
+        self.metrics.stage_latencies_ms = stages
+            .iter()
+            .filter(|s| s.executed)
+            .map(|s| StageLatency {
+                stage_id: s.stage_id.clone(),
+                latency_ms: s.latency_ms,
+            })
+            .collect();
         self.stages = stages;
+    }
+
+    /// Populate LLM-specific metrics (TTFT, tok/s, token counts) from the
+    /// final envelope's metadata map. Per-stage latencies are populated
+    /// separately by `with_stages`.
+    pub fn populate_metrics_from_envelope(&mut self, envelope: &Envelope) {
+        let parsed = InferenceMetrics::from_metadata(&envelope.metadata, self.latency_ms);
+        self.metrics.ttft_ms = parsed.ttft_ms;
+        self.metrics.tokens_per_second = parsed.tokens_per_second;
+        self.metrics.prefill_tps = parsed.prefill_tps;
+        self.metrics.decode_tps = parsed.decode_tps;
+        self.metrics.tokens_in = parsed.tokens_in;
+        self.metrics.tokens_out = parsed.tokens_out;
+        self.metrics.total_ms = self.latency_ms;
     }
 
     /// Check if the result contains text output.
@@ -346,6 +385,7 @@ impl Default for FfiPipelineExecutionResult {
             stages: Vec::new(),
             stages_executed: 0,
             stages_skipped: 0,
+            metrics: InferenceMetrics::default(),
         }
     }
 }
@@ -496,6 +536,42 @@ mod tests {
         assert_eq!(result.stages.len(), 3);
         assert_eq!(result.stages_executed, 2);
         assert_eq!(result.stages_skipped, 1);
+        // Stage latencies populated from executed stages only.
+        assert_eq!(result.metrics.stage_latencies_ms.len(), 2);
+        assert_eq!(result.metrics.stage_latencies_ms[0].stage_id, "stage1");
+        assert_eq!(result.metrics.stage_latencies_ms[0].latency_ms, 50);
+        assert_eq!(result.metrics.stage_latencies_ms[1].stage_id, "stage2");
+        assert_eq!(result.metrics.stage_latencies_ms[1].latency_ms, 100);
+    }
+
+    #[test]
+    fn test_pipeline_execution_result_populate_metrics_from_envelope() {
+        use std::collections::HashMap;
+        use xybrid_core::ir::{Envelope, EnvelopeKind};
+
+        let mut result = FfiPipelineExecutionResult::success(
+            "text",
+            Some("hi".to_string()),
+            None,
+            500,
+            "llm-model",
+        );
+
+        let mut metadata = HashMap::new();
+        metadata.insert("ttft_ms".to_string(), "120".to_string());
+        metadata.insert("tokens_per_second".to_string(), "42.50".to_string());
+        metadata.insert("tokens_generated".to_string(), "256".to_string());
+
+        let envelope = Envelope {
+            kind: EnvelopeKind::Text("hi".to_string()),
+            metadata,
+        };
+        result.populate_metrics_from_envelope(&envelope);
+
+        assert_eq!(result.metrics.total_ms, 500);
+        assert_eq!(result.metrics.ttft_ms, Some(120));
+        assert_eq!(result.metrics.tokens_per_second, Some(42.5));
+        assert_eq!(result.metrics.tokens_out, Some(256));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/pipeline/result.rs
+++ b/crates/xybrid-sdk/src/pipeline/result.rs
@@ -27,7 +27,6 @@
 
 use crate::result::{InferenceMetrics, StageLatency};
 use serde::{Deserialize, Serialize};
-use xybrid_core::ir::Envelope;
 
 // ============================================================================
 // Stage Execution Result (FFI-safe)
@@ -160,10 +159,14 @@ pub struct FfiPipelineExecutionResult {
     pub stages_executed: u32,
     /// Stages skipped (due to conditions)
     pub stages_skipped: u32,
-    /// Typed metrics (TTFT, tok/s, per-stage latencies).
+    /// Typed metrics (`total_ms`, per-stage latencies).
     ///
-    /// `stage_latencies_ms` is populated from `stages` by `with_stages`.
-    /// LLM-specific fields are populated by `populate_metrics_from_envelope`.
+    /// `total_ms` is set by the constructors; `stage_latencies_ms` is
+    /// populated from `stages` by `with_stages`. LLM-specific fields
+    /// (`ttft_ms`, `tokens_per_second`, `tokens_out`, …) stay `None` on
+    /// pipeline results today — they will be wired in a follow-up PR that
+    /// hoists them from the final stage's envelope. For single-model LLM
+    /// runs, use `InferenceResult::metrics()` which already populates them.
     #[serde(default)]
     pub metrics: InferenceMetrics,
 }
@@ -339,20 +342,6 @@ impl FfiPipelineExecutionResult {
             })
             .collect();
         self.stages = stages;
-    }
-
-    /// Populate LLM-specific metrics (TTFT, tok/s, token counts) from the
-    /// final envelope's metadata map. Per-stage latencies are populated
-    /// separately by `with_stages`.
-    pub fn populate_metrics_from_envelope(&mut self, envelope: &Envelope) {
-        let parsed = InferenceMetrics::from_metadata(&envelope.metadata, self.latency_ms);
-        self.metrics.ttft_ms = parsed.ttft_ms;
-        self.metrics.tokens_per_second = parsed.tokens_per_second;
-        self.metrics.prefill_tps = parsed.prefill_tps;
-        self.metrics.decode_tps = parsed.decode_tps;
-        self.metrics.tokens_in = parsed.tokens_in;
-        self.metrics.tokens_out = parsed.tokens_out;
-        self.metrics.total_ms = self.latency_ms;
     }
 
     /// Check if the result contains text output.
@@ -542,36 +531,6 @@ mod tests {
         assert_eq!(result.metrics.stage_latencies_ms[0].latency_ms, 50);
         assert_eq!(result.metrics.stage_latencies_ms[1].stage_id, "stage2");
         assert_eq!(result.metrics.stage_latencies_ms[1].latency_ms, 100);
-    }
-
-    #[test]
-    fn test_pipeline_execution_result_populate_metrics_from_envelope() {
-        use std::collections::HashMap;
-        use xybrid_core::ir::{Envelope, EnvelopeKind};
-
-        let mut result = FfiPipelineExecutionResult::success(
-            "text",
-            Some("hi".to_string()),
-            None,
-            500,
-            "llm-model",
-        );
-
-        let mut metadata = HashMap::new();
-        metadata.insert("ttft_ms".to_string(), "120".to_string());
-        metadata.insert("tokens_per_second".to_string(), "42.50".to_string());
-        metadata.insert("tokens_generated".to_string(), "256".to_string());
-
-        let envelope = Envelope {
-            kind: EnvelopeKind::Text("hi".to_string()),
-            metadata,
-        };
-        result.populate_metrics_from_envelope(&envelope);
-
-        assert_eq!(result.metrics.total_ms, 500);
-        assert_eq!(result.metrics.ttft_ms, Some(120));
-        assert_eq!(result.metrics.tokens_per_second, Some(42.5));
-        assert_eq!(result.metrics.tokens_out, Some(256));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/result.rs
+++ b/crates/xybrid-sdk/src/result.rs
@@ -20,13 +20,16 @@ pub struct StageLatency {
 /// Typed inference metrics surfaced on every `InferenceResult`.
 ///
 /// LLM-specific fields (`ttft_ms`, `tokens_per_second`, `prefill_tps`,
-/// `decode_tps`, `tokens_in`, `tokens_out`) are `None` for ASR/TTS/embedding
-/// runs. `stage_latencies_ms` is empty for `model.run()` and populated for
+/// `decode_tps`, `tokens_out`) are `None` for ASR/TTS/embedding runs.
+/// `stage_latencies_ms` is empty for `model.run()` and populated for
 /// `pipeline.run()`.
 ///
-/// The wire-level source is the `Envelope.metadata` string map written by
-/// `runtime_adapter::llm` and `execution::executor`. `from_metadata` parses
-/// the known keys with graceful failure on unparseable values.
+/// Population is best-effort: fields parse from the `Envelope.metadata`
+/// string map written by `runtime_adapter::llm` and `execution::executor`.
+/// Local LLM runs populate the LLM fields; cloud LLM runs currently surface
+/// only `total_ms` (the cloud adapter writes `backend` to envelope metadata
+/// but not the per-run scalars — those ride on span metadata today).
+/// Unparseable values become `None`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct InferenceMetrics {
     /// Wall-clock latency in ms (mirrors `InferenceResult.latency_ms`).
@@ -39,8 +42,6 @@ pub struct InferenceMetrics {
     pub prefill_tps: Option<f32>,
     /// Decode phase tok/s. LLM only.
     pub decode_tps: Option<f32>,
-    /// Prompt tokens consumed. LLM only.
-    pub tokens_in: Option<u32>,
     /// Completion tokens produced. LLM only.
     pub tokens_out: Option<u32>,
     /// Per-stage wall-clock latencies. Empty for single-model runs.
@@ -62,8 +63,6 @@ impl InferenceMetrics {
             tokens_per_second: parse_f32(metadata, "tokens_per_second"),
             prefill_tps: parse_f32(metadata, "prefill_tps"),
             decode_tps: parse_f32(metadata, "decode_tps"),
-            tokens_in: parse_u32(metadata, "tokens_in")
-                .or_else(|| parse_u32(metadata, "prompt_tokens")),
             tokens_out: parse_u32(metadata, "tokens_out")
                 .or_else(|| parse_u32(metadata, "tokens_generated")),
             stage_latencies_ms: Vec::new(),
@@ -198,12 +197,6 @@ impl InferenceResult {
     /// Typed metrics for this run (TTFT, tok/s, per-stage latencies, etc.).
     pub fn metrics(&self) -> &InferenceMetrics {
         &self.metrics
-    }
-
-    /// Mutable access to metrics — used by pipeline call sites to populate
-    /// `stage_latencies_ms` after construction.
-    pub fn metrics_mut(&mut self) -> &mut InferenceMetrics {
-        &mut self.metrics
     }
 
     /// Get a reference to the underlying envelope.
@@ -383,7 +376,6 @@ mod tests {
         metadata.insert("prefill_tps".to_string(), "180.0".to_string());
         metadata.insert("decode_tps".to_string(), "42.5".to_string());
         metadata.insert("tokens_generated".to_string(), "256".to_string());
-        metadata.insert("prompt_tokens".to_string(), "32".to_string());
 
         let envelope = Envelope {
             kind: EnvelopeKind::Text("hi".to_string()),
@@ -397,7 +389,6 @@ mod tests {
         assert_eq!(m.tokens_per_second, Some(42.5));
         assert_eq!(m.prefill_tps, Some(180.0));
         assert_eq!(m.decode_tps, Some(42.5));
-        assert_eq!(m.tokens_in, Some(32));
         assert_eq!(m.tokens_out, Some(256));
         assert!(m.stage_latencies_ms.is_empty());
     }
@@ -413,7 +404,6 @@ mod tests {
         assert_eq!(m.total_ms, 50);
         assert_eq!(m.ttft_ms, None);
         assert_eq!(m.tokens_per_second, None);
-        assert_eq!(m.tokens_in, None);
         assert_eq!(m.tokens_out, None);
     }
 
@@ -434,17 +424,16 @@ mod tests {
     }
 
     #[test]
-    fn test_metrics_aliased_keys() {
+    fn test_metrics_tokens_out_canonical_key_wins_over_alias() {
         let mut metadata = HashMap::new();
-        metadata.insert("tokens_in".to_string(), "16".to_string());
         metadata.insert("tokens_out".to_string(), "64".to_string());
+        metadata.insert("tokens_generated".to_string(), "999".to_string());
 
         let envelope = Envelope {
             kind: EnvelopeKind::Text("x".to_string()),
             metadata,
         };
         let result = InferenceResult::new(envelope, "m", 10);
-        assert_eq!(result.metrics().tokens_in, Some(16));
         assert_eq!(result.metrics().tokens_out, Some(64));
     }
 

--- a/crates/xybrid-sdk/src/result.rs
+++ b/crates/xybrid-sdk/src/result.rs
@@ -4,7 +4,80 @@
 //! with convenient accessors for different output types.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use xybrid_core::ir::{Envelope, EnvelopeKind};
+
+/// Per-stage latency entry for pipeline runs.
+///
+/// One entry per executed stage; the `stage_id` matches the stage name in the
+/// pipeline definition.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StageLatency {
+    pub stage_id: String,
+    pub latency_ms: u32,
+}
+
+/// Typed inference metrics surfaced on every `InferenceResult`.
+///
+/// LLM-specific fields (`ttft_ms`, `tokens_per_second`, `prefill_tps`,
+/// `decode_tps`, `tokens_in`, `tokens_out`) are `None` for ASR/TTS/embedding
+/// runs. `stage_latencies_ms` is empty for `model.run()` and populated for
+/// `pipeline.run()`.
+///
+/// The wire-level source is the `Envelope.metadata` string map written by
+/// `runtime_adapter::llm` and `execution::executor`. `from_metadata` parses
+/// the known keys with graceful failure on unparseable values.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct InferenceMetrics {
+    /// Wall-clock latency in ms (mirrors `InferenceResult.latency_ms`).
+    pub total_ms: u32,
+    /// Time to first token, ms. LLM streaming only.
+    pub ttft_ms: Option<u32>,
+    /// Generation throughput, tokens/sec. LLM only.
+    pub tokens_per_second: Option<f32>,
+    /// Prefill phase tok/s. LLM only.
+    pub prefill_tps: Option<f32>,
+    /// Decode phase tok/s. LLM only.
+    pub decode_tps: Option<f32>,
+    /// Prompt tokens consumed. LLM only.
+    pub tokens_in: Option<u32>,
+    /// Completion tokens produced. LLM only.
+    pub tokens_out: Option<u32>,
+    /// Per-stage wall-clock latencies. Empty for single-model runs.
+    pub stage_latencies_ms: Vec<StageLatency>,
+}
+
+impl InferenceMetrics {
+    /// Build metrics from an envelope's metadata map.
+    ///
+    /// `total_ms` is passed in from the caller's outer latency measurement
+    /// (envelope metadata doesn't carry it). LLM keys that are absent or
+    /// fail to parse become `None`. `stage_latencies_ms` is left empty —
+    /// pipeline call sites populate it from their `FfiStageExecutionResult`
+    /// list.
+    pub fn from_metadata(metadata: &HashMap<String, String>, total_ms: u32) -> Self {
+        Self {
+            total_ms,
+            ttft_ms: parse_u32(metadata, "ttft_ms"),
+            tokens_per_second: parse_f32(metadata, "tokens_per_second"),
+            prefill_tps: parse_f32(metadata, "prefill_tps"),
+            decode_tps: parse_f32(metadata, "decode_tps"),
+            tokens_in: parse_u32(metadata, "tokens_in")
+                .or_else(|| parse_u32(metadata, "prompt_tokens")),
+            tokens_out: parse_u32(metadata, "tokens_out")
+                .or_else(|| parse_u32(metadata, "tokens_generated")),
+            stage_latencies_ms: Vec::new(),
+        }
+    }
+}
+
+fn parse_u32(metadata: &HashMap<String, String>, key: &str) -> Option<u32> {
+    metadata.get(key).and_then(|v| v.parse::<u32>().ok())
+}
+
+fn parse_f32(metadata: &HashMap<String, String>, key: &str) -> Option<f32> {
+    metadata.get(key).and_then(|v| v.parse::<f32>().ok())
+}
 
 /// Output type enumeration for model inference results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +136,8 @@ pub struct InferenceResult {
     latency_ms: u32,
     /// Model ID that produced this result
     model_id: String,
+    /// Typed metrics parsed from `envelope.metadata`
+    metrics: InferenceMetrics,
 }
 
 impl InferenceResult {
@@ -73,12 +148,14 @@ impl InferenceResult {
             EnvelopeKind::Audio(_) => OutputType::Audio,
             EnvelopeKind::Embedding(_) => OutputType::Embedding,
         };
+        let metrics = InferenceMetrics::from_metadata(&envelope.metadata, latency_ms);
 
         Self {
             envelope,
             output_type,
             latency_ms,
             model_id: model_id.into(),
+            metrics,
         }
     }
 
@@ -89,11 +166,13 @@ impl InferenceResult {
         model_id: impl Into<String>,
         latency_ms: u32,
     ) -> Self {
+        let metrics = InferenceMetrics::from_metadata(&envelope.metadata, latency_ms);
         Self {
             envelope,
             output_type,
             latency_ms,
             model_id: model_id.into(),
+            metrics,
         }
     }
 
@@ -114,6 +193,17 @@ impl InferenceResult {
     /// Get the model ID that produced this result.
     pub fn model_id(&self) -> &str {
         &self.model_id
+    }
+
+    /// Typed metrics for this run (TTFT, tok/s, per-stage latencies, etc.).
+    pub fn metrics(&self) -> &InferenceMetrics {
+        &self.metrics
+    }
+
+    /// Mutable access to metrics — used by pipeline call sites to populate
+    /// `stage_latencies_ms` after construction.
+    pub fn metrics_mut(&mut self) -> &mut InferenceMetrics {
+        &mut self.metrics
     }
 
     /// Get a reference to the underlying envelope.
@@ -226,7 +316,6 @@ impl InferenceResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
     #[test]
     fn test_text_result() {
@@ -284,6 +373,79 @@ mod tests {
         };
         let result = InferenceResult::new(envelope, "model", 0);
         result.unwrap_text(); // Should panic
+    }
+
+    #[test]
+    fn test_metrics_parsed_from_envelope_metadata() {
+        let mut metadata = HashMap::new();
+        metadata.insert("ttft_ms".to_string(), "120".to_string());
+        metadata.insert("tokens_per_second".to_string(), "42.50".to_string());
+        metadata.insert("prefill_tps".to_string(), "180.0".to_string());
+        metadata.insert("decode_tps".to_string(), "42.5".to_string());
+        metadata.insert("tokens_generated".to_string(), "256".to_string());
+        metadata.insert("prompt_tokens".to_string(), "32".to_string());
+
+        let envelope = Envelope {
+            kind: EnvelopeKind::Text("hi".to_string()),
+            metadata,
+        };
+        let result = InferenceResult::new(envelope, "llm-model", 500);
+
+        let m = result.metrics();
+        assert_eq!(m.total_ms, 500);
+        assert_eq!(m.ttft_ms, Some(120));
+        assert_eq!(m.tokens_per_second, Some(42.5));
+        assert_eq!(m.prefill_tps, Some(180.0));
+        assert_eq!(m.decode_tps, Some(42.5));
+        assert_eq!(m.tokens_in, Some(32));
+        assert_eq!(m.tokens_out, Some(256));
+        assert!(m.stage_latencies_ms.is_empty());
+    }
+
+    #[test]
+    fn test_metrics_missing_keys_default_to_none() {
+        let envelope = Envelope {
+            kind: EnvelopeKind::Audio(vec![1, 2]),
+            metadata: HashMap::new(),
+        };
+        let result = InferenceResult::new(envelope, "tts-model", 50);
+        let m = result.metrics();
+        assert_eq!(m.total_ms, 50);
+        assert_eq!(m.ttft_ms, None);
+        assert_eq!(m.tokens_per_second, None);
+        assert_eq!(m.tokens_in, None);
+        assert_eq!(m.tokens_out, None);
+    }
+
+    #[test]
+    fn test_metrics_unparseable_values_become_none() {
+        let mut metadata = HashMap::new();
+        metadata.insert("ttft_ms".to_string(), "not-a-number".to_string());
+        metadata.insert("tokens_per_second".to_string(), "nan-ish".to_string());
+
+        let envelope = Envelope {
+            kind: EnvelopeKind::Text("x".to_string()),
+            metadata,
+        };
+        let result = InferenceResult::new(envelope, "m", 10);
+        let m = result.metrics();
+        assert_eq!(m.ttft_ms, None);
+        assert_eq!(m.tokens_per_second, None);
+    }
+
+    #[test]
+    fn test_metrics_aliased_keys() {
+        let mut metadata = HashMap::new();
+        metadata.insert("tokens_in".to_string(), "16".to_string());
+        metadata.insert("tokens_out".to_string(), "64".to_string());
+
+        let envelope = Envelope {
+            kind: EnvelopeKind::Text("x".to_string()),
+            metadata,
+        };
+        let result = InferenceResult::new(envelope, "m", 10);
+        assert_eq!(result.metrics().tokens_in, Some(16));
+        assert_eq!(result.metrics().tokens_out, Some(64));
     }
 
     #[test]

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -734,6 +734,88 @@ public sealed class InferenceResult : IDisposable
 public enum OutputType { Text, Audio, Embedding, Unknown }
 ```
 
+### InferenceMetrics
+
+Typed inference metrics surfaced on every `XybridResult`. LLM-specific fields
+(`ttftMs`, `tokensPerSecond`, `prefillTps`, `decodeTps`, `tokensIn`,
+`tokensOut`) are `null` when the model is ASR/TTS/embedding. `stageLatenciesMs`
+is empty for `model.run()` and populated for `pipeline.run()`.
+
+Wire-level source: the `Envelope.metadata` string map written by
+`runtime_adapter::llm` and `execution::executor`. The SDK parses known keys
+with graceful failure — unparseable values become `null`.
+
+```dart
+class XybridInferenceMetrics {
+  final int totalMs;
+  final int? ttftMs;
+  final double? tokensPerSecond;
+  final double? prefillTps;
+  final double? decodeTps;
+  final int? tokensIn;
+  final int? tokensOut;
+  final List<XybridStageLatency> stageLatenciesMs;
+}
+
+class XybridStageLatency {
+  final String stageId;
+  final int latencyMs;
+}
+```
+
+```kotlin
+data class XybridInferenceMetrics(
+  val totalMs: Int,
+  val ttftMs: Int?,
+  val tokensPerSecond: Double?,
+  val prefillTps: Double?,
+  val decodeTps: Double?,
+  val tokensIn: Int?,
+  val tokensOut: Int?,
+  val stageLatenciesMs: List<XybridStageLatency>
+)
+
+data class XybridStageLatency(val stageId: String, val latencyMs: Int)
+```
+
+```swift
+public struct XybridInferenceMetrics {
+  public let totalMs: Int
+  public let ttftMs: Int?
+  public let tokensPerSecond: Double?
+  public let prefillTps: Double?
+  public let decodeTps: Double?
+  public let tokensIn: Int?
+  public let tokensOut: Int?
+  public let stageLatenciesMs: [XybridStageLatency]
+}
+
+public struct XybridStageLatency {
+  public let stageId: String
+  public let latencyMs: Int
+}
+```
+
+```csharp
+public sealed class InferenceMetrics
+{
+  public uint TotalMs { get; }
+  public uint? TtftMs { get; }
+  public float? TokensPerSecond { get; }
+  public float? PrefillTps { get; }
+  public float? DecodeTps { get; }
+  public uint? TokensIn { get; }
+  public uint? TokensOut { get; }
+  public IReadOnlyList<StageLatency> StageLatenciesMs { get; }
+}
+
+public sealed class StageLatency
+{
+  public string StageId { get; }
+  public uint LatencyMs { get; }
+}
+```
+
 ### Implementation Status
 
 | Property | Dart | Kotlin | Swift | C# |
@@ -748,6 +830,10 @@ public enum OutputType { Text, Audio, Embedding, Unknown }
 | `modelId` | — | — | — | ✅ |
 | `isFailure` | ✅ | ✅ | ✅ | ✅ |
 | `audioAsWav()` | ✅ | — | — | — |
+| `metrics` | — | — | — | — |
+| `metrics.ttftMs` | — | — | — | — |
+| `metrics.tokensPerSecond` | — | — | — | — |
+| `metrics.stageLatenciesMs` | — | — | — | — |
 
 ---
 

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -737,13 +737,18 @@ public enum OutputType { Text, Audio, Embedding, Unknown }
 ### InferenceMetrics
 
 Typed inference metrics surfaced on every `XybridResult`. LLM-specific fields
-(`ttftMs`, `tokensPerSecond`, `prefillTps`, `decodeTps`, `tokensIn`,
-`tokensOut`) are `null` when the model is ASR/TTS/embedding. `stageLatenciesMs`
-is empty for `model.run()` and populated for `pipeline.run()`.
+(`ttftMs`, `tokensPerSecond`, `prefillTps`, `decodeTps`, `tokensOut`) are
+`null` when the model is ASR/TTS/embedding. `stageLatenciesMs` is empty for
+`model.run()` and populated for `pipeline.run()`.
 
-Wire-level source: the `Envelope.metadata` string map written by
-`runtime_adapter::llm` and `execution::executor`. The SDK parses known keys
-with graceful failure — unparseable values become `null`.
+Population is best-effort: fields are parsed from the `Envelope.metadata`
+string map written by `runtime_adapter::llm` and `execution::executor`.
+Local LLM runs populate the LLM scalars; **cloud LLM runs currently surface
+only `totalMs`** (the cloud adapter writes `backend` to envelope metadata
+but not per-run scalars — those ride on span metadata today). Unparseable
+values become `null`. Input-token counts (`promptTokens` / `tokensIn`) are
+not on this surface yet — they exist as span metadata only and will be
+added once an adapter writes the key to the envelope.
 
 ```dart
 class XybridInferenceMetrics {
@@ -752,7 +757,6 @@ class XybridInferenceMetrics {
   final double? tokensPerSecond;
   final double? prefillTps;
   final double? decodeTps;
-  final int? tokensIn;
   final int? tokensOut;
   final List<XybridStageLatency> stageLatenciesMs;
 }
@@ -770,7 +774,6 @@ data class XybridInferenceMetrics(
   val tokensPerSecond: Double?,
   val prefillTps: Double?,
   val decodeTps: Double?,
-  val tokensIn: Int?,
   val tokensOut: Int?,
   val stageLatenciesMs: List<XybridStageLatency>
 )
@@ -785,7 +788,6 @@ public struct XybridInferenceMetrics {
   public let tokensPerSecond: Double?
   public let prefillTps: Double?
   public let decodeTps: Double?
-  public let tokensIn: Int?
   public let tokensOut: Int?
   public let stageLatenciesMs: [XybridStageLatency]
 }
@@ -804,7 +806,6 @@ public sealed class InferenceMetrics
   public float? TokensPerSecond { get; }
   public float? PrefillTps { get; }
   public float? DecodeTps { get; }
-  public uint? TokensIn { get; }
   public uint? TokensOut { get; }
   public IReadOnlyList<StageLatency> StageLatenciesMs { get; }
 }

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -318,6 +318,57 @@ classes:
       audioAsWav:
         type: "Uint8List?"
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
+      metrics:
+        type: InferenceMetrics
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+
+  InferenceMetrics:
+    type: data
+    section: "7. Result Types"
+    dart_name: XybridInferenceMetrics
+    kotlin_name: XybridInferenceMetrics
+    swift_name: XybridInferenceMetrics
+    csharp_name: InferenceMetrics
+    properties:
+      totalMs:
+        type: int
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      ttftMs:
+        type: "int?"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      tokensPerSecond:
+        type: "double?"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      prefillTps:
+        type: "double?"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      decodeTps:
+        type: "double?"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      tokensIn:
+        type: "int?"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      tokensOut:
+        type: "int?"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      stageLatenciesMs:
+        type: "List<StageLatency>"
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+
+  StageLatency:
+    type: data
+    section: "7. Result Types"
+    dart_name: XybridStageLatency
+    kotlin_name: XybridStageLatency
+    swift_name: XybridStageLatency
+    csharp_name: StageLatency
+    properties:
+      stageId:
+        type: String
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      latencyMs:
+        type: int
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
 
   # -------------------------------------------------------------------
   # 8. Supporting Types

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -345,9 +345,6 @@ classes:
       decodeTps:
         type: "double?"
         status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
-      tokensIn:
-        type: "int?"
-        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
       tokensOut:
         type: "int?"
         status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }


### PR DESCRIPTION
## Summary

PR-A of the INF-15 binding-propagation series. Adds a typed `InferenceMetrics` (TTFT, tok/s, prefill/decode TPS, token counts, per-stage latencies) on `InferenceResult` and `FfiPipelineExecutionResult`, parsed from the existing `Envelope.metadata` string map written by `runtime_adapter::llm` and `execution::executor`. Wire schema is **unchanged** — bindings can now read `result.metrics().ttft_ms` instead of `result.metadata("ttft_ms").and_then(|s| s.parse().ok())`. Updates `docs/sdk/api-surface.yaml` and `docs/sdk/API_REFERENCE.md` per the spec-first rule. Linear: [INF-15](https://linear.app/xybrid/issue/INF-15).

## Test plan

- [x] `cargo test -p xybrid-sdk` — 33/33 pass (5 new metric tests in `result.rs` covering parse, missing-keys, unparseable values, aliased keys (`tokens_in`/`prompt_tokens`, `tokens_out`/`tokens_generated`), and `total_ms`; 1 new in `pipeline/result.rs` for envelope hoist)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `tools/scripts/api-contract-check.sh` — 0 errors (24 pre-existing warnings, none on the new types)
- [ ] Gates PR-B (Kotlin + Swift via shared `xybrid-uniffi`), PR-C (Flutter FRB), PR-D (Unity C FFI), PR-E (sync-api + binding examples)