### PR TITLE
feat(sdk): route streaming fallback with live device signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: macos-platform
+          key: macos-platform-no-bin
+          cache-bin: false
       - name: Check platform-macos
         run: cargo check -p xybrid-sdk --features platform-macos
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9775,6 +9775,7 @@ dependencies = [
  "oslog",
  "tokio",
  "tokio-stream",
+ "url",
  "xybrid-core",
  "xybrid-sdk",
 ]

--- a/bindings/flutter/analysis_options.yaml
+++ b/bindings/flutter/analysis_options.yaml
@@ -2,6 +2,7 @@ include: package:flutter_lints/flutter.yaml
 
 analyzer:
   exclude:
+    - cargokit/build_tool/**
     - lib/src/rust/**
   language:
     strict-casts: true

--- a/bindings/flutter/lib/src/model_loader.dart
+++ b/bindings/flutter/lib/src/model_loader.dart
@@ -12,6 +12,7 @@ import 'generation_config.dart';
 import 'llm.dart';
 import 'result.dart';
 import 'rust/api/model.dart';
+import 'run_options.dart';
 
 /// Exception thrown when Xybrid operations fail.
 class XybridException implements Exception {
@@ -290,6 +291,66 @@ class XybridModel {
       }
     } catch (e) {
       // Emit error token
+      yield StreamToken(
+        token: '',
+        index: 0,
+        cumulativeText: '',
+        isFinal: true,
+        finishReason: 'error: $e',
+      );
+    }
+  }
+
+  /// Run streaming inference with local abort and cloud fallback.
+  Stream<StreamToken> runStreamingWithFallback(
+    XybridEnvelope envelope, {
+    required RunOptions options,
+    GenerationConfig? config,
+  }) async* {
+    try {
+      final stream = inner.runStreamWithFallback(
+        envelope: envelope.inner,
+        options: options.toFfi(),
+        config: config?.toFfi(),
+      );
+
+      var emittedFinal = false;
+
+      await for (final event in stream) {
+        switch (event) {
+          case FfiStreamEvent_Token(:final field0):
+            final isFinal = field0.finishReason != null;
+            if (isFinal) emittedFinal = true;
+            yield StreamToken(
+              token: field0.token,
+              index: field0.index,
+              cumulativeText: field0.cumulativeText,
+              isFinal: isFinal,
+              finishReason: field0.finishReason,
+            );
+          case FfiStreamEvent_Complete(:final field0):
+            if (!emittedFinal) {
+              yield StreamToken(
+                token: '',
+                index: 0,
+                cumulativeText: field0.text ?? '',
+                isFinal: true,
+                finishReason: 'stop',
+              );
+            }
+          case FfiStreamEvent_Error(:final field0):
+            if (!emittedFinal) {
+              yield StreamToken(
+                token: '',
+                index: 0,
+                cumulativeText: '',
+                isFinal: true,
+                finishReason: 'error: $field0',
+              );
+            }
+        }
+      }
+    } catch (e) {
       yield StreamToken(
         token: '',
         index: 0,

--- a/bindings/flutter/lib/src/run_options.dart
+++ b/bindings/flutter/lib/src/run_options.dart
@@ -1,0 +1,79 @@
+library;
+
+import 'rust/api/model.dart';
+import 'runtime_config.dart';
+
+/// Resource or cancellation signals that can stop a local run.
+enum AbortSignal {
+  memoryPressureCritical,
+  thermalCritical,
+}
+
+/// Per-run abort behavior exposed to Flutter callers.
+class AbortPolicy {
+  final Set<AbortSignal> stopOn;
+  final bool fallbackToCloud;
+  final int? maxGraceTokens;
+
+  const AbortPolicy({
+    this.stopOn = const {
+      AbortSignal.memoryPressureCritical,
+      AbortSignal.thermalCritical,
+    },
+    this.fallbackToCloud = false,
+    this.maxGraceTokens,
+  });
+
+  const AbortPolicy.cloudFallback({
+    this.stopOn = const {
+      AbortSignal.memoryPressureCritical,
+      AbortSignal.thermalCritical,
+    },
+    this.maxGraceTokens,
+  }) : fallbackToCloud = true;
+}
+
+/// Per-run controls for SDK execution.
+class RunOptions {
+  final AbortPolicy abortPolicy;
+  final String? cloudProvider;
+  final String? cloudModel;
+  final String? cloudGatewayUrl;
+  final String? correlationId;
+  final int? maxGraceTokens;
+
+  const RunOptions({
+    this.abortPolicy = const AbortPolicy(),
+    this.cloudProvider,
+    this.cloudModel,
+    this.cloudGatewayUrl,
+    this.correlationId,
+    this.maxGraceTokens,
+  });
+
+  /// Enable local streaming abort with authenticated cloud fallback.
+  const RunOptions.cloudFallback({
+    this.abortPolicy = const AbortPolicy.cloudFallback(),
+    this.cloudProvider,
+    this.cloudModel,
+    this.cloudGatewayUrl,
+    this.correlationId,
+    this.maxGraceTokens,
+  });
+
+  FfiRunOptions toFfi() {
+    final graceTokens = abortPolicy.maxGraceTokens ?? maxGraceTokens;
+    return FfiRunOptions(
+      cloudProvider: cloudProvider,
+      cloudModel: cloudModel,
+      cloudGatewayUrl: cloudGatewayUrl ?? XybridRuntimeConfig.gatewayUrl,
+      correlationId: correlationId,
+      abortOnMemoryPressureCritical:
+          abortPolicy.stopOn.contains(AbortSignal.memoryPressureCritical),
+      abortOnThermalCritical:
+          abortPolicy.stopOn.contains(AbortSignal.thermalCritical),
+      fallbackToCloud: abortPolicy.fallbackToCloud,
+      maxGraceTokens: graceTokens,
+    );
+  }
+}

--- a/bindings/flutter/lib/src/runtime_config.dart
+++ b/bindings/flutter/lib/src/runtime_config.dart
@@ -1,0 +1,8 @@
+library;
+
+/// Process-local SDK runtime configuration shared by Dart wrappers.
+class XybridRuntimeConfig {
+  static String? gatewayUrl;
+
+  XybridRuntimeConfig._();
+}

--- a/bindings/flutter/lib/src/rust/api/device.dart
+++ b/bindings/flutter/lib/src/rust/api/device.dart
@@ -10,10 +10,19 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+// These functions are ignored because they are not marked as `pub`: `current_snapshot_with_debug_memory_pressure`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<XybridDevice>>
 abstract class XybridDevice implements RustOpaqueInterface {
+  /// Inject a short-lived critical memory-pressure sample for dogfood tests.
+  ///
+  /// The next fallback stream resource checks observe
+  /// `MemoryPressure::Critical`, then the override expires. This keeps the
+  /// demo deterministic without leaving the process permanently poisoned.
+  static void applyDebugMemoryPressure() => XybridRustLib.instance.api
+      .crateApiDeviceXybridDeviceApplyDebugMemoryPressure();
+
   /// Mark the battery level as unknown.
   ///
   /// Hosts call this on observer teardown or when the OS reports an
@@ -22,6 +31,10 @@ abstract class XybridDevice implements RustOpaqueInterface {
   /// than substituting an optimistic default.
   static void clearBatteryLevel() =>
       XybridRustLib.instance.api.crateApiDeviceXybridDeviceClearBatteryLevel();
+
+  /// Clear any pending debug memory-pressure override.
+  static void clearDebugMemoryPressure() => XybridRustLib.instance.api
+      .crateApiDeviceXybridDeviceClearDebugMemoryPressure();
 
   /// Mark the thermal state as unknown.
   static void clearThermalState() =>

--- a/bindings/flutter/lib/src/rust/api/model.dart
+++ b/bindings/flutter/lib/src/rust/api/model.dart
@@ -15,7 +15,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'result.dart';
 part 'model.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `apply_cloud_fallback_metadata`, `non_empty`, `to_sdk`, `to_sdk`
+// These functions are ignored because they are not marked as `pub`: `apply_cloud_fallback_metadata`, `is_debug_gateway_host`, `is_ipv6_link_local`, `is_ipv6_unique_local`, `is_v1_gateway_base`, `is_xybrid_gateway_host`, `non_empty`, `normalize_gateway_url`, `to_sdk`, `to_sdk`, `validate_cloud_gateway_url`, `validated_cloud_gateway_url`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `FlutterFallbackResourceProvider`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `current_snapshot`, `fmt`, `from`
 

--- a/bindings/flutter/lib/src/rust/api/model.dart
+++ b/bindings/flutter/lib/src/rust/api/model.dart
@@ -15,8 +15,9 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'result.dart';
 part 'model.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `to_sdk`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `from`
+// These functions are ignored because they are not marked as `pub`: `apply_cloud_fallback_metadata`, `non_empty`, `to_sdk`, `to_sdk`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `FlutterFallbackResourceProvider`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `current_snapshot`, `fmt`, `from`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FfiModel>>
 abstract class FfiModel implements RustOpaqueInterface {
@@ -56,6 +57,17 @@ abstract class FfiModel implements RustOpaqueInterface {
   Stream<FfiStreamEvent> runStreamWithContext(
       {required FfiEnvelope envelope,
       required FfiConversationContext context,
+      FfiGenerationConfig? config});
+
+  /// Run streaming inference with local abort and Xybrid cloud fallback.
+  ///
+  /// The Rust SDK owns the fallback semantics: abort on configured resource
+  /// pressure, re-check cloud policy, retry the original prompt through the
+  /// authenticated gateway, and emit local/cloud telemetry under one
+  /// correlation id.
+  Stream<FfiStreamEvent> runStreamWithFallback(
+      {required FfiEnvelope envelope,
+      required FfiRunOptions options,
       FfiGenerationConfig? config});
 
   /// Run inference with conversation context.
@@ -194,6 +206,58 @@ sealed class FfiLoadEvent with _$FfiLoadEvent {
   const factory FfiLoadEvent.error(
     String field0,
   ) = FfiLoadEvent_Error;
+}
+
+/// Cloud fallback controls exposed to Flutter callers.
+///
+/// This mirrors the customer-facing Dart `RunOptions` wrapper and maps into
+/// `xybrid_sdk::RunOptions` at the FFI boundary.
+class FfiRunOptions {
+  final String? cloudProvider;
+  final String? cloudModel;
+  final String? cloudGatewayUrl;
+  final String? correlationId;
+  final bool abortOnMemoryPressureCritical;
+  final bool abortOnThermalCritical;
+  final bool fallbackToCloud;
+  final int? maxGraceTokens;
+
+  const FfiRunOptions({
+    this.cloudProvider,
+    this.cloudModel,
+    this.cloudGatewayUrl,
+    this.correlationId,
+    required this.abortOnMemoryPressureCritical,
+    required this.abortOnThermalCritical,
+    required this.fallbackToCloud,
+    this.maxGraceTokens,
+  });
+
+  @override
+  int get hashCode =>
+      cloudProvider.hashCode ^
+      cloudModel.hashCode ^
+      cloudGatewayUrl.hashCode ^
+      correlationId.hashCode ^
+      abortOnMemoryPressureCritical.hashCode ^
+      abortOnThermalCritical.hashCode ^
+      fallbackToCloud.hashCode ^
+      maxGraceTokens.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FfiRunOptions &&
+          runtimeType == other.runtimeType &&
+          cloudProvider == other.cloudProvider &&
+          cloudModel == other.cloudModel &&
+          cloudGatewayUrl == other.cloudGatewayUrl &&
+          correlationId == other.correlationId &&
+          abortOnMemoryPressureCritical ==
+              other.abortOnMemoryPressureCritical &&
+          abortOnThermalCritical == other.abortOnThermalCritical &&
+          fallbackToCloud == other.fallbackToCloud &&
+          maxGraceTokens == other.maxGraceTokens;
 }
 
 @freezed

--- a/bindings/flutter/lib/src/rust/api/sdk_client.dart
+++ b/bindings/flutter/lib/src/rust/api/sdk_client.dart
@@ -10,8 +10,23 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+// These functions are ignored because they are not marked as `pub`: `initialize_telemetry_once`, `parse_resource_telemetry_mode`
+
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<XybridSdkClient>>
 abstract class XybridSdkClient implements RustOpaqueInterface {
+  static void configurePlatformTelemetry(
+          {required String apiKey,
+          String? ingestUrl,
+          String? resourceTelemetry}) =>
+      XybridRustLib.instance.api
+          .crateApiSdkClientXybridSdkClientConfigurePlatformTelemetry(
+              apiKey: apiKey,
+              ingestUrl: ingestUrl,
+              resourceTelemetry: resourceTelemetry);
+
+  static void flushPlatformTelemetry() => XybridRustLib.instance.api
+      .crateApiSdkClientXybridSdkClientFlushPlatformTelemetry();
+
   static void initSdkCacheDir({required String cacheDir}) =>
       XybridRustLib.instance.api
           .crateApiSdkClientXybridSdkClientInitSdkCacheDir(cacheDir: cacheDir);
@@ -56,4 +71,8 @@ abstract class XybridSdkClient implements RustOpaqueInterface {
 
   static void setApiKey({required String apiKey}) => XybridRustLib.instance.api
       .crateApiSdkClientXybridSdkClientSetApiKey(apiKey: apiKey);
+
+  static void setGatewayUrl({required String gatewayUrl}) => XybridRustLib
+      .instance.api
+      .crateApiSdkClientXybridSdkClientSetGatewayUrl(gatewayUrl: gatewayUrl);
 }

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class XybridRustLib extends BaseEntrypoint<XybridRustLibApi,
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 2045382748;
+  int get rustContentHash => -250798265;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -178,6 +178,12 @@ abstract class XybridRustLibApi extends BaseApi {
       required FfiConversationContext context,
       FfiGenerationConfig? config});
 
+  Stream<FfiStreamEvent> crateApiModelFfiModelRunStreamWithFallback(
+      {required FfiModel that,
+      required FfiEnvelope envelope,
+      required FfiRunOptions options,
+      FfiGenerationConfig? config});
+
   Future<FfiResult> crateApiModelFfiModelRunWithContext(
       {required FfiModel that,
       required FfiEnvelope envelope,
@@ -200,7 +206,11 @@ abstract class XybridRustLibApi extends BaseApi {
   List<String> crateApiPipelineFfiPipelineStageNames(
       {required FfiPipeline that});
 
+  void crateApiDeviceXybridDeviceApplyDebugMemoryPressure();
+
   void crateApiDeviceXybridDeviceClearBatteryLevel();
+
+  void crateApiDeviceXybridDeviceClearDebugMemoryPressure();
 
   void crateApiDeviceXybridDeviceClearThermalState();
 
@@ -210,6 +220,11 @@ abstract class XybridRustLibApi extends BaseApi {
 
   void crateApiDeviceXybridDeviceSetThermalState(
       {required FfiThermalState state});
+
+  void crateApiSdkClientXybridSdkClientConfigurePlatformTelemetry(
+      {required String apiKey, String? ingestUrl, String? resourceTelemetry});
+
+  void crateApiSdkClientXybridSdkClientFlushPlatformTelemetry();
 
   void crateApiSdkClientXybridSdkClientInitSdkCacheDir(
       {required String cacheDir});
@@ -222,6 +237,9 @@ abstract class XybridRustLibApi extends BaseApi {
   bool crateApiSdkClientXybridSdkClientIsTelemetryInitialized();
 
   void crateApiSdkClientXybridSdkClientSetApiKey({required String apiKey});
+
+  void crateApiSdkClientXybridSdkClientSetGatewayUrl(
+      {required String gatewayUrl});
 
   FfiGenerationConfig crateApiModelFfiGenerationConfigCreative();
 
@@ -1046,6 +1064,43 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  Stream<FfiStreamEvent> crateApiModelFfiModelRunStreamWithFallback(
+      {required FfiModel that,
+      required FfiEnvelope envelope,
+      required FfiRunOptions options,
+      FfiGenerationConfig? config}) {
+    final sink = RustStreamSink<FfiStreamEvent>();
+    unawaited(handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiModel(
+            that, serializer);
+        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiEnvelope(
+            envelope, serializer);
+        sse_encode_box_autoadd_ffi_run_options(options, serializer);
+        sse_encode_opt_box_autoadd_ffi_generation_config(config, serializer);
+        sse_encode_StreamSink_ffi_stream_event_Sse(sink, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 28, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiModelFfiModelRunStreamWithFallbackConstMeta,
+      argValues: [that, envelope, options, config, sink],
+      apiImpl: this,
+    )));
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateApiModelFfiModelRunStreamWithFallbackConstMeta =>
+      const TaskConstMeta(
+        debugName: "FfiModel_run_stream_with_fallback",
+        argNames: ["that", "envelope", "options", "config", "sink"],
+      );
+
+  @override
   Future<FfiResult> crateApiModelFfiModelRunWithContext(
       {required FfiModel that,
       required FfiEnvelope envelope,
@@ -1062,7 +1117,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
             context, serializer);
         sse_encode_opt_box_autoadd_ffi_generation_config(config, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 28, port: port_);
+            funcId: 29, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_result,
@@ -1086,7 +1141,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1111,7 +1166,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1136,7 +1191,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(yaml, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1162,7 +1217,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiPipeline(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -1191,7 +1246,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiEnvelope(
             envelope, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 33, port: port_);
+            funcId: 34, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_result,
@@ -1216,7 +1271,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiPipeline(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_usize,
@@ -1242,7 +1297,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiPipeline(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -1261,11 +1316,35 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  void crateApiDeviceXybridDeviceApplyDebugMemoryPressure() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiDeviceXybridDeviceApplyDebugMemoryPressureConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiDeviceXybridDeviceApplyDebugMemoryPressureConstMeta =>
+          const TaskConstMeta(
+            debugName: "XybridDevice_apply_debug_memory_pressure",
+            argNames: [],
+          );
+
+  @override
   void crateApiDeviceXybridDeviceClearBatteryLevel() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1284,11 +1363,35 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  void crateApiDeviceXybridDeviceClearDebugMemoryPressure() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiDeviceXybridDeviceClearDebugMemoryPressureConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiDeviceXybridDeviceClearDebugMemoryPressureConstMeta =>
+          const TaskConstMeta(
+            debugName: "XybridDevice_clear_debug_memory_pressure",
+            argNames: [],
+          );
+
+  @override
   void crateApiDeviceXybridDeviceClearThermalState() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1311,7 +1414,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_resource_snapshot,
@@ -1335,7 +1438,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_8(percent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1360,7 +1463,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_ffi_thermal_state(state, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1379,13 +1482,67 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  void crateApiSdkClientXybridSdkClientConfigurePlatformTelemetry(
+      {required String apiKey, String? ingestUrl, String? resourceTelemetry}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(apiKey, serializer);
+        sse_encode_opt_String(ingestUrl, serializer);
+        sse_encode_opt_String(resourceTelemetry, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiSdkClientXybridSdkClientConfigurePlatformTelemetryConstMeta,
+      argValues: [apiKey, ingestUrl, resourceTelemetry],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiSdkClientXybridSdkClientConfigurePlatformTelemetryConstMeta =>
+          const TaskConstMeta(
+            debugName: "XybridSdkClient_configure_platform_telemetry",
+            argNames: ["apiKey", "ingestUrl", "resourceTelemetry"],
+          );
+
+  @override
+  void crateApiSdkClientXybridSdkClientFlushPlatformTelemetry() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiSdkClientXybridSdkClientFlushPlatformTelemetryConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiSdkClientXybridSdkClientFlushPlatformTelemetryConstMeta =>
+          const TaskConstMeta(
+            debugName: "XybridSdkClient_flush_platform_telemetry",
+            argNames: [],
+          );
+
+  @override
   void crateApiSdkClientXybridSdkClientInitSdkCacheDir(
       {required String cacheDir}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(cacheDir, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1411,7 +1568,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(endpoint, serializer);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1436,7 +1593,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(modelId, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1459,7 +1616,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1485,7 +1642,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1504,11 +1661,36 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  void crateApiSdkClientXybridSdkClientSetGatewayUrl(
+      {required String gatewayUrl}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(gatewayUrl, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiSdkClientXybridSdkClientSetGatewayUrlConstMeta,
+      argValues: [gatewayUrl],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSdkClientXybridSdkClientSetGatewayUrlConstMeta =>
+      const TaskConstMeta(
+        debugName: "XybridSdkClient_set_gateway_url",
+        argNames: ["gatewayUrl"],
+      );
+
+  @override
   FfiGenerationConfig crateApiModelFfiGenerationConfigCreative() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -1531,7 +1713,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -1824,6 +2006,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  FfiRunOptions dco_decode_box_autoadd_ffi_run_options(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_ffi_run_options(raw);
+  }
+
+  @protected
   FfiStreamToken dco_decode_box_autoadd_ffi_stream_token(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_ffi_stream_token(raw);
@@ -1937,6 +2125,24 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       audioBytes: dco_decode_opt_list_prim_u_8_strict(arr[2]),
       embedding: dco_decode_opt_list_prim_f_32_strict(arr[3]),
       latencyMs: dco_decode_u_32(arr[4]),
+    );
+  }
+
+  @protected
+  FfiRunOptions dco_decode_ffi_run_options(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return FfiRunOptions(
+      cloudProvider: dco_decode_opt_String(arr[0]),
+      cloudModel: dco_decode_opt_String(arr[1]),
+      cloudGatewayUrl: dco_decode_opt_String(arr[2]),
+      correlationId: dco_decode_opt_String(arr[3]),
+      abortOnMemoryPressureCritical: dco_decode_bool(arr[4]),
+      abortOnThermalCritical: dco_decode_bool(arr[5]),
+      fallbackToCloud: dco_decode_bool(arr[6]),
+      maxGraceTokens: dco_decode_opt_box_autoadd_u_32(arr[7]),
     );
   }
 
@@ -2361,6 +2567,13 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  FfiRunOptions sse_decode_box_autoadd_ffi_run_options(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_ffi_run_options(deserializer));
+  }
+
+  @protected
   FfiStreamToken sse_decode_box_autoadd_ffi_stream_token(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -2489,6 +2702,28 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         audioBytes: var_audioBytes,
         embedding: var_embedding,
         latencyMs: var_latencyMs);
+  }
+
+  @protected
+  FfiRunOptions sse_decode_ffi_run_options(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_cloudProvider = sse_decode_opt_String(deserializer);
+    var var_cloudModel = sse_decode_opt_String(deserializer);
+    var var_cloudGatewayUrl = sse_decode_opt_String(deserializer);
+    var var_correlationId = sse_decode_opt_String(deserializer);
+    var var_abortOnMemoryPressureCritical = sse_decode_bool(deserializer);
+    var var_abortOnThermalCritical = sse_decode_bool(deserializer);
+    var var_fallbackToCloud = sse_decode_bool(deserializer);
+    var var_maxGraceTokens = sse_decode_opt_box_autoadd_u_32(deserializer);
+    return FfiRunOptions(
+        cloudProvider: var_cloudProvider,
+        cloudModel: var_cloudModel,
+        cloudGatewayUrl: var_cloudGatewayUrl,
+        correlationId: var_correlationId,
+        abortOnMemoryPressureCritical: var_abortOnMemoryPressureCritical,
+        abortOnThermalCritical: var_abortOnThermalCritical,
+        fallbackToCloud: var_fallbackToCloud,
+        maxGraceTokens: var_maxGraceTokens);
   }
 
   @protected
@@ -3001,6 +3236,13 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  void sse_encode_box_autoadd_ffi_run_options(
+      FfiRunOptions self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ffi_run_options(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_ffi_stream_token(
       FfiStreamToken self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -3102,6 +3344,20 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_opt_list_prim_u_8_strict(self.audioBytes, serializer);
     sse_encode_opt_list_prim_f_32_strict(self.embedding, serializer);
     sse_encode_u_32(self.latencyMs, serializer);
+  }
+
+  @protected
+  void sse_encode_ffi_run_options(
+      FfiRunOptions self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_String(self.cloudProvider, serializer);
+    sse_encode_opt_String(self.cloudModel, serializer);
+    sse_encode_opt_String(self.cloudGatewayUrl, serializer);
+    sse_encode_opt_String(self.correlationId, serializer);
+    sse_encode_bool(self.abortOnMemoryPressureCritical, serializer);
+    sse_encode_bool(self.abortOnThermalCritical, serializer);
+    sse_encode_bool(self.fallbackToCloud, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.maxGraceTokens, serializer);
   }
 
   @protected
@@ -3524,6 +3780,19 @@ class FfiModelImpl extends RustOpaque implements FfiModel {
           FfiGenerationConfig? config}) =>
       XybridRustLib.instance.api.crateApiModelFfiModelRunStreamWithContext(
           that: this, envelope: envelope, context: context, config: config);
+
+  /// Run streaming inference with local abort and Xybrid cloud fallback.
+  ///
+  /// The Rust SDK owns the fallback semantics: abort on configured resource
+  /// pressure, re-check cloud policy, retry the original prompt through the
+  /// authenticated gateway, and emit local/cloud telemetry under one
+  /// correlation id.
+  Stream<FfiStreamEvent> runStreamWithFallback(
+          {required FfiEnvelope envelope,
+          required FfiRunOptions options,
+          FfiGenerationConfig? config}) =>
+      XybridRustLib.instance.api.crateApiModelFfiModelRunStreamWithFallback(
+          that: this, envelope: envelope, options: options, config: config);
 
   /// Run inference with conversation context.
   ///

--- a/bindings/flutter/lib/src/rust/frb_generated.io.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.io.dart
@@ -184,6 +184,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiResult dco_decode_box_autoadd_ffi_result(dynamic raw);
 
   @protected
+  FfiRunOptions dco_decode_box_autoadd_ffi_run_options(dynamic raw);
+
+  @protected
   FfiStreamToken dco_decode_box_autoadd_ffi_stream_token(dynamic raw);
 
   @protected
@@ -218,6 +221,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   FfiResult dco_decode_ffi_result(dynamic raw);
+
+  @protected
+  FfiRunOptions dco_decode_ffi_run_options(dynamic raw);
 
   @protected
   FfiStreamEvent dco_decode_ffi_stream_event(dynamic raw);
@@ -428,6 +434,10 @@ abstract class XybridRustLibApiImplPlatform
   FfiResult sse_decode_box_autoadd_ffi_result(SseDeserializer deserializer);
 
   @protected
+  FfiRunOptions sse_decode_box_autoadd_ffi_run_options(
+      SseDeserializer deserializer);
+
+  @protected
   FfiStreamToken sse_decode_box_autoadd_ffi_stream_token(
       SseDeserializer deserializer);
 
@@ -466,6 +476,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   FfiResult sse_decode_ffi_result(SseDeserializer deserializer);
+
+  @protected
+  FfiRunOptions sse_decode_ffi_run_options(SseDeserializer deserializer);
 
   @protected
   FfiStreamEvent sse_decode_ffi_stream_event(SseDeserializer deserializer);
@@ -680,6 +693,10 @@ abstract class XybridRustLibApiImplPlatform
       FfiResult self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_ffi_run_options(
+      FfiRunOptions self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_ffi_stream_token(
       FfiStreamToken self, SseSerializer serializer);
 
@@ -720,6 +737,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   void sse_encode_ffi_result(FfiResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_ffi_run_options(FfiRunOptions self, SseSerializer serializer);
 
   @protected
   void sse_encode_ffi_stream_event(

--- a/bindings/flutter/lib/src/rust/frb_generated.web.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.web.dart
@@ -186,6 +186,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiResult dco_decode_box_autoadd_ffi_result(dynamic raw);
 
   @protected
+  FfiRunOptions dco_decode_box_autoadd_ffi_run_options(dynamic raw);
+
+  @protected
   FfiStreamToken dco_decode_box_autoadd_ffi_stream_token(dynamic raw);
 
   @protected
@@ -220,6 +223,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   FfiResult dco_decode_ffi_result(dynamic raw);
+
+  @protected
+  FfiRunOptions dco_decode_ffi_run_options(dynamic raw);
 
   @protected
   FfiStreamEvent dco_decode_ffi_stream_event(dynamic raw);
@@ -430,6 +436,10 @@ abstract class XybridRustLibApiImplPlatform
   FfiResult sse_decode_box_autoadd_ffi_result(SseDeserializer deserializer);
 
   @protected
+  FfiRunOptions sse_decode_box_autoadd_ffi_run_options(
+      SseDeserializer deserializer);
+
+  @protected
   FfiStreamToken sse_decode_box_autoadd_ffi_stream_token(
       SseDeserializer deserializer);
 
@@ -468,6 +478,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   FfiResult sse_decode_ffi_result(SseDeserializer deserializer);
+
+  @protected
+  FfiRunOptions sse_decode_ffi_run_options(SseDeserializer deserializer);
 
   @protected
   FfiStreamEvent sse_decode_ffi_stream_event(SseDeserializer deserializer);
@@ -682,6 +695,10 @@ abstract class XybridRustLibApiImplPlatform
       FfiResult self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_ffi_run_options(
+      FfiRunOptions self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_ffi_stream_token(
       FfiStreamToken self, SseSerializer serializer);
 
@@ -722,6 +739,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   void sse_encode_ffi_result(FfiResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_ffi_run_options(FfiRunOptions self, SseSerializer serializer);
 
   @protected
   void sse_encode_ffi_stream_event(

--- a/bindings/flutter/lib/src/xybrid.dart
+++ b/bindings/flutter/lib/src/xybrid.dart
@@ -13,8 +13,10 @@ import 'package:xybrid_flutter/src/rust/api/sdk_client.dart';
 import 'package:path_provider/path_provider.dart';
 import 'rust/frb_generated.dart';
 
-import '../xybrid.dart';
 import 'device_snapshot.dart';
+import 'model_loader.dart';
+import 'pipeline.dart';
+import 'runtime_config.dart';
 
 /// Main entry point for the Xybrid SDK.
 ///
@@ -65,15 +67,33 @@ class Xybrid {
   /// ```
   ///
   /// Throws an exception if initialization fails (e.g., native library not found).
-  static Future<void> init() async {
+  static Future<void> init({
+    String? apiKey,
+    String? gatewayUrl,
+    String? ingestUrl,
+    String? resourceTelemetry,
+  }) async {
     // Fast path: already initialized
     if (_initialized) {
+      _applyRuntimeConfig(
+        apiKey: apiKey,
+        gatewayUrl: gatewayUrl,
+        ingestUrl: ingestUrl,
+        resourceTelemetry: resourceTelemetry,
+      );
       return;
     }
 
     // Handle concurrent initialization attempts
     if (_initializing) {
-      return _initCompleter.future;
+      await _initCompleter.future;
+      _applyRuntimeConfig(
+        apiKey: apiKey,
+        gatewayUrl: gatewayUrl,
+        ingestUrl: ingestUrl,
+        resourceTelemetry: resourceTelemetry,
+      );
+      return;
     }
 
     _initializing = true;
@@ -99,6 +119,12 @@ class Xybrid {
 
       _initialized = true;
       _initCompleter.complete();
+      _applyRuntimeConfig(
+        apiKey: apiKey,
+        gatewayUrl: gatewayUrl,
+        ingestUrl: ingestUrl,
+        resourceTelemetry: resourceTelemetry,
+      );
     } catch (e) {
       _initCompleter.completeError(e);
       _initializing = false;
@@ -113,6 +139,15 @@ class Xybrid {
 
   static void setApiKey(String apiKey) {
     XybridSdkClient.setApiKey(apiKey: apiKey);
+  }
+
+  static void setGatewayUrl(String gatewayUrl) {
+    XybridRuntimeConfig.gatewayUrl = gatewayUrl;
+    XybridSdkClient.setGatewayUrl(gatewayUrl: gatewayUrl);
+  }
+
+  static void applyDebugMemoryPressure() {
+    XybridDevice.applyDebugMemoryPressure();
   }
 
   /// Check if a model is cached locally (extracted and ready to use).
@@ -164,7 +199,8 @@ class Xybrid {
   ///   runApp(...);
   /// }
   /// ```
-  static void initTelemetry({required String endpoint, required String apiKey}) {
+  static void initTelemetry(
+      {required String endpoint, required String apiKey}) {
     if (!_initialized) {
       throw StateError('Xybrid.init() must complete before initTelemetry()');
     }
@@ -193,6 +229,37 @@ class Xybrid {
   /// not poll this — the engine reads it internally.
   static DeviceSnapshot currentDeviceSnapshot() {
     return DeviceSnapshot.fromFfi(XybridDevice.currentSnapshot());
+  }
+
+  static void _applyRuntimeConfig({
+    String? apiKey,
+    String? gatewayUrl,
+    String? ingestUrl,
+    String? resourceTelemetry,
+  }) {
+    final key = _nonEmpty(apiKey);
+    final gateway = _nonEmpty(gatewayUrl);
+    final ingest = _nonEmpty(ingestUrl);
+    final resourceMode = _nonEmpty(resourceTelemetry);
+
+    if (key != null) {
+      setApiKey(key);
+    }
+    if (gateway != null) {
+      setGatewayUrl(gateway);
+    }
+    if (key != null && ingest != null) {
+      XybridSdkClient.configurePlatformTelemetry(
+        apiKey: key,
+        ingestUrl: ingest,
+        resourceTelemetry: resourceMode,
+      );
+    }
+  }
+
+  static String? _nonEmpty(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
   }
 
   /// Create a ModelLoader for the specified model.

--- a/bindings/flutter/lib/xybrid.dart
+++ b/bindings/flutter/lib/xybrid.dart
@@ -72,13 +72,22 @@
 library;
 
 export 'src/context.dart' show ConversationContext, MessageRole;
-export 'src/device_snapshot.dart' show DeviceSnapshot, MemoryPressure, ThermalState;
+export 'src/device_snapshot.dart'
+    show DeviceSnapshot, MemoryPressure, ThermalState;
 export 'src/envelope.dart' show XybridEnvelope;
 export 'src/generation_config.dart' show GenerationConfig;
 export 'src/llm.dart' show StreamToken;
 export 'src/model_loader.dart'
-    show XybridModelLoader, XybridModel, XybridException, LoadEvent, LoadProgress, LoadComplete, LoadError;
+    show
+        XybridModelLoader,
+        XybridModel,
+        XybridException,
+        LoadEvent,
+        LoadProgress,
+        LoadComplete,
+        LoadError;
 export 'src/pipeline.dart' show XybridPipeline;
 export 'src/result.dart' show XybridResult;
+export 'src/run_options.dart' show AbortPolicy, AbortSignal, RunOptions;
 export 'src/utils/utils.dart';
 export 'src/xybrid.dart' show Xybrid;

--- a/bindings/flutter/lib/xybrid_flutter.dart
+++ b/bindings/flutter/lib/xybrid_flutter.dart
@@ -2,6 +2,6 @@
 ///
 /// This is the main entry point for the xybrid_flutter package.
 /// See [xybrid.dart] for detailed API documentation.
-library xybrid_flutter;
+library;
 
 export 'xybrid.dart';

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -18,6 +18,7 @@ xybrid-core = { path = "../../../crates/xybrid-core", default-features = false }
 # Async runtime for streaming
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
+url = "2.5"
 
 # Logging (optional - for debugging)
 log = "0.4"

--- a/bindings/flutter/rust/src/api/device.rs
+++ b/bindings/flutter/rust/src/api/device.rs
@@ -24,11 +24,34 @@
 //! signal coverage on a given platform without round-tripping through
 //! a telemetry event.
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use flutter_rust_bridge::frb;
+use xybrid_sdk::{MemoryPressure, ResourceSnapshot};
 
 use super::FLUTTER_BINDING;
+
+const DEBUG_MEMORY_PRESSURE_READS: u8 = 2;
+
+static DEBUG_MEMORY_PRESSURE_REMAINING: AtomicU8 = AtomicU8::new(0);
+
+pub(crate) fn current_snapshot_with_debug_memory_pressure(max_age: Duration) -> ResourceSnapshot {
+    let mut snapshot = xybrid_sdk::ResourceMonitor::global().current_snapshot(max_age);
+    let previous = DEBUG_MEMORY_PRESSURE_REMAINING
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+            if remaining > 0 {
+                Some(remaining - 1)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+    if previous > 0 {
+        snapshot.memory_pressure = MemoryPressure::Critical;
+    }
+    snapshot
+}
 
 /// Thermal pressure state forwarded by the host.
 ///
@@ -188,9 +211,25 @@ impl XybridDevice {
     #[frb(sync)]
     pub fn current_snapshot() -> FfiResourceSnapshot {
         xybrid_sdk::set_binding(FLUTTER_BINDING);
-        xybrid_sdk::ResourceMonitor::global()
-            .current_snapshot(Duration::ZERO)
-            .into()
+        current_snapshot_with_debug_memory_pressure(Duration::ZERO).into()
+    }
+
+    /// Inject a short-lived critical memory-pressure sample for dogfood tests.
+    ///
+    /// The next fallback stream resource checks observe
+    /// `MemoryPressure::Critical`, then the override expires. This keeps the
+    /// demo deterministic without leaving the process permanently poisoned.
+    #[frb(sync)]
+    pub fn apply_debug_memory_pressure() {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
+        DEBUG_MEMORY_PRESSURE_REMAINING.store(DEBUG_MEMORY_PRESSURE_READS, Ordering::Release);
+    }
+
+    /// Clear any pending debug memory-pressure override.
+    #[frb(sync)]
+    pub fn clear_debug_memory_pressure() {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
+        DEBUG_MEMORY_PRESSURE_REMAINING.store(0, Ordering::Release);
     }
 }
 

--- a/bindings/flutter/rust/src/api/mod.rs
+++ b/bindings/flutter/rust/src/api/mod.rs
@@ -21,6 +21,8 @@ pub mod sdk_client;
 pub use context::{FfiConversationContext, FfiMessageRole};
 pub use device::{FfiThermalState, XybridDevice};
 pub use envelope::FfiEnvelope;
-pub use model::{FfiGenerationConfig, FfiModel, FfiModelLoader, FfiStreamEvent, FfiStreamToken};
+pub use model::{
+    FfiGenerationConfig, FfiModel, FfiModelLoader, FfiRunOptions, FfiStreamEvent, FfiStreamToken,
+};
 pub use pipeline::FfiPipeline;
 pub use result::FfiResult;

--- a/bindings/flutter/rust/src/api/model.rs
+++ b/bindings/flutter/rust/src/api/model.rs
@@ -1,11 +1,17 @@
 //! Model loading FFI wrappers for Flutter.
 use flutter_rust_bridge::frb;
 use std::sync::Arc;
-use xybrid_sdk::{GenerationConfig, ModelLoader, XybridModel};
+use std::time::Duration;
+use xybrid_core::device::{ResourceSnapshot, ResourceSnapshotProvider};
+use xybrid_core::runtime_adapter::CloudRuntimeAdapter;
+use xybrid_sdk::{
+    AbortPolicy, AbortSignal, GenerationConfig, ModelLoader, RunOptions, XybridModel,
+};
 
 use crate::frb_generated::StreamSink;
 
 use super::context::FfiConversationContext;
+use super::device;
 use super::result::FfiResult;
 
 /// Generation parameters for LLM inference.
@@ -82,6 +88,102 @@ impl FfiGenerationConfig {
             config.stop_sequences = v.clone();
         }
         config
+    }
+}
+
+/// Cloud fallback controls exposed to Flutter callers.
+///
+/// This mirrors the customer-facing Dart `RunOptions` wrapper and maps into
+/// `xybrid_sdk::RunOptions` at the FFI boundary.
+pub struct FfiRunOptions {
+    pub cloud_provider: Option<String>,
+    pub cloud_model: Option<String>,
+    pub cloud_gateway_url: Option<String>,
+    pub correlation_id: Option<String>,
+    pub abort_on_memory_pressure_critical: bool,
+    pub abort_on_thermal_critical: bool,
+    pub fallback_to_cloud: bool,
+    pub max_grace_tokens: Option<u32>,
+}
+
+impl FfiRunOptions {
+    fn to_sdk(&self, generation_config: Option<GenerationConfig>) -> RunOptions {
+        let mut policy = AbortPolicy::default()
+            .with_cloud_fallback(self.fallback_to_cloud)
+            .with_max_grace_tokens(self.max_grace_tokens.unwrap_or(0));
+        if self.abort_on_memory_pressure_critical {
+            policy = policy.stop_on(AbortSignal::MemoryPressureCritical);
+        }
+        if self.abort_on_thermal_critical {
+            policy = policy.stop_on(AbortSignal::ThermalCritical);
+        }
+
+        let mut options = RunOptions::new()
+            .with_abort_policy(policy)
+            .with_resource_provider(Arc::new(FlutterFallbackResourceProvider));
+
+        if let Some(config) = generation_config {
+            options = options.with_generation_config(config);
+        }
+
+        if let Some(correlation_id) = non_empty(self.correlation_id.as_deref()) {
+            options = options.with_correlation_id(correlation_id.to_string());
+        }
+
+        options
+    }
+}
+
+#[derive(Debug)]
+struct FlutterFallbackResourceProvider;
+
+impl ResourceSnapshotProvider for FlutterFallbackResourceProvider {
+    fn current_snapshot(&self, max_age: Duration) -> ResourceSnapshot {
+        device::current_snapshot_with_debug_memory_pressure(max_age)
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|v| {
+        let trimmed = v.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+fn apply_cloud_fallback_metadata(
+    envelope: &mut xybrid_sdk::ir::Envelope,
+    options: &FfiRunOptions,
+    config: Option<&FfiGenerationConfig>,
+) {
+    let provider = non_empty(options.cloud_provider.as_deref()).unwrap_or("openai");
+    let model = non_empty(options.cloud_model.as_deref()).unwrap_or("gpt-4o-mini");
+    envelope
+        .metadata
+        .insert("provider".to_string(), provider.to_string());
+    envelope
+        .metadata
+        .insert("model".to_string(), model.to_string());
+    envelope
+        .metadata
+        .insert("backend".to_string(), "gateway".to_string());
+
+    if let Some(gateway_url) = non_empty(options.cloud_gateway_url.as_deref()) {
+        envelope
+            .metadata
+            .insert("gateway_url".to_string(), gateway_url.to_string());
+    }
+
+    if let Some(config) = config {
+        if let Some(max_tokens) = config.max_tokens {
+            envelope
+                .metadata
+                .insert("max_tokens".to_string(), max_tokens.to_string());
+        }
+        if let Some(temperature) = config.temperature {
+            envelope
+                .metadata
+                .insert("temperature".to_string(), temperature.to_string());
+        }
     }
 }
 
@@ -396,5 +498,95 @@ impl FfiModel {
                 }
             }
         });
+    }
+
+    /// Run streaming inference with local abort and Xybrid cloud fallback.
+    ///
+    /// The Rust SDK owns the fallback semantics: abort on configured resource
+    /// pressure, re-check cloud policy, retry the original prompt through the
+    /// authenticated gateway, and emit local/cloud telemetry under one
+    /// correlation id.
+    pub fn run_stream_with_fallback(
+        &self,
+        envelope: super::envelope::FfiEnvelope,
+        options: FfiRunOptions,
+        config: Option<FfiGenerationConfig>,
+        sink: StreamSink<FfiStreamEvent>,
+    ) {
+        let model = self.0.clone();
+        let mut env = envelope.into_envelope();
+        apply_cloud_fallback_metadata(&mut env, &options, config.as_ref());
+        let sdk_config = config.map(|c| c.to_sdk());
+        let run_options = options.to_sdk(sdk_config);
+        let cloud_adapter = match non_empty(options.cloud_gateway_url.as_deref()) {
+            Some(gateway_url) => CloudRuntimeAdapter::with_gateway(gateway_url),
+            None => CloudRuntimeAdapter::new(),
+        };
+
+        std::thread::spawn(move || {
+            let mut token_index = 0u32;
+            let result = {
+                let mut on_token = |token: xybrid_core::runtime_adapter::types::PartialToken| {
+                    let ffi_token = FfiStreamToken {
+                        token: token.token.clone(),
+                        token_id: token.token_id,
+                        index: token_index,
+                        cumulative_text: token.cumulative_text.clone(),
+                        finish_reason: token.finish_reason.clone(),
+                    };
+                    token_index = token_index.saturating_add(1);
+                    let _ = sink.add(FfiStreamEvent::Token(ffi_token));
+                    Ok(())
+                };
+                let mut on_seam = |_seam: xybrid_sdk::model::SeamInfo| {};
+
+                model.run_streaming_with_fallback(
+                    &env,
+                    &run_options,
+                    &cloud_adapter,
+                    &mut on_token,
+                    &mut on_seam,
+                )
+            };
+
+            match result {
+                Ok(inference_result) => {
+                    let ffi_result = FfiResult::from_inference_result(&inference_result);
+                    let _ = sink.add(FfiStreamEvent::Complete(ffi_result));
+                }
+                Err(e) => {
+                    let _ = sink.add(FfiStreamEvent::Error(e.to_string()));
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ffi_run_options_maps_abort_policy_to_sdk() {
+        let ffi = FfiRunOptions {
+            cloud_provider: Some("openai".to_string()),
+            cloud_model: Some("gpt-4o-mini".to_string()),
+            cloud_gateway_url: Some("http://127.0.0.1:3001/v1".to_string()),
+            correlation_id: Some("corr-flutter".to_string()),
+            abort_on_memory_pressure_critical: true,
+            abort_on_thermal_critical: false,
+            fallback_to_cloud: false,
+            max_grace_tokens: Some(2),
+        };
+
+        let sdk = ffi.to_sdk(None);
+
+        assert!(sdk
+            .abort_policy
+            .observes(AbortSignal::MemoryPressureCritical));
+        assert!(!sdk.abort_policy.observes(AbortSignal::ThermalCritical));
+        assert!(!sdk.abort_policy.fallback_to_cloud);
+        assert_eq!(sdk.abort_policy.max_grace_tokens, 2);
+        assert_eq!(sdk.correlation_id.as_deref(), Some("corr-flutter"));
     }
 }

--- a/bindings/flutter/rust/src/api/model.rs
+++ b/bindings/flutter/rust/src/api/model.rs
@@ -2,6 +2,7 @@
 use flutter_rust_bridge::frb;
 use std::sync::Arc;
 use std::time::Duration;
+use url::Url;
 use xybrid_core::device::{ResourceSnapshot, ResourceSnapshotProvider};
 use xybrid_core::runtime_adapter::CloudRuntimeAdapter;
 use xybrid_sdk::{
@@ -154,7 +155,7 @@ fn apply_cloud_fallback_metadata(
     envelope: &mut xybrid_sdk::ir::Envelope,
     options: &FfiRunOptions,
     config: Option<&FfiGenerationConfig>,
-) {
+) -> Result<Option<String>, String> {
     let provider = non_empty(options.cloud_provider.as_deref()).unwrap_or("openai");
     let model = non_empty(options.cloud_model.as_deref()).unwrap_or("gpt-4o-mini");
     envelope
@@ -167,7 +168,8 @@ fn apply_cloud_fallback_metadata(
         .metadata
         .insert("backend".to_string(), "gateway".to_string());
 
-    if let Some(gateway_url) = non_empty(options.cloud_gateway_url.as_deref()) {
+    let gateway_url = options.validated_cloud_gateway_url()?;
+    if let Some(gateway_url) = gateway_url.as_deref() {
         envelope
             .metadata
             .insert("gateway_url".to_string(), gateway_url.to_string());
@@ -185,6 +187,101 @@ fn apply_cloud_fallback_metadata(
                 .insert("temperature".to_string(), temperature.to_string());
         }
     }
+
+    Ok(gateway_url)
+}
+
+impl FfiRunOptions {
+    fn validated_cloud_gateway_url(&self) -> Result<Option<String>, String> {
+        non_empty(self.cloud_gateway_url.as_deref())
+            .map(validate_cloud_gateway_url)
+            .transpose()
+    }
+}
+
+fn validate_cloud_gateway_url(gateway_url: &str) -> Result<String, String> {
+    let parsed = Url::parse(gateway_url)
+        .map_err(|e| format!("Invalid cloud gateway URL '{}': {}", gateway_url, e))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => {
+            return Err(format!(
+                "Invalid cloud gateway URL '{}': unsupported scheme '{}'",
+                gateway_url, scheme
+            ));
+        }
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("Invalid cloud gateway URL: credentials are not allowed".to_string());
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(
+            "Invalid cloud gateway URL: query strings and fragments are not allowed".to_string(),
+        );
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "Invalid cloud gateway URL: host is required".to_string())?;
+    if !is_v1_gateway_base(&parsed) {
+        return Err("Invalid cloud gateway URL: base URL must include /v1".to_string());
+    }
+
+    if parsed.scheme() == "https" && is_xybrid_gateway_host(host) {
+        return Ok(normalize_gateway_url(parsed));
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        if is_debug_gateway_host(host) {
+            return Ok(normalize_gateway_url(parsed));
+        }
+    }
+
+    Err(
+        "Invalid cloud gateway URL: release builds only allow HTTPS Xybrid gateway hosts"
+            .to_string(),
+    )
+}
+
+fn normalize_gateway_url(parsed: Url) -> String {
+    parsed.as_str().trim_end_matches('/').to_string()
+}
+
+fn is_v1_gateway_base(parsed: &Url) -> bool {
+    let path = parsed.path().trim_end_matches('/');
+    path == "/v1" || path.starts_with("/v1/")
+}
+
+fn is_xybrid_gateway_host(host: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    host == "xybrid.dev" || host.ends_with(".xybrid.dev")
+}
+
+#[cfg(debug_assertions)]
+fn is_debug_gateway_host(host: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    if host == "localhost" || host.ends_with(".localhost") {
+        return true;
+    }
+
+    match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(ip)) => ip.is_loopback() || ip.is_private() || ip.is_link_local(),
+        Ok(std::net::IpAddr::V6(ip)) => {
+            ip.is_loopback() || is_ipv6_link_local(ip) || is_ipv6_unique_local(ip)
+        }
+        Err(_) => false,
+    }
+}
+
+#[cfg(debug_assertions)]
+fn is_ipv6_link_local(ip: std::net::Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
+}
+
+#[cfg(debug_assertions)]
+fn is_ipv6_unique_local(ip: std::net::Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
 }
 
 /// Event emitted during model loading with progress.
@@ -515,10 +612,16 @@ impl FfiModel {
     ) {
         let model = self.0.clone();
         let mut env = envelope.into_envelope();
-        apply_cloud_fallback_metadata(&mut env, &options, config.as_ref());
+        let gateway_url = match apply_cloud_fallback_metadata(&mut env, &options, config.as_ref()) {
+            Ok(gateway_url) => gateway_url,
+            Err(e) => {
+                let _ = sink.add(FfiStreamEvent::Error(e));
+                return;
+            }
+        };
         let sdk_config = config.map(|c| c.to_sdk());
         let run_options = options.to_sdk(sdk_config);
-        let cloud_adapter = match non_empty(options.cloud_gateway_url.as_deref()) {
+        let cloud_adapter = match gateway_url.as_deref() {
             Some(gateway_url) => CloudRuntimeAdapter::with_gateway(gateway_url),
             None => CloudRuntimeAdapter::new(),
         };
@@ -588,5 +691,36 @@ mod tests {
         assert!(!sdk.abort_policy.fallback_to_cloud);
         assert_eq!(sdk.abort_policy.max_grace_tokens, 2);
         assert_eq!(sdk.correlation_id.as_deref(), Some("corr-flutter"));
+    }
+
+    #[test]
+    fn cloud_gateway_url_accepts_xybrid_https_v1_base() {
+        let url = validate_cloud_gateway_url("https://api.xybrid.dev/v1/").unwrap();
+        assert_eq!(url, "https://api.xybrid.dev/v1");
+    }
+
+    #[test]
+    fn cloud_gateway_url_rejects_public_http_hosts() {
+        let err = validate_cloud_gateway_url("http://example.com/v1").unwrap_err();
+        assert!(err.contains("HTTPS Xybrid gateway hosts"));
+    }
+
+    #[test]
+    fn cloud_gateway_url_rejects_embedded_credentials() {
+        let err = validate_cloud_gateway_url("https://token@api.xybrid.dev/v1").unwrap_err();
+        assert!(err.contains("credentials"));
+    }
+
+    #[test]
+    fn cloud_gateway_url_rejects_missing_v1_base() {
+        let err = validate_cloud_gateway_url("https://api.xybrid.dev/").unwrap_err();
+        assert!(err.contains("/v1"));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn cloud_gateway_url_accepts_debug_localhost_gateway() {
+        let url = validate_cloud_gateway_url("http://127.0.0.1:3001/v1").unwrap();
+        assert_eq!(url, "http://127.0.0.1:3001/v1");
     }
 }

--- a/bindings/flutter/rust/src/api/sdk_client.rs
+++ b/bindings/flutter/rust/src/api/sdk_client.rs
@@ -73,7 +73,7 @@ impl XybridSdkClient {
     #[frb(sync)]
     pub fn set_gateway_url(gateway_url: String) {
         xybrid_sdk::set_binding(FLUTTER_BINDING);
-        std::env::set_var("XYBRID_GATEWAY_URL", gateway_url);
+        xybrid_sdk::set_gateway_url(gateway_url);
     }
 
     /// Initialize the platform telemetry exporter for this process.

--- a/bindings/flutter/rust/src/api/sdk_client.rs
+++ b/bindings/flutter/rust/src/api/sdk_client.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use flutter_rust_bridge::frb;
+use xybrid_sdk::ResourceTelemetryMode;
 
 use super::FLUTTER_BINDING;
 
@@ -21,6 +22,41 @@ static TELEMETRY_INITIALIZED: AtomicBool = AtomicBool::new(false);
 #[frb(opaque)]
 pub struct XybridSdkClient;
 
+fn initialize_telemetry_once(config: xybrid_sdk::TelemetryConfig) {
+    if TELEMETRY_INITIALIZED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    xybrid_sdk::telemetry::init_platform_telemetry(config);
+}
+
+fn parse_resource_telemetry_mode(value: Option<&str>) -> Option<ResourceTelemetryMode> {
+    let raw = value?.trim().to_ascii_lowercase();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let (head, interval) = match raw.split_once(':') {
+        Some((head, tail)) => (head, tail.parse::<u32>().ok()),
+        None => (raw.as_str(), None),
+    };
+    let default_interval = ResourceTelemetryMode::DEFAULT_SUMMARY_INTERVAL_MS;
+    let mode = match head {
+        "off" => ResourceTelemetryMode::Off,
+        "boundary" => ResourceTelemetryMode::Boundary,
+        "summary" => ResourceTelemetryMode::Summary {
+            interval_ms: interval.unwrap_or(default_interval),
+        },
+        "debug_local" | "debuglocal" | "debug-local" => ResourceTelemetryMode::DebugLocal {
+            interval_ms: interval.unwrap_or(default_interval),
+        },
+        _ => return None,
+    };
+    Some(mode.normalized())
+}
+
 impl XybridSdkClient {
     #[frb(sync)]
     pub fn init_sdk_cache_dir(cache_dir: String) {
@@ -32,6 +68,12 @@ impl XybridSdkClient {
     pub fn set_api_key(api_key: &str) {
         xybrid_sdk::set_binding(FLUTTER_BINDING);
         xybrid_sdk::set_api_key(api_key);
+    }
+
+    #[frb(sync)]
+    pub fn set_gateway_url(gateway_url: String) {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
+        std::env::set_var("XYBRID_GATEWAY_URL", gateway_url);
     }
 
     /// Initialize the platform telemetry exporter for this process.
@@ -55,14 +97,32 @@ impl XybridSdkClient {
     #[frb(sync)]
     pub fn init_telemetry(endpoint: String, api_key: String) {
         xybrid_sdk::set_binding(FLUTTER_BINDING);
-        if TELEMETRY_INITIALIZED
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return;
-        }
         let config = xybrid_sdk::TelemetryConfig::new(endpoint, api_key);
-        xybrid_sdk::telemetry::init_platform_telemetry(config);
+        initialize_telemetry_once(config);
+    }
+
+    #[frb(sync)]
+    pub fn configure_platform_telemetry(
+        api_key: String,
+        ingest_url: Option<String>,
+        resource_telemetry: Option<String>,
+    ) {
+        xybrid_sdk::set_binding(FLUTTER_BINDING);
+        xybrid_sdk::set_api_key(&api_key);
+
+        let Some(endpoint) = ingest_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+
+        let mut config = xybrid_sdk::TelemetryConfig::new(endpoint, api_key);
+        if let Some(mode) = parse_resource_telemetry_mode(resource_telemetry.as_deref()) {
+            config = config.with_resource_telemetry(mode);
+        }
+        initialize_telemetry_once(config);
     }
 
     /// Whether [`Self::init_telemetry`] has run at least once in this
@@ -71,6 +131,11 @@ impl XybridSdkClient {
     #[frb(sync)]
     pub fn is_telemetry_initialized() -> bool {
         TELEMETRY_INITIALIZED.load(Ordering::Acquire)
+    }
+
+    #[frb(sync)]
+    pub fn flush_platform_telemetry() {
+        xybrid_sdk::telemetry::flush_platform_telemetry();
     }
 
     /// Check if a model is cached locally (extracted and ready to use).

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2045382748;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -250798265;
 
 // Section: executor
 
@@ -1276,6 +1276,71 @@ fn wire__crate__api__model__FfiModel_run_stream_with_context_impl(
         },
     )
 }
+fn wire__crate__api__model__FfiModel_run_stream_with_fallback_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "FfiModel_run_stream_with_fallback",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FfiModel>,
+            >>::sse_decode(&mut deserializer);
+            let api_envelope = <FfiEnvelope>::sse_decode(&mut deserializer);
+            let api_options = <crate::api::model::FfiRunOptions>::sse_decode(&mut deserializer);
+            let api_config =
+                <Option<crate::api::model::FfiGenerationConfig>>::sse_decode(&mut deserializer);
+            let api_sink = <StreamSink<
+                crate::api::model::FfiStreamEvent,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::model::FfiModel::run_stream_with_fallback(
+                            &*api_that_guard,
+                            api_envelope,
+                            api_options,
+                            api_config,
+                            api_sink,
+                        );
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__model__FfiModel_run_with_context_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1628,6 +1693,37 @@ fn wire__crate__api__pipeline__FfiPipeline_stage_names_impl(
         },
     )
 }
+fn wire__crate__api__device__XybridDevice_apply_debug_memory_pressure_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridDevice_apply_debug_memory_pressure",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::device::XybridDevice::apply_debug_memory_pressure();
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__device__XybridDevice_clear_battery_level_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -1653,6 +1749,37 @@ fn wire__crate__api__device__XybridDevice_clear_battery_level_impl(
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok({
                     crate::api::device::XybridDevice::clear_battery_level();
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__device__XybridDevice_clear_debug_memory_pressure_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridDevice_clear_debug_memory_pressure",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::device::XybridDevice::clear_debug_memory_pressure();
                 })?;
                 Ok(output_ok)
             })())
@@ -1778,6 +1905,75 @@ fn wire__crate__api__device__XybridDevice_set_thermal_state_impl(
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok({
                     crate::api::device::XybridDevice::set_thermal_state(api_state);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__sdk_client__XybridSdkClient_configure_platform_telemetry_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridSdkClient_configure_platform_telemetry",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_api_key = <String>::sse_decode(&mut deserializer);
+            let api_ingest_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_resource_telemetry = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sdk_client::XybridSdkClient::configure_platform_telemetry(
+                        api_api_key,
+                        api_ingest_url,
+                        api_resource_telemetry,
+                    );
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__sdk_client__XybridSdkClient_flush_platform_telemetry_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridSdkClient_flush_platform_telemetry",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sdk_client::XybridSdkClient::flush_platform_telemetry();
                 })?;
                 Ok(output_ok)
             })())
@@ -1941,6 +2137,38 @@ fn wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok({
                     crate::api::sdk_client::XybridSdkClient::set_api_key(&api_api_key);
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__sdk_client__XybridSdkClient_set_gateway_url_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "XybridSdkClient_set_gateway_url",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_gateway_url = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::sdk_client::XybridSdkClient::set_gateway_url(api_gateway_url);
                 })?;
                 Ok(output_ok)
             })())
@@ -2348,6 +2576,30 @@ impl SseDecode for crate::api::result::FfiResult {
     }
 }
 
+impl SseDecode for crate::api::model::FfiRunOptions {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_cloudProvider = <Option<String>>::sse_decode(deserializer);
+        let mut var_cloudModel = <Option<String>>::sse_decode(deserializer);
+        let mut var_cloudGatewayUrl = <Option<String>>::sse_decode(deserializer);
+        let mut var_correlationId = <Option<String>>::sse_decode(deserializer);
+        let mut var_abortOnMemoryPressureCritical = <bool>::sse_decode(deserializer);
+        let mut var_abortOnThermalCritical = <bool>::sse_decode(deserializer);
+        let mut var_fallbackToCloud = <bool>::sse_decode(deserializer);
+        let mut var_maxGraceTokens = <Option<u32>>::sse_decode(deserializer);
+        return crate::api::model::FfiRunOptions {
+            cloud_provider: var_cloudProvider,
+            cloud_model: var_cloudModel,
+            cloud_gateway_url: var_cloudGatewayUrl,
+            correlation_id: var_correlationId,
+            abort_on_memory_pressure_critical: var_abortOnMemoryPressureCritical,
+            abort_on_thermal_critical: var_abortOnThermalCritical,
+            fallback_to_cloud: var_fallbackToCloud,
+            max_grace_tokens: var_maxGraceTokens,
+        };
+    }
+}
+
 impl SseDecode for crate::api::model::FfiStreamEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2636,13 +2888,19 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__model__FfiModel_run_with_context_impl(
+        28 => wire__crate__api__model__FfiModel_run_stream_with_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__pipeline__FfiPipeline_run_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__model__FfiModel_run_with_context_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        34 => wire__crate__api__pipeline__FfiPipeline_run_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2725,68 +2983,93 @@ fn pde_ffi_dispatcher_sync_impl(
         22 => {
             wire__crate__api__model__FfiModelLoader_from_registry_impl(ptr, rust_vec_len, data_len)
         }
-        29 => wire__crate__api__pipeline__FfiPipeline_from_bundle_impl(ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__pipeline__FfiPipeline_from_file_impl(ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__pipeline__FfiPipeline_from_yaml_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__pipeline__FfiPipeline_name_impl(ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__pipeline__FfiPipeline_stage_count_impl(ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__pipeline__FfiPipeline_stage_names_impl(ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__device__XybridDevice_clear_battery_level_impl(
+        30 => wire__crate__api__pipeline__FfiPipeline_from_bundle_impl(ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__pipeline__FfiPipeline_from_file_impl(ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__pipeline__FfiPipeline_from_yaml_impl(ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__pipeline__FfiPipeline_name_impl(ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__pipeline__FfiPipeline_stage_count_impl(ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__pipeline__FfiPipeline_stage_names_impl(ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__device__XybridDevice_apply_debug_memory_pressure_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__device__XybridDevice_clear_thermal_state_impl(
+        38 => wire__crate__api__device__XybridDevice_clear_battery_level_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__device__XybridDevice_current_snapshot_impl(
+        39 => wire__crate__api__device__XybridDevice_clear_debug_memory_pressure_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__device__XybridDevice_set_battery_level_impl(
+        40 => wire__crate__api__device__XybridDevice_clear_thermal_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__device__XybridDevice_set_thermal_state_impl(
+        41 => wire__crate__api__device__XybridDevice_current_snapshot_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
+        42 => wire__crate__api__device__XybridDevice_set_battery_level_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__sdk_client__XybridSdkClient_init_telemetry_impl(
+        43 => wire__crate__api__device__XybridDevice_set_thermal_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
+        44 => wire__crate__api__sdk_client__XybridSdkClient_configure_platform_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__sdk_client__XybridSdkClient_is_telemetry_initialized_impl(
+        45 => wire__crate__api__sdk_client__XybridSdkClient_flush_platform_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
+        46 => wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => wire__crate__api__model__ffi_generation_config_creative_impl(
+        47 => wire__crate__api__sdk_client__XybridSdkClient_init_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => {
+        48 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        49 => wire__crate__api__sdk_client__XybridSdkClient_is_telemetry_initialized_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        50 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        51 => wire__crate__api__sdk_client__XybridSdkClient_set_gateway_url_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        52 => wire__crate__api__model__ffi_generation_config_creative_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        53 => {
             wire__crate__api__model__ffi_generation_config_greedy_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),
@@ -3049,6 +3332,35 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::result::FfiResult>
     for crate::api::result::FfiResult
 {
     fn into_into_dart(self) -> crate::api::result::FfiResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::model::FfiRunOptions {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.cloud_provider.into_into_dart().into_dart(),
+            self.cloud_model.into_into_dart().into_dart(),
+            self.cloud_gateway_url.into_into_dart().into_dart(),
+            self.correlation_id.into_into_dart().into_dart(),
+            self.abort_on_memory_pressure_critical
+                .into_into_dart()
+                .into_dart(),
+            self.abort_on_thermal_critical.into_into_dart().into_dart(),
+            self.fallback_to_cloud.into_into_dart().into_dart(),
+            self.max_grace_tokens.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::model::FfiRunOptions
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::model::FfiRunOptions>
+    for crate::api::model::FfiRunOptions
+{
+    fn into_into_dart(self) -> crate::api::model::FfiRunOptions {
         self
     }
 }
@@ -3408,6 +3720,20 @@ impl SseEncode for crate::api::result::FfiResult {
         <Option<Vec<u8>>>::sse_encode(self.audio_bytes, serializer);
         <Option<Vec<f32>>>::sse_encode(self.embedding, serializer);
         <u32>::sse_encode(self.latency_ms, serializer);
+    }
+}
+
+impl SseEncode for crate::api::model::FfiRunOptions {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<String>>::sse_encode(self.cloud_provider, serializer);
+        <Option<String>>::sse_encode(self.cloud_model, serializer);
+        <Option<String>>::sse_encode(self.cloud_gateway_url, serializer);
+        <Option<String>>::sse_encode(self.correlation_id, serializer);
+        <bool>::sse_encode(self.abort_on_memory_pressure_critical, serializer);
+        <bool>::sse_encode(self.abort_on_thermal_critical, serializer);
+        <bool>::sse_encode(self.fallback_to_cloud, serializer);
+        <Option<u32>>::sse_encode(self.max_grace_tokens, serializer);
     }
 }
 

--- a/bindings/flutter/test/run_options_test.dart
+++ b/bindings/flutter/test/run_options_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xybrid_flutter/xybrid_flutter.dart';
+
+void main() {
+  test('default run options do not opt into cloud fallback', () {
+    const options = RunOptions();
+
+    expect(options.abortPolicy.fallbackToCloud, isFalse);
+    expect(options.toFfi().fallbackToCloud, isFalse);
+  });
+
+  test('cloud fallback run options expose abort policy controls', () {
+    const policy = AbortPolicy.cloudFallback(maxGraceTokens: 2);
+    const options = RunOptions.cloudFallback(
+      cloudProvider: 'openai',
+      cloudModel: 'gpt-4o-mini',
+      cloudGatewayUrl: 'http://127.0.0.1:3001/v1',
+      correlationId: 'run-123',
+      abortPolicy: policy,
+    );
+
+    expect(options.abortPolicy.fallbackToCloud, isTrue);
+    expect(
+      options.abortPolicy.stopOn,
+      containsAll({
+        AbortSignal.memoryPressureCritical,
+        AbortSignal.thermalCritical,
+      }),
+    );
+    final ffi = options.toFfi();
+    expect(ffi.abortOnMemoryPressureCritical, isTrue);
+    expect(ffi.abortOnThermalCritical, isTrue);
+    expect(ffi.fallbackToCloud, isTrue);
+    expect(ffi.maxGraceTokens, 2);
+  });
+
+  test('custom abort policy maps stop signals and fallback permission to FFI',
+      () {
+    const options = RunOptions(
+      abortPolicy: AbortPolicy(
+        stopOn: {AbortSignal.memoryPressureCritical},
+        fallbackToCloud: false,
+        maxGraceTokens: 1,
+      ),
+    );
+
+    final ffi = options.toFfi();
+
+    expect(ffi.abortOnMemoryPressureCritical, isTrue);
+    expect(ffi.abortOnThermalCritical, isFalse);
+    expect(ffi.fallbackToCloud, isFalse);
+    expect(ffi.maxGraceTokens, 1);
+  });
+
+  test('legacy maxGraceTokens still maps to fallback policy grace tokens', () {
+    const options = RunOptions.cloudFallback(maxGraceTokens: 3);
+
+    expect(options.abortPolicy.maxGraceTokens, isNull);
+    expect(options.toFfi().maxGraceTokens, 3);
+    expect(options.toFfi().fallbackToCloud, isTrue);
+  });
+}

--- a/crates/xybrid-core/examples/authority_demo.rs
+++ b/crates/xybrid-core/examples/authority_demo.rs
@@ -157,6 +157,8 @@ fn demo_single_model(authority: &LocalAuthority, model_id: &str, metrics: &Devic
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: None, // Let authority decide
+        device_class: None,
+        device_class_schema_version: None,
     };
 
     let target_decision = authority.resolve_target(&stage_context);
@@ -211,6 +213,8 @@ fn demo_pipeline(authority: &LocalAuthority, metrics: &DeviceMetrics) {
             metrics: metrics.clone(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            device_class: None,
+            device_class_schema_version: None,
         };
         let target = authority.resolve_target(&context);
 
@@ -253,6 +257,8 @@ fn demo_explicit_target(authority: &LocalAuthority, metrics: &DeviceMetrics) {
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: None, // Auto-routing
+        device_class: None,
+        device_class_schema_version: None,
     };
 
     let decision_auto = authority.resolve_target(&context_auto);
@@ -267,6 +273,8 @@ fn demo_explicit_target(authority: &LocalAuthority, metrics: &DeviceMetrics) {
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: Some(ExecutionTarget::Device), // Force on-device
+        device_class: None,
+        device_class_schema_version: None,
     };
 
     let decision_forced = authority.resolve_target(&context_forced);

--- a/crates/xybrid-core/src/context.rs
+++ b/crates/xybrid-core/src/context.rs
@@ -9,6 +9,13 @@ use crate::device::{detect_capabilities, HardwareCapabilities, ResourceSnapshot}
 pub use crate::ir::{Envelope, EnvelopeKind};
 use crate::pipeline::{ExecutionTarget, IntegrationProvider, StageOptions};
 
+/// Current canonical schema version for device-class buckets.
+///
+/// The contract is documented in the meta workspace at
+/// `docs/device-class.md`; SDK emitters include this value when routing advice
+/// is keyed by `device_class`.
+pub const DEVICE_CLASS_SCHEMA_VERSION: u16 = 1;
+
 /// Live device signals consumed by the orchestrator.
 ///
 /// Two members:
@@ -53,6 +60,40 @@ impl DeviceMetrics {
         }
         metrics.capabilities.thermal_state = snapshot.thermal_state;
         metrics
+    }
+
+    /// Best-effort canonical device-class bucket derived from the static
+    /// capability view.
+    ///
+    /// Native bindings can pass a more precise hardware family through
+    /// `StageContext::device_class` (for example `iphone-15-pro`). This fallback
+    /// intentionally avoids transient resource values so the bucket is stable
+    /// across app launches.
+    pub fn canonical_device_class(&self) -> String {
+        let platform = self.capabilities.platform.as_str();
+        let arch = normalized_arch(std::env::consts::ARCH);
+        match platform {
+            "android" => format!("android-{arch}-unknown"),
+            "ios" => format!("unknown-ios-{arch}"),
+            "macos" | "linux" | "windows" => {
+                let accelerator = if self.capabilities.has_npu {
+                    self.capabilities.npu_type.as_str()
+                } else if self.capabilities.has_gpu {
+                    self.capabilities.gpu_type.as_str()
+                } else {
+                    "cpu"
+                };
+                format!("desktop-{platform}-{arch}-{accelerator}")
+            }
+            _ => format!("unknown-{platform}-{arch}"),
+        }
+    }
+}
+
+fn normalized_arch(arch: &str) -> String {
+    match arch {
+        "aarch64" => "arm64".to_string(),
+        other => other.to_ascii_lowercase().replace('_', "-"),
     }
 }
 
@@ -142,7 +183,7 @@ impl StageDescriptor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::device::{MemoryPressure, ThermalState};
+    use crate::device::{GpuType, MemoryPressure, Platform, ThermalState};
 
     #[test]
     fn default_device_metrics_carries_unknown_memory_pressure() {
@@ -191,5 +232,30 @@ mod tests {
 
         assert_eq!(merged.capabilities.battery_level, 42);
         assert_eq!(merged.capabilities.thermal_state, ThermalState::Hot);
+    }
+
+    #[test]
+    fn canonical_device_class_uses_stable_desktop_capability_bucket() {
+        let mut metrics = DeviceMetrics::default();
+        metrics.capabilities.platform = Platform::MacOS;
+        metrics.capabilities.has_npu = false;
+        metrics.capabilities.has_gpu = true;
+        metrics.capabilities.gpu_type = GpuType::Metal;
+
+        let class = metrics.canonical_device_class();
+
+        assert!(class.starts_with("desktop-macos-"));
+        assert!(class.ends_with("-metal"));
+    }
+
+    #[test]
+    fn canonical_device_class_uses_android_unknown_fallback() {
+        let mut metrics = DeviceMetrics::default();
+        metrics.capabilities.platform = Platform::Android;
+
+        let class = metrics.canonical_device_class();
+
+        assert!(class.starts_with("android-"));
+        assert!(class.ends_with("-unknown"));
     }
 }

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -46,6 +46,7 @@ pub use authority::{
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal imports
 // ─────────────────────────────────────────────────────────────────────────────
+use crate::context::DEVICE_CLASS_SCHEMA_VERSION;
 use crate::context::{DeviceMetrics, StageDescriptor};
 use crate::control_sync::ControlSync;
 use crate::device::ResourceMonitor;
@@ -347,6 +348,8 @@ impl Orchestrator {
             metrics: metrics.clone(),
             resource_monitor: self.resource_monitor.clone(),
             explicit_target: stage.target.clone(),
+            device_class: Some(metrics.canonical_device_class()),
+            device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
         };
         let target_resolution = self.authority.resolve_target_with_feedback(&stage_context);
 
@@ -590,6 +593,8 @@ impl Orchestrator {
             metrics: metrics.clone(),
             resource_monitor: self.resource_monitor.clone(),
             explicit_target: stage.target.clone(),
+            device_class: Some(metrics.canonical_device_class()),
+            device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
         };
         let target_resolution = self.authority.resolve_target_with_feedback(&stage_context);
 
@@ -1081,6 +1086,8 @@ mod tests {
             metrics: DeviceMetrics::default(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            device_class: None,
+            device_class_schema_version: None,
         }
     }
 

--- a/crates/xybrid-core/src/orchestrator/authority/local.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/local.rs
@@ -634,6 +634,8 @@ signature: "test-deny-all"
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            device_class: None,
+            device_class_schema_version: None,
         }
     }
 
@@ -670,6 +672,8 @@ signature: "test-deny-all"
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: Some(ExecutionTarget::Device),
+            device_class: None,
+            device_class_schema_version: None,
         };
 
         let decision = authority.resolve_target(&context);
@@ -687,6 +691,8 @@ signature: "test-deny-all"
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: Some(ExecutionTarget::Cloud),
+            device_class: None,
+            device_class_schema_version: None,
         };
 
         let decision = authority.resolve_target(&context);

--- a/crates/xybrid-core/src/orchestrator/authority/mod.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/mod.rs
@@ -182,6 +182,8 @@ mod tests {
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: Some(crate::pipeline::ExecutionTarget::Device),
+            device_class: None,
+            device_class_schema_version: None,
         };
 
         let decision = authority.resolve_target(&context);

--- a/crates/xybrid-core/src/orchestrator/authority/remote.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/remote.rs
@@ -25,6 +25,7 @@
 use super::local::LocalAuthority;
 use super::types::*;
 use super::OrchestrationAuthority;
+use crate::context::DeviceMetrics;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -119,25 +120,35 @@ impl RemoteAuthority {
         &self.endpoint
     }
 
-    fn target_cache_key(context: &StageContext) -> String {
+    fn target_cache_key(context: &StageContext, metrics: &DeviceMetrics) -> String {
         format!(
-            "{}|{}|{}|{}|{}|{}|{}",
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             context.stage_id,
             context.model_id,
             context.input_kind.as_str(),
-            context.metrics.capabilities.battery_level,
-            context.metrics.capabilities.thermal_state.as_str(),
-            context.metrics.resource.memory_pressure.as_str(),
-            context
-                .metrics
+            context.device_class.as_deref().unwrap_or("unknown-device"),
+            if context.device_class.is_some() {
+                context.device_class_schema_version.unwrap_or(1).to_string()
+            } else {
+                "unknown-schema".to_string()
+            },
+            metrics.capabilities.battery_level,
+            metrics.capabilities.thermal_state.as_str(),
+            metrics.resource.memory_pressure.as_str(),
+            metrics
                 .resource
                 .cpu_pct
                 .map(|cpu| format!("{cpu:.0}"))
-                .unwrap_or_else(|| "unknown".to_string())
+                .unwrap_or_else(|| "unknown".to_string()),
+            context
+                .explicit_target
+                .as_ref()
+                .map(|target| target.to_string())
+                .unwrap_or_else(|| "auto".to_string())
         )
     }
 
-    fn target_advice_url(&self, context: &StageContext) -> Option<String> {
+    fn target_advice_url(&self, context: &StageContext, metrics: &DeviceMetrics) -> Option<String> {
         let mut url = Url::parse(&self.endpoint)
             .ok()?
             .join("/v1/routing/advice")
@@ -147,19 +158,18 @@ impl RemoteAuthority {
             qp.append_pair("stage_id", &context.stage_id);
             qp.append_pair("model_id", &context.model_id);
             qp.append_pair("input_kind", context.input_kind.as_str());
+            if let Some(device_class) = context.device_class.as_deref() {
+                qp.append_pair("device_class", device_class);
+                let schema_version = context.device_class_schema_version.unwrap_or(1);
+                qp.append_pair("device_class_schema_version", &schema_version.to_string());
+            }
             qp.append_pair(
                 "battery_pct",
-                &context.metrics.capabilities.battery_level.to_string(),
+                &metrics.capabilities.battery_level.to_string(),
             );
-            qp.append_pair(
-                "thermal_state",
-                context.metrics.capabilities.thermal_state.as_str(),
-            );
-            qp.append_pair(
-                "memory_pressure",
-                context.metrics.resource.memory_pressure.as_str(),
-            );
-            if let Some(cpu_pct) = context.metrics.resource.cpu_pct {
+            qp.append_pair("thermal_state", metrics.capabilities.thermal_state.as_str());
+            qp.append_pair("memory_pressure", metrics.resource.memory_pressure.as_str());
+            if let Some(cpu_pct) = metrics.resource.cpu_pct {
                 qp.append_pair("cpu_pct", &format!("{cpu_pct:.2}"));
             }
             if let Some(explicit_target) = &context.explicit_target {
@@ -172,8 +182,9 @@ impl RemoteAuthority {
     fn fetch_target_advice(
         &self,
         context: &StageContext,
+        metrics: &DeviceMetrics,
     ) -> Option<AuthorityDecision<ResolvedTarget>> {
-        let url = self.target_advice_url(context)?;
+        let url = self.target_advice_url(context, metrics)?;
         let mut request = ureq::get(&url).timeout(Duration::from_millis(750));
         let auth_header = self
             .api_key
@@ -206,7 +217,7 @@ impl RemoteAuthority {
             .unwrap_or_else(|| "Remote routing advice".to_string());
         let decision = AuthorityDecision::new(result, reason, DecisionSource::Remote, confidence);
         let ttl_ms = advice.ttl_ms.unwrap_or(30_000);
-        let key = Self::target_cache_key(context);
+        let key = Self::target_cache_key(context, metrics);
         let expires_at_ms = decision.timestamp_ms.saturating_add(ttl_ms);
 
         if ttl_ms > 0 {
@@ -227,8 +238,9 @@ impl RemoteAuthority {
     fn cached_target_advice(
         &self,
         context: &StageContext,
+        metrics: &DeviceMetrics,
     ) -> Option<AuthorityDecision<ResolvedTarget>> {
-        let key = Self::target_cache_key(context);
+        let key = Self::target_cache_key(context, metrics);
         let now = now_ms();
         let mut cache = self.target_cache.lock().ok()?;
         let cached = cache.get(&key)?;
@@ -278,16 +290,20 @@ impl OrchestrationAuthority for RemoteAuthority {
             .current_snapshot(Duration::from_millis(500));
         let live_metrics = context.metrics.with_live_snapshot(snapshot);
         let signal = Some(SignalContext::from_metrics(&live_metrics));
+        let live_context = StageContext {
+            metrics: live_metrics.clone(),
+            ..context.clone()
+        };
 
-        if let Some(decision) = self.cached_target_advice(context) {
+        if let Some(decision) = self.cached_target_advice(&live_context, &live_metrics) {
             return TargetResolution::new(decision, context.model_id.clone(), signal);
         }
 
-        if let Some(decision) = self.fetch_target_advice(context) {
+        if let Some(decision) = self.fetch_target_advice(&live_context, &live_metrics) {
             return TargetResolution::new(decision, context.model_id.clone(), signal);
         }
 
-        let mut resolution = self.fallback.resolve_target_with_feedback(context);
+        let mut resolution = self.fallback.resolve_target_with_feedback(&live_context);
         resolution.decision.source = DecisionSource::Default;
         resolution.decision.reason = format!(
             "Fallback to local (remote unavailable): {}",
@@ -358,6 +374,16 @@ mod tests {
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            device_class: None,
+            device_class_schema_version: None,
+        }
+    }
+
+    fn context_with_device_class(endpoint_stage: &str, device_class: &str) -> StageContext {
+        StageContext {
+            device_class: Some(device_class.to_string()),
+            device_class_schema_version: Some(1),
+            ..default_context(endpoint_stage)
         }
     }
 
@@ -497,6 +523,115 @@ mod tests {
             request_lower.contains("authorization: bearer sk_test_routing"),
             "request should carry bearer auth header, got: {request}"
         );
+    }
+
+    #[test]
+    fn target_advice_url_includes_device_class_and_schema_when_available() {
+        let authority = RemoteAuthority::new("https://api.xybrid.dev");
+        let context = context_with_device_class("classed", "iphone-15-pro");
+        let url = authority
+            .target_advice_url(&context, &context.metrics)
+            .expect("routing advice url");
+
+        assert!(url.contains("device_class=iphone-15-pro"), "{url}");
+        assert!(url.contains("device_class_schema_version=1"), "{url}");
+    }
+
+    #[test]
+    fn target_advice_url_omits_device_class_when_unavailable() {
+        let authority = RemoteAuthority::new("https://api.xybrid.dev");
+        let context = default_context("unclassed");
+        let url = authority
+            .target_advice_url(&context, &context.metrics)
+            .expect("routing advice url");
+
+        assert!(!url.contains("device_class="), "{url}");
+        assert!(!url.contains("device_class_schema_version="), "{url}");
+    }
+
+    #[test]
+    fn target_advice_url_uses_live_metrics_argument() {
+        let authority = RemoteAuthority::new("https://api.xybrid.dev");
+        let context = default_context("live");
+        let mut live_metrics = context.metrics.clone();
+        live_metrics.capabilities.battery_level = 7;
+        live_metrics.capabilities.thermal_state = crate::device::ThermalState::Hot;
+        live_metrics.resource.memory_pressure = crate::device::MemoryPressure::Critical;
+        live_metrics.resource.cpu_pct = Some(98.4);
+
+        let url = authority
+            .target_advice_url(&context, &live_metrics)
+            .expect("routing advice url");
+
+        assert!(url.contains("battery_pct=7"), "{url}");
+        assert!(url.contains("thermal_state=hot"), "{url}");
+        assert!(url.contains("memory_pressure=critical"), "{url}");
+        assert!(url.contains("cpu_pct=98.40"), "{url}");
+    }
+
+    #[test]
+    fn target_cache_key_differs_by_device_class_and_schema() {
+        let a = context_with_device_class("cached-class", "iphone-15-pro");
+        let b = context_with_device_class("cached-class", "iphone-15");
+        let mut c = context_with_device_class("cached-class", "iphone-15-pro");
+        c.device_class_schema_version = Some(2);
+
+        let key_a = RemoteAuthority::target_cache_key(&a, &a.metrics);
+        let key_b = RemoteAuthority::target_cache_key(&b, &b.metrics);
+        let key_c = RemoteAuthority::target_cache_key(&c, &c.metrics);
+
+        assert_ne!(key_a, key_b);
+        assert_ne!(key_a, key_c);
+    }
+
+    #[test]
+    fn target_cache_key_differs_by_live_resource_fields() {
+        let context = context_with_device_class("cached-resource", "iphone-15-pro");
+        let mut baseline = context.metrics.clone();
+        baseline.capabilities.battery_level = 80;
+        baseline.capabilities.thermal_state = crate::device::ThermalState::Normal;
+        baseline.resource.memory_pressure = crate::device::MemoryPressure::Normal;
+        baseline.resource.cpu_pct = Some(20.0);
+
+        let mut low_battery = baseline.clone();
+        low_battery.capabilities.battery_level = 7;
+
+        let mut hot_thermal = baseline.clone();
+        hot_thermal.capabilities.thermal_state = crate::device::ThermalState::Hot;
+
+        let mut critical_memory = baseline.clone();
+        critical_memory.resource.memory_pressure = crate::device::MemoryPressure::Critical;
+
+        let mut high_cpu = baseline.clone();
+        high_cpu.resource.cpu_pct = Some(98.4);
+
+        let key = RemoteAuthority::target_cache_key(&context, &baseline);
+
+        assert_ne!(
+            key,
+            RemoteAuthority::target_cache_key(&context, &low_battery)
+        );
+        assert_ne!(
+            key,
+            RemoteAuthority::target_cache_key(&context, &hot_thermal)
+        );
+        assert_ne!(
+            key,
+            RemoteAuthority::target_cache_key(&context, &critical_memory)
+        );
+        assert_ne!(key, RemoteAuthority::target_cache_key(&context, &high_cpu));
+    }
+
+    #[test]
+    fn target_cache_key_differs_by_explicit_target() {
+        let auto_context = context_with_device_class("cached-explicit", "iphone-15-pro");
+        let mut cloud_context = auto_context.clone();
+        cloud_context.explicit_target = Some(crate::pipeline::ExecutionTarget::Cloud);
+
+        let auto_key = RemoteAuthority::target_cache_key(&auto_context, &auto_context.metrics);
+        let cloud_key = RemoteAuthority::target_cache_key(&cloud_context, &cloud_context.metrics);
+
+        assert_ne!(auto_key, cloud_key);
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator/authority/remote.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/remote.rs
@@ -27,10 +27,12 @@ use super::types::*;
 use super::OrchestrationAuthority;
 use crate::context::DeviceMetrics;
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::sync::Mutex;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 use url::Url;
+
+const TARGET_ADVICE_CACHE_CAPACITY: usize = 256;
 
 /// Remote orchestration authority - delegates to xybrid backend.
 ///
@@ -60,13 +62,78 @@ pub struct RemoteAuthority {
     fallback: LocalAuthority,
     /// Successful target advice cache. Keeps remote routing resilient when the
     /// same hot path resolves repeatedly during a short session.
-    target_cache: Mutex<HashMap<String, CachedTargetAdvice>>,
+    target_cache: Mutex<TargetAdviceCache>,
 }
 
 #[derive(Debug, Clone)]
 struct CachedTargetAdvice {
     decision: AuthorityDecision<ResolvedTarget>,
     expires_at_ms: u64,
+}
+
+#[derive(Debug, Default)]
+struct TargetAdviceCache {
+    entries: HashMap<String, CachedTargetAdvice>,
+    lru: VecDeque<String>,
+}
+
+impl TargetAdviceCache {
+    fn insert(&mut self, key: String, advice: CachedTargetAdvice, now_ms: u64) {
+        self.entries.insert(key.clone(), advice);
+        self.promote(&key);
+        self.evict_expired(now_ms);
+        self.evict_over_capacity();
+    }
+
+    fn get_fresh(&mut self, key: &str, now_ms: u64) -> Option<AuthorityDecision<ResolvedTarget>> {
+        let cached = self.entries.get(key).cloned()?;
+        if cached.expires_at_ms <= now_ms {
+            self.remove(key);
+            return None;
+        }
+
+        self.promote(key);
+        let mut decision = cached.decision;
+        decision.source = DecisionSource::Cached;
+        decision.timestamp_ms = now_ms;
+        Some(decision)
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.lru.clear();
+    }
+
+    fn promote(&mut self, key: &str) {
+        self.lru.retain(|candidate| candidate != key);
+        self.lru.push_back(key.to_string());
+    }
+
+    fn remove(&mut self, key: &str) {
+        self.entries.remove(key);
+        self.lru.retain(|candidate| candidate != key);
+    }
+
+    fn evict_expired(&mut self, now_ms: u64) {
+        let expired: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|(_, advice)| advice.expires_at_ms <= now_ms)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in expired {
+            self.remove(&key);
+        }
+    }
+
+    fn evict_over_capacity(&mut self) {
+        while self.entries.len() > TARGET_ADVICE_CACHE_CAPACITY {
+            let Some(key) = self.lru.pop_front() else {
+                break;
+            };
+            self.entries.remove(&key);
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -95,7 +162,7 @@ impl RemoteAuthority {
             endpoint: endpoint.to_string(),
             api_key: None,
             fallback: LocalAuthority::new(),
-            target_cache: Mutex::new(HashMap::new()),
+            target_cache: Mutex::new(TargetAdviceCache::default()),
         }
     }
 
@@ -105,7 +172,7 @@ impl RemoteAuthority {
             endpoint: endpoint.to_string(),
             api_key: None,
             fallback,
-            target_cache: Mutex::new(HashMap::new()),
+            target_cache: Mutex::new(TargetAdviceCache::default()),
         }
     }
 
@@ -120,6 +187,28 @@ impl RemoteAuthority {
         &self.endpoint
     }
 
+    fn target_cache_guard(&self) -> MutexGuard<'_, TargetAdviceCache> {
+        self.target_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn battery_cache_bucket(battery_pct: u8) -> String {
+        let bucket = (battery_pct.min(100) / 10) * 10;
+        bucket.to_string()
+    }
+
+    fn cpu_cache_bucket(cpu_pct: Option<f32>) -> String {
+        let Some(cpu_pct) = cpu_pct else {
+            return "unknown".to_string();
+        };
+        if !cpu_pct.is_finite() {
+            return "unknown".to_string();
+        }
+        let bucket = ((cpu_pct.clamp(0.0, 100.0) / 10.0).floor() * 10.0) as u8;
+        bucket.to_string()
+    }
+
     fn target_cache_key(context: &StageContext, metrics: &DeviceMetrics) -> String {
         format!(
             "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
@@ -132,14 +221,10 @@ impl RemoteAuthority {
             } else {
                 "unknown-schema".to_string()
             },
-            metrics.capabilities.battery_level,
+            Self::battery_cache_bucket(metrics.capabilities.battery_level),
             metrics.capabilities.thermal_state.as_str(),
             metrics.resource.memory_pressure.as_str(),
-            metrics
-                .resource
-                .cpu_pct
-                .map(|cpu| format!("{cpu:.0}"))
-                .unwrap_or_else(|| "unknown".to_string()),
+            Self::cpu_cache_bucket(metrics.resource.cpu_pct),
             context
                 .explicit_target
                 .as_ref()
@@ -221,15 +306,14 @@ impl RemoteAuthority {
         let expires_at_ms = decision.timestamp_ms.saturating_add(ttl_ms);
 
         if ttl_ms > 0 {
-            if let Ok(mut cache) = self.target_cache.lock() {
-                cache.insert(
-                    key,
-                    CachedTargetAdvice {
-                        decision: decision.clone(),
-                        expires_at_ms,
-                    },
-                );
-            }
+            self.target_cache_guard().insert(
+                key,
+                CachedTargetAdvice {
+                    decision: decision.clone(),
+                    expires_at_ms,
+                },
+                decision.timestamp_ms,
+            );
         }
 
         Some(decision)
@@ -242,17 +326,7 @@ impl RemoteAuthority {
     ) -> Option<AuthorityDecision<ResolvedTarget>> {
         let key = Self::target_cache_key(context, metrics);
         let now = now_ms();
-        let mut cache = self.target_cache.lock().ok()?;
-        let cached = cache.get(&key)?;
-        if cached.expires_at_ms <= now {
-            cache.remove(&key);
-            return None;
-        }
-
-        let mut decision = cached.decision.clone();
-        decision.source = DecisionSource::Cached;
-        decision.timestamp_ms = now;
-        Some(decision)
+        self.target_cache_guard().get_fresh(&key, now)
     }
 }
 
@@ -337,9 +411,7 @@ impl OrchestrationAuthority for RemoteAuthority {
     }
 
     fn invalidate_cache(&self) {
-        if let Ok(mut cache) = self.target_cache.lock() {
-            cache.clear();
-        }
+        self.target_cache_guard().clear();
     }
 
     fn name(&self) -> &str {
@@ -620,6 +692,70 @@ mod tests {
             RemoteAuthority::target_cache_key(&context, &critical_memory)
         );
         assert_ne!(key, RemoteAuthority::target_cache_key(&context, &high_cpu));
+    }
+
+    #[test]
+    fn target_cache_key_buckets_high_cardinality_percentages() {
+        let context = context_with_device_class("bucketed-resource", "iphone-15-pro");
+        let mut baseline = context.metrics.clone();
+        baseline.capabilities.battery_level = 83;
+        baseline.resource.cpu_pct = Some(24.2);
+
+        let mut same_bucket = baseline.clone();
+        same_bucket.capabilities.battery_level = 89;
+        same_bucket.resource.cpu_pct = Some(29.9);
+
+        let mut different_bucket = baseline.clone();
+        different_bucket.capabilities.battery_level = 72;
+        different_bucket.resource.cpu_pct = Some(31.0);
+
+        assert_eq!(
+            RemoteAuthority::target_cache_key(&context, &baseline),
+            RemoteAuthority::target_cache_key(&context, &same_bucket)
+        );
+        assert_ne!(
+            RemoteAuthority::target_cache_key(&context, &baseline),
+            RemoteAuthority::target_cache_key(&context, &different_bucket)
+        );
+    }
+
+    #[test]
+    fn target_advice_cache_evicts_least_recent_entries() {
+        let mut cache = TargetAdviceCache::default();
+        for index in 0..(TARGET_ADVICE_CACHE_CAPACITY + 8) {
+            cache.insert(
+                format!("key-{index}"),
+                CachedTargetAdvice {
+                    decision: AuthorityDecision::new(
+                        ResolvedTarget::Device,
+                        "cached".to_string(),
+                        DecisionSource::Remote,
+                        0.8,
+                    ),
+                    expires_at_ms: u64::MAX,
+                },
+                1,
+            );
+        }
+
+        assert_eq!(cache.entries.len(), TARGET_ADVICE_CACHE_CAPACITY);
+        assert!(!cache.entries.contains_key("key-0"));
+        assert!(cache
+            .entries
+            .contains_key(&format!("key-{}", TARGET_ADVICE_CACHE_CAPACITY + 7)));
+    }
+
+    #[test]
+    fn remote_authority_recovers_poisoned_target_cache_lock() {
+        let authority = RemoteAuthority::new("https://api.xybrid.dev");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = authority.target_cache.lock().expect("cache lock");
+            panic!("poison target cache");
+        }));
+        assert!(result.is_err());
+
+        authority.invalidate_cache();
+        assert!(authority.target_cache_guard().entries.is_empty());
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator/authority/types.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/types.rs
@@ -30,6 +30,10 @@ pub struct StageContext {
     pub resource_monitor: Arc<ResourceMonitor>,
     /// Explicit target from pipeline YAML (if specified).
     pub explicit_target: Option<ExecutionTarget>,
+    /// Canonical stable hardware-family bucket used by fleet reliability.
+    pub device_class: Option<String>,
+    /// Schema version for `device_class`.
+    pub device_class_schema_version: Option<u16>,
 }
 
 /// Request for model selection.

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -162,8 +162,8 @@ pub use benchmark::{compare_benchmarks, BenchmarkResult, ExecutionProviderInfo};
 pub use cache::{CacheManager, CacheStatus, SdkCacheProvider};
 pub use device::{device_id, Device};
 pub use llm::{
-    default_gateway_url, ChatMessage, CompletionRequest, CompletionResponse, LlmBackend,
-    LlmClientConfig, MessageRole, TokenUsage,
+    default_gateway_url, set_gateway_url, ChatMessage, CompletionRequest, CompletionResponse,
+    LlmBackend, LlmClientConfig, MessageRole, TokenUsage,
 };
 pub use model::SdkError;
 pub use model::{

--- a/crates/xybrid-sdk/src/llm.rs
+++ b/crates/xybrid-sdk/src/llm.rs
@@ -34,6 +34,7 @@
 //! ```
 
 use serde::{Deserialize, Serialize};
+use std::sync::{OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 // ============================================================================
 // LLM Backend Configuration
@@ -137,12 +138,49 @@ impl Default for LlmClientConfig {
 // Helper Functions
 // ============================================================================
 
+static GATEWAY_URL_OVERRIDE: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn gateway_url_override() -> &'static RwLock<Option<String>> {
+    GATEWAY_URL_OVERRIDE.get_or_init(|| RwLock::new(None))
+}
+
+fn read_gateway_url_override() -> RwLockReadGuard<'static, Option<String>> {
+    gateway_url_override()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn write_gateway_url_override() -> RwLockWriteGuard<'static, Option<String>> {
+    gateway_url_override()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Set the process-local Xybrid gateway URL used by SDK-created LLM clients.
+///
+/// This is intentionally not backed by `std::env::set_var`: platform bindings
+/// may call it from multi-threaded runtimes where mutating process environment
+/// is not synchronized.
+pub fn set_gateway_url(gateway_url: impl Into<String>) {
+    let gateway_url = gateway_url.into().trim().to_string();
+    if gateway_url.is_empty() {
+        return;
+    }
+    *write_gateway_url_override() = Some(gateway_url);
+}
+
+#[cfg(test)]
+fn clear_gateway_url_override() {
+    *write_gateway_url_override() = None;
+}
+
 /// Get default gateway URL from environment or fallback to production URL.
 ///
 /// Priority:
-/// 1. `XYBRID_GATEWAY_URL` env var (explicit override, should include `/v1`)
-/// 2. `XYBRID_PLATFORM_URL` env var + `/v1` suffix (shared with telemetry)
-/// 3. Default production URL (`https://api.xybrid.dev/v1`)
+/// 1. Process-local override set with [`set_gateway_url`]
+/// 2. `XYBRID_GATEWAY_URL` env var (explicit override, should include `/v1`)
+/// 3. `XYBRID_PLATFORM_URL` env var + `/v1` suffix (shared with telemetry)
+/// 4. Default production URL (`https://api.xybrid.dev/v1`)
 ///
 /// # Note
 ///
@@ -159,6 +197,9 @@ impl Default for LlmClientConfig {
 /// assert!(url.ends_with("/v1"));
 /// ```
 pub fn default_gateway_url() -> String {
+    if let Some(url) = read_gateway_url_override().clone() {
+        return url;
+    }
     if let Ok(url) = std::env::var("XYBRID_GATEWAY_URL") {
         return url;
     }
@@ -525,6 +566,14 @@ mod tests {
             "gateway_url should end with '/v1', got: {}",
             url
         );
+    }
+
+    #[test]
+    fn test_process_local_gateway_url_override() {
+        clear_gateway_url_override();
+        set_gateway_url("https://local.gateway.test/v1");
+        assert_eq!(default_gateway_url(), "https://local.gateway.test/v1");
+        clear_gateway_url_override();
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -2871,6 +2871,35 @@ mod tests {
         }
     }
 
+    struct FailingCloudAdapter {
+        calls: AtomicUsize,
+    }
+
+    impl FailingCloudAdapter {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl xybrid_core::runtime_adapter::CloudStreaming for FailingCloudAdapter {
+        fn execute_streaming(
+            &self,
+            _input: &xybrid_core::ir::Envelope,
+            _on_token: xybrid_core::runtime_adapter::types::StreamingCallback<'_>,
+        ) -> xybrid_core::runtime_adapter::AdapterResult<xybrid_core::ir::Envelope> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(xybrid_core::runtime_adapter::AdapterError::RuntimeError(
+                "gateway unavailable".to_string(),
+            ))
+        }
+    }
+
     #[derive(Debug)]
     struct FixedUnitResourceProvider {
         snapshot: xybrid_core::device::ResourceSnapshot,
@@ -3216,6 +3245,64 @@ mod tests {
             xybrid_core::orchestrator::authority::ResolvedTarget::Cloud { .. }
         ));
         assert_eq!(outcomes[1].model_id.as_deref(), Some("deepseek-chat"));
+    }
+
+    #[test]
+    fn dispatch_after_local_records_cloud_retry_failure() {
+        let cloud = FailingCloudAdapter::new();
+        let authority = FakeAuthority::allow();
+        let mut envelope = text_envelope("write a haiku");
+        envelope
+            .metadata
+            .insert("provider".to_string(), "openai".to_string());
+        envelope
+            .metadata
+            .insert("model".to_string(), "gpt-4o-mini".to_string());
+        let mut on_token =
+            |_: xybrid_core::runtime_adapter::types::PartialToken| -> Result<(), Box<dyn std::error::Error + Send + Sync>> { Ok(()) };
+        let mut on_seam = |_s: SeamInfo| {};
+        let local_result: SdkResult<InferenceResult> = Err(SdkError::AbortedForCloudFallback {
+            reason: xybrid_core::abort::AbortReason::StressMemory,
+        });
+
+        let result = dispatch_after_local(
+            local_result,
+            &envelope,
+            &cloud,
+            "corr-cloud-fail".to_string(),
+            "local-model",
+            2,
+            120,
+            None,
+            &authority,
+            default_metrics(),
+            Some(default_signal()),
+            None,
+            &mut on_token,
+            &mut on_seam,
+        );
+
+        match result {
+            Err(SdkError::InferenceError(message)) => {
+                assert!(message.contains("gateway unavailable"), "{message}");
+            }
+            other => panic!("expected cloud retry failure, got {other:?}"),
+        }
+        assert_eq!(cloud.call_count(), 1);
+
+        let outcomes = authority.outcomes();
+        assert_eq!(outcomes.len(), 2);
+        assert!(matches!(
+            outcomes[0].category,
+            Some(
+                xybrid_core::orchestrator::authority::OutcomeCategory::AbortedForCloudFallback { .. }
+            )
+        ));
+        assert!(matches!(
+            outcomes[1].category,
+            Some(xybrid_core::orchestrator::authority::OutcomeCategory::HardFail { .. })
+        ));
+        assert_eq!(outcomes[1].model_id.as_deref(), Some("gpt-4o-mini"));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -24,8 +24,9 @@ use xybrid_core::execution::{
 use xybrid_core::ir::Envelope;
 use xybrid_core::orchestrator::authority::{
     ExecutionOutcome, LocalAuthority, OrchestrationAuthority, OutcomeCategory, PolicyOutcome,
-    PolicyRequest, ResolvedTarget, SignalContext,
+    PolicyRequest, ResolvedTarget, SignalContext, StageContext,
 };
+use xybrid_core::orchestrator::routing_engine::LocalReliabilityHint;
 use xybrid_core::runtime_adapter::types::GenerationConfig;
 use xybrid_core::streaming::{StreamConfig as CoreStreamConfig, VadStreamConfig as CoreVadConfig};
 
@@ -277,6 +278,27 @@ fn record_cloud_outcome(
     });
 }
 
+fn local_reliability_hint_after_abort(
+    authority: &dyn OrchestrationAuthority,
+    model_id: &str,
+    envelope: &Envelope,
+    metrics: &xybrid_core::context::DeviceMetrics,
+) -> Option<LocalReliabilityHint> {
+    let context = StageContext {
+        stage_id: model_id.to_string(),
+        model_id: model_id.to_string(),
+        input_kind: envelope.kind.clone(),
+        metrics: metrics.clone(),
+        resource_monitor: xybrid_core::device::ResourceMonitor::global(),
+        explicit_target: None,
+        device_class: Some(metrics.canonical_device_class()),
+        device_class_schema_version: Some(xybrid_core::context::DEVICE_CLASS_SCHEMA_VERSION),
+    };
+    authority
+        .resolve_target_with_feedback(&context)
+        .local_reliability_hint
+}
+
 /// Inspect the local-leg result and, on a typed cloud-fallback abort, fire
 /// `on_seam`, retry on the cloud adapter, and return the cloud
 /// [`InferenceResult`]. On any other shape the original result is returned
@@ -298,6 +320,7 @@ fn dispatch_after_local<F, S>(
     model_id: &str,
     local_tokens: u32,
     local_latency_ms: u32,
+    local_resource_summary: Option<xybrid_core::device::ResourceUsageSummary>,
     authority: &dyn OrchestrationAuthority,
     policy_metrics: xybrid_core::context::DeviceMetrics,
     signal_context: Option<SignalContext>,
@@ -315,21 +338,25 @@ where
     match local_result {
         Ok(result) => Ok(result),
         Err(SdkError::AbortedForCloudFallback { reason }) => {
-            // Emit `LocalAborted` before the user's `on_seam` callback fires so
-            // the audit trail exists even if the caller's seam handler panics.
-            crate::telemetry::publish_local_aborted(
-                &correlation_id,
-                model_id,
-                reason,
-                local_latency_ms,
-                local_tokens,
-            );
             record_local_abort_outcome(
                 authority,
                 model_id,
                 reason,
                 local_latency_ms,
                 signal_context,
+            );
+            let local_reliability_hint =
+                local_reliability_hint_after_abort(authority, model_id, envelope, &policy_metrics);
+            // Emit `LocalAborted` before the user's `on_seam` callback fires so
+            // the audit trail exists even if the caller's seam handler panics.
+            crate::telemetry::publish_local_aborted_with_details(
+                &correlation_id,
+                model_id,
+                reason,
+                local_latency_ms,
+                local_tokens,
+                local_resource_summary,
+                local_reliability_hint,
             );
 
             let seam = SeamInfo {
@@ -1306,7 +1333,15 @@ impl ModelLoader {
         })
     }
 
+    fn is_llm_template(metadata: &ModelMetadata) -> bool {
+        matches!(metadata.execution_template, ExecutionTemplate::Gguf { .. })
+    }
+
     fn check_streaming_support(metadata: &ModelMetadata) -> bool {
+        if Self::is_llm_template(metadata) {
+            return true;
+        }
+
         // Check if this is an ASR model (supports streaming)
         // Look at metadata task or model type (metadata is HashMap<String, serde_json::Value>)
         if let Some(task) = metadata.metadata.get("task").and_then(|v| v.as_str()) {
@@ -1334,6 +1369,10 @@ impl ModelLoader {
     }
 
     fn infer_output_type(metadata: &ModelMetadata) -> OutputType {
+        if Self::is_llm_template(metadata) {
+            return OutputType::Text;
+        }
+
         // Check metadata hints (metadata is HashMap<String, serde_json::Value>)
         if let Some(task) = metadata.metadata.get("task").and_then(|v| v.as_str()) {
             match task {
@@ -1531,6 +1570,7 @@ impl XybridModel {
         use xybrid_core::ir::EnvelopeKind;
 
         log::info!(target: "xybrid_sdk", "Warming up model: {}", self.model_id);
+        let is_llm = self.is_llm();
 
         // Create a minimal input based on expected input type
         let warmup_input = match self.output_type {
@@ -1540,7 +1580,7 @@ impl XybridModel {
                 metadata: std::collections::HashMap::new(),
             },
             // For ASR models, use minimal audio (1 second of silence at 16kHz)
-            OutputType::Text if self.supports_streaming => {
+            OutputType::Text if self.supports_streaming && !is_llm => {
                 // Create a minimal WAV file with silence
                 let silence_samples = vec![0i16; 16000]; // 1 second at 16kHz
                 let audio_bytes = Self::create_wav_bytes(&silence_samples, 16000);
@@ -1595,6 +1635,7 @@ impl XybridModel {
         let model_id = self.model_id.clone();
         let output_type = self.output_type;
         let supports_streaming = self.supports_streaming;
+        let is_llm = self.is_llm();
 
         tokio::task::spawn_blocking(move || {
             use xybrid_core::ir::EnvelopeKind;
@@ -1607,7 +1648,7 @@ impl XybridModel {
                     kind: EnvelopeKind::Text("Hi".to_string()),
                     metadata: std::collections::HashMap::new(),
                 },
-                OutputType::Text if supports_streaming => {
+                OutputType::Text if supports_streaming && !is_llm => {
                     let silence_samples = vec![0i16; 16000];
                     let audio_bytes = Self::create_wav_bytes(&silence_samples, 16000);
                     Envelope {
@@ -2289,6 +2330,7 @@ impl XybridModel {
 
         let local_tokens = Arc::new(AtomicU32::new(0));
         let local_start = Instant::now();
+        let local_resource_guard = crate::telemetry::begin_resource_run();
 
         let local_result = {
             let local_tokens = local_tokens.clone();
@@ -2299,6 +2341,7 @@ impl XybridModel {
         };
 
         let local_latency_ms = local_start.elapsed().as_millis() as u32;
+        let local_resource_summary = local_resource_guard.finish();
         let policy_metrics = fallback_policy_metrics(options);
         let signal_context = Some(SignalContext::from_metrics(&policy_metrics));
 
@@ -2310,6 +2353,7 @@ impl XybridModel {
             &self.model_id,
             local_tokens.load(Ordering::SeqCst),
             local_latency_ms,
+            local_resource_summary,
             fallback_authority(),
             policy_metrics,
             signal_context,
@@ -2725,6 +2769,23 @@ mod tests {
     }
 
     #[test]
+    fn gguf_models_are_streaming_text_models() {
+        let mut metadata = ModelMetadata::onnx("qwen2.5-0.5b-instruct", "1.0", "model.gguf");
+        metadata.execution_template = ExecutionTemplate::Gguf {
+            model_file: "model.gguf".to_string(),
+            chat_template: None,
+            context_length: 2048,
+            generation_params: None,
+        };
+
+        assert!(
+            ModelLoader::check_streaming_support(&metadata),
+            "GGUF LLMs stream tokens and must run abort checks between chunks"
+        );
+        assert_eq!(ModelLoader::infer_output_type(&metadata), OutputType::Text);
+    }
+
+    #[test]
     #[allow(deprecated)]
     fn test_model_loader_from_legacy_registry() {
         let loader = ModelLoader::from_legacy_registry("http://localhost:8080", "whisper", "1.0");
@@ -2992,6 +3053,7 @@ mod tests {
             "test-model",
             3,
             100,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3057,6 +3119,48 @@ mod tests {
     }
 
     #[test]
+    fn run_streaming_with_fallback_retries_cloud_on_pre_run_thermal_pressure() {
+        let model = test_loaded_model(true);
+        let cloud = FakeCloudAdapter::new("hello from cloud");
+        let mut critical_snapshot = xybrid_core::device::ResourceSnapshot::unknown();
+        critical_snapshot.thermal_state = xybrid_core::device::ThermalState::Critical;
+        let resource_provider = Arc::new(FixedUnitResourceProvider::new(critical_snapshot));
+        let options = RunOptions::new()
+            .with_abort_policy(
+                crate::run_options::AbortPolicy::default()
+                    .stop_on(crate::run_options::AbortSignal::ThermalCritical)
+                    .with_cloud_fallback(true)
+                    .with_max_grace_tokens(0),
+            )
+            .with_resource_provider(resource_provider)
+            .with_correlation_id("corr-thermal-pre-run");
+        let envelope = text_envelope("write me a haiku");
+        let collected: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let collected_for_cb = collected.clone();
+        let mut on_token = move |t: xybrid_core::runtime_adapter::types::PartialToken| {
+            collected_for_cb.lock().unwrap().push(t.token);
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
+        };
+        let seam_count = Arc::new(AtomicUsize::new(0));
+        let seam_count_for_cb = seam_count.clone();
+        let mut on_seam = move |s: SeamInfo| {
+            seam_count_for_cb.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(s.reason, xybrid_core::abort::AbortReason::StressThermal);
+            assert_eq!(s.correlation_id, "corr-thermal-pre-run");
+            assert_eq!(s.local_tokens, 0);
+        };
+
+        let result = model
+            .run_streaming_with_fallback(&envelope, &options, &cloud, &mut on_token, &mut on_seam)
+            .expect("pre-run thermal pressure should retry on cloud");
+
+        assert_eq!(seam_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(cloud.call_count(), 1);
+        assert_eq!(result.text(), Some("hello from cloud"));
+        assert_eq!(collected.lock().unwrap().as_slice(), ["hello from cloud"]);
+    }
+
+    #[test]
     fn dispatch_after_local_records_local_abort_and_cloud_success_outcomes() {
         let cloud = FakeCloudAdapter::new("hello from cloud");
         let authority = FakeAuthority::allow();
@@ -3079,6 +3183,7 @@ mod tests {
             "local-model",
             7,
             321,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3147,6 +3252,7 @@ mod tests {
             "local-model",
             4,
             123,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3194,6 +3300,7 @@ mod tests {
             "local-model",
             0,
             0,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3234,6 +3341,7 @@ mod tests {
             "local-model",
             7,
             321,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3291,6 +3399,7 @@ mod tests {
             "qwen2.5-0.5b-instruct",
             5,
             220,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3327,6 +3436,7 @@ mod tests {
             "local-only-model",
             0,
             0,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3363,6 +3473,7 @@ mod tests {
             "test-model",
             10,
             200,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3402,6 +3513,7 @@ mod tests {
             "test-model",
             0,
             0,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),
@@ -3444,6 +3556,7 @@ mod tests {
             "test-model",
             0,
             0,
+            None,
             &authority,
             default_metrics(),
             Some(default_signal()),

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -62,14 +62,20 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
-use xybrid_core::context::{DeviceMetrics, StageDescriptor};
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+use xybrid_core::cache_provider::CacheProvider;
+use xybrid_core::context::{DeviceMetrics, StageDescriptor, DEVICE_CLASS_SCHEMA_VERSION};
 use xybrid_core::device::ResourceMonitor;
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+use xybrid_core::event_bus::{EventContext, OrchestratorEvent};
 use xybrid_core::ir::{Envelope, EnvelopeKind};
 use xybrid_core::orchestrator::routing_engine::LocalAvailability;
 use xybrid_core::orchestrator::{
     LocalAuthority, OrchestrationAuthority, Orchestrator, ResolvedTarget, StageContext,
     StageExecutionResult,
 };
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+use xybrid_core::orchestrator::{PolicyOutcome, PolicyRequest};
 use xybrid_core::pipeline::{ExecutionTarget, IntegrationProvider, StageOptions};
 use xybrid_core::pipeline_config::PipelineConfig;
 
@@ -310,6 +316,150 @@ impl PipelineExecutionResult {
 
 fn pipeline_metrics(options: &RunOptions) -> DeviceMetrics {
     options.device_metrics.as_ref().cloned().unwrap_or_default()
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+struct StreamingFastPathCacheProvider {
+    model_id: String,
+    model_path: PathBuf,
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+impl StreamingFastPathCacheProvider {
+    fn new(model_id: impl Into<String>, model_path: PathBuf) -> Self {
+        Self {
+            model_id: model_id.into(),
+            model_path,
+        }
+    }
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+impl CacheProvider for StreamingFastPathCacheProvider {
+    fn is_model_cached(&self, model_id: &str) -> bool {
+        model_id == self.model_id && self.model_path.exists()
+    }
+
+    fn get_model_path(&self, model_id: &str) -> Option<PathBuf> {
+        self.is_model_cached(model_id)
+            .then(|| self.model_path.clone())
+    }
+
+    fn cache_dir(&self) -> PathBuf {
+        self.model_path
+            .parent()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| self.model_path.clone())
+    }
+
+    fn name(&self) -> &'static str {
+        "streaming-fast-path"
+    }
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+#[derive(Debug, Clone)]
+struct StreamingFastPathRoute {
+    policy_allowed: bool,
+    policy_reason: Option<String>,
+    target: String,
+    reason: String,
+    recent_abort_rate: f32,
+    sample_size: u32,
+    can_stream_locally: bool,
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn resolve_streaming_fast_path_route(
+    authority: &dyn OrchestrationAuthority,
+    stage: &StageDescriptor,
+    model_id: &str,
+    envelope: &Envelope,
+    metrics: &DeviceMetrics,
+) -> StreamingFastPathRoute {
+    let policy_decision = authority.apply_policy(&PolicyRequest {
+        stage_id: stage.name.clone(),
+        envelope: envelope.clone(),
+        metrics: metrics.clone(),
+    });
+    let policy_allowed = policy_decision.result.is_allowed();
+    let policy_transform = matches!(policy_decision.result, PolicyOutcome::Transform { .. });
+    let policy_reason = Some(policy_decision.reason.clone());
+
+    let context = StageContext {
+        stage_id: stage.name.clone(),
+        model_id: model_id.to_string(),
+        input_kind: envelope.kind.clone(),
+        metrics: metrics.clone(),
+        resource_monitor: ResourceMonitor::global(),
+        explicit_target: stage.target.clone(),
+        device_class: Some(metrics.canonical_device_class()),
+        device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
+    };
+    let resolution = authority.resolve_target_with_feedback(&context);
+    let target = match &resolution.decision.result {
+        ResolvedTarget::Device => "local".to_string(),
+        ResolvedTarget::Cloud { .. } => "cloud".to_string(),
+        ResolvedTarget::Server { endpoint } => format!("fallback:{endpoint}"),
+    };
+    let hint = resolution.local_reliability_hint.unwrap_or_default();
+    let can_stream_locally = policy_allowed
+        && matches!(resolution.decision.result, ResolvedTarget::Device)
+        && !policy_transform;
+
+    StreamingFastPathRoute {
+        policy_allowed,
+        policy_reason,
+        target,
+        reason: format!(
+            "[{}] {} (confidence: {:.0}%)",
+            resolution.decision.source,
+            resolution.decision.reason,
+            resolution.decision.confidence * 100.0
+        ),
+        recent_abort_rate: hint.recent_abort_rate,
+        sample_size: hint.sample_size,
+        can_stream_locally,
+    }
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn streaming_fast_path_events(
+    stage_name: &str,
+    model_id: &str,
+    route: &StreamingFastPathRoute,
+) -> Vec<OrchestratorEvent> {
+    let context = EventContext::default().with_model_id(model_id.to_string());
+    vec![
+        OrchestratorEvent::PolicyEvaluated {
+            stage_name: stage_name.to_string(),
+            allowed: route.policy_allowed,
+            reason: route.policy_reason.clone(),
+            context: context.clone(),
+        },
+        OrchestratorEvent::RoutingDecided {
+            stage_name: stage_name.to_string(),
+            target: route.target.clone(),
+            reason: route.reason.clone(),
+            recent_abort_rate: route.recent_abort_rate,
+            sample_size: route.sample_size,
+            context,
+        },
+    ]
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn publish_streaming_fast_path_events(
+    stage_name: &str,
+    model_id: &str,
+    route: &StreamingFastPathRoute,
+    pipeline_id: Option<uuid::Uuid>,
+    trace_id: Option<uuid::Uuid>,
+) {
+    for event in streaming_fast_path_events(stage_name, model_id, route) {
+        let telemetry = crate::telemetry::convert_orchestrator_event(&event);
+        crate::telemetry::publish_telemetry_event_in_context(telemetry, pipeline_id, trace_id);
+    }
 }
 
 fn pipeline_complete_data(
@@ -742,6 +892,8 @@ impl Pipeline {
                 metrics: metrics.clone(),
                 resource_monitor: ResourceMonitor::global(),
                 explicit_target,
+                device_class: Some(metrics.canonical_device_class()),
+                device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
             };
 
             let decision = authority.resolve_target(&stage_context);
@@ -1327,7 +1479,8 @@ impl Xybrid {
         // For streaming, we need to identify if there's an LLM stage and execute it with streaming
         // For now, support single-stage LLM pipelines
         if handle.stage_descriptors.len() == 1 {
-            let stage_name = handle.stage_descriptors[0].name.clone();
+            let stage_descriptor = handle.stage_descriptors[0].clone();
+            let stage_name = stage_descriptor.name.clone();
             if let Some(bundle_path) = handle.bundle_paths.get(&stage_name) {
                 let bundle_path = bundle_path.clone(); // Clone to avoid borrow issues
                 let metadata_path = bundle_path.join("model_metadata.json");
@@ -1345,7 +1498,46 @@ impl Xybrid {
                         metadata.execution_template,
                         xybrid_core::execution::ExecutionTemplate::Gguf { .. }
                     ) {
+                        let model_id = metadata.model_id.clone();
+                        let metrics = pipeline_metrics(&RunOptions::default());
+                        let authority = LocalAuthority::with_cache_provider(Arc::new(
+                            StreamingFastPathCacheProvider::new(
+                                model_id.clone(),
+                                bundle_path.clone(),
+                            ),
+                        ));
+                        let route = resolve_streaming_fast_path_route(
+                            &authority,
+                            &stage_descriptor,
+                            &model_id,
+                            envelope,
+                            &metrics,
+                        );
+
+                        if !route.can_stream_locally {
+                            drop(handle);
+                            return pipeline.run(envelope);
+                        }
+
                         drop(handle); // Release lock before executor call
+
+                        let trace_id = uuid::Uuid::new_v4();
+                        let pipeline_id = pipeline
+                            .name
+                            .as_ref()
+                            .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
+                        let _context_guard =
+                            crate::telemetry::TelemetryPipelineContextGuard::install(
+                                pipeline_id,
+                                Some(trace_id),
+                            );
+                        publish_streaming_fast_path_events(
+                            &stage_name,
+                            &model_id,
+                            &route,
+                            pipeline_id,
+                            Some(trace_id),
+                        );
 
                         let mut executor =
                             TemplateExecutor::with_base_path(bundle_path.to_str().unwrap_or(""));
@@ -1367,8 +1559,8 @@ impl Xybrid {
                             stages: vec![StageTiming {
                                 name: pipeline_ref.config.stages[0].model_id(),
                                 latency_ms: total_latency_ms,
-                                target: "local".to_string(),
-                                reason: "streaming".to_string(),
+                                target: route.target,
+                                reason: route.reason,
                             }],
                             total_latency_ms,
                             output_type,
@@ -1460,6 +1652,115 @@ stages:
     fn xybrid_run_pipeline_with_options_is_public_api() {
         let _method: fn(&str, &Envelope, &RunOptions) -> PipelineResult<PipelineExecutionResult> =
             Xybrid::run_pipeline_with_options;
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_route_uses_policy_and_local_routing() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let model_id = "streaming-local-model";
+        let authority = LocalAuthority::with_cache_provider(Arc::new(
+            StreamingFastPathCacheProvider::new(model_id, tempdir.path().to_path_buf()),
+        ));
+        let stage = StageDescriptor::new("llm")
+            .with_model(model_id)
+            .with_target(ExecutionTarget::Device);
+        let envelope = Envelope::new(EnvelopeKind::Text("prompt".to_string()));
+        let metrics = DeviceMetrics::default();
+
+        let route =
+            resolve_streaming_fast_path_route(&authority, &stage, model_id, &envelope, &metrics);
+
+        assert!(route.policy_allowed);
+        assert!(route.can_stream_locally);
+        assert_eq!(route.target, "local");
+        assert_eq!(route.sample_size, 0);
+        assert!(route.reason.contains("Explicit target"));
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_policy_deny_disables_local_streaming() {
+        use xybrid_core::orchestrator::policy_engine::{DefaultPolicyEngine, PolicyEngine};
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let model_id = "streaming-denied-model";
+        let mut policy_engine = DefaultPolicyEngine::new();
+        policy_engine
+            .load_policies(
+                br#"
+version: "0.1.0"
+deny_cloud_if:
+  - input.kind == "text"
+signature: "test-deny-text"
+"#
+                .to_vec(),
+            )
+            .expect("policy loads");
+        let authority = LocalAuthority::with_policy_and_cache(
+            policy_engine,
+            Arc::new(StreamingFastPathCacheProvider::new(
+                model_id,
+                tempdir.path().to_path_buf(),
+            )),
+        );
+        let stage = StageDescriptor::new("llm")
+            .with_model(model_id)
+            .with_target(ExecutionTarget::Device);
+        let envelope = Envelope::new(EnvelopeKind::Text("prompt".to_string()));
+        let metrics = DeviceMetrics::default();
+
+        let route =
+            resolve_streaming_fast_path_route(&authority, &stage, model_id, &envelope, &metrics);
+
+        assert!(!route.policy_allowed);
+        assert!(
+            !route.can_stream_locally,
+            "streaming fast path must not execute when policy denies the prompt"
+        );
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_events_emit_policy_before_routing_with_hint() {
+        let route = StreamingFastPathRoute {
+            policy_allowed: true,
+            policy_reason: Some("Local policy evaluation".to_string()),
+            target: "local".to_string(),
+            reason: "[local] default_local (confidence: 80%)".to_string(),
+            recent_abort_rate: 0.25,
+            sample_size: 4,
+            can_stream_locally: true,
+        };
+
+        let events = streaming_fast_path_events("llm", "qwen2.5-0.5b", &route);
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            OrchestratorEvent::PolicyEvaluated { .. }
+        ));
+        assert!(matches!(
+            events[1],
+            OrchestratorEvent::RoutingDecided { .. }
+        ));
+
+        let telemetry = crate::telemetry::convert_orchestrator_event(&events[1]);
+        assert_eq!(telemetry.event_type, "RoutingDecided");
+        assert_eq!(telemetry.stage_name.as_deref(), Some("llm"));
+        assert_eq!(telemetry.target.as_deref(), Some("local"));
+
+        let data: serde_json::Value =
+            serde_json::from_str(telemetry.data.as_ref().expect("routing data")).unwrap();
+        assert_eq!(
+            data["local_reliability_hint"]["recent_abort_rate"].as_f64(),
+            Some(0.25)
+        );
+        assert_eq!(
+            data["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(4)
+        );
+        assert_eq!(data["model_id"].as_str(), Some("qwen2.5-0.5b"));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -1461,6 +1461,21 @@ impl Xybrid {
         envelope: &Envelope,
         on_token: xybrid_core::runtime_adapter::types::StreamingCallback<'a>,
     ) -> PipelineResult<PipelineExecutionResult> {
+        Self::run_pipeline_streaming_with_options(yaml, envelope, &RunOptions::default(), on_token)
+    }
+
+    /// Run a pipeline from YAML with streaming and per-run controls.
+    ///
+    /// Uses `RunOptions::device_metrics` for the single-stage streaming LLM
+    /// routing fast path, so the streaming path observes the same caller-supplied
+    /// routing context as non-streaming `run_pipeline_with_options`.
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    pub fn run_pipeline_streaming_with_options<'a>(
+        yaml: &str,
+        envelope: &Envelope,
+        options: &RunOptions,
+        on_token: xybrid_core::runtime_adapter::types::StreamingCallback<'a>,
+    ) -> PipelineResult<PipelineExecutionResult> {
         use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
 
         let pipeline_ref = PipelineRef::from_yaml(yaml)?;
@@ -1499,7 +1514,7 @@ impl Xybrid {
                         xybrid_core::execution::ExecutionTemplate::Gguf { .. }
                     ) {
                         let model_id = metadata.model_id.clone();
-                        let metrics = pipeline_metrics(&RunOptions::default());
+                        let metrics = pipeline_metrics(options);
                         let authority = LocalAuthority::with_cache_provider(Arc::new(
                             StreamingFastPathCacheProvider::new(
                                 model_id.clone(),
@@ -1516,7 +1531,7 @@ impl Xybrid {
 
                         if !route.can_stream_locally {
                             drop(handle);
-                            return pipeline.run(envelope);
+                            return pipeline.run_with_options(envelope, options);
                         }
 
                         drop(handle); // Release lock before executor call
@@ -1573,7 +1588,7 @@ impl Xybrid {
 
         // Fall back to non-streaming execution for multi-stage or non-LLM pipelines
         drop(handle);
-        pipeline.run(envelope)
+        pipeline.run_with_options(envelope, options)
     }
 
     /// Stub for when LLM features are disabled.
@@ -1589,6 +1604,18 @@ impl Xybrid {
     ) -> PipelineResult<PipelineExecutionResult> {
         // Without LLM features, just run normally
         Self::run_pipeline(yaml, envelope)
+    }
+
+    /// Stub for when LLM features are disabled.
+    #[cfg(not(any(feature = "llm-mistral", feature = "llm-llamacpp")))]
+    #[allow(unused_variables)]
+    pub fn run_pipeline_streaming_with_options<'a>(
+        yaml: &str,
+        envelope: &Envelope,
+        options: &RunOptions,
+        on_token: xybrid_core::runtime_adapter::types::StreamingCallback<'a>,
+    ) -> PipelineResult<PipelineExecutionResult> {
+        Self::run_pipeline_with_options(yaml, envelope, options)
     }
 }
 
@@ -1652,6 +1679,16 @@ stages:
     fn xybrid_run_pipeline_with_options_is_public_api() {
         let _method: fn(&str, &Envelope, &RunOptions) -> PipelineResult<PipelineExecutionResult> =
             Xybrid::run_pipeline_with_options;
+    }
+
+    #[test]
+    fn xybrid_run_pipeline_streaming_with_options_is_public_api() {
+        let _method: for<'a> fn(
+            &str,
+            &Envelope,
+            &RunOptions,
+            xybrid_core::runtime_adapter::types::StreamingCallback<'a>,
+        ) -> PipelineResult<PipelineExecutionResult> = Xybrid::run_pipeline_streaming_with_options;
     }
 
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]

--- a/crates/xybrid-sdk/src/run_options.rs
+++ b/crates/xybrid-sdk/src/run_options.rs
@@ -13,7 +13,7 @@ use xybrid_core::device::{
 };
 use xybrid_core::runtime_adapter::types::GenerationConfig;
 
-const RESOURCE_ABORT_CHECK_INTERVAL: Duration = Duration::from_millis(500);
+const RESOURCE_ABORT_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 
 pub(crate) trait ResourceSnapshotReader: Send + Sync {
     fn current_snapshot(&self, max_age: Duration) -> ResourceSnapshot;
@@ -893,6 +893,36 @@ mod tests {
         assert_eq!(
             xybrid_core::abort::cloud_fallback_reason_from_error(err.as_ref()),
             Some(xybrid_core::abort::AbortReason::StressMemory)
+        );
+    }
+
+    #[test]
+    fn streaming_thermal_abort_check_stays_within_low_end_android_budget() {
+        let snapshot = ResourceSnapshot {
+            thermal_state: ThermalState::Critical,
+            ..Default::default()
+        };
+        let reader = Arc::new(CountingResourceReader::new(snapshot));
+        let options = RunOptions::new().with_abort_policy(
+            AbortPolicy::default()
+                .stop_on(AbortSignal::ThermalCritical)
+                .with_cloud_fallback(true),
+        );
+        let mut state = AbortState::with_resource_reader(&options, reader);
+
+        let started = Instant::now();
+        let err = check_abort_for_streaming(/* supports_streaming */ true, &mut state, true)
+            .expect_err("streaming thermal pressure must become a cloud fallback abort");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed <= Duration::from_millis(200),
+            "low-end Android thermal cancellation budget exceeded: {:?}",
+            elapsed
+        );
+        assert_eq!(
+            xybrid_core::abort::cloud_fallback_reason_from_error(err.as_ref()),
+            Some(xybrid_core::abort::AbortReason::StressThermal)
         );
     }
 }

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -36,6 +36,7 @@ use xybrid_core::device::{ResourceMonitor, ResourceTelemetryMode, ResourceUsageS
 use xybrid_core::event_bus::{EventContext, OrchestratorEvent};
 use xybrid_core::execution::listener::{self as execution_listener, ExecutionEvent};
 use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy};
