### PR TITLE
feat(unity): expose InferenceMetrics via C FFI accessors (PR-D)

### DIFF
--- a/bindings/unity/Runtime/Api/InferenceResult.cs
+++ b/bindings/unity/Runtime/Api/InferenceResult.cs
@@ -2,11 +2,71 @@
 // Wrapper for the output of model inference.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Xybrid.Native;
 
 namespace Xybrid
 {
+    /// <summary>
+    /// Per-stage latency entry for pipeline runs. One entry per executed
+    /// stage; <see cref="StageId"/> matches the stage name in the pipeline
+    /// definition.
+    /// </summary>
+    public sealed class StageLatency
+    {
+        public string StageId { get; }
+        public uint LatencyMs { get; }
+
+        internal StageLatency(string stageId, uint latencyMs)
+        {
+            StageId = stageId;
+            LatencyMs = latencyMs;
+        }
+    }
+
+    /// <summary>
+    /// Typed inference metrics surfaced on every <see cref="InferenceResult"/>.
+    /// </summary>
+    /// <remarks>
+    /// LLM-specific fields (<see cref="TtftMs"/>, <see cref="TokensPerSecond"/>,
+    /// <see cref="PrefillTps"/>, <see cref="DecodeTps"/>, <see cref="TokensOut"/>)
+    /// are <c>null</c> for ASR/TTS/embedding runs. For pipeline runs they are
+    /// parsed from the final stage's envelope only, so they are also <c>null</c>
+    /// when the final stage isn't the LLM (e.g. an ASR → LLM → TTS pipeline).
+    ///
+    /// <see cref="StageLatenciesMs"/> is empty for <c>model.Run()</c> and
+    /// populated for pipeline runs.
+    /// </remarks>
+    public sealed class InferenceMetrics
+    {
+        public uint TotalMs { get; }
+        public uint? TtftMs { get; }
+        public float? TokensPerSecond { get; }
+        public float? PrefillTps { get; }
+        public float? DecodeTps { get; }
+        public uint? TokensOut { get; }
+        public IReadOnlyList<StageLatency> StageLatenciesMs { get; }
+
+        internal InferenceMetrics(
+            uint totalMs,
+            uint? ttftMs,
+            float? tokensPerSecond,
+            float? prefillTps,
+            float? decodeTps,
+            uint? tokensOut,
+            IReadOnlyList<StageLatency> stageLatenciesMs)
+        {
+            TotalMs = totalMs;
+            TtftMs = ttftMs;
+            TokensPerSecond = tokensPerSecond;
+            PrefillTps = prefillTps;
+            DecodeTps = decodeTps;
+            TokensOut = tokensOut;
+            StageLatenciesMs = stageLatenciesMs;
+        }
+    }
+
     /// <summary>
     /// Represents the result of model inference.
     /// </summary>
@@ -27,6 +87,7 @@ namespace Xybrid
         private readonly OutputType _outputType;
         private readonly byte[] _audioBytes;
         private readonly float[] _embedding;
+        private readonly InferenceMetrics _metrics;
 
         /// <summary>
         /// Gets whether this result has been disposed.
@@ -79,6 +140,16 @@ namespace Xybrid
         /// </summary>
         public bool HasEmbedding => _embedding != null && _embedding.Length > 0;
 
+        /// <summary>
+        /// Gets the typed inference metrics (TTFT, tok/s, per-stage latencies).
+        /// </summary>
+        /// <remarks>
+        /// LLM-specific fields are <c>null</c> for ASR/TTS/embedding runs;
+        /// <see cref="InferenceMetrics.StageLatenciesMs"/> is empty for
+        /// single-model runs.
+        /// </remarks>
+        public InferenceMetrics Metrics => _metrics;
+
         internal unsafe InferenceResult(XybridResultHandle* handle)
         {
             _handle = handle;
@@ -128,6 +199,34 @@ namespace Xybrid
                     Marshal.Copy((IntPtr)embPtr, _embedding, 0, (int)embLen);
                 }
             }
