### PR TITLE
feat(flutter): expose InferenceMetrics on Dart XybridResult (INF-15 PR-C)

### DIFF
--- a/bindings/flutter/lib/src/result.dart
+++ b/bindings/flutter/lib/src/result.dart
@@ -9,6 +9,59 @@ import 'dart:typed_data';
 import 'rust/api/result.dart';
 import 'utils/audio.dart';
 
+/// Per-stage latency entry for pipeline runs.
+///
+/// One entry per executed stage; the [stageId] matches the stage name in
+/// the pipeline definition.
+class XybridStageLatency {
+  XybridStageLatency.fromFfi(FfiStageLatency inner)
+      : stageId = inner.stageId,
+        latencyMs = inner.latencyMs;
+
+  final String stageId;
+  final int latencyMs;
+}
+
+/// Typed inference metrics surfaced on every [XybridResult].
+///
+/// LLM-specific fields ([ttftMs], [tokensPerSecond], [prefillTps],
+/// [decodeTps], [tokensOut]) are `null` for ASR/TTS/embedding runs.
+/// [stageLatenciesMs] is empty for `model.run()` and populated for
+/// `pipeline.run()`.
+class XybridInferenceMetrics {
+  XybridInferenceMetrics.fromFfi(FfiInferenceMetrics inner)
+      : totalMs = inner.totalMs,
+        ttftMs = inner.ttftMs,
+        tokensPerSecond = inner.tokensPerSecond,
+        prefillTps = inner.prefillTps,
+        decodeTps = inner.decodeTps,
+        tokensOut = inner.tokensOut,
+        stageLatenciesMs = inner.stageLatenciesMs
+            .map(XybridStageLatency.fromFfi)
+            .toList(growable: false);
+
+  /// Wall-clock latency in ms (mirrors [XybridResult.latencyMs]).
+  final int totalMs;
+
+  /// Time to first token, ms. LLM streaming only.
+  final int? ttftMs;
+
+  /// Generation throughput, tokens/sec. LLM only.
+  final double? tokensPerSecond;
+
+  /// Prefill phase tok/s. LLM only.
+  final double? prefillTps;
+
+  /// Decode phase tok/s. LLM only.
+  final double? decodeTps;
+
+  /// Completion tokens produced. LLM only.
+  final int? tokensOut;
+
+  /// Per-stage wall-clock latencies. Empty for single-model runs.
+  final List<XybridStageLatency> stageLatenciesMs;
+}
+
 /// Result of a model inference operation.
 ///
 /// Access the output using the appropriate getter based on model type:
@@ -65,4 +118,11 @@ class XybridResult {
 
   /// Inference latency in milliseconds.
   int get latencyMs => _inner.latencyMs;
+
+  /// Typed metrics for this run (TTFT, tok/s, per-stage latencies, etc.).
+  ///
+  /// LLM-specific fields are null for ASR/TTS/embedding runs;
+  /// `stageLatenciesMs` is empty for single-model runs.
+  XybridInferenceMetrics get metrics =>
+      XybridInferenceMetrics.fromFfi(_inner.metrics);
 }