+use xybrid_core::orchestrator::routing_engine::LocalReliabilityHint;
 use xybrid_core::tracing as core_tracing;
 
 /// Telemetry event type (simplified for FFI)
@@ -1517,25 +1518,67 @@ pub fn local_aborted_event(
     latency_ms: u32,
     tokens_emitted: u32,
 ) -> TelemetryEvent {
+    local_aborted_event_with_details(
+        correlation_id,
+        model_id,
+        abort_reason,
+        latency_ms,
+        tokens_emitted,
+        None,
+        None,
+    )
+}
+
+/// Build a `LocalAborted` event with resource and reliability context.
+///
+/// This is the cloud-fallback telemetry shape used by customer-ready routing:
+/// analytics can join the local/cloud legs by `correlation_id`, inspect the
+/// live resource summary that caused the abort, and feed the local reliability
+/// hint back into fleet-aware routing decisions.
+pub fn local_aborted_event_with_details(
+    correlation_id: &str,
+    model_id: &str,
+    abort_reason: xybrid_core::abort::AbortReason,
+    latency_ms: u32,
+    tokens_emitted: u32,
+    resource_summary: Option<ResourceUsageSummary>,
+    local_reliability_hint: Option<LocalReliabilityHint>,
+) -> TelemetryEvent {
+    let mut data = serde_json::json!({
+        "model_id": model_id,
+        "correlation_id": correlation_id,
+        "outcome_category": {
+            "kind": "aborted_for_cloud_fallback",
+            "reason": abort_reason.as_str(),
+        },
+        "abort_reason": abort_reason.as_str(),
+        "tokens_emitted": tokens_emitted,
+    });
+
+    if let Some(obj) = data.as_object_mut() {
+        if let Some(summary) =
+            resource_summary.and_then(|summary| serde_json::to_value(summary).ok())
+        {
+            obj.insert("resource_summary".to_string(), summary);
+        }
+        if let Some(hint) = local_reliability_hint {
+            obj.insert(
+                "local_reliability_hint".to_string(),
+                serde_json::json!({
+                    "recent_abort_rate": hint.recent_abort_rate,
+                    "sample_size": hint.sample_size,
+                }),
+            );
+        }
+    }
+
     TelemetryEvent {
         event_type: "LocalAborted".to_string(),
         stage_name: Some(model_id.to_string()),
         target: Some("local".to_string()),
         latency_ms: Some(latency_ms),
         error: None,
-        data: Some(
-            serde_json::json!({
-                "model_id": model_id,
-                "correlation_id": correlation_id,
-                "outcome_category": {
-                    "kind": "aborted_for_cloud_fallback",
-                    "reason": abort_reason.as_str(),
-                },
-                "abort_reason": abort_reason.as_str(),
-                "tokens_emitted": tokens_emitted,
-            })
-            .to_string(),
-        ),
+        data: Some(data.to_string()),
         timestamp_ms: SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
@@ -1557,6 +1600,26 @@ pub fn publish_local_aborted(
         abort_reason,
         latency_ms,
         tokens_emitted,
+    ));
+}
+
+pub(crate) fn publish_local_aborted_with_details(
+    correlation_id: &str,
+    model_id: &str,
+    abort_reason: xybrid_core::abort::AbortReason,
+    latency_ms: u32,
+    tokens_emitted: u32,
+    resource_summary: Option<ResourceUsageSummary>,
+    local_reliability_hint: Option<LocalReliabilityHint>,
+) {
+    publish_telemetry_event(local_aborted_event_with_details(
+        correlation_id,
+        model_id,
+        abort_reason,
+        latency_ms,
+        tokens_emitted,
+        resource_summary,
+        local_reliability_hint,
     ));
 }
 
