### PR TITLE
test: cover AudioFormat accessor variants

### DIFF
--- a/crates/xybrid-core/src/audio/format.rs
+++ b/crates/xybrid-core/src/audio/format.rs
@@ -156,10 +156,23 @@ mod tests {
     }
 
     #[test]
+    fn test_audio_format_pcm32() {
+        let format = AudioFormat::Pcm32 {
+            sample_rate: 48000,
+            channels: 2,
+        };
+        assert_eq!(format.sample_rate(), Some(48000));
+        assert_eq!(format.channels(), Some(2));
+        assert_eq!(format.bytes_per_sample(), Some(4));
+        assert_eq!(format.as_str(), "pcm32");
+    }
+
+    #[test]
     fn test_audio_format_wav() {
         let format = AudioFormat::Wav;
         assert_eq!(format.sample_rate(), None);
         assert_eq!(format.channels(), None);
+        assert_eq!(format.bytes_per_sample(), None);
         assert_eq!(format.as_str(), "wav");
     }
 


### PR DESCRIPTION
## Summary
- add direct Pcm32 accessor assertions for sample rate, channels, bytes per sample, and string name
- add the missing WAV bytes-per-sample assertion

Fixes #129

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p xybrid-core format::tests` blocked locally because the default feature build requires CMake for llama.cpp
- `cargo test -p xybrid-core --lib --no-default-features format::tests` blocked locally on this macOS/CLT setup by the CoreML/ort linker symbol `_OBJC_CLASS_$_MLComputePlan`