### PR TITLE
fix(telemetry): filter orchestrator pipeline-frame events at SDK bridge

### DIFF
--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -2612,7 +2612,43 @@ fn drain_available_orchestrator_events(subscription: &xybrid_core::event_bus::Su
     }
 }
 
+/// Returns `true` when the orchestrator event is wire-noise that the SDK
+/// already covers via its own publish sites, and should be dropped before
+/// reaching the registered telemetry sender.
+///
+/// Single-stage local LLM calls were producing 6–9 dashboard rows per
+/// turn because the orchestrator emits a full pipeline-execution event
+/// chain (`PipelineStart`, `StageStart`, `ExecutionStarted`,
+/// `ExecutionCompleted`, `StageComplete`, `PipelineComplete`) on top of
+/// the SDK's own `ModelComplete` / `PipelineComplete` — every one of
+/// these landed as its own row. The orchestrator-side events are useful
+/// for in-process subscribers (other code listening on the event bus)
+/// but they're noise at the wire boundary, where the user-facing
+/// contract is one row per turn (the SDK's completion event).
+///
+/// Keep: `PolicyEvaluated`, `RoutingDecided` (routing-decision metadata
+/// shown alongside the completion row), `StageError`, `ExecutionFailed`
+/// (errors must always reach the wire).
+///
+/// Drop: pipeline-frame and per-stage success-path events. Errors on
+/// these paths still surface via the `*Failed` / `*Error` variants
+/// above, which the filter passes through.
+fn orchestrator_event_is_wire_noise(event: &OrchestratorEvent) -> bool {
+    matches!(
+        event,
+        OrchestratorEvent::PipelineStart { .. }
+            | OrchestratorEvent::PipelineComplete { .. }
+            | OrchestratorEvent::StageStart { .. }
+            | OrchestratorEvent::StageComplete { .. }
+            | OrchestratorEvent::ExecutionStarted { .. }
+            | OrchestratorEvent::ExecutionCompleted { .. }
+    )
+}
+
 fn publish_orchestrator_event(event: OrchestratorEvent) {
+    if orchestrator_event_is_wire_noise(&event) {
+        return;
+    }
     let telemetry_event = convert_orchestrator_event(&event);
     publish_telemetry_event(telemetry_event);
 }

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -1119,6 +1119,148 @@ fn pipeline_streaming_fast_path_emits_one_model_complete_event() {
     );
 }
 
+/// Regression guard: when the streaming fast path's
+/// `route.can_stream_locally` evaluates to `false` (e.g. in the standard
+/// test environment where the authority routes to cloud under
+/// stress-throttle conditions), `Xybrid::run_pipeline_streaming` bails to
+/// `pipeline.run_with_options`. That path went through the full
+/// orchestrator-pipeline execution chain, which used to emit
+/// `PipelineStart` / `StageStart` / `ExecutionStarted` /
+/// `ExecutionCompleted` / `StageComplete` plus a duplicate
+/// `PipelineComplete` on top of the SDK wrapper's own — 9 wire events
+/// for a single user turn. The bridge filter at
+/// `publish_orchestrator_event` now drops the pipeline-frame /
+/// per-stage success-path events, leaving the wire shape at the same
+/// three events the streaming-fast-path branch produces: routing
+/// metadata + the SDK's single completion event.
+#[cfg(feature = "llm-llamacpp")]
+#[test]
+fn pipeline_streaming_fallback_emits_bounded_event_shape() {
+    use xybrid_core::execution::listener;
+
+    let _serial = listener_test_lock();
+
+    let Some(_model_dir) = model_fixtures::model_or_skip("qwen2.5-0.5b-instruct") else {
+        return;
+    };
+
+    let (tx, rx) = mpsc::channel::<TelemetryEvent>();
+    register_telemetry_sender(tx);
+
+    listener::set_execution_listener(|event| {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let telemetry_event = match event {
+            xybrid_sdk::ExecutionEvent::Started { model_id, method } => TelemetryEvent {
+                event_type: "ExecutionStarted(listener)".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: None,
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Completed {
+                model_id,
+                method,
+                latency_ms,
+            } => TelemetryEvent {
+                event_type: "ExecutionCompleted(listener)".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Failed {
+                model_id,
+                method,
+                latency_ms,
+                error,
+            } => TelemetryEvent {
+                event_type: "ExecutionFailed(listener)".to_string(),
+                stage_name: Some(model_id.clone()),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: Some(error),
+                data: Some(format!(
+                    r#"{{"model":"{}","method":"{}"}}"#,
+                    model_id, method
+                )),
+                timestamp_ms,
+            },
+        };
+
+        publish_telemetry_event(telemetry_event);
+    });
+
+    // No `target: device` — forces the streaming fast path to bail and
+    // route through `pipeline.run_with_options`, exercising the
+    // orchestrator's full pipeline-execution event chain.
+    let yaml = "name: \"streaming-fallback-diagnostic\"\n\
+                stages:\n  - model: qwen2.5-0.5b-instruct\n";
+
+    let input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
+
+    // Ignore the result: fallback path may error out in test env when
+    // the cloud target isn't reachable; we only care about the events
+    // captured up to that point.
+    let _ = xybrid_sdk::Xybrid::run_pipeline_streaming(yaml, &input, Box::new(|_| Ok(())));
+
+    std::thread::sleep(Duration::from_millis(100));
+    listener::clear_execution_listener();
+
+    let mut collected: Vec<TelemetryEvent> = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        collected.push(ev);
+    }
+
+    // No pipeline-frame / per-stage success-path noise should reach
+    // the wire on this path — bridge filter at
+    // `publish_orchestrator_event` drops them. Errors (`StageError`,
+    // `ExecutionFailed`) still pass through if they fire.
+    let leaked: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.event_type.as_str(),
+                "PipelineStart"
+                    | "StageStart"
+                    | "StageComplete"
+                    | "ExecutionStarted"
+                    | "ExecutionCompleted"
+            )
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "orchestrator pipeline-frame / per-stage success events must not \
+         reach the wire — they duplicate the SDK's own completion event \
+         and produce dashboard row fan-out. Leaked: {:#?}",
+        leaked
+    );
+
+    // At most one `PipelineComplete` per turn. The orchestrator's
+    // version was the duplicate; the SDK wrapper at
+    // `Pipeline::run_with_options` is the wire-authoritative one
+    // (better stage-name attribution for single-stage pipelines).
+    let pipeline_completes: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| e.event_type == "PipelineComplete")
+        .collect();
+    assert!(
+        pipeline_completes.len() <= 1,
+        "fallback path must emit at most one PipelineComplete per turn; \
+         got {}: {:#?}",
+        pipeline_completes.len(),
+        pipeline_completes
+    );
+}
+
 /// Smoke test: MNIST inference works without telemetry (no env vars needed).
 /// Ensures the model fixture is valid and the execution pipeline doesn't panic.
 #[test]


