### PR TITLE
feat(examples): surface InferenceMetrics in Flutter demos + Unity docs (INF-15 PR-E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           key: ubuntu-latest-ort-download
 
       - name: Run tests
-        run: cargo test --workspace --features ort-download
+        run: cargo test --workspace --features ort-download --lib --tests
 
   # Linux-only on push/PR. Per-platform CLI builds run in release.yml.
   build-cli:

--- a/bindings/flutter/lib/xybrid.dart
+++ b/bindings/flutter/lib/xybrid.dart
@@ -87,7 +87,8 @@ export 'src/model_loader.dart'
         LoadComplete,
         LoadError;
 export 'src/pipeline.dart' show XybridPipeline;
-export 'src/result.dart' show XybridResult;
+export 'src/result.dart'
+    show XybridInferenceMetrics, XybridResult, XybridStageLatency;
 export 'src/run_options.dart' show AbortPolicy, AbortSignal, RunOptions;
 export 'src/utils/utils.dart';
 export 'src/xybrid.dart' show Xybrid;

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -144,6 +144,34 @@ result.ThrowIfFailed();
 Debug.Log($"Player said: {result.Text}");
 ```
 
+### Inference Metrics
+
+Every `InferenceResult` carries a typed `InferenceMetrics` with TTFT,
+tok/s, per-stage latencies, and token counts. LLM-specific fields are
+`null` for ASR / TTS / embedding runs.
+
+```csharp
+using Xybrid;
+
+using var model = XybridClient.LoadModel("lfm2.5-350m");
+using var result = model.Run(Envelope.Text("Tell me a joke."));
+result.ThrowIfFailed();
+
+var metrics = result.Metrics;
+Debug.Log($"Total: {metrics.TotalMs} ms");
+if (metrics.TtftMs.HasValue)
+    Debug.Log($"TTFT: {metrics.TtftMs.Value} ms");
+if (metrics.TokensPerSecond.HasValue)
+    Debug.Log($"Throughput: {metrics.TokensPerSecond.Value:F1} tok/s");
+if (metrics.TokensOut.HasValue)
+    Debug.Log($"Tokens out: {metrics.TokensOut.Value}");
+
+// For pipeline runs, per-stage latencies are populated.
+// model.Run() leaves StageLatenciesMs empty.
+foreach (var stage in metrics.StageLatenciesMs)
+    Debug.Log($"  stage {stage.StageId}: {stage.LatencyMs} ms");
+```
+
 ### Multi-Turn Conversation
 
 ```csharp

--- a/examples/flutter/lib/screens/asr_demo_screen.dart
+++ b/examples/flutter/lib/screens/asr_demo_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:xybrid_example/utils/recorder.dart';
+import 'package:xybrid_example/widgets/metrics_card.dart';
 import 'package:xybrid_example/widgets/model_status_card.dart';
 import 'package:xybrid_flutter/xybrid.dart';
 
@@ -76,6 +77,9 @@ class _SpeechToTextScreenState extends State<SpeechToTextScreen> {
 
   /// Latency of the last inference in milliseconds.
   int? _latencyMs;
+
+  /// Typed metrics from the last inference (if any).
+  XybridInferenceMetrics? _metrics;
 
   /// Transcribed text from last inference.
   String? _transcribedText;
@@ -221,6 +225,7 @@ class _SpeechToTextScreenState extends State<SpeechToTextScreen> {
           _state = const AsrReady();
           _transcribedText = '(No speech detected)';
           _latencyMs = result.latencyMs;
+          _metrics = result.metrics;
         });
         return;
       }
@@ -230,6 +235,7 @@ class _SpeechToTextScreenState extends State<SpeechToTextScreen> {
           _state = const AsrReady();
           _transcribedText = transcribedText;
           _latencyMs = result.latencyMs;
+          _metrics = result.metrics;
         });
       }
     } on XybridException catch (e) {
@@ -507,6 +513,10 @@ class _SpeechToTextScreenState extends State<SpeechToTextScreen> {
                   ),
                 ],
               ),
+              if (_metrics != null) ...[
+                const SizedBox(height: 12),
+                MetricsCard(metrics: _metrics!),
+              ],
             ],
           ],
         ),

--- a/examples/flutter/lib/screens/pipeline_demo_screen.dart
+++ b/examples/flutter/lib/screens/pipeline_demo_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:xybrid_example/ui.dart';
+import 'package:xybrid_example/widgets/metrics_card.dart';
 import 'package:xybrid_flutter/xybrid.dart';
 
 /// Pipeline demo screen.