+
+            // Cache typed metrics. Sentinel conventions match the C ABI:
+            // -1 for absent optional integers, NaN for absent optional floats.
+            long ttft = NativeMethods.xybrid_result_ttft_ms(handle);
+            float tps = NativeMethods.xybrid_result_tokens_per_second(handle);
+            float prefill = NativeMethods.xybrid_result_prefill_tps(handle);
+            float decode = NativeMethods.xybrid_result_decode_tps(handle);
+            long tokensOut = NativeMethods.xybrid_result_tokens_out(handle);
+
+            nuint stageCount = NativeMethods.xybrid_result_stage_count(handle);
+            var stages = new List<StageLatency>((int)stageCount);
+            for (nuint i = 0; i < stageCount; i++)
+            {
+                byte* stageIdPtr = NativeMethods.xybrid_result_stage_id(handle, i);
+                string stageId = NativeHelpers.FromUtf8Ptr(stageIdPtr) ?? string.Empty;
+                uint stageLatencyMs = NativeMethods.xybrid_result_stage_latency_ms(handle, i);
+                stages.Add(new StageLatency(stageId, stageLatencyMs));
+            }
+
+            _metrics = new InferenceMetrics(
+                totalMs: _latencyMs,
+                ttftMs: ttft < 0 ? (uint?)null : (uint)ttft,
+                tokensPerSecond: float.IsNaN(tps) ? (float?)null : tps,
+                prefillTps: float.IsNaN(prefill) ? (float?)null : prefill,
+                decodeTps: float.IsNaN(decode) ? (float?)null : decode,
+                tokensOut: tokensOut < 0 ? (uint?)null : (uint)tokensOut,
+                stageLatenciesMs: stages
+            );
         }
 
         /// <summary>

--- a/bindings/unity/Runtime/Native/NativeMethods.g.cs
+++ b/bindings/unity/Runtime/Native/NativeMethods.g.cs
@@ -1395,6 +1395,79 @@ namespace Xybrid.Native
         internal static extern void xybrid_result_free(XybridResultHandle* handle);
 
         /// <summary>
+        ///  Get time-to-first-token in milliseconds (LLM only).
+        ///
+        ///  Returns `-1` if the result is not from an LLM run, the LLM did not
+        ///  emit a `ttft_ms` metric, or the handle is null/invalid.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_ttft_ms", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern long xybrid_result_ttft_ms(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get generation throughput in tokens/sec (LLM only).
+        ///
+        ///  Returns `f32::NAN` when the metric is absent (non-LLM run, the LLM
+        ///  did not emit it, or the handle is null/invalid). Use `isnan()` to
+        ///  check.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_tokens_per_second", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern float xybrid_result_tokens_per_second(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get prefill-phase throughput in tokens/sec (LLM only).
+        ///
+        ///  Returns `f32::NAN` when the metric is absent.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_prefill_tps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern float xybrid_result_prefill_tps(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get decode-phase throughput in tokens/sec (LLM only).
+        ///
+        ///  Returns `f32::NAN` when the metric is absent.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_decode_tps", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern float xybrid_result_decode_tps(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get completion token count (LLM only).
+        ///
+        ///  Returns `-1` when the metric is absent.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_tokens_out", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern long xybrid_result_tokens_out(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get the number of per-stage latency entries.
+        ///
+        ///  Returns 0 for `model.run()` results (no stages) or when the handle
+        ///  is null/invalid. Pipeline runs return one entry per executed stage.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_stage_count", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern nuint xybrid_result_stage_count(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get the stage_id string for the entry at `index`.
+        ///
+        ///  Returns a thread-local pointer valid until the next call to this
+        ///  function on the same thread. Do NOT free. Returns null if `index`
+        ///  is out of bounds or the handle is null/invalid. Callers should
+        ///  check `xybrid_result_stage_count` first.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_stage_id", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* xybrid_result_stage_id(XybridResultHandle* result, nuint index);
+
+        /// <summary>
+        ///  Get the latency_ms value for the stage at `index`.
+        ///
+        ///  Returns 0 if `index` is out of bounds or the handle is null/invalid.
+        ///  Callers should check `xybrid_result_stage_count` first to disambiguate
+        ///  "stage took 0 ms" from "index out of bounds".
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_stage_latency_ms", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern uint xybrid_result_stage_latency_ms(XybridResultHandle* result, nuint index);
+
+        /// <summary>
         ///  Open a .xyb bundle file and return a handle.
         ///
         ///  Loads the bundle into memory (decompresses zstd, parses tar, validates manifest).

