### PR TITLE
docs(streaming): document XYBRID_LLAMACPP_VERBOSITY

### DIFF
--- a/docs/content/docs/concepts/streaming.mdx
+++ b/docs/content/docs/concepts/streaming.mdx
@@ -89,6 +89,30 @@ string response = model.RunStreamingText("Tell me a story.", token =>
 
 ---
 
+## Troubleshooting
+
+### Surfacing llama.cpp C++ logs
+
+When debugging model load failures, unexpected streaming output, or other backend issues, set the `XYBRID_LLAMACPP_VERBOSITY` environment variable before your process starts. This raises the verbosity of llama.cpp's internal C++ logger from the default (suppressed at normal log levels).
+
+| Value | Meaning |
+|-------|---------|
+| `0` | Silent (no llama.cpp logs) |
+| `1` | Errors only |
+| `2` | Warnings and errors |
+| `3` | Info, warnings, and errors |
+| `4` | Full debug output (all library logs) |
+
+Example invocation:
+
+```bash
+XYBRID_LLAMACPP_VERBOSITY=4 ./my-xybrid-app
+```
+
+Use `4` when investigating model load failures: it surfaces the underlying llama.cpp diagnostic that the Rust-side error wraps. The variable is read once when the llama.cpp backend is initialized, so set it before launching the process. Available since `v0.1.0-beta5`.
+
+---
+
 ## Real-Time Audio Streaming (Planned)
 
 Real-time audio transcription with partial results (chunked Whisper inference) is planned for a future release. This will enable:

--- a/docs/content/docs/concepts/streaming.zh.mdx
+++ b/docs/content/docs/concepts/streaming.zh.mdx
@@ -89,6 +89,30 @@ string response = model.RunStreamingText("Tell me a story.", token =>
 
 ---
 
+## 故障排查
+
+### 显示 llama.cpp C++ 日志
+
+当排查模型加载失败、流式输出异常或其他后端问题时，可以在启动进程前设置环境变量 `XYBRID_LLAMACPP_VERBOSITY`。该变量会提升 llama.cpp 内部 C++ 日志器的详细等级（默认在普通日志级别下被抑制）。
+
+| 值 | 含义 |
+|-------|---------|
+| `0` | 静默（不输出 llama.cpp 日志）|
+| `1` | 仅错误 |
+| `2` | 警告和错误 |
+| `3` | 信息、警告和错误 |
+| `4` | 全部调试输出（所有库日志）|
+
+调用示例：
+
+```bash
+XYBRID_LLAMACPP_VERBOSITY=4 ./my-xybrid-app
+```
+
+排查模型加载失败时建议使用 `4`：它会展示 Rust 层错误所包装的底层 llama.cpp 诊断信息。该变量仅在 llama.cpp 后端初始化时读取一次，所以请在启动进程之前设置。自 `v0.1.0-beta5` 起可用。
+
+---
+
 ## 实时音频流式输出（规划中）
 
 基于分块 Whisper 推理的实时音频转录（含部分结果输出）已列入未来版本计划，将支持：


### PR DESCRIPTION
## Summary

Closes #155. `XYBRID_LLAMACPP_VERBOSITY` was added in v0.1.0-beta5 for surfacing llama.cpp's internal C++ logs during debugging, but the docs site never mentioned it - so users hitting model load failures had no way to discover it from the rendered docs. Add a Troubleshooting section to `streaming.mdx` covering what the variable does, the five valid integer values, a copy-paste runnable example, and the gotcha that the value is read once at backend init. Mirror the same section in `streaming.zh.mdx`.

## Why this matters

The CHANGELOG entry advertises the variable but the documented user surface (the docs site) didn't follow up. The acceptance criteria on the issue call out "Env var is greppable in the rendered docs site" - this PR makes that true.

The five-level mapping in the docs comes directly from `crates/xybrid-core/src/telemetry/events.rs:58-66` (`to_llamacpp_verbosity`: 0=silent, 1=errors, 2=warnings, 3=info, 4=debug), not from memory. The init-once gotcha matches the reader at `crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs:125-135`, which is wrapped in `BACKEND_INIT.call_once(...)` and only reads `std::env::var("XYBRID_LLAMACPP_VERBOSITY")` on first backend initialization. Setting the variable after the first model load has no effect; that's worth telling users explicitly so they don't waste time toggling it inside a running process.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) - docs-only change, no Rust code touched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md)) - mdx matches surrounding section style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## Testing

Docs-only - no code paths touched. Both files render as mdx; the new section uses the same heading depth, table syntax, and code-fence style as the surrounding content.

Acceptance check from #155:

- Env var is greppable in the rendered docs site: it appears in the new "Troubleshooting" sections of both `streaming.mdx` and `streaming.zh.mdx`.
- Example is copy-paste runnable: `XYBRID_LLAMACPP_VERBOSITY=4 ./my-xybrid-app` (shell-line, no escaping needed).
- Both EN and ZH pages updated.

Fixes #155

AI-assisted.
