### PR TITLE
docs: sync install snippet versions in READMEs to 0.1.0-rc3

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -145,7 +145,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.1.0
+  xybrid_flutter: ^0.1.0-rc3
 ```
 
 **モデルを実行:**
@@ -162,7 +162,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.1.0-rc1")
+    implementation("ai.xybrid:xybrid-kotlin:0.1.0-rc3")
 }
 ```
 
@@ -180,7 +180,7 @@ val result = model.run(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", exact: "0.1.0-beta13")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", exact: "0.1.0-rc3")
 ]
 ```
 
@@ -216,7 +216,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.1"
+xybrid = "0.1.0-rc3"
 ```
 
 **モデルを実行:**

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.1.0
+  xybrid_flutter: ^0.1.0-rc3
 ```
 
 **Run a model:**
@@ -144,7 +144,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.1.0-rc1")
+    implementation("ai.xybrid:xybrid-kotlin:0.1.0-rc3")
 }
 ```
 
@@ -162,7 +162,7 @@ val result = model.run(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", exact: "0.1.0-rc1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", exact: "0.1.0-rc3")
 ]
 ```
 
@@ -198,7 +198,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.1"
+xybrid = "0.1.0-rc3"
 ```
 
 **Run a model:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,7 +145,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.1.0
+  xybrid_flutter: ^0.1.0-rc3
 ```
 
 **运行模型：**
@@ -162,7 +162,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.1.0-rc1")
+    implementation("ai.xybrid:xybrid-kotlin:0.1.0-rc3")
 }
 ```
 
@@ -180,7 +180,7 @@ val result = model.run(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", exact: "0.1.0-beta13")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", exact: "0.1.0-rc3")
 ]
 ```
 
@@ -216,7 +216,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.1"
+xybrid = "0.1.0-rc3"
 ```
 
 **运行模型：**


### PR DESCRIPTION
## Summary

The Kotlin, Swift, Flutter, and Rust install snippets in the English, Japanese, and Simplified Chinese top-level READMEs referenced a mix of `0.1.0-rc1`, `0.1.0-beta13`, and unpinned `0.1` — none of which match the current workspace version `0.1.0-rc3`. This PR aligns all three READMEs on `0.1.0-rc3` so users following the quick-start get a buildable version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)