@@ -1700,18 +1763,30 @@ pub fn cloud_retry_event(
     error: Option<&str>,
 ) -> TelemetryEvent {
     let provider_value = provider.unwrap_or("xybrid");
-    let status = if error.is_some() { "error" } else { "ok" };
+    let redacted_error = error.map(redact_error_for_telemetry);
+    let (status, outcome_category) = if let Some(reason) = redacted_error.as_deref() {
+        (
+            "error",
+            serde_json::json!({
+                "kind": "hard_fail",
+                "reason": reason,
+            }),
+        )
+    } else {
+        ("ok", serde_json::json!("cloud_success"))
+    };
     TelemetryEvent {
         event_type: "CloudRetry".to_string(),
         stage_name: Some(model_id.to_string()),
         target: Some("cloud".to_string()),
         latency_ms: Some(latency_ms),
-        error: error.map(redact_error_for_telemetry),
+        error: redacted_error,
         data: Some(
             serde_json::json!({
                 "model_id": model_id,
                 "correlation_id": correlation_id,
                 "provider": provider_value,
+                "outcome_category": outcome_category,
                 "tokens_emitted": tokens_emitted,
                 "status": status,
             })
@@ -2861,6 +2936,7 @@ mod tests {
         assert_eq!(local_data["outcome_category"]["reason"], "stress_memory");
         assert_eq!(local_data["tokens_emitted"], 4);
         assert_eq!(cloud_data["provider"], "openai");
+        assert_eq!(cloud_data["outcome_category"], "cloud_success");
         assert_eq!(cloud_data["tokens_emitted"], 38);
 
         // The platform-event hoist promotes `correlation_id` and `abort_reason`
@@ -2878,8 +2954,74 @@ mod tests {
             Some("run-abc-123")
         );
         assert_eq!(
+            platform_cloud.outcome_category.as_ref(),
+            Some(&serde_json::json!("cloud_success"))
+        );
+        assert_eq!(
+            platform_cloud.payload["outcome_category"],
+            serde_json::json!("cloud_success")
+        );
+        assert_eq!(
             platform_local.abort_reason.as_deref(),
             Some("stress_memory")
+        );
+    }
+
+    #[test]
+    fn local_aborted_event_carries_resource_summary_and_reliability_hint() {
+        let summary = ResourceUsageSummary {
+            cpu_avg_pct: Some(61.0),
+            cpu_peak_pct: Some(88.5),
+            process_rss_peak_mb: Some(2048),
+            available_mem_min_mb: Some(512),
+            memory_pressure_peak: xybrid_core::device::MemoryPressure::Critical,
+            thermal_state_peak: xybrid_core::device::ThermalState::Hot,
+            battery_pct_end: Some(51),
+            sample_count: 3,
+            sampling_mode: "debug_local".to_string(),
+            sampling_interval_ms: Some(100),
+        };
+        let local = local_aborted_event_with_details(
+            "run-rich-123",
+            "qwen2.5-0.5b",
+            xybrid_core::abort::AbortReason::StressMemory,
+            180,
+            4,
+            Some(summary),
+            Some(LocalReliabilityHint {
+                recent_abort_rate: 0.5,
+                sample_size: 2,
+            }),
+        );
+
+        let data: serde_json::Value =
+            serde_json::from_str(local.data.as_ref().expect("data present")).unwrap();
+        assert_eq!(
+            data["resource_summary"]["memory_pressure_peak"].as_str(),
+            Some("critical")
+        );
+        assert_eq!(
+            data["resource_summary"]["sampling_interval_ms"].as_i64(),
+            Some(100)
+        );
+        assert_eq!(
+            data["local_reliability_hint"]["recent_abort_rate"].as_f64(),
+            Some(0.5)
+        );
+        assert_eq!(
+            data["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(2)
+        );
+
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&local, &config, None, None, None);
+        assert_eq!(
+            platform.payload["resource_summary"]["sample_count"].as_i64(),
+            Some(3)
+        );
+        assert_eq!(
+            platform.payload["local_reliability_hint"]["sample_size"].as_i64(),
+            Some(2)
         );
     }
 
@@ -2889,6 +3031,7 @@ mod tests {
         let cloud_data: serde_json::Value =
             serde_json::from_str(cloud.data.as_ref().unwrap()).unwrap();
         assert_eq!(cloud_data["provider"], "xybrid");
+        assert_eq!(cloud_data["outcome_category"], "cloud_success");
         assert_eq!(cloud_data["status"], "ok");
         assert!(cloud.error.is_none());
     }
@@ -2913,7 +3056,22 @@ mod tests {
             Some("Gateway returned 502: Provider error")
         );
         assert_eq!(cloud_data["status"], "error");
+        assert_eq!(cloud_data["outcome_category"]["kind"], "hard_fail");
+        assert_eq!(
+            cloud_data["outcome_category"]["reason"],
+            "Gateway returned 502: Provider error"
+        );
         assert_eq!(cloud_data["tokens_emitted"], 0);
+
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&cloud, &config, None, None, None);
+        assert_eq!(
+            platform.outcome_category.as_ref(),
+            Some(&serde_json::json!({
+                "kind": "hard_fail",
+                "reason": "Gateway returned 502: Provider error"
+            }))
+        );
     }
 
     #[test]

--- a/crates/xybrid-sdk/tests/cloud_fallback_e2e.rs
+++ b/crates/xybrid-sdk/tests/cloud_fallback_e2e.rs
@@ -10,12 +10,13 @@
 //!
 //! 2. **End-to-end (manual)** (`cloud_fallback_demo_runs_end_to_end` —
 //!    `#[ignore]`'d): drives `run_streaming_with_fallback` through a real
-//!    cached `qwen2.5-0.5b` and a mock cloud target. Run with
+//!    cached `qwen2.5-0.5b-instruct` and a mock cloud target. Run with
 //!    `cargo test --features platform-macos,dev-tools,llm-llamacpp \
 //!     --test cloud_fallback_e2e -- --ignored`.
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use xybrid_core::abort::AbortReason as CoreAbortReason;
 use xybrid_core::device::{MemoryPressure, ResourceSnapshot, ResourceSnapshotProvider};
@@ -23,7 +24,7 @@ use xybrid_core::ir::{Envelope, EnvelopeKind};
 use xybrid_core::orchestrator::authority::test_seams::{
     FixedResourceProvider, StagedResourceProvider,
 };
-use xybrid_core::runtime_adapter::types::{PartialToken, StreamingCallback};
+use xybrid_core::runtime_adapter::types::{GenerationConfig, PartialToken, StreamingCallback};
 use xybrid_core::runtime_adapter::{
     AdapterError, AdapterResult, CloudRuntimeAdapter, CloudStreaming,
 };
@@ -47,7 +48,7 @@ fn cloud_fallback_api_surface_compiles() {
                 .with_cloud_fallback(true)
                 .with_max_grace_tokens(0),
         )
-        .with_resource_provider(provider);
+        .with_resource_provider(provider.clone());
 
     let _adapter: Box<dyn CloudStreaming> =
         Box::new(CloudRuntimeAdapter::with_gateway("http://example.test"));
@@ -101,6 +102,46 @@ impl CloudStreaming for RecordingCloud {
     }
 }
 