--- a/bindings/flutter/lib/src/result.dart
+++ b/bindings/flutter/lib/src/result.dart
@@ -25,7 +25,11 @@ class XybridStageLatency {
 /// Typed inference metrics surfaced on every [XybridResult].
 ///
 /// LLM-specific fields ([ttftMs], [tokensPerSecond], [prefillTps],
-/// [decodeTps], [tokensOut]) are `null` for ASR/TTS/embedding runs.
+/// [decodeTps], [tokensOut]) are `null` for ASR/TTS/embedding runs. For
+/// pipeline runs they are parsed from the **final** stage envelope only,
+/// so they are also `null` when the final stage isn't the LLM (e.g. an
+/// `ASR → LLM → TTS` pipeline).
+///
 /// [stageLatenciesMs] is empty for `model.run()` and populated for
 /// `pipeline.run()`.
 class XybridInferenceMetrics {
@@ -123,6 +127,6 @@ class XybridResult {
   ///
   /// LLM-specific fields are null for ASR/TTS/embedding runs;
   /// `stageLatenciesMs` is empty for single-model runs.
-  XybridInferenceMetrics get metrics =>
+  late final XybridInferenceMetrics metrics =
       XybridInferenceMetrics.fromFfi(_inner.metrics);
 }

--- a/bindings/flutter/lib/src/rust/api/pipeline.dart
+++ b/bindings/flutter/lib/src/rust/api/pipeline.dart
@@ -42,6 +42,14 @@ abstract class FfiPipeline implements RustOpaqueInterface {
   /// Execute the pipeline with the given input envelope.
   ///
   /// Returns the inference result from the final stage.
+  ///
+  /// LLM-specific metric fields (`ttft_ms`, `tokens_per_second`,
+  /// `prefill_tps`, `decode_tps`, `tokens_out`) are parsed from the
+  /// **final** stage envelope's metadata, so they are `None` whenever the
+  /// final stage isn't the LLM — e.g. an `ASR → LLM → TTS` pipeline
+  /// produces a TTS envelope and the LLM metrics are not surfaced here.
+  /// Hoisting them from intermediate stages is a follow-up at the SDK
+  /// layer.
   Future<FfiResult> run({required FfiEnvelope envelope});
 
   /// Get the number of stages in the pipeline.

--- a/bindings/flutter/lib/src/rust/api/result.dart
+++ b/bindings/flutter/lib/src/rust/api/result.dart
@@ -10,8 +10,56 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `from_inference_result`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`
+// These functions are ignored because they are not marked as `pub`: `from_core`, `from_core`, `from_inference_result`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`
+
+/// Typed inference metrics.
+///
+/// Mirrors `xybrid_sdk::InferenceMetrics`. LLM-specific fields are `None`
+/// for ASR/TTS/embedding runs. `stage_latencies_ms` is empty for
+/// `model.run()` and populated for `pipeline.run()`.
+class FfiInferenceMetrics {
+  final int totalMs;
+  final int? ttftMs;
+  final double? tokensPerSecond;
+  final double? prefillTps;
+  final double? decodeTps;
+  final int? tokensOut;
+  final List<FfiStageLatency> stageLatenciesMs;
+
+  const FfiInferenceMetrics({
+    required this.totalMs,
+    this.ttftMs,
+    this.tokensPerSecond,
+    this.prefillTps,
+    this.decodeTps,
+    this.tokensOut,
+    required this.stageLatenciesMs,
+  });
+
+  @override
+  int get hashCode =>
+      totalMs.hashCode ^
+      ttftMs.hashCode ^
+      tokensPerSecond.hashCode ^
+      prefillTps.hashCode ^
+      decodeTps.hashCode ^
+      tokensOut.hashCode ^
+      stageLatenciesMs.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FfiInferenceMetrics &&
+          runtimeType == other.runtimeType &&
+          totalMs == other.totalMs &&
+          ttftMs == other.ttftMs &&
+          tokensPerSecond == other.tokensPerSecond &&
+          prefillTps == other.prefillTps &&
+          decodeTps == other.decodeTps &&
+          tokensOut == other.tokensOut &&
+          stageLatenciesMs == other.stageLatenciesMs;
+}
 
 /// FFI wrapper for inference results.
 /// Fields are public and accessible directly via FRB-generated bindings.
@@ -21,6 +69,7 @@ class FfiResult {
   final Uint8List? audioBytes;
   final Float32List? embedding;
   final int latencyMs;
+  final FfiInferenceMetrics metrics;
 
   const FfiResult({
     required this.success,
@@ -28,6 +77,7 @@ class FfiResult {
     this.audioBytes,
     this.embedding,
     required this.latencyMs,
+    required this.metrics,
   });
 
   @override
@@ -36,7 +86,8 @@ class FfiResult {
       text.hashCode ^
       audioBytes.hashCode ^
       embedding.hashCode ^
-      latencyMs.hashCode;
+      latencyMs.hashCode ^
+      metrics.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -47,5 +98,31 @@ class FfiResult {
           text == other.text &&
           audioBytes == other.audioBytes &&
           embedding == other.embedding &&
+          latencyMs == other.latencyMs &&
+          metrics == other.metrics;
+}
+
+/// Per-stage latency entry for pipeline runs.
+///
+/// Mirrors `xybrid_sdk::StageLatency`. One entry per executed stage; the
+/// `stage_id` matches the stage name in the pipeline definition.
+class FfiStageLatency {
+  final String stageId;
+  final int latencyMs;
+
+  const FfiStageLatency({
+    required this.stageId,
+    required this.latencyMs,
+  });
+
+  @override
+  int get hashCode => stageId.hashCode ^ latencyMs.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FfiStageLatency &&
+          runtimeType == other.runtimeType &&
+          stageId == other.stageId &&
           latencyMs == other.latencyMs;
 }

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -3990,6 +3990,14 @@ class FfiPipelineImpl extends RustOpaque implements FfiPipeline {
   /// Execute the pipeline with the given input envelope.
   ///
   /// Returns the inference result from the final stage.
+  ///
+  /// LLM-specific metric fields (`ttft_ms`, `tokens_per_second`,
+  /// `prefill_tps`, `decode_tps`, `tokens_out`) are parsed from the
+  /// **final** stage envelope's metadata, so they are `None` whenever the
+  /// final stage isn't the LLM — e.g. an `ASR → LLM → TTS` pipeline
+  /// produces a TTS envelope and the LLM metrics are not surfaced here.
+  /// Hoisting them from intermediate stages is a follow-up at the SDK
+  /// layer.
   Future<FfiResult> run({required FfiEnvelope envelope}) =>
       XybridRustLib.instance.api
           .crateApiPipelineFfiPipelineRun(that: this, envelope: envelope);

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -2065,6 +2065,23 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  FfiInferenceMetrics dco_decode_ffi_inference_metrics(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return FfiInferenceMetrics(
+      totalMs: dco_decode_u_32(arr[0]),
+      ttftMs: dco_decode_opt_box_autoadd_u_32(arr[1]),
+      tokensPerSecond: dco_decode_opt_box_autoadd_f_32(arr[2]),
+      prefillTps: dco_decode_opt_box_autoadd_f_32(arr[3]),
+      decodeTps: dco_decode_opt_box_autoadd_f_32(arr[4]),
+      tokensOut: dco_decode_opt_box_autoadd_u_32(arr[5]),
+      stageLatenciesMs: dco_decode_list_ffi_stage_latency(arr[6]),
+    );
+  }
+
+  @protected
   FfiLoadEvent dco_decode_ffi_load_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
@@ -2117,14 +2134,15 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   FfiResult dco_decode_ffi_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 6)
+      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return FfiResult(
       success: dco_decode_bool(arr[0]),
       text: dco_decode_opt_String(arr[1]),
       audioBytes: dco_decode_opt_list_prim_u_8_strict(arr[2]),
       embedding: dco_decode_opt_list_prim_f_32_strict(arr[3]),
       latencyMs: dco_decode_u_32(arr[4]),
+      metrics: dco_decode_ffi_inference_metrics(arr[5]),
     );
   }
 
@@ -2143,6 +2161,18 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       abortOnThermalCritical: dco_decode_bool(arr[5]),
       fallbackToCloud: dco_decode_bool(arr[6]),
       maxGraceTokens: dco_decode_opt_box_autoadd_u_32(arr[7]),
+    );
+  }
+
+  @protected
+  FfiStageLatency dco_decode_ffi_stage_latency(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return FfiStageLatency(
+      stageId: dco_decode_String(arr[0]),
+      latencyMs: dco_decode_u_32(arr[1]),
     );
   }
 
@@ -2204,6 +2234,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   List<String> dco_decode_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_String).toList();
+  }
+
+  @protected
+  List<FfiStageLatency> dco_decode_list_ffi_stage_latency(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_ffi_stage_latency).toList();
   }
 
   @protected