--- a/bindings/unity/Runtime/Native/xybrid.h
+++ b/bindings/unity/Runtime/Native/xybrid.h
@@ -1503,6 +1503,71 @@ uintptr_t xybrid_result_embedding_len(struct XybridResultHandle *result);
 void xybrid_result_free(struct XybridResultHandle *handle);
 
 /*
+ Get time-to-first-token in milliseconds (LLM only).
+
+ Returns `-1` if the result is not from an LLM run, the LLM did not
+ emit a `ttft_ms` metric, or the handle is null/invalid.
+ */
+int64_t xybrid_result_ttft_ms(struct XybridResultHandle *result);
+
+/*
+ Get generation throughput in tokens/sec (LLM only).
+
+ Returns `f32::NAN` when the metric is absent (non-LLM run, the LLM
+ did not emit it, or the handle is null/invalid). Use `isnan()` to
+ check.
+ */
+float xybrid_result_tokens_per_second(struct XybridResultHandle *result);
+
+/*
+ Get prefill-phase throughput in tokens/sec (LLM only).
+
+ Returns `f32::NAN` when the metric is absent.
+ */
+float xybrid_result_prefill_tps(struct XybridResultHandle *result);
+
+/*
+ Get decode-phase throughput in tokens/sec (LLM only).
+
+ Returns `f32::NAN` when the metric is absent.
+ */
+float xybrid_result_decode_tps(struct XybridResultHandle *result);
+
+/*
+ Get completion token count (LLM only).
+
+ Returns `-1` when the metric is absent.
+ */
+int64_t xybrid_result_tokens_out(struct XybridResultHandle *result);
+
+/*
+ Get the number of per-stage latency entries.
+
+ Returns 0 for `model.run()` results (no stages) or when the handle
+ is null/invalid. Pipeline runs return one entry per executed stage.
+ */
+uintptr_t xybrid_result_stage_count(struct XybridResultHandle *result);
+
+/*
+ Get the stage_id string for the entry at `index`.
+
+ Returns a thread-local pointer valid until the next call to this
+ function on the same thread. Do NOT free. Returns null if `index`
+ is out of bounds or the handle is null/invalid. Callers should
+ check `xybrid_result_stage_count` first.
+ */
+const char *xybrid_result_stage_id(struct XybridResultHandle *result, uintptr_t index);
+
+/*
+ Get the latency_ms value for the stage at `index`.
+
+ Returns 0 if `index` is out of bounds or the handle is null/invalid.
+ Callers should check `xybrid_result_stage_count` first to disambiguate
+ "stage took 0 ms" from "index out of bounds".
+ */
+uint32_t xybrid_result_stage_latency_ms(struct XybridResultHandle *result, uintptr_t index);
+
+/*
  Open a .xyb bundle file and return a handle.
 
  Loads the bundle into memory (decompresses zstd, parses tar, validates manifest).

--- a/crates/xybrid-ffi/include/xybrid.h
+++ b/crates/xybrid-ffi/include/xybrid.h
@@ -1503,6 +1503,71 @@ uintptr_t xybrid_result_embedding_len(struct XybridResultHandle *result);
 void xybrid_result_free(struct XybridResultHandle *handle);
 
 /*
+ Get time-to-first-token in milliseconds (LLM only).
+
+ Returns `-1` if the result is not from an LLM run, the LLM did not
+ emit a `ttft_ms` metric, or the handle is null/invalid.
+ */
+int64_t xybrid_result_ttft_ms(struct XybridResultHandle *result);
+
+/*
+ Get generation throughput in tokens/sec (LLM only).
+
+ Returns `f32::NAN` when the metric is absent (non-LLM run, the LLM
+ did not emit it, or the handle is null/invalid). Use `isnan()` to
+ check.
+ */
+float xybrid_result_tokens_per_second(struct XybridResultHandle *result);
+
+/*
+ Get prefill-phase throughput in tokens/sec (LLM only).
+
+ Returns `f32::NAN` when the metric is absent.
+ */
+float xybrid_result_prefill_tps(struct XybridResultHandle *result);
+
+/*
+ Get decode-phase throughput in tokens/sec (LLM only).
+
+ Returns `f32::NAN` when the metric is absent.
+ */
+float xybrid_result_decode_tps(struct XybridResultHandle *result);
+
+/*
+ Get completion token count (LLM only).
+
+ Returns `-1` when the metric is absent.
+ */
+int64_t xybrid_result_tokens_out(struct XybridResultHandle *result);
+
+/*
+ Get the number of per-stage latency entries.
+
+ Returns 0 for `model.run()` results (no stages) or when the handle
+ is null/invalid. Pipeline runs return one entry per executed stage.
+ */
+uintptr_t xybrid_result_stage_count(struct XybridResultHandle *result);
+
+/*
+ Get the stage_id string for the entry at `index`.
+
+ Returns a thread-local pointer valid until the next call to this
+ function on the same thread. Do NOT free. Returns null if `index`
+ is out of bounds or the handle is null/invalid. Callers should
+ check `xybrid_result_stage_count` first.
+ */
+const char *xybrid_result_stage_id(struct XybridResultHandle *result, uintptr_t index);
+
+/*
+ Get the latency_ms value for the stage at `index`.
+
+ Returns 0 if `index` is out of bounds or the handle is null/invalid.
+ Callers should check `xybrid_result_stage_count` first to disambiguate
+ "stage took 0 ms" from "index out of bounds".
+ */
+uint32_t xybrid_result_stage_latency_ms(struct XybridResultHandle *result, uintptr_t index);
+
+/*
  Open a .xyb bundle file and return a handle.
 
  Loads the bundle into memory (decompresses zstd, parses tar, validates manifest).

--- a/crates/xybrid-ffi/src/lib.rs
+++ b/crates/xybrid-ffi/src/lib.rs
@@ -161,6 +161,10 @@ pub(crate) struct ResultData {
     pub audio_bytes: Option<Vec<u8>>,
     /// Inference latency in milliseconds.
     pub latency_ms: u32,
+    /// Typed inference metrics (TTFT, tok/s, per-stage latencies).
+    /// All LLM-specific fields are `None` on error paths and for
+    /// non-LLM models; `stage_latencies_ms` is empty for `model.run()`.
+    pub metrics: xybrid_sdk::InferenceMetrics,
 }
 
 /// Internal conversation context.
@@ -325,6 +329,7 @@ fn inference_result_to_data(result: &xybrid_sdk::InferenceResult) -> ResultData 
         embedding: result.embedding().map(|e| e.to_vec()),
         audio_bytes: result.audio_bytes().map(|b| b.to_vec()),
         latency_ms: result.latency_ms(),
+        metrics: result.metrics().clone(),
     }
 }
 
@@ -2349,6 +2354,7 @@ pub unsafe extern "C" fn xybrid_model_run(
                     embedding: None,
                     audio_bytes: None,
                     latency_ms: 0,
+                    metrics: xybrid_sdk::InferenceMetrics::default(),
                 };
                 return XybridResultHandle::from_boxed(Box::new(result));
             }
@@ -2371,6 +2377,7 @@ pub unsafe extern "C" fn xybrid_model_run(
                 embedding: None,
                 audio_bytes: None,
                 latency_ms: 0,
+                metrics: xybrid_sdk::InferenceMetrics::default(),
             };
             XybridResultHandle::from_boxed(Box::new(result))
         }
@@ -2499,6 +2506,7 @@ pub unsafe extern "C" fn xybrid_model_run_with_context(
                     embedding: None,
                     audio_bytes: None,
                     latency_ms: 0,
+                    metrics: xybrid_sdk::InferenceMetrics::default(),
                 };
                 return XybridResultHandle::from_boxed(Box::new(result));
             }
@@ -2524,6 +2532,7 @@ pub unsafe extern "C" fn xybrid_model_run_with_context(
                 embedding: None,
                 audio_bytes: None,
                 latency_ms: 0,
+                metrics: xybrid_sdk::InferenceMetrics::default(),
             };
             XybridResultHandle::from_boxed(Box::new(result))
         }
@@ -2921,6 +2930,7 @@ pub unsafe extern "C" fn xybrid_model_run_streaming(
                     embedding: None,
                     audio_bytes: None,
                     latency_ms: 0,
+                    metrics: xybrid_sdk::InferenceMetrics::default(),
                 };
                 XybridResultHandle::from_boxed(Box::new(result))
             }
@@ -2943,6 +2953,7 @@ pub unsafe extern "C" fn xybrid_model_run_streaming(
                 embedding: None,
                 audio_bytes: None,
                 latency_ms: 0,
+                metrics: xybrid_sdk::InferenceMetrics::default(),
             };
             XybridResultHandle::from_boxed(Box::new(result))
         }
@@ -3076,6 +3087,7 @@ pub unsafe extern "C" fn xybrid_model_run_streaming_with_context(
                     embedding: None,
                     audio_bytes: None,
                     latency_ms: 0,
+                    metrics: xybrid_sdk::InferenceMetrics::default(),
                 };
                 XybridResultHandle::from_boxed(Box::new(result))
             }
@@ -3098,6 +3110,7 @@ pub unsafe extern "C" fn xybrid_model_run_streaming_with_context(
                 embedding: None,
                 audio_bytes: None,
                 latency_ms: 0,
+                metrics: xybrid_sdk::InferenceMetrics::default(),
             };
             XybridResultHandle::from_boxed(Box::new(result))
         }
@@ -3545,6 +3558,170 @@ pub unsafe extern "C" fn xybrid_result_free(handle: *mut XybridResultHandle) {
     if !handle.is_null() {
         // Take ownership and let it drop to free memory
         let _ = XybridResultHandle::into_boxed(handle);
+    }
+}
+
+// ============================================================================
+// Inference Metrics Accessors
+// ============================================================================
+//
+// Sentinel convention:
+// - Optional `u32` fields return `i64`; absent value is `-1`, present
+//   values fit in `u32` and are zero-extended into `i64`.
+// - Optional `f32` fields return `f32`; absent value is `f32::NAN`.
+// - `stage_count` is the total number of stage-latency entries.
+// - `stage_id(idx)` / `stage_latency_ms(idx)` return null / 0 for
+//   out-of-bounds indices; callers should check `stage_count` first.
+
+/// Get time-to-first-token in milliseconds (LLM only).
+///
+/// Returns `-1` if the result is not from an LLM run, the LLM did not
+/// emit a `ttft_ms` metric, or the handle is null/invalid.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_ttft_ms(result: *mut XybridResultHandle) -> i64 {
+    if result.is_null() {
+        return -1;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => match data.metrics.ttft_ms {
+            Some(v) => v as i64,
+            None => -1,
+        },
+        None => -1,
+    }
+}
+
+/// Get generation throughput in tokens/sec (LLM only).
+///
+/// Returns `f32::NAN` when the metric is absent (non-LLM run, the LLM
+/// did not emit it, or the handle is null/invalid). Use `isnan()` to
+/// check.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_tokens_per_second(result: *mut XybridResultHandle) -> f32 {
+    if result.is_null() {
+        return f32::NAN;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => data.metrics.tokens_per_second.unwrap_or(f32::NAN),
+        None => f32::NAN,
+    }
+}
+
+/// Get prefill-phase throughput in tokens/sec (LLM only).
+///
+/// Returns `f32::NAN` when the metric is absent.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_prefill_tps(result: *mut XybridResultHandle) -> f32 {
+    if result.is_null() {
+        return f32::NAN;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => data.metrics.prefill_tps.unwrap_or(f32::NAN),
+        None => f32::NAN,
+    }
+}
+
+/// Get decode-phase throughput in tokens/sec (LLM only).
+///
+/// Returns `f32::NAN` when the metric is absent.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_decode_tps(result: *mut XybridResultHandle) -> f32 {
+    if result.is_null() {
+        return f32::NAN;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => data.metrics.decode_tps.unwrap_or(f32::NAN),
+        None => f32::NAN,
+    }
+}
+
+/// Get completion token count (LLM only).
+///
+/// Returns `-1` when the metric is absent.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_tokens_out(result: *mut XybridResultHandle) -> i64 {
+    if result.is_null() {
+        return -1;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => match data.metrics.tokens_out {
+            Some(v) => v as i64,
+            None => -1,
+        },
+        None => -1,
+    }
+}
+
+/// Get the number of per-stage latency entries.
+///
+/// Returns 0 for `model.run()` results (no stages) or when the handle
+/// is null/invalid. Pipeline runs return one entry per executed stage.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_stage_count(result: *mut XybridResultHandle) -> usize {
+    if result.is_null() {
+        return 0;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => data.metrics.stage_latencies_ms.len(),
+        None => 0,
+    }
+}
+
+/// Get the stage_id string for the entry at `index`.
+///
+/// Returns a thread-local pointer valid until the next call to this
+/// function on the same thread. Do NOT free. Returns null if `index`
+/// is out of bounds or the handle is null/invalid. Callers should
+/// check `xybrid_result_stage_count` first.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_stage_id(
+    result: *mut XybridResultHandle,
+    index: usize,
+) -> *const c_char {
+    if result.is_null() {
+        return std::ptr::null();
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => match data.metrics.stage_latencies_ms.get(index) {
+            Some(stage) => {
+                thread_local! {
+                    static RESULT_STAGE_ID: RefCell<Option<CString>> = const { RefCell::new(None) };
+                }
+                RESULT_STAGE_ID.with(|e| {
+                    *e.borrow_mut() = CString::new(stage.stage_id.as_str()).ok();
+                    match e.borrow().as_ref() {
+                        Some(cstr) => cstr.as_ptr(),
+                        None => std::ptr::null(),
+                    }
+                })
+            }
+            None => std::ptr::null(),
+        },
+        None => std::ptr::null(),
+    }
+}
+
+/// Get the latency_ms value for the stage at `index`.
+///
+/// Returns 0 if `index` is out of bounds or the handle is null/invalid.
+/// Callers should check `xybrid_result_stage_count` first to disambiguate
+/// "stage took 0 ms" from "index out of bounds".
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_result_stage_latency_ms(
+    result: *mut XybridResultHandle,
+    index: usize,
+) -> u32 {
+    if result.is_null() {
+        return 0;
+    }
+    match XybridResultHandle::as_ref(result) {
+        Some(data) => data
+            .metrics
+            .stage_latencies_ms
+            .get(index)
+            .map(|s| s.latency_ms)
+            .unwrap_or(0),
+        None => 0,
     }
 }
 
@@ -4553,6 +4730,7 @@ mod tests {
             embedding: None,
             audio_bytes: None,
             latency_ms: 100,
+            metrics: xybrid_sdk::InferenceMetrics::default(),
         });
 
         let handle = XybridResultHandle::from_boxed(result);
@@ -4581,6 +4759,7 @@ mod tests {
             embedding: None,
             audio_bytes: None,
             latency_ms: 0,
+            metrics: xybrid_sdk::InferenceMetrics::default(),
         });
 
         let handle = XybridResultHandle::from_boxed(result);

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -890,10 +890,10 @@ public sealed class StageLatency
 | `modelId` | — | — | — | ✅ |
 | `isFailure` | ✅ | ✅ | ✅ | ✅ |
 | `audioAsWav()` | ✅ | — | — | — |
-| `metrics` | ✅ | ✅ | ✅ | — |
-| `metrics.ttftMs` | ✅ | ✅ | ✅ | — |
-| `metrics.tokensPerSecond` | ✅ | ✅ | ✅ | — |
-| `metrics.stageLatenciesMs` | ✅ | ✅ | ✅ | — |
+| `metrics` | ✅ | ✅ | ✅ | ✅ |
+| `metrics.ttftMs` | ✅ | ✅ | ✅ | ✅ |
+| `metrics.tokensPerSecond` | ✅ | ✅ | ✅ | ✅ |
+| `metrics.stageLatenciesMs` | ✅ | ✅ | ✅ | ✅ |
 
 ---
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -267,7 +267,7 @@ classes:
         status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       embedding:
         params: [{ name: embedding, type: "List<double>" }]
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       textWithRole:
         params:
           - { name: text, type: String }
@@ -353,7 +353,7 @@ classes:
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
       metrics:
         type: InferenceMetrics
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
 
   InferenceMetrics:
     type: data
@@ -365,25 +365,25 @@ classes:
     properties:
       totalMs:
         type: int
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       ttftMs:
         type: "int?"
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       tokensPerSecond:
         type: "double?"
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       prefillTps:
         type: "double?"
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       decodeTps:
         type: "double?"
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       tokensOut:
         type: "int?"
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       stageLatenciesMs:
         type: "List<StageLatency>"
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
 
   StageLatency:
     type: data
@@ -395,10 +395,10 @@ classes:
     properties:
       stageId:
         type: String
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       latencyMs:
         type: int
-        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
 
   # -------------------------------------------------------------------
   # 8. Supporting Types


### PR DESCRIPTION
## Summary

PR-D of the INF-15 binding-propagation series. Adds eight new `extern "C"` accessors on `xybrid-ffi` and a typed `InferenceMetrics` / `StageLatency` surface in Unity's `Xybrid.InferenceResult`, mirroring the typed surface added in [PR-A (#120)](https://github.com/xybrid-ai/xybrid/pull/120) / [PR-B (#131)](https://github.com/xybrid-ai/xybrid/pull/131) / [PR-C (#135)](https://github.com/xybrid-ai/xybrid/pull/135). Completes the binding surface for INF-15 — Flutter, Kotlin, Swift, and Unity now expose `result.metrics.ttftMs`, `result.metrics.tokensPerSecond`, `result.metrics.stageLatenciesMs`, etc.

Sentinel convention for the C ABI:
- Optional `u32` (`ttft_ms`, `tokens_out`) → `int64_t`; `-1` for None
- Optional `f32` (`tokens_per_second`, `prefill_tps`, `decode_tps`) → `float`; `NaN` for None
- `stage_count()` → `uintptr_t`; `stage_id(idx)` → `const char*` (thread-local, null on OOB); `stage_latency_ms(idx)` → `uint32_t` (0 on OOB)

Linear: [INF-15](https://linear.app/xybrid/issue/INF-15).

## Test plan

- [x] `cargo test -p xybrid-ffi` — 63/63 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo xtask build-unity --csharp` regenerates `NativeMethods.g.cs` with all 8 new entry points
- [x] `bindings/unity/Runtime/Native/xybrid.h` synced from cbindgen output (1889 lines, +65 over master)
- [ ] Gates PR-E (sync-api + binding examples — Flutter demo screens, Unity demo scene)