### PR TITLE
docs(sdk): document vision envelopes and multi-part user messages

### DIFF
--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -518,7 +518,7 @@ class XybridEnvelope {
   });
   factory XybridEnvelope.embedding(List<double> embedding);
 
-  // Vision (planned for v0.2.0)
+  // Vision (planned)
   factory XybridEnvelope.image(
     List<int> imageBytes,
     String format,        // "png" | "jpeg" | "webp"
@@ -550,7 +550,7 @@ sealed class XybridEnvelope {
   ) : XybridEnvelope()
   data class Embedding(val embedding: FloatArray) : XybridEnvelope()
 
-  // Vision (planned for v0.2.0)
+  // Vision (planned)
   data class Image(
     val imageBytes: ByteArray,
     val format: String,          // "png" | "jpeg" | "webp"
@@ -573,7 +573,7 @@ sealed class XybridEnvelope {
     ): XybridEnvelope = Audio(audioBytes, sampleRate, channels)
     fun embedding(embedding: FloatArray): XybridEnvelope = Embedding(embedding)
 
-    // Vision (planned for v0.2.0)
+    // Vision (planned)
     fun image(
       imageBytes: ByteArray,
       format: String,
@@ -599,7 +599,7 @@ sealed class XybridEnvelope {
 | `image()` | 📋 | 📋 | 📋 | 📋 |
 | `userMessage()` | 📋 | 📋 | 📋 | 📋 |
 
-Legend: ✅ implemented · 📋 planned (v0.2.0) · — not applicable for this binding.
+Legend: ✅ implemented · 📋 planned · — not applicable for this binding.
 
 ---
 
@@ -810,11 +810,11 @@ class ConversationContext {
 }
 ```
 
-**Multi-turn vision** (planned for v0.2.0): when a user message contains images
+**Multi-turn vision** (planned): when a user message contains images
 (built via `Envelope.userMessage(text, images: [...])`), the image-bearing envelope
 stays attached to its turn in the conversation history. Vision-capable backends
 re-prefill image tokens at each turn that references them, matching `llama.cpp`'s
-`mtmd` defaults. There is no separate image-embedding cache in v0.2.0; image bytes
+`mtmd` defaults. There is no separate image-embedding cache in the planned initial implementation; image bytes
 remain in memory for as long as the `ConversationContext` references them.
 
 ### MessageRole

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -497,6 +497,10 @@ are passed through to pipeline stages that understand them. Stages that don't ne
 simply ignore them. This allows a single envelope type to flow through multi-stage pipelines
 (e.g., ASR → LLM → TTS) without type changes.
 
+Image envelopes carry raw bytes plus a `format` tag (`"png" | "jpeg" | "webp"`); preprocessing
+pipelines decode and resize them. Multi-part user messages combine a text prompt with one or
+more image envelopes for vision-language models — see `Envelope.userMessage` below.
+
 ### Dart
 
 ```dart
@@ -513,6 +517,16 @@ class XybridEnvelope {
     int channels = 1,
   });
   factory XybridEnvelope.embedding(List<double> embedding);
+
+  // Vision (planned for v0.2.0)
+  factory XybridEnvelope.image(
+    List<int> imageBytes,
+    String format,        // "png" | "jpeg" | "webp"
+  );
+  factory XybridEnvelope.userMessage(
+    String text, {
+    List<XybridEnvelope> images = const [],
+  });
 
   // Role support (for conversational context)
   factory XybridEnvelope.textWithRole(String text, MessageRole role);
@@ -536,6 +550,16 @@ sealed class XybridEnvelope {
   ) : XybridEnvelope()
   data class Embedding(val embedding: FloatArray) : XybridEnvelope()
 
+  // Vision (planned for v0.2.0)
+  data class Image(
+    val imageBytes: ByteArray,
+    val format: String,          // "png" | "jpeg" | "webp"
+  ) : XybridEnvelope()
+  data class UserMessage(
+    val text: String,
+    val images: List<XybridEnvelope> = emptyList(),
+  ) : XybridEnvelope()
+
   companion object {
     fun text(
       text: String,
@@ -548,6 +572,16 @@ sealed class XybridEnvelope {
       channels: Int = 1
     ): XybridEnvelope = Audio(audioBytes, sampleRate, channels)
     fun embedding(embedding: FloatArray): XybridEnvelope = Embedding(embedding)
+
+    // Vision (planned for v0.2.0)
+    fun image(
+      imageBytes: ByteArray,
+      format: String,
+    ): XybridEnvelope = Image(imageBytes, format)
+    fun userMessage(
+      text: String,
+      images: List<XybridEnvelope> = emptyList(),
+    ): XybridEnvelope = UserMessage(text, images)
   }
 }
 ```
@@ -562,6 +596,10 @@ sealed class XybridEnvelope {
 | `embedding()` | ✅ | ✅ | ✅ | — |
 | `textWithRole()` | ✅ | — | — | ✅ |
 | `withRole()` | ✅ | — | — | — |
+| `image()` | 📋 | 📋 | 📋 | 📋 |
+| `userMessage()` | 📋 | 📋 | 📋 | 📋 |
+
+Legend: ✅ implemented · 📋 planned (v0.2.0) · — not applicable for this binding.
 
 ---
 
@@ -771,6 +809,13 @@ class ConversationContext {
   fun push(message: Envelope)
 }
 ```
+
+**Multi-turn vision** (planned for v0.2.0): when a user message contains images
+(built via `Envelope.userMessage(text, images: [...])`), the image-bearing envelope
+stays attached to its turn in the conversation history. Vision-capable backends
+re-prefill image tokens at each turn that references them, matching `llama.cpp`'s
+`mtmd` defaults. There is no separate image-embedding cache in v0.2.0; image bytes
+remain in memory for as long as the `ConversationContext` references them.
 
 ### MessageRole
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -250,6 +250,16 @@ classes:
           - { name: text, type: String }
           - { name: role, type: MessageRole }
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: implemented }
+      image:
+        params:
+          - { name: imageBytes, type: "List<int>" }
+          - { name: format, type: String }
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
+      userMessage:
+        params:
+          - { name: text, type: String }
+          - { name: images, type: "List<XybridEnvelope>", default: "[]" }
+        status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }
 
   # -------------------------------------------------------------------
   # 6. VoiceInfo


### PR DESCRIPTION
## Summary

- Declares `Envelope.image(imageBytes, format)` and `Envelope.userMessage(text, images)` as new factories in the SDK contract, marked planned across all four bindings.
- Documents multi-turn vision semantics for `ConversationContext`: image-bearing envelopes persist attached to their turn; backends re-prefill image tokens each turn, matching llama.cpp `mtmd` defaults.
- Spec-only — no code changes in any crate or binding. Implementations land in follow-up PRs.

## Test plan

- [x] `yq '.' docs/sdk/api-surface.yaml` parses clean
- [x] `tools/scripts/api-contract-check.sh` warnings unchanged from master baseline (24 pre-existing, 0 errors)
- [x] Only `docs/sdk/api-surface.yaml` and `docs/sdk/API_REFERENCE.md` changed
- [x] Manual cross-language param-name consistency check (Dart ↔ Kotlin ↔ YAML)