@@ -39,6 +40,9 @@ stages:
   /// Result text from the last execution (if any).
   String? _resultText;
 
+  /// Typed metrics from the last execution (if any).
+  XybridInferenceMetrics? _metrics;
+
   @override
   void dispose() {
     _yamlController.dispose();
@@ -62,6 +66,7 @@ stages:
       _pipeline = null;
       _resultText = null;
       _latencyMs = null;
+      _metrics = null;
     });
 
     try {
@@ -98,6 +103,7 @@ stages:
       _errorMessage = null;
       _resultText = null;
       _latencyMs = null;
+      _metrics = null;
     });
 
     try {
@@ -115,6 +121,7 @@ stages:
         setState(() {
           _state = _PipelineState.loaded;
           _latencyMs = result.latencyMs;
+          _metrics = result.metrics;
           _resultText = result.text ?? '(No text output)';
         });
       }
@@ -143,6 +150,7 @@ stages:
       _errorMessage = null;
       _resultText = null;
       _latencyMs = null;
+      _metrics = null;
     });
   }
 
@@ -447,6 +455,10 @@ stages:
                   ),
                 ],
               ),
+            if (_metrics != null) ...[
+              const SizedBox(height: 12),
+              MetricsCard(metrics: _metrics!),
+            ],
           ],
         ),
       ),

--- a/examples/flutter/lib/screens/tts_demo_screen.dart
+++ b/examples/flutter/lib/screens/tts_demo_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:xybrid_example/widgets/metrics_card.dart';
 import 'package:xybrid_example/widgets/model_status_card.dart';
 import 'package:xybrid_flutter/xybrid.dart';
 