@@ -2632,6 +2668,27 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  FfiInferenceMetrics sse_decode_ffi_inference_metrics(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_totalMs = sse_decode_u_32(deserializer);
+    var var_ttftMs = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_tokensPerSecond = sse_decode_opt_box_autoadd_f_32(deserializer);
+    var var_prefillTps = sse_decode_opt_box_autoadd_f_32(deserializer);
+    var var_decodeTps = sse_decode_opt_box_autoadd_f_32(deserializer);
+    var var_tokensOut = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_stageLatenciesMs = sse_decode_list_ffi_stage_latency(deserializer);
+    return FfiInferenceMetrics(
+        totalMs: var_totalMs,
+        ttftMs: var_ttftMs,
+        tokensPerSecond: var_tokensPerSecond,
+        prefillTps: var_prefillTps,
+        decodeTps: var_decodeTps,
+        tokensOut: var_tokensOut,
+        stageLatenciesMs: var_stageLatenciesMs);
+  }
+
+  @protected
   FfiLoadEvent sse_decode_ffi_load_event(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
 
@@ -2696,12 +2753,14 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     var var_audioBytes = sse_decode_opt_list_prim_u_8_strict(deserializer);
     var var_embedding = sse_decode_opt_list_prim_f_32_strict(deserializer);
     var var_latencyMs = sse_decode_u_32(deserializer);
+    var var_metrics = sse_decode_ffi_inference_metrics(deserializer);
     return FfiResult(
         success: var_success,
         text: var_text,
         audioBytes: var_audioBytes,
         embedding: var_embedding,
-        latencyMs: var_latencyMs);
+        latencyMs: var_latencyMs,
+        metrics: var_metrics);
   }
 
   @protected
@@ -2724,6 +2783,14 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         abortOnThermalCritical: var_abortOnThermalCritical,
         fallbackToCloud: var_fallbackToCloud,
         maxGraceTokens: var_maxGraceTokens);
+  }
+
+  @protected
+  FfiStageLatency sse_decode_ffi_stage_latency(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_stageId = sse_decode_String(deserializer);
+    var var_latencyMs = sse_decode_u_32(deserializer);
+    return FfiStageLatency(stageId: var_stageId, latencyMs: var_latencyMs);
   }
 
   @protected
@@ -2789,6 +2856,19 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     var ans_ = <String>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<FfiStageLatency> sse_decode_list_ffi_stage_latency(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <FfiStageLatency>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_ffi_stage_latency(deserializer));
     }
     return ans_;
   }
@@ -3294,6 +3374,19 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   }
 
   @protected
