### PR TITLE
Release v0.1.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.0-rc3] - 2026-05-16
+
+### Added
+
+- **Adaptive cloud fallback for streaming LLM** (#114): Streaming LLM pipelines can now transparently fall back to a cloud runtime when on-device generation stalls or errors mid-stream. New `RunOptions` controls expose the fallback policy on the SDK; the cloud runtime adapter, llama.cpp adapter, mistral adapter, and orchestrator authority layer all participate in the new flow.
+
+### Fixed
+
+- **Backend and quantization tags on streaming LLM spans** (#118): Telemetry spans emitted from streaming and chat-context LLM execution now carry backend and quantization labels (previously dropped on these code paths), so dashboards correctly attribute traffic to the runtime that actually served the request.
+- **Hybrid LLM architecture support in llama.cpp adapter** (#109, #117): Skip KV prefix-reuse and broaden the recurrent-state gate so hybrid (Mamba / SSM-style) architectures load and run cleanly through the llama.cpp runtime adapter. Adds an `llm_context_integration` test to lock in the behavior.
+
+### Build / CI
+
+- **Inline Flutter publish in release workflow** (#116): The release workflow no longer composes `publish-flutter` as a reusable job — inlining it avoids the `actions/checkout@v6` ref-moved guard that was triggered by the rc2 manifest-checksum self-patch (which force-moves the tag).
+
+---
+
 ## [0.1.0-rc2] - 2026-05-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
  "candle-kernels 0.10.2",
  "candle-metal-kernels 0.10.2",
  "candle-ug",
- "cudarc 0.19.6",
+ "cudarc 0.19.7",
  "float8",
  "gemm 0.19.0",
  "half",
@@ -1664,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83be2fd94791d2580692ced87ea19e9728102ce75582543b82765dbe3e884557"
+checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
 dependencies = [
  "float8",
  "half",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -4461,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "anyhow",
  "candle-core 0.10.2",
@@ -4488,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-audio"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "anyhow",
  "apodize",
@@ -4499,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "ahash",
  "akin",
@@ -4540,6 +4540,7 @@ dependencies = [
  "libc",
  "llguidance",
  "lrtable",
+ "mime_guess",
  "minijinja",
  "minijinja-contrib",
  "mistralrs-audio",
@@ -4597,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-macros"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4608,12 +4609,13 @@ dependencies = [
 [[package]]
 name = "mistralrs-mcp"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures-util",
  "http 1.4.0",
+ "image 0.25.10",
  "reqwest 0.13.3",
  "rust-mcp-schema",
  "serde",
@@ -4628,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "anyhow",
  "candle-core 0.10.2",
@@ -4645,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "byteorder",
  "candle-core 0.10.2",
@@ -4675,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.8.1"
-source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#2d4ba4f16f61e5e18be085d0dd137bc95cba038a"
+source = "git+https://github.com/EricLBuehler/mistral.rs.git?branch=master#a4529dc3266a213107becc8f25de16b435f4f6d6"
 dependencies = [
  "candle-core 0.10.2",
  "image 0.25.10",
@@ -8009,7 +8011,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8018,7 +8020,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -9468,9 +9470,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9603,7 +9605,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -9618,7 +9620,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9645,7 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -9710,7 +9712,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -9721,7 +9723,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9730,7 +9732,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9756,7 +9758,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-uniffi"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 dependencies = [
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.1.0-rc2"
+let sdkVersion = "0.1.0-rc3"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-rc3
+
+* Adaptive cloud fallback for streaming LLM: pipelines can now transparently fall back to a cloud runtime when on-device streaming generation stalls or errors mid-stream; configurable via new run options on the underlying SDK
+* Streaming and chat-context LLM telemetry spans now include backend and quantization tags (previously dropped on these code paths)
+* Hybrid LLM architectures (Mamba / SSM-style) now load and run cleanly through the bundled llama.cpp runtime
+
 ## 0.1.0-rc2
 
 * Republishes 0.1.0-rc1 — the rc1 pub.dev publish was skipped due to an upstream compile failure in `xybrid-core` on `aarch64-linux-android` (fixed in xybrid-ai/xybrid#112). No API or behavior changes in the Flutter binding itself.

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.1.0-rc2
+version: 0.1.0-rc3
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.1.0-rc2",
+  "version": "0.1.0-rc3",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary

Release bump to `0.1.0-rc3` across the workspace (Cargo, Swift Package, Flutter pubspec, Kotlin/Android, Unity), with `Cargo.lock` regenerated. Adds CHANGELOG entries for rc3 covering adaptive cloud fallback for streaming LLM (#114), backend/quantization tags on streaming + chat-context LLM telemetry spans (#118), hybrid (Mamba/SSM) LLM architecture support in the llama.cpp adapter (#109, #117), and the inlined Flutter publish step in the release workflow (#116).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below)

Release version bump + changelog update for `0.1.0-rc3`.

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)