+#[derive(Debug)]
+struct TimedStagedResourceProvider {
+    normal: ResourceSnapshot,
+    stressed: ResourceSnapshot,
+    normal_reads: usize,
+    reads_so_far: AtomicUsize,
+    first_stressed_read_at: Mutex<Option<Instant>>,
+}
+
+impl TimedStagedResourceProvider {
+    fn new(normal_reads: usize, stressed: ResourceSnapshot) -> Self {
+        Self {
+            normal: ResourceSnapshot::unknown(),
+            stressed,
+            normal_reads,
+            reads_so_far: AtomicUsize::new(0),
+            first_stressed_read_at: Mutex::new(None),
+        }
+    }
+
+    fn first_stressed_read_at(&self) -> Option<Instant> {
+        *self.first_stressed_read_at.lock().unwrap()
+    }
+}
+
+impl ResourceSnapshotProvider for TimedStagedResourceProvider {
+    fn current_snapshot(&self, _max_age: Duration) -> ResourceSnapshot {
+        let n = self.reads_so_far.fetch_add(1, Ordering::SeqCst);
+        if n < self.normal_reads {
+            self.normal
+        } else {
+            let mut first_stressed_read_at = self.first_stressed_read_at.lock().unwrap();
+            if first_stressed_read_at.is_none() {
+                *first_stressed_read_at = Some(Instant::now());
+            }
+            self.stressed
+        }
+    }
+}
+
 #[test]
 fn cloud_fallback_dispatch_with_fake_adapter() {
     // Sanity check that a `CloudStreaming` implementation talks to its
@@ -132,12 +173,12 @@ fn cloud_fallback_dispatch_with_fake_adapter() {
 
 /// End-to-end exercise of `run_streaming_with_fallback` against a real local
 /// LLM and a mock cloud. Excluded from default `cargo test` because it
-/// requires `qwen2.5-0.5b` to be present in the registry cache.
+/// requires `qwen2.5-0.5b-instruct` to be present in the registry cache.
 ///
 /// Run manually:
 ///
 /// ```bash
-/// xybrid run --model qwen2.5-0.5b --input-text "warmup"
+/// xybrid run --model qwen2.5-0.5b-instruct --input-text "warmup"
 /// cargo test --features platform-macos,dev-tools,llm-llamacpp \
 ///   --test cloud_fallback_e2e -- --ignored
 /// ```
@@ -146,13 +187,17 @@ fn cloud_fallback_dispatch_with_fake_adapter() {
 fn cloud_fallback_demo_runs_end_to_end() {
     use xybrid_sdk::ModelLoader;
 
-    let model = ModelLoader::from_registry("qwen2.5-0.5b")
+    const FALLBACK_ABORT_LATENCY_BUDGET: Duration = Duration::from_millis(200);
+
+    let model_id = std::env::var("XYBRID_FALLBACK_E2E_MODEL_ID")
+        .unwrap_or_else(|_| "qwen2.5-0.5b-instruct".to_string());
+    let model = ModelLoader::from_registry(&model_id)
         .load()
-        .expect("model must be cached for this test");
+        .unwrap_or_else(|err| panic!("{model_id} must be cached for this test: {err}"));
 
     let mut crit = ResourceSnapshot::unknown();
     crit.memory_pressure = MemoryPressure::Critical;
-    let provider = Arc::new(StagedResourceProvider::new(3, crit));
+    let provider = Arc::new(TimedStagedResourceProvider::new(2, crit));
 
     let cloud = RecordingCloud::new("hello from cloud");
 
@@ -163,10 +208,11 @@ fn cloud_fallback_demo_runs_end_to_end() {
                 .with_cloud_fallback(true)
                 .with_max_grace_tokens(0),
         )
-        .with_resource_provider(provider);
+        .with_resource_provider(provider.clone())
+        .with_generation_config(GenerationConfig::greedy().with_max_tokens(256));
 
     let mut envelope = Envelope::new(EnvelopeKind::Text(
-        "Write a haiku about the sea.".to_string(),
+        "Write a long numbered list of short reasons adaptive compute keeps mobile LLM apps responsive. Do not stop early.".to_string(),
     ));
     envelope
         .metadata
@@ -179,6 +225,7 @@ fn cloud_fallback_demo_runs_end_to_end() {
     let cloud_count = Arc::new(AtomicU32::new(0));
     let on_cloud = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let captured_seam: Arc<Mutex<Option<SeamInfo>>> = Arc::new(Mutex::new(None));
+    let seam_observed_at: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
 
     let local_count_cb = local_count.clone();
     let cloud_count_cb = cloud_count.clone();
@@ -195,8 +242,10 @@ fn cloud_fallback_demo_runs_end_to_end() {
 
     let on_cloud_seam = on_cloud.clone();
     let captured_seam_for_cb = captured_seam.clone();
+    let seam_observed_at_for_cb = seam_observed_at.clone();
     let mut on_seam = move |info: SeamInfo| {
         on_cloud_seam.store(true, Ordering::SeqCst);
+        *seam_observed_at_for_cb.lock().unwrap() = Some(Instant::now());
         *captured_seam_for_cb.lock().unwrap() = Some(info);
     };
 
@@ -206,6 +255,18 @@ fn cloud_fallback_demo_runs_end_to_end() {
 
     let seam = captured_seam.lock().unwrap().clone();
     assert!(seam.is_some(), "seam should fire when pressure trips");
+    let first_stressed_read_at = provider
+        .first_stressed_read_at()
+        .expect("provider should have returned a stressed snapshot");
+    let seam_observed_at = (*seam_observed_at.lock().unwrap())
+        .expect("seam callback should record when abort surfaced");
+    let abort_latency = seam_observed_at.duration_since(first_stressed_read_at);
+    assert!(
+        abort_latency <= FALLBACK_ABORT_LATENCY_BUDGET,
+        "local abort exceeded one-token low-end budget: {:?} > {:?}",
+        abort_latency,
+        FALLBACK_ABORT_LATENCY_BUDGET
+    );
     assert!(
         local_count.load(Ordering::SeqCst) >= 1,
         "local should emit at least one token"

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -302,6 +302,11 @@ class XybridModel {
     required Envelope envelope,
     GenerationConfig? config,
   });
+  Stream<StreamToken> runStreamingWithFallback({
+    required Envelope envelope,
+    required RunOptions options,
+    GenerationConfig? config,
+  });
   Stream<StreamToken> runStreamingWithContext({
     required Envelope envelope,
     required ConversationContext context,
@@ -382,6 +387,7 @@ impl XybridModel {
 | `runWithContextOptions()` / `run_with_context_options()` | Rust ✅ | planned | planned | planned |
 | `runStreaming()` | ✅ | — | — | ✅ |
 | `runStreamingWithOptions()` / `run_streaming_with_options()` | Rust ✅ | planned | planned | planned |
+| `runStreamingWithFallback()` | ✅ | planned | planned | planned |
 | `runStreamingWithContext()` | ✅ | — | — | ✅ |
 | `runStreamingWithContextOptions()` / `run_streaming_with_context_options()` | Rust ✅ | planned | planned | planned |
 | `benchmark()` | — | — | — | — |
@@ -871,6 +877,13 @@ let result = model.run_streaming_with_options(&envelope, &options, |token| {
 `fallback_to_cloud` is carried in policy and telemetry contracts so binding
 layers and platform routing can restart on cloud where supported; local Rust
 streaming abort is cooperative and checked before every emitted token.
+
+Flutter exposes the customer opt-in surface as `RunOptions.cloudFallback(...)`
+plus `AbortPolicy.cloudFallback(...)`; plain `RunOptions()` stays neutral and
+does not opt into cloud retry. The Flutter FFI adapter maps that policy to the
+Rust SDK abort policy, including the selected memory/thermal stop signals,
+`fallbackToCloud`, and grace-token budget, and uses
+`runStreamingWithFallback(...)` for the continuous token stream.
 
 Routing feedback is recorded inside the core orchestrator using low-cardinality
 resource buckets. The SDK keeps `correlation_id` as an opaque string for

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -906,6 +906,13 @@ Rust SDK abort policy, including the selected memory/thermal stop signals,
 `fallbackToCloud`, and grace-token budget, and uses
 `runStreamingWithFallback(...)` for the continuous token stream.
 
+`cloudGatewayUrl` is an optional override for the Xybrid cloud gateway base URL.
+Customer builds accept HTTPS Xybrid gateway hosts with a `/v1` base path. Debug
+builds also accept localhost, private IP, and link-local gateways so apps can
+exercise fallback against the local platform stack. URLs with embedded
+credentials, query strings, fragments, unsupported schemes, or missing `/v1`
+are rejected before the cloud retry starts.
+
 Routing feedback is recorded inside the core orchestrator using low-cardinality
 resource buckets. The SDK keeps `correlation_id` as an opaque string for
 cross-binding compatibility; telemetry may include flat `routing_source`,

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -60,10 +60,16 @@ The main SDK entry point with static methods.
 ```dart
 class Xybrid {
   // Initialization
-  static Future<void> init();
+  static Future<void> init({
+    String? apiKey,
+    String? gatewayUrl,
+    String? ingestUrl,
+    String? resourceTelemetry,
+  });
 
-  // API Key Management
+  // Runtime configuration
   static void setApiKey(String apiKey);
+  static void setGatewayUrl(String gatewayUrl);
 
   // Model Loading (returns XybridModelLoader)
   static XybridModelLoader model({
@@ -110,6 +116,7 @@ object Xybrid {
 |--------|------|--------|-------|----|
 | `init()` | ✅ | ✅ | — | ✅ |
 | `setApiKey()` | ✅ | — | — | — |
+| `setGatewayUrl()` | ✅ | — | — | — |
 | `model()` | ✅ | — | — | ✅ |
 | `pipeline()` | ✅ | — | — | — |
 | `isModelCached()` | ✅ | — | — | — |
@@ -471,6 +478,13 @@ impl Xybrid {
         envelope: &Envelope,
         options: &RunOptions,
     ) -> PipelineResult<PipelineExecutionResult>;
+
+    pub fn run_pipeline_streaming_with_options<F>(
+        yaml: &str,
+        envelope: &Envelope,
+        options: &RunOptions,
+        on_token: F,
+    ) -> PipelineResult<PipelineExecutionResult>;
 }
 ```
 
@@ -488,6 +502,7 @@ impl Xybrid {
 | `load()` | ✅ | — | — | — |
 | `run()` | ✅ | — | — | — |
 | `runWithOptions()` / `run_with_options()` | Rust ✅ | planned | planned | planned |
+| `runPipelineStreamingWithOptions()` / `run_pipeline_streaming_with_options()` | Rust ✅ | planned | planned | planned |
 
 > **Note**: The Dart SDK currently uses a single `XybridPipeline` class (no separate `PipelineRef`).
 > The Kotlin spec shows the two-step `PipelineRef` → `Pipeline` pattern which is the target design.
@@ -852,7 +867,8 @@ Per-run controls for cooperative cancellation and resource-driven local abort.
 Rust SDK methods with options are available as model-level `run_with_options`,
 `run_with_context_options`, `run_streaming_with_options`, and
 `run_streaming_with_context_options`, plus pipeline-level `run_with_options`,
-`run_async_with_options`, and `Xybrid::run_pipeline_with_options`.
+`run_async_with_options`, `Xybrid::run_pipeline_with_options`, and
+`Xybrid::run_pipeline_streaming_with_options`.
 
 ```rust
 let token = CancellationToken::new();
@@ -878,6 +894,11 @@ let result = model.run_streaming_with_options(&envelope, &options, |token| {
 layers and platform routing can restart on cloud where supported; local Rust
 streaming abort is cooperative and checked before every emitted token.
 
+`AbortSignal` is the shared policy enum. Rust currently supports
+`UserCancelled`, `MemoryPressureWarn`, `MemoryPressureCritical`, `ThermalHot`,
+and `ThermalCritical`; Flutter currently exposes the customer-facing fallback
+signals `memoryPressureCritical` and `thermalCritical`.
+
 Flutter exposes the customer opt-in surface as `RunOptions.cloudFallback(...)`
 plus `AbortPolicy.cloudFallback(...)`; plain `RunOptions()` stays neutral and
 does not opt into cloud retry. The Flutter FFI adapter maps that policy to the
@@ -900,6 +921,7 @@ cross-binding compatibility; telemetry may include flat `routing_source`,
 | `GenerationConfig` | ✅ | ✅ | ✅ | ✅ |
 | `RunOptions` | ✅ | planned | planned | planned |
 | `AbortPolicy` | ✅ | planned | planned | planned |
+| `AbortSignal` | ✅ | planned | planned | planned |
 | `CancellationToken` | ✅ | planned | planned | planned |
 | `StreamToken` | ✅ | — | — | ✅ |
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -150,6 +150,13 @@ classes:
           - { name: options, type: RunOptions }
         return: "Stream<StreamToken>"
         status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      runStreamingWithFallback:
+        params:
+          - { name: envelope, type: Envelope }
+          - { name: options, type: RunOptions }
+          - { name: config, type: "GenerationConfig?", default: "null" }
+        return: "Stream<StreamToken>"
+        status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
       runStreamingWithContext:
         params:
           - { name: envelope, type: Envelope }
@@ -608,6 +615,25 @@ classes:
   RunOptions:
     type: data
     section: "8. Supporting Types"
+    properties:
+      abortPolicy:
+        type: AbortPolicy
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
+      cloudProvider:
+        type: "String?"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
+      cloudModel:
+        type: "String?"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
+      cloudGatewayUrl:
+        type: "String?"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
+      correlationId:
+        type: "String?"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
+      maxGraceTokens:
+        type: "int?"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
     methods:
       with_generation_config:
         params: [{ name: config, type: GenerationConfig }]
@@ -629,12 +655,21 @@ classes:
       stop_on:
         type: "List<AbortSignal>"
         status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      stopOn:
+        type: "Set<AbortSignal>"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
       fallback_to_cloud:
         type: bool
         status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      fallbackToCloud:
+        type: bool
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
       max_grace_tokens:
         type: int
         status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      maxGraceTokens:
+        type: "int?"
+        status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
 
   CancellationToken:
     type: class

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -19,9 +19,17 @@ classes:
     methods:
       init:
         async: true
+        params:
+          - { name: apiKey, type: "String?" }
+          - { name: gatewayUrl, type: "String?" }
+          - { name: ingestUrl, type: "String?" }
+          - { name: resourceTelemetry, type: "String?" }
         status: { dart: implemented, kotlin: implemented, swift: planned, csharp: implemented }
       setApiKey:
         params: [{ name: apiKey, type: String }]
+        status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
+      setGatewayUrl:
+        params: [{ name: gatewayUrl, type: String }]
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
       model:
         params:
@@ -212,6 +220,14 @@ classes:
           - { name: envelope, type: Envelope }
           - { name: options, type: RunOptions }
         status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      runPipelineStreamingWithOptions:
+        params:
+          - { name: yaml, type: String }
+          - { name: envelope, type: Envelope }
+          - { name: options, type: RunOptions }
+          - { name: on_token, type: StreamingCallback }
+        status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+        notes: "Single-stage LLM streaming fast path that preserves caller RunOptions for routing metrics and fallback to non-streaming pipeline execution."
     properties:
       name:
         type: "String?"
@@ -670,6 +686,21 @@ classes:
       maxGraceTokens:
         type: "int?"
         status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
+
+  AbortSignal:
+    type: enum
+    section: "8. Supporting Types"
+    variants:
+      UserCancelled:
+        status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      MemoryPressureWarn:
+        status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      MemoryPressureCritical:
+        status: { rust: implemented, dart: implemented, kotlin: planned, swift: planned, csharp: planned }
+      ThermalHot:
+        status: { rust: implemented, dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      ThermalCritical:
+        status: { rust: implemented, dart: implemented, kotlin: planned, swift: planned, csharp: planned }
 
   CancellationToken:
     type: class

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -643,6 +643,7 @@ classes:
         status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
       cloudGatewayUrl:
         type: "String?"
+        notes: "Optional Xybrid cloud gateway base URL. Customer builds accept HTTPS Xybrid hosts with a /v1 base path; debug builds also accept local/private gateways for local platform stacks."
         status: { dart: implemented, rust: planned, kotlin: planned, swift: planned, csharp: planned }
       correlationId:
         type: "String?"


### PR DESCRIPTION
## Summary
- Routes streaming fallback through live resource snapshots, abort policy checks, and cloud retry using the original prompt.
- Exposes the fallback controls through the SDK and Flutter binding surface needed by app integrations.
- Preserves joined telemetry with correlation IDs, abort/resource metadata, and reliability hints for downstream routing.

## Verification
- cargo test -p xybrid-sdk --lib --features llm-llamacpp streaming_fast_path
- cargo test -p xybrid-sdk --lib run_streaming_with_fallback_retries_cloud_on_pre_run
- cargo test -p xybrid-core target_advice_url --lib
- cargo test -p xybrid-core target_cache_key --lib
- cargo test -p xybrid-sdk --lib cloud_retry_event
- cargo test -p xybrid-sdk --lib local_aborted_event_carries_resource_summary_and_reliability_hint
- cargo test -p xybrid-sdk --lib dispatch_after_local
- cargo test -p xybrid-sdk --features platform-macos,dev-tools --test cloud_fallback_e2e
- cargo test -p xybrid-sdk --features platform-macos,dev-tools --test cloud_fallback_e2e -- --ignored --nocapture
- cargo clippy -p xybrid-sdk --lib --features llm-llamacpp -- -D warnings
- cargo clippy -p xybrid-core --lib -- -D warnings
- cargo bench -p xybrid-core --bench resource_telemetry
- cargo bench -p xybrid-core --bench routing_feedback
- flutter test test/run_options_test.dart
- flutter analyze
- git diff --check