### PR TITLE
docs: point new contributors at good-first-issue and area labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 Thank you for your interest in contributing to Xybrid! This guide will help you get started.
 
+## Where to start
+
+If you're looking for a first task, browse the [`good first issue`](https://github.com/xybrid-ai/xybrid/labels/good%20first%20issue) label — these are scoped to be self-contained, with clear acceptance criteria and no platform-internals knowledge required.
+
+Issues are also grouped by area so you can find ones that match your interest:
+
+- [`area: core`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20core) — `xybrid-core` (execution, audio, runtime adapters)
+- [`area: sdk`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20sdk) — `xybrid-sdk` (registry client, high-level Rust API)
+- [`area: examples`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20examples) — example apps and runnable demos
+- [`area: bindings`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20bindings) — Flutter, Kotlin, Swift, Unity bindings
+- [`area: tests`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20tests) — test coverage and the test harness
+
+Medium-difficulty tasks are labeled [`help wanted`](https://github.com/xybrid-ai/xybrid/labels/help%20wanted). If you want to claim an issue, leave a comment so we can avoid duplicate work — no formal assignment process is needed.
+
 ## Prerequisites
 
 - **Rust** 1.75+ with `cargo` ([rustup.rs](https://rustup.rs))

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 
 We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on setting up your development environment, submitting pull requests, and adding new models.
 
+**New here?** Browse the [`good first issue`](https://github.com/xybrid-ai/xybrid/labels/good%20first%20issue) label for small, self-contained tasks. Tasks are also grouped by area: [`area: core`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20core), [`area: sdk`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20sdk), [`area: examples`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20examples), [`area: bindings`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20bindings), [`area: tests`](https://github.com/xybrid-ai/xybrid/labels/area%3A%20tests). Medium-difficulty tasks live under [`help wanted`](https://github.com/xybrid-ai/xybrid/labels/help%20wanted).
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=xybrid-ai/xybrid&type=date&legend=bottom-right)](https://www.star-history.com/#xybrid-ai/xybrid&type=date&legend=bottom-right)


### PR DESCRIPTION
## Summary
- Adds a **Where to start** section to `CONTRIBUTING.md` linking the [`good first issue`](https://github.com/xybrid-ai/xybrid/labels/good%20first%20issue) label, the per-area labels (`area: core` / `sdk` / `examples` / `bindings` / `tests`), and the [`help wanted`](https://github.com/xybrid-ai/xybrid/labels/help%20wanted) label for medium-difficulty tasks.
- Adds a one-line hook to the README's Contributing section pointing at the same labels so newcomers can find the curated backlog from the landing page.

Pairs with the 5 issues just filed under `good first issue` (#125–#129).

## Test plan
- [ ] Render preview on GitHub shows label links resolve and badges look right.