+  void sse_encode_ffi_inference_metrics(
+      FfiInferenceMetrics self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.totalMs, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.ttftMs, serializer);
+    sse_encode_opt_box_autoadd_f_32(self.tokensPerSecond, serializer);
+    sse_encode_opt_box_autoadd_f_32(self.prefillTps, serializer);
+    sse_encode_opt_box_autoadd_f_32(self.decodeTps, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.tokensOut, serializer);
+    sse_encode_list_ffi_stage_latency(self.stageLatenciesMs, serializer);
+  }
+
+  @protected
   void sse_encode_ffi_load_event(FfiLoadEvent self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     switch (self) {
@@ -3344,6 +3437,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_opt_list_prim_u_8_strict(self.audioBytes, serializer);
     sse_encode_opt_list_prim_f_32_strict(self.embedding, serializer);
     sse_encode_u_32(self.latencyMs, serializer);
+    sse_encode_ffi_inference_metrics(self.metrics, serializer);
   }
 
   @protected
@@ -3358,6 +3452,14 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_bool(self.abortOnThermalCritical, serializer);
     sse_encode_bool(self.fallbackToCloud, serializer);
     sse_encode_opt_box_autoadd_u_32(self.maxGraceTokens, serializer);
+  }
+
+  @protected
+  void sse_encode_ffi_stage_latency(
+      FfiStageLatency self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.stageId, serializer);
+    sse_encode_u_32(self.latencyMs, serializer);
   }
 
   @protected
@@ -3413,6 +3515,16 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_String(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_ffi_stage_latency(
+      List<FfiStageLatency> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_ffi_stage_latency(item, serializer);
     }
   }
 

--- a/bindings/flutter/lib/src/rust/frb_generated.io.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.io.dart
@@ -208,6 +208,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiGenerationConfig dco_decode_ffi_generation_config(dynamic raw);
 
   @protected
+  FfiInferenceMetrics dco_decode_ffi_inference_metrics(dynamic raw);
+
+  @protected
   FfiLoadEvent dco_decode_ffi_load_event(dynamic raw);
 
   @protected
@@ -226,6 +229,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiRunOptions dco_decode_ffi_run_options(dynamic raw);
 
   @protected
+  FfiStageLatency dco_decode_ffi_stage_latency(dynamic raw);
+
+  @protected
   FfiStreamEvent dco_decode_ffi_stream_event(dynamic raw);
 
   @protected
@@ -242,6 +248,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<FfiStageLatency> dco_decode_list_ffi_stage_latency(dynamic raw);
 
   @protected
   List<double> dco_decode_list_prim_f_32_loose(dynamic raw);
@@ -461,6 +470,10 @@ abstract class XybridRustLibApiImplPlatform
       SseDeserializer deserializer);
 
   @protected
+  FfiInferenceMetrics sse_decode_ffi_inference_metrics(
+      SseDeserializer deserializer);
+
+  @protected
   FfiLoadEvent sse_decode_ffi_load_event(SseDeserializer deserializer);
 
   @protected
@@ -481,6 +494,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiRunOptions sse_decode_ffi_run_options(SseDeserializer deserializer);
 
   @protected
+  FfiStageLatency sse_decode_ffi_stage_latency(SseDeserializer deserializer);
+
+  @protected
   FfiStreamEvent sse_decode_ffi_stream_event(SseDeserializer deserializer);
 
   @protected
@@ -497,6 +513,10 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<FfiStageLatency> sse_decode_list_ffi_stage_latency(
+      SseDeserializer deserializer);
 
   @protected
   List<double> sse_decode_list_prim_f_32_loose(SseDeserializer deserializer);
