### PR TITLE
ci: Discord notifications and welcome workflow for new contributors

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,91 @@
+name: Discord notify (contributor activity)
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request_target:
+    types: [opened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify-issue:
+    if: >-
+      github.event_name == 'issues' &&
+      (
+        (github.event.action == 'opened' &&
+          (contains(github.event.issue.labels.*.name, 'good first issue') ||
+           contains(github.event.issue.labels.*.name, 'help wanted'))) ||
+        (github.event.action == 'labeled' &&
+          (github.event.label.name == 'good first issue' ||
+           github.event.label.name == 'help wanted'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post issue to Discord
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_DEV_TESTS }}
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK_DEV_TESTS is unset — skipping post."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "🆕 New contributor issue: $TITLE" \
+            --arg url "$URL" \
+            --arg desc "Author: \`$AUTHOR\` • Label: \`${LABEL:-good first issue}\`" \
+            '{
+              username: "Xybrid Bot",
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 5814783
+              }]
+            }')
+          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$WEBHOOK" > /dev/null
+
+  notify-pr:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'opened' &&
+      (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+       github.event.pull_request.author_association == 'FIRST_TIMER' ||
+       github.event.pull_request.author_association == 'NONE')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post PR to Discord
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_DEV_TESTS }}
+          TITLE: ${{ github.event.pull_request.title }}
+          URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          ASSOC: ${{ github.event.pull_request.author_association }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "DISCORD_WEBHOOK_DEV_TESTS is unset — skipping post."
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg title "🎉 First-time contributor PR: $TITLE" \
+            --arg url "$URL" \
+            --arg desc "Author: \`$AUTHOR\` • Association: \`$ASSOC\`" \
+            '{
+              username: "Xybrid Bot",
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 3066993
+              }]
+            }')
+          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$WEBHOOK" > /dev/null

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,45 @@
+name: Welcome first-time contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/first-interaction@3c71ce730280171fd1cfb57c00c774f8998586f7 # v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            👋 Thanks for opening your first issue on `xybrid-ai/xybrid`!
+
+            A maintainer will triage and label this shortly. While you wait, a few pointers:
+
+            - If this is a bug, including a minimal repro (model id, command, error output) makes triage 10× faster.
+            - If you're looking for somewhere to start contributing, see the [`good first issue`](https://github.com/xybrid-ai/xybrid/labels/good%20first%20issue) label and `CONTRIBUTING.md`.
+
+            Welcome aboard.
+          pr-message: |
+            🎉 Thanks for opening your first PR on `xybrid-ai/xybrid` — welcome!
+
+            Before review, please confirm the local checks pass:
+
+            - [ ] `cargo fmt --all` clean
+            - [ ] `cargo clippy --workspace -- -D warnings` clean
+            - [ ] `cargo test -p <affected-crate>` passes
+            - [ ] Commits are DCO-signed (`git commit -s`)
+
+            See [`CONTRIBUTING.md`](https://github.com/xybrid-ai/xybrid/blob/master/CONTRIBUTING.md#where-to-start) for the full guide. A maintainer will be along for review.


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to improve contributor onboarding:

- `discord-notify.yml` — posts to the `DISCORD_WEBHOOK_DEV_TESTS` webhook when an issue is opened or labeled with `good first issue`/`help wanted`, and when a first-time contributor opens a PR. Skips cleanly if the secret is unset.
- `welcome.yml` — uses pinned `actions/first-interaction` to greet first-time issue and PR authors with repro guidance, links to `CONTRIBUTING.md`/`good first issue`, and a local-checks checklist (fmt, clippy, test, DCO sign-off).

Both workflows pin permissions to least-privilege and use concurrency groups to avoid duplicate posts on rapid event sequences.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (CI / contributor experience)

## Checklist

- [x] Tests pass (`cargo test`) — N/A, CI-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No breaking changes