@@ -82,6 +83,9 @@ class _TextToSpeechScreenState extends State<TextToSpeechScreen> {
 
   /// Latency of the last inference in milliseconds.
   int? _latencyMs;
+
+  /// Typed metrics from the last inference (if any).
+  XybridInferenceMetrics? _metrics;
 
   /// Whether audio is currently playing.
   bool _isPlaying = false;
@@ -211,6 +215,7 @@ class _TextToSpeechScreenState extends State<TextToSpeechScreen> {
         setState(() {
           _state = const TtsPlaying();
           _latencyMs = result.latencyMs;
+          _metrics = result.metrics;
         });
 
         await _playAudio(wavBytes);
@@ -423,6 +428,10 @@ class _TextToSpeechScreenState extends State<TextToSpeechScreen> {
                   'Inference latency: ${_latencyMs}ms',
                   style: theme.textTheme.bodyMedium,
                 ),
+              ],
+              if (_metrics != null) ...[
+                const SizedBox(height: 12),
+                MetricsCard(metrics: _metrics!),
               ],
               if (_isPlaying) ...[
                 const SizedBox(height: 16),

--- a/examples/flutter/lib/widgets/metrics_card.dart
+++ b/examples/flutter/lib/widgets/metrics_card.dart
@@ -1,0 +1,99 @@
+// Reusable card that renders the typed metrics surfaced on every
+// [XybridResult]. The card auto-hides when no metric has a value —
+// ASR/TTS/embedding runs (which don't emit LLM-specific fields and
+// don't carry stage latencies) produce an empty section, so showing
+// nothing is the intended UX.
+
+import 'package:flutter/material.dart';
+import 'package:xybrid_flutter/xybrid_flutter.dart';
+
+class MetricsCard extends StatelessWidget {
+  const MetricsCard({super.key, required this.metrics});
+
+  final XybridInferenceMetrics metrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final rows = <_MetricRow>[];
+
+    final ttft = metrics.ttftMs;
+    if (ttft != null) {
+      rows.add(_MetricRow('TTFT', '$ttft ms'));
+    }
+    final tps = metrics.tokensPerSecond;
+    if (tps != null) {
+      rows.add(_MetricRow('Throughput', '${tps.toStringAsFixed(1)} tok/s'));
+    }
+    final prefill = metrics.prefillTps;
+    if (prefill != null) {
+      rows.add(_MetricRow('Prefill', '${prefill.toStringAsFixed(1)} tok/s'));
+    }
+    final decode = metrics.decodeTps;
+    if (decode != null) {
+      rows.add(_MetricRow('Decode', '${decode.toStringAsFixed(1)} tok/s'));
+    }
+    final tokensOut = metrics.tokensOut;
+    if (tokensOut != null) {
+      rows.add(_MetricRow('Tokens out', '$tokensOut'));
+    }
+    if (metrics.stageLatenciesMs.isNotEmpty) {
+      final stages = metrics.stageLatenciesMs
+          .map((s) => '${s.stageId}=${s.latencyMs}ms')
+          .join(', ');
+      rows.add(_MetricRow('Stages', stages));
+    }
+
+    if (rows.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withAlpha(120),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Metrics',
+            style: theme.textTheme.labelLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          for (final row in rows)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Row(
+                children: [
+                  Text(
+                    row.label,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    row.value,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricRow {
+  const _MetricRow(this.label, this.value);
+  final String label;
+  final String value;
+}

--- a/examples/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import audio_session
 import audioplayers_darwin
+import battery_plus
 import just_audio
 import path_provider_foundation
 import record_macos
@@ -14,6 +15,7 @@ import record_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  BatteryPlusMacosPlugin.register(with: registry.registrar(forPlugin: "BatteryPlusMacosPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))

--- a/examples/flutter/pubspec.lock
+++ b/examples/flutter/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   audio_session:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: audioplayers
-      sha256: "5441fa0ceb8807a5ad701199806510e56afde2b4913d9d17c2f19f2902cf0ae4"
+      sha256: a72dd459d1a48f61a6fb9c0134dba26597c9236af40639ff0eb70eb4e0baab70
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.1"
+    version: "6.6.0"
   audioplayers_android:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: audioplayers_darwin
-      sha256: "0811d6924904ca13f9ef90d19081e4a87f7297ddc19fc3d31f60af1aaafee333"
+      sha256: c994b3bb3a921e4904ac40e013fbc94488e824fd7c1de6326f549943b0b44a91
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   audioplayers_linux:
     dependency: transitive
     description:
@@ -85,18 +85,34 @@ packages:
     dependency: transitive
     description:
       name: audioplayers_web
-      sha256: "1c0f17cec68455556775f1e50ca85c40c05c714a99c5eb1d2d57cc17ba5522d7"
+      sha256: faa8fa6587f996a6f604433b53af44c57a1407d4fe8dff5766cf63d6875e8de9
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.2.0"
   audioplayers_windows:
     dependency: transitive
     description:
       name: audioplayers_windows
-      sha256: "4048797865105b26d47628e6abb49231ea5de84884160229251f37dfcbe52fd7"
+      sha256: bafff2b38b6f6d331887558ba6e0a01c9c208d9dbb3ad0005234db065122a734
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "4.3.0"
+  battery_plus:
+    dependency: transitive
+    description:
+      name: battery_plus
+      sha256: "03d5a6bb36db9d2b977c548f6b0262d5a84c4d5a4cfee2edac4a91d57011b365"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.3"
+  battery_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: battery_plus_platform_interface
+      sha256: e8342c0f32de4b1dfd0223114b6785e48e579bfc398da9471c9179b907fa4910
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -173,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "7931c90b84bc573fef103548e354258ae4c9d28d140e41961df6843c5d60d4d8"
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.3"
+    version: "8.12.6"
   characters:
     dependency: transitive
     description:
@@ -245,10 +261,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   dart_style:
     dependency: transitive
     description:
@@ -257,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -269,10 +293,10 @@ packages:
     dependency: "direct dev"
     description:
       name: ffi
-      sha256: d07d37192dbf97461359c1518788f203b0c9102cfd2c35a716b823741219542c
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   ffigen:
     dependency: "direct dev"
     description:
@@ -327,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_rust_bridge
-      sha256: "37ef40bc6f863652e865f0b2563ea07f0d3c58d8efad803cc01933a4b2ee067e"
+      sha256: e87d6b9ee934dcd24a128ccb2bd91905d2d5fe5c06245d6a8f5477d4907a437a
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.12.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -423,6 +447,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   js:
     dependency: transitive
     description:
@@ -435,10 +475,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "805fa86df56383000f640384b282ce0cb8431f1a7a2396de92fb66186d8c57df"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.12.0"
   just_audio:
     dependency: "direct main"
     description:
@@ -507,10 +547,10 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
@@ -571,10 +611,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.3.1"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -655,6 +695,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -723,10 +771,10 @@ packages:
     dependency: transitive
     description:
       name: record_android
-      sha256: "3bb3c6abbcb5fc1e86719fc6f0acdee89dfe8078543b92caad11854c487e435a"
+      sha256: "94783f08403aed33ffb68797bf0715b0812eb852f3c7985644c945faea462ba1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   record_ios:
     dependency: transitive
     description:
@@ -747,10 +795,10 @@ packages:
     dependency: transitive
     description:
       name: record_macos
-      sha256: f04d1547ff61ae54b4154e9726f656a17ad993f1a90f8f44bc40de94bafa072f
+      sha256: "084902e63fc9c0c224c29203d6c75f0bdf9b6a40536c9d916393c8f4c4256488"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   record_platform_interface:
     dependency: transitive
     description:
@@ -816,10 +864,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -900,14 +948,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  upower:
+    dependency: transitive
+    description:
+      name: upower
+      sha256: cf042403154751180affa1d15614db7fa50234bc2373cd21c3db666c38543ebf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -920,10 +976,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
@@ -972,14 +1028,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   xybrid_flutter:
     dependency: "direct main"
     description:
-      name: xybrid_flutter
-      sha256: "8e0042408ca4247eb5906cac3f4d966021cd836c7cd8a3793d9c34ecb67b84f1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0-beta7"
+      path: "../../bindings/flutter"
+      relative: true
+    source: path
+    version: "0.1.0-rc3"
   yaml:
     dependency: transitive
     description:
@@ -992,10 +1055,10 @@ packages:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: ec709065bb2c911b336853b67f3732dd13e0336bd065cc2f1061d7610ddf45e3
+      sha256: "07c9e63ba42519745182b88ca12264a7ba2484d8239958778dfe4d44fe760488"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.35.6"

--- a/examples/flutter/pubspec.yaml
+++ b/examples/flutter/pubspec.yaml
@@ -33,11 +33,11 @@ dependencies:
 
   # Xybrid SDK - Hybrid cloud-edge ML inference orchestrator
   xybrid_flutter:
-    # path: ../../bindings/flutter
-    git:
-      url: https://github.com/xybrid-ai/xybrid.git
-      ref: master
-      path: bindings/flutter
+    path: ../../bindings/flutter
+    # git:
+    #   url: https://github.com/xybrid-ai/xybrid.git
+    #   ref: master
+    #   path: bindings/flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary

Closes the INF-15 binding-propagation series. Renders the typed `InferenceMetrics` (TTFT, tok/s, prefill/decode TPS, tokens out, per-stage latencies) added in [PR-A (#120)](https://github.com/xybrid-ai/xybrid/pull/120) / [PR-B (#131)](https://github.com/xybrid-ai/xybrid/pull/131) / [PR-C (#135)](https://github.com/xybrid-ai/xybrid/pull/135) / [PR-D (#138)](https://github.com/xybrid-ai/xybrid/pull/138) in every demo surface that gets a final `XybridResult`. Also fixes a PR-C export oversight — `XybridInferenceMetrics` / `XybridStageLatency` weren't re-exported from the top-level `xybrid.dart` package, so downstream consumers couldn't reference them by name. Linear: [INF-15](https://linear.app/xybrid/issue/INF-15).

What's in:
- `examples/flutter/lib/widgets/metrics_card.dart` — reusable Material card; auto-hides when no field has a value
- `examples/flutter/lib/screens/{pipeline,tts,asr}_demo_screen.dart` — wired to `result.metrics`
- `examples/flutter/pubspec.yaml` — `xybrid_flutter` flipped from `git: master` to `path: ../../bindings/flutter` (standard repo-internal example pattern; the git ref couldn't reference types added in the same PR before they reach master)
- `bindings/unity/README.md` — new "Inference Metrics" code snippet
- `bindings/flutter/lib/xybrid.dart` — fix-up export of `XybridInferenceMetrics` / `XybridStageLatency`

The Android + iOS UniFFI examples already render the equivalent `MetricsSection` from PR-B.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `flutter analyze` in `bindings/flutter` — no issues
- [x] `flutter analyze` in `examples/flutter` — only one pre-existing deprecation warning (`activeColor`), unrelated
- [x] Spec docs unchanged (already `implemented` for all four bindings post-PR-D); contract check is a no-op
- [ ] INF-15 binding surface complete across Flutter, Kotlin, Swift, and Unity once merged