@@ -721,6 +741,10 @@ abstract class XybridRustLibApiImplPlatform
       FfiGenerationConfig self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_inference_metrics(
+      FfiInferenceMetrics self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_load_event(FfiLoadEvent self, SseSerializer serializer);
 
   @protected
@@ -742,6 +766,10 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_ffi_run_options(FfiRunOptions self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_stage_latency(
+      FfiStageLatency self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_stream_event(
       FfiStreamEvent self, SseSerializer serializer);
 
@@ -761,6 +789,10 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_ffi_stage_latency(
+      List<FfiStageLatency> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_f_32_loose(

--- a/bindings/flutter/lib/src/rust/frb_generated.web.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.web.dart
@@ -210,6 +210,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiGenerationConfig dco_decode_ffi_generation_config(dynamic raw);
 
   @protected
+  FfiInferenceMetrics dco_decode_ffi_inference_metrics(dynamic raw);
+
+  @protected
   FfiLoadEvent dco_decode_ffi_load_event(dynamic raw);
 
   @protected
@@ -228,6 +231,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiRunOptions dco_decode_ffi_run_options(dynamic raw);
 
   @protected
+  FfiStageLatency dco_decode_ffi_stage_latency(dynamic raw);
+
+  @protected
   FfiStreamEvent dco_decode_ffi_stream_event(dynamic raw);
 
   @protected
@@ -244,6 +250,9 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<FfiStageLatency> dco_decode_list_ffi_stage_latency(dynamic raw);
 
   @protected
   List<double> dco_decode_list_prim_f_32_loose(dynamic raw);
@@ -463,6 +472,10 @@ abstract class XybridRustLibApiImplPlatform
       SseDeserializer deserializer);
 
   @protected
+  FfiInferenceMetrics sse_decode_ffi_inference_metrics(
+      SseDeserializer deserializer);
+
+  @protected
   FfiLoadEvent sse_decode_ffi_load_event(SseDeserializer deserializer);
 
   @protected
@@ -483,6 +496,9 @@ abstract class XybridRustLibApiImplPlatform
   FfiRunOptions sse_decode_ffi_run_options(SseDeserializer deserializer);
 
   @protected
+  FfiStageLatency sse_decode_ffi_stage_latency(SseDeserializer deserializer);
+
+  @protected
   FfiStreamEvent sse_decode_ffi_stream_event(SseDeserializer deserializer);
 
   @protected
@@ -499,6 +515,10 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<FfiStageLatency> sse_decode_list_ffi_stage_latency(
+      SseDeserializer deserializer);
 
   @protected
   List<double> sse_decode_list_prim_f_32_loose(SseDeserializer deserializer);
@@ -723,6 +743,10 @@ abstract class XybridRustLibApiImplPlatform
       FfiGenerationConfig self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_inference_metrics(
+      FfiInferenceMetrics self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_load_event(FfiLoadEvent self, SseSerializer serializer);
 
   @protected
@@ -744,6 +768,10 @@ abstract class XybridRustLibApiImplPlatform
   void sse_encode_ffi_run_options(FfiRunOptions self, SseSerializer serializer);
 
   @protected
+  void sse_encode_ffi_stage_latency(
+      FfiStageLatency self, SseSerializer serializer);
+
+  @protected
   void sse_encode_ffi_stream_event(
       FfiStreamEvent self, SseSerializer serializer);
 
@@ -763,6 +791,10 @@ abstract class XybridRustLibApiImplPlatform
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_ffi_stage_latency(
+      List<FfiStageLatency> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_prim_f_32_loose(

--- a/bindings/flutter/rust/src/api/pipeline.rs
+++ b/bindings/flutter/rust/src/api/pipeline.rs
@@ -45,16 +45,48 @@ impl FfiPipeline {
     ///
     /// Returns the inference result from the final stage.
     pub fn run(&self, envelope: FfiEnvelope) -> Result<FfiResult, String> {
+        use xybrid_sdk::InferenceMetrics;
+
         let input = envelope.into_envelope();
         let result = self.0.run(&input).map_err(|e| e.to_string())?;
 
-        // Convert PipelineExecutionResult to FfiResult
+        // Build typed metrics from the final envelope's metadata and the
+        // per-stage timings recorded by the pipeline. LLM-specific fields
+        // fall out of `InferenceMetrics::from_metadata` automatically;
+        // stage latencies come from `result.stages`.
+        let mut metrics =
+            InferenceMetrics::from_metadata(&result.output.metadata, result.total_latency_ms);
+        metrics.stage_latencies_ms = result
+            .stages
+            .iter()
+            .map(|s| xybrid_sdk::StageLatency {
+                stage_id: s.name.clone(),
+                latency_ms: s.latency_ms,
+            })
+            .collect();
+
         Ok(FfiResult {
             success: true,
             text: result.text().map(|s| s.to_string()),
             audio_bytes: result.audio_bytes().map(|b| b.to_vec()),
             embedding: result.embedding().map(|e| e.to_vec()),
             latency_ms: result.total_latency_ms,
+            metrics: crate::api::result::FfiInferenceMetrics {
+                total_ms: metrics.total_ms,
+                ttft_ms: metrics.ttft_ms,
+                tokens_per_second: metrics.tokens_per_second,
+                prefill_tps: metrics.prefill_tps,
+                decode_tps: metrics.decode_tps,
+                tokens_out: metrics.tokens_out,
+                stage_latencies_ms: metrics
+                    .stage_latencies_ms
+                    .into_iter()
+                    .map(|s| crate::api::result::FfiStageLatency {
+                        stage_id: s.stage_id,
+                        latency_ms: s.latency_ms,
+                    })
+                    .collect(),
+            },
         })
     }
 

--- a/bindings/flutter/rust/src/api/pipeline.rs
+++ b/bindings/flutter/rust/src/api/pipeline.rs
@@ -44,16 +44,20 @@ impl FfiPipeline {
     /// Execute the pipeline with the given input envelope.
     ///
     /// Returns the inference result from the final stage.
+    ///
+    /// LLM-specific metric fields (`ttft_ms`, `tokens_per_second`,
+    /// `prefill_tps`, `decode_tps`, `tokens_out`) are parsed from the
+    /// **final** stage envelope's metadata, so they are `None` whenever the
+    /// final stage isn't the LLM — e.g. an `ASR → LLM → TTS` pipeline
+    /// produces a TTS envelope and the LLM metrics are not surfaced here.
+    /// Hoisting them from intermediate stages is a follow-up at the SDK
+    /// layer.
     pub fn run(&self, envelope: FfiEnvelope) -> Result<FfiResult, String> {
         use xybrid_sdk::InferenceMetrics;
 
         let input = envelope.into_envelope();
         let result = self.0.run(&input).map_err(|e| e.to_string())?;
 
-        // Build typed metrics from the final envelope's metadata and the
-        // per-stage timings recorded by the pipeline. LLM-specific fields
-        // fall out of `InferenceMetrics::from_metadata` automatically;
-        // stage latencies come from `result.stages`.
         let mut metrics =
             InferenceMetrics::from_metadata(&result.output.metadata, result.total_latency_ms);
         metrics.stage_latencies_ms = result
@@ -71,22 +75,7 @@ impl FfiPipeline {
             audio_bytes: result.audio_bytes().map(|b| b.to_vec()),
             embedding: result.embedding().map(|e| e.to_vec()),
             latency_ms: result.total_latency_ms,
-            metrics: crate::api::result::FfiInferenceMetrics {
-                total_ms: metrics.total_ms,
-                ttft_ms: metrics.ttft_ms,
-                tokens_per_second: metrics.tokens_per_second,
-                prefill_tps: metrics.prefill_tps,
-                decode_tps: metrics.decode_tps,
-                tokens_out: metrics.tokens_out,
-                stage_latencies_ms: metrics
-                    .stage_latencies_ms
-                    .into_iter()
-                    .map(|s| crate::api::result::FfiStageLatency {
-                        stage_id: s.stage_id,
-                        latency_ms: s.latency_ms,
-                    })
-                    .collect(),
-            },
+            metrics: crate::api::result::FfiInferenceMetrics::from_core(&metrics),
         })
     }
 

--- a/bindings/flutter/rust/src/api/result.rs
+++ b/bindings/flutter/rust/src/api/result.rs
@@ -1,5 +1,58 @@
 //! Inference result FFI wrappers for Flutter.
-use xybrid_sdk::InferenceResult;
+use xybrid_sdk::{InferenceMetrics, InferenceResult, StageLatency};
+
+/// Per-stage latency entry for pipeline runs.
+///
+/// Mirrors `xybrid_sdk::StageLatency`. One entry per executed stage; the
+/// `stage_id` matches the stage name in the pipeline definition.
+#[derive(Clone)]
+pub struct FfiStageLatency {
+    pub stage_id: String,
+    pub latency_ms: u32,
+}
+
+impl FfiStageLatency {
+    fn from_core(s: &StageLatency) -> Self {
+        Self {
+            stage_id: s.stage_id.clone(),
+            latency_ms: s.latency_ms,
+        }
+    }
+}
+
+/// Typed inference metrics.
+///
+/// Mirrors `xybrid_sdk::InferenceMetrics`. LLM-specific fields are `None`
+/// for ASR/TTS/embedding runs. `stage_latencies_ms` is empty for
+/// `model.run()` and populated for `pipeline.run()`.
+#[derive(Clone)]
+pub struct FfiInferenceMetrics {
+    pub total_ms: u32,
+    pub ttft_ms: Option<u32>,
+    pub tokens_per_second: Option<f32>,
+    pub prefill_tps: Option<f32>,
+    pub decode_tps: Option<f32>,
+    pub tokens_out: Option<u32>,
+    pub stage_latencies_ms: Vec<FfiStageLatency>,
+}
+
+impl FfiInferenceMetrics {
+    fn from_core(m: &InferenceMetrics) -> Self {
+        Self {
+            total_ms: m.total_ms,
+            ttft_ms: m.ttft_ms,
+            tokens_per_second: m.tokens_per_second,
+            prefill_tps: m.prefill_tps,
+            decode_tps: m.decode_tps,
+            tokens_out: m.tokens_out,
+            stage_latencies_ms: m
+                .stage_latencies_ms
+                .iter()
+                .map(FfiStageLatency::from_core)
+                .collect(),
+        }
+    }
+}
 
 /// FFI wrapper for inference results.
 /// Fields are public and accessible directly via FRB-generated bindings.
@@ -10,6 +63,7 @@ pub struct FfiResult {
     pub audio_bytes: Option<Vec<u8>>,
     pub embedding: Option<Vec<f32>>,
     pub latency_ms: u32,
+    pub metrics: FfiInferenceMetrics,
 }
 
 impl FfiResult {
@@ -20,6 +74,7 @@ impl FfiResult {
             audio_bytes: r.audio_bytes().map(|b| b.to_vec()),
             embedding: r.embedding().map(|e| e.to_vec()),
             latency_ms: r.latency_ms(),
+            metrics: FfiInferenceMetrics::from_core(r.metrics()),
         }
     }
 }

--- a/bindings/flutter/rust/src/api/result.rs
+++ b/bindings/flutter/rust/src/api/result.rs
@@ -12,7 +12,7 @@ pub struct FfiStageLatency {
 }
 
 impl FfiStageLatency {
-    fn from_core(s: &StageLatency) -> Self {
+    pub(crate) fn from_core(s: &StageLatency) -> Self {
         Self {
             stage_id: s.stage_id.clone(),
             latency_ms: s.latency_ms,
@@ -37,7 +37,7 @@ pub struct FfiInferenceMetrics {
 }
 
 impl FfiInferenceMetrics {
-    fn from_core(m: &InferenceMetrics) -> Self {
+    pub(crate) fn from_core(m: &InferenceMetrics) -> Self {
         Self {
             total_ms: m.total_ms,
             ttft_ms: m.ttft_ms,

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -2483,6 +2483,29 @@ impl SseDecode for crate::api::model::FfiGenerationConfig {
     }
 }
 
+impl SseDecode for crate::api::result::FfiInferenceMetrics {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_totalMs = <u32>::sse_decode(deserializer);
+        let mut var_ttftMs = <Option<u32>>::sse_decode(deserializer);
+        let mut var_tokensPerSecond = <Option<f32>>::sse_decode(deserializer);
+        let mut var_prefillTps = <Option<f32>>::sse_decode(deserializer);
+        let mut var_decodeTps = <Option<f32>>::sse_decode(deserializer);
+        let mut var_tokensOut = <Option<u32>>::sse_decode(deserializer);
+        let mut var_stageLatenciesMs =
+            <Vec<crate::api::result::FfiStageLatency>>::sse_decode(deserializer);
+        return crate::api::result::FfiInferenceMetrics {
+            total_ms: var_totalMs,
+            ttft_ms: var_ttftMs,
+            tokens_per_second: var_tokensPerSecond,
+            prefill_tps: var_prefillTps,
+            decode_tps: var_decodeTps,
+            tokens_out: var_tokensOut,
+            stage_latencies_ms: var_stageLatenciesMs,
+        };
+    }
+}
+
 impl SseDecode for crate::api::model::FfiLoadEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2566,12 +2589,14 @@ impl SseDecode for crate::api::result::FfiResult {
         let mut var_audioBytes = <Option<Vec<u8>>>::sse_decode(deserializer);
         let mut var_embedding = <Option<Vec<f32>>>::sse_decode(deserializer);
         let mut var_latencyMs = <u32>::sse_decode(deserializer);
+        let mut var_metrics = <crate::api::result::FfiInferenceMetrics>::sse_decode(deserializer);
         return crate::api::result::FfiResult {
             success: var_success,
             text: var_text,
             audio_bytes: var_audioBytes,
             embedding: var_embedding,
             latency_ms: var_latencyMs,
+            metrics: var_metrics,
         };
     }
 }
@@ -2596,6 +2621,18 @@ impl SseDecode for crate::api::model::FfiRunOptions {
             abort_on_thermal_critical: var_abortOnThermalCritical,
             fallback_to_cloud: var_fallbackToCloud,
             max_grace_tokens: var_maxGraceTokens,
+        };
+    }
+}
+
+impl SseDecode for crate::api::result::FfiStageLatency {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_stageId = <String>::sse_decode(deserializer);
+        let mut var_latencyMs = <u32>::sse_decode(deserializer);
+        return crate::api::result::FfiStageLatency {
+            stage_id: var_stageId,
+            latency_ms: var_latencyMs,
         };
     }
 }
@@ -2677,6 +2714,20 @@ impl SseDecode for Vec<String> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<String>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::result::FfiStageLatency> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::result::FfiStageLatency>::sse_decode(
+                deserializer,
+            ));
         }
         return ans_;
     }
@@ -3215,6 +3266,32 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::model::FfiGenerationConfig>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::result::FfiInferenceMetrics {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.total_ms.into_into_dart().into_dart(),
+            self.ttft_ms.into_into_dart().into_dart(),
+            self.tokens_per_second.into_into_dart().into_dart(),
+            self.prefill_tps.into_into_dart().into_dart(),
+            self.decode_tps.into_into_dart().into_dart(),
+            self.tokens_out.into_into_dart().into_dart(),
+            self.stage_latencies_ms.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::result::FfiInferenceMetrics
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::result::FfiInferenceMetrics>
+    for crate::api::result::FfiInferenceMetrics
+{
+    fn into_into_dart(self) -> crate::api::result::FfiInferenceMetrics {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::model::FfiLoadEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -3323,6 +3400,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::result::FfiResult {
             self.audio_bytes.into_into_dart().into_dart(),
             self.embedding.into_into_dart().into_dart(),
             self.latency_ms.into_into_dart().into_dart(),
+            self.metrics.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -3361,6 +3439,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::model::FfiRunOptions>
     for crate::api::model::FfiRunOptions
 {
     fn into_into_dart(self) -> crate::api::model::FfiRunOptions {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::result::FfiStageLatency {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.stage_id.into_into_dart().into_dart(),
+            self.latency_ms.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::result::FfiStageLatency
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::result::FfiStageLatency>
+    for crate::api::result::FfiStageLatency
+{
+    fn into_into_dart(self) -> crate::api::result::FfiStageLatency {
         self
     }
 }
@@ -3641,6 +3740,19 @@ impl SseEncode for crate::api::model::FfiGenerationConfig {
     }
 }
 
+impl SseEncode for crate::api::result::FfiInferenceMetrics {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.total_ms, serializer);
+        <Option<u32>>::sse_encode(self.ttft_ms, serializer);
+        <Option<f32>>::sse_encode(self.tokens_per_second, serializer);
+        <Option<f32>>::sse_encode(self.prefill_tps, serializer);
+        <Option<f32>>::sse_encode(self.decode_tps, serializer);
+        <Option<u32>>::sse_encode(self.tokens_out, serializer);
+        <Vec<crate::api::result::FfiStageLatency>>::sse_encode(self.stage_latencies_ms, serializer);
+    }
+}
+
 impl SseEncode for crate::api::model::FfiLoadEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3720,6 +3832,7 @@ impl SseEncode for crate::api::result::FfiResult {
         <Option<Vec<u8>>>::sse_encode(self.audio_bytes, serializer);
         <Option<Vec<f32>>>::sse_encode(self.embedding, serializer);
         <u32>::sse_encode(self.latency_ms, serializer);
+        <crate::api::result::FfiInferenceMetrics>::sse_encode(self.metrics, serializer);
     }
 }
 
@@ -3734,6 +3847,14 @@ impl SseEncode for crate::api::model::FfiRunOptions {
         <bool>::sse_encode(self.abort_on_thermal_critical, serializer);
         <bool>::sse_encode(self.fallback_to_cloud, serializer);
         <Option<u32>>::sse_encode(self.max_grace_tokens, serializer);
+    }
+}
+
+impl SseEncode for crate::api::result::FfiStageLatency {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.stage_id, serializer);
+        <u32>::sse_encode(self.latency_ms, serializer);
     }
 }
 
@@ -3809,6 +3930,16 @@ impl SseEncode for Vec<String> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <String>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::result::FfiStageLatency> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::result::FfiStageLatency>::sse_encode(item, serializer);
         }
     }
 }

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -890,10 +890,10 @@ public sealed class StageLatency
 | `modelId` | — | — | — | ✅ |
 | `isFailure` | ✅ | ✅ | ✅ | ✅ |
 | `audioAsWav()` | ✅ | — | — | — |
-| `metrics` | — | ✅ | ✅ | — |
-| `metrics.ttftMs` | — | ✅ | ✅ | — |
-| `metrics.tokensPerSecond` | — | ✅ | ✅ | — |
-| `metrics.stageLatenciesMs` | — | ✅ | ✅ | — |
+| `metrics` | ✅ | ✅ | ✅ | — |
+| `metrics.ttftMs` | ✅ | ✅ | ✅ | — |
+| `metrics.tokensPerSecond` | ✅ | ✅ | ✅ | — |
+| `metrics.stageLatenciesMs` | ✅ | ✅ | ✅ | — |
 
 ---
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -353,7 +353,7 @@ classes:
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
       metrics:
         type: InferenceMetrics
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
 
   InferenceMetrics:
     type: data
@@ -365,25 +365,25 @@ classes:
     properties:
       totalMs:
         type: int
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       ttftMs:
         type: "int?"
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       tokensPerSecond:
         type: "double?"
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       prefillTps:
         type: "double?"
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       decodeTps:
         type: "double?"
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       tokensOut:
         type: "int?"
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       stageLatenciesMs:
         type: "List<StageLatency>"
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
 
   StageLatency:
     type: data
@@ -395,10 +395,10 @@ classes:
     properties:
       stageId:
         type: String
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       latencyMs:
         type: int
-        status: { dart: planned, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
 
   # -------------------------------------------------------------------
   # 8. Supporting Types


### PR DESCRIPTION
## Summary

PR-C of the INF-15 binding-propagation series. Builds on the typed `InferenceMetrics` landed in [PR-A (#120)](https://github.com/xybrid-ai/xybrid/pull/120) and the UniFFI Kotlin/Swift surfacing in [PR-B (#131)](https://github.com/xybrid-ai/xybrid/pull/131). Mirrors `xybrid_sdk::InferenceMetrics` and `StageLatency` through flutter_rust_bridge so Dart consumers can read `result.metrics.ttftMs`, `result.metrics.tokensPerSecond`, `result.metrics.stageLatenciesMs`, etc. without re-parsing the `result.metadata` string map. Both `model.run()` and `pipeline.run()` produce the same metrics shape — the pipeline path builds it from `PipelineExecutionResult.output.metadata` and the per-stage `StageTiming` list. Linear: [INF-15](https://linear.app/xybrid/issue/INF-15).

## Test plan

- [x] `cargo build -p xybrid_flutter` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 4/4 pass
- [x] FRB codegen regenerated `bindings/flutter/lib/src/rust/**` cleanly
- [ ] Gates PR-D (Unity C FFI), PR-E (sync-api + Flutter demo-screen metrics rendering)