### PR DESCRIPTION
## Summary

- A single local LLM turn on the streaming fallback path (`Xybrid::run_pipeline_streaming` with no explicit `target: device` → fast path bails to `pipeline.run_with_options`) was producing **9 wire events**: `PipelineStart`, `StageStart`, `PolicyEvaluated`, `RoutingDecided`, `ExecutionStarted`, `ExecutionCompleted`, `StageComplete`, **`PipelineComplete` × 2** (orchestrator + SDK wrapper). Every one renders as its own row on the Traces dashboard, drowning the actual completion in pipeline-frame and per-stage internal-state noise.
- Add `orchestrator_event_is_wire_noise` filter at `publish_orchestrator_event` — the SDK → wire bridge. Drops the pipeline-frame / per-stage success-path event types before they reach the registered telemetry sender. Errors (`StageError`, `ExecutionFailed`) and routing-decision metadata (`PolicyEvaluated`, `RoutingDecided`) still pass through.
- Same philosophy as the silent-guard work at the executor layer in xybrid#96 / #105 — applied one layer up where the orchestrator's analog events were slipping past those guards.

### Before / after

**Before** (fallback path, 9 events):

```
PipelineStart, StageStart, PolicyEvaluated, RoutingDecided,
ExecutionStarted, ExecutionCompleted, StageComplete,
PipelineComplete (orchestrator, stage=None target=None),
PipelineComplete (SDK wrapper, stage="qwen…" target="cloud")
```

**After** (fallback path, 3 events):

```
PolicyEvaluated, RoutingDecided, PipelineComplete   # SDK wrapper's,
                                                    # well-attributed
```

Matches the streaming-fast-path branch's existing shape (`PolicyEvaluated`, `RoutingDecided`, `ModelComplete` — landed in #137).

## Why

The orchestrator's pipeline-execution events are useful for **in-process subscribers** listening on its event bus (other code observing pipeline state in-flight) — but they're **noise at the wire boundary**, where the user-facing contract is one row per turn. The orchestrator can keep emitting them for in-process consumers; this filter just stops them from reaching the registered telemetry sender.

## Test plan

- [x] New `pipeline_streaming_fallback_emits_bounded_event_shape` asserts no leaked pipeline-frame / per-stage success events on the fallback path and at most one `PipelineComplete` per turn
- [x] `cargo test -p xybrid-sdk --features platform-macos --test telemetry_integration` — 11 pass, 1 ignored
- [x] `cargo test -p xybrid-sdk --features platform-macos --lib` — 331 pass
- [x] `cargo test -p xybrid-core --features llm-llamacpp --lib` — 921 pass
- [x] `cargo clippy --workspace --tests --benches --features platform-macos -- -D warnings` — clean
- [ ] On-device verify: CLI REPL streaming on a local LLM should now produce one `LLM / <model>` row per turn on the Traces dashboard, with `backend = llamacpp`, `quantization`, latency, TTFT all populated. No leftover pipeline-frame / Started/Completed rows.

## Notes

- Builds on #137 (streaming-fast-path `ModelComplete` publish, already merged).
- `convert_orchestrator_event` is unchanged — the per-type conversion still works for any caller that invokes it directly (in-process subscribers, future custom bridges). Filter applies only to the default SDK → wire bridge.
- For multi-stage pipelines (ASR → LLM → TTS), the per-stage detail still surfaces through `PlatformEvent.stages[].spans[].metadata` (the trace flamegraph), not through individual top-level `StageStart` / `StageComplete` events. Multi-stage `PipelineComplete` is still emitted by the SDK wrapper with proper attribution.