### PR TITLE
feat(telemetry): emit ModelWarmup from XybridModel::warmup; route CLI REPL warmup through it

### DIFF
--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -175,7 +175,7 @@ pub(crate) fn handle_repl_command(
     let mut orchestrator = Orchestrator::new();
     let bridge = xybrid_sdk::bridge_orchestrator_events(&orchestrator);
 
-    warmup_models(&mut orchestrator, &stages, &metrics, &availability_fn);
+    warmup_models(&stages);
 
     println!();
     ui::hint("Enter text and press Enter to run inference");
@@ -356,25 +356,74 @@ fn ensure_model_cached(
     Ok(())
 }
 
-fn warmup_models(
-    orchestrator: &mut Orchestrator,
-    stages: &[StageDescriptor],
-    metrics: &xybrid_core::context::DeviceMetrics,
-    availability_fn: &dyn Fn(&str) -> LocalAvailability,
-) {
+/// Warm up local stages by constructing an `XybridModel` per stage with
+/// a populated `bundle_path` and calling `model.warmup()`.
+///
+/// Why not just call `orchestrator.execute_pipeline()` (which also runs
+/// a forward pass per stage)? The orchestrator emits a full pipeline
+/// execution event chain (`PipelineStart`, `StageStart`,
+/// `PolicyEvaluated`, `RoutingDecided`, `ExecutionStarted`,
+/// `ExecutionCompleted`, `StageComplete`, `PipelineComplete`). The
+/// SDK→wire bridge filter drops most of those, but `PolicyEvaluated`
+/// and `RoutingDecided` legitimately pass through (they're routing
+/// metadata). On a real inference those events sit behind a
+/// `ModelComplete` / `PipelineComplete` row on the dashboard; on a
+/// warmup pass there's no completion event behind them, so they
+/// render as phantom 0 ms rows.
+///
+/// `XybridModel::warmup` goes directly through the executor — no
+/// orchestrator events fire — and publishes a single `ModelWarmup`
+/// event per stage with measured latency. The Traces dashboard then
+/// sees one labelled warmup row per local stage instead of two phantom
+/// rows per stage.
+///
+/// Stages without a `bundle_path` (remote-only / integration stages)
+/// can't warm locally and are skipped.
+fn warmup_models(stages: &[StageDescriptor]) {
     let sp = ui::spinner("Warming up models...");
-    let warmup_input = Envelope {
-        kind: EnvelopeKind::Text("Hi".to_string()),
-        metadata: std::collections::HashMap::new(),
-    };
-    match orchestrator.execute_pipeline(stages, &warmup_input, metrics, availability_fn) {
-        Ok(_) => {
-            sp.finish_and_clear();
+    let mut warmed = 0_usize;
+    let mut failed: Vec<(String, String)> = Vec::new();
+
+    for stage in stages {
+        let Some(bundle_path_str) = stage.bundle_path.as_ref() else {
+            // Remote / integration stage — nothing to warm locally.
+            continue;
+        };
+        let bundle_path = PathBuf::from(bundle_path_str);
+
+        let loader_result = if bundle_path
+            .extension()
+            .is_some_and(|ext| ext == "xyb")
+        {
+            ModelLoader::from_bundle(&bundle_path)
+        } else {
+            ModelLoader::from_directory(&bundle_path)
+        };
+
+        let warmup_result = loader_result
+            .and_then(|loader| loader.load())
+            .and_then(|model| model.warmup());
+
+        match warmup_result {
+            Ok(()) => warmed += 1,
+            Err(e) => failed.push((stage.name.clone(), e.to_string())),
+        }
+    }
+
+    sp.finish_and_clear();
+    if failed.is_empty() {
+        if warmed == 0 {
+            // All stages were remote — nothing to warm; treat as silent OK.
+            ui::ok("No local stages to warm. Ready for input!");
+        } else {
             ui::ok("Models loaded and warm. Ready for input!");
         }
-        Err(e) => {
-            sp.finish_and_clear();
-            ui::warning(&format!("Warmup failed ({}), first query may be slow", e));
+    } else {
+        for (stage_name, err) in &failed {
+            ui::warning(&format!(
+                "Warmup failed for {} ({}), first query may be slow",
+                stage_name, err
+            ));
         }
     }
 }

--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -391,10 +391,7 @@ fn warmup_models(stages: &[StageDescriptor]) {
         };
         let bundle_path = PathBuf::from(bundle_path_str);
 
-        let loader_result = if bundle_path
-            .extension()
-            .is_some_and(|ext| ext == "xyb")
-        {
+        let loader_result = if bundle_path.extension().is_some_and(|ext| ext == "xyb") {
             ModelLoader::from_bundle(&bundle_path)
         } else {
             ModelLoader::from_directory(&bundle_path)

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1596,6 +1596,17 @@ impl XybridModel {
             },
         };
 
+        // Warmup measures model-load + first-token latency, not full
+        // generation. Cap LLM decoding at 1 token so a 2048-token
+        // `GenerationConfig::default()` doesn't turn warmup into a real
+        // inference. `executor::execute_llm` reads this from envelope
+        // metadata when no explicit `GenerationConfig` is passed;
+        // non-LLM paths ignore it.
+        let mut warmup_input = warmup_input;
+        warmup_input
+            .metadata
+            .insert("max_tokens".to_string(), "1".to_string());
+
         // Run the inference inline (rather than delegating to `self.run`)
         // so the publish at the end is a `ModelWarmup` event rather than
         // a `ModelComplete`. Warmups should be visible to billing /
@@ -1705,6 +1716,13 @@ impl XybridModel {
                     metadata: std::collections::HashMap::new(),
                 },
             };
+
+            // See sync `warmup()` for rationale — cap LLM decoding at
+            // 1 token so warmup doesn't run a full generation.
+            let mut warmup_input = warmup_input;
+            warmup_input
+                .metadata
+                .insert("max_tokens".to_string(), "1".to_string());
 
             let start = Instant::now();
             let resource_guard = crate::telemetry::begin_resource_run();

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1596,16 +1596,62 @@ impl XybridModel {
             },
         };
 
-        // Run inference (this loads the model)
+        // Run the inference inline (rather than delegating to `self.run`)
+        // so the publish at the end is a `ModelWarmup` event rather than
+        // a `ModelComplete`. Warmups should be visible to billing /
+        // perf-debugging but distinguishable from real inferences on
+        // the Traces dashboard — `ModelWarmup` carries the same
+        // attribution fields (`stage_name`, `target`, `latency_ms`) but
+        // its own event_type so the platform can render with a `warmup`
+        // badge and default-filter it out of cost-attribution rollups.
         let start = Instant::now();
-        let _ = self.run(&warmup_input, None)?;
-        let elapsed = start.elapsed();
+        let resource_guard = crate::telemetry::begin_resource_run();
+        let trace_id = uuid::Uuid::new_v4();
+        let _telemetry_ctx =
+            crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
+
+        {
+            let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+            if !handle.loaded {
+                return Err(SdkError::NotLoaded);
+            }
+            let metadata = handle.metadata.clone();
+            handle
+                .executor
+                .execute(&metadata, &warmup_input, None)
+                .map_err(|e| {
+                    SdkError::InferenceError(format!("Warmup execution failed: {}", e))
+                })?;
+        }
+
+        let latency_ms = start.elapsed().as_millis() as u32;
+
+        let event = crate::telemetry::TelemetryEvent {
+            event_type: "ModelWarmup".to_string(),
+            stage_name: Some(self.model_id.clone()),
+            target: Some("local".to_string()),
+            latency_ms: Some(latency_ms),
+            error: None,
+            data: Some(
+                serde_json::json!({
+                    "model_id": self.model_id,
+                    "version": self.version,
+                    "output_type": format!("{:?}", self.output_type),
+                })
+                .to_string(),
+            ),
+            timestamp_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+        };
+        crate::telemetry::publish_with_resource_summary(event, resource_guard);
 
         log::info!(
             target: "xybrid_sdk",
-            "Model {} warmed up in {:?}",
+            "Model {} warmed up in {}ms",
             self.model_id,
-            elapsed
+            latency_ms
         );
 
         Ok(())
@@ -1663,25 +1709,61 @@ impl XybridModel {
             };
 
             let start = Instant::now();
+            let resource_guard = crate::telemetry::begin_resource_run();
+            let trace_id = uuid::Uuid::new_v4();
+            let _telemetry_ctx =
+                crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
-            // Run inference
-            let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
-            if !guard.loaded {
-                return Err(SdkError::NotLoaded);
+            // Run inference inline and publish a `ModelWarmup` event —
+            // same shape as the sync `warmup()` above. Previously this
+            // path published nothing at all, so async warmups were
+            // silent on the wire (visible only via logs).
+            let version_for_event;
+            let output_type_str;
+            {
+                let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
+                if !guard.loaded {
+                    return Err(SdkError::NotLoaded);
+                }
+
+                let metadata = guard.metadata.clone();
+                guard
+                    .executor
+                    .execute(&metadata, &warmup_input, None)
+                    .map_err(|e| SdkError::InferenceError(format!("Warmup failed: {}", e)))?;
+
+                version_for_event = metadata.version.clone();
+                output_type_str = format!("{:?}", output_type);
             }
 
-            let metadata = guard.metadata.clone();
-            let _ = guard
-                .executor
-                .execute(&metadata, &warmup_input, None)
-                .map_err(|e| SdkError::InferenceError(format!("Warmup failed: {}", e)))?;
+            let latency_ms = start.elapsed().as_millis() as u32;
 
-            let elapsed = start.elapsed();
+            let event = crate::telemetry::TelemetryEvent {
+                event_type: "ModelWarmup".to_string(),
+                stage_name: Some(model_id.clone()),
+                target: Some("local".to_string()),
+                latency_ms: Some(latency_ms),
+                error: None,
+                data: Some(
+                    serde_json::json!({
+                        "model_id": model_id,
+                        "version": version_for_event,
+                        "output_type": output_type_str,
+                    })
+                    .to_string(),
+                ),
+                timestamp_ms: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            };
+            crate::telemetry::publish_with_resource_summary(event, resource_guard);
+
             log::info!(
                 target: "xybrid_sdk",
-                "Model {} warmed up (async) in {:?}",
+                "Model {} warmed up (async) in {}ms",
                 model_id,
-                elapsed
+                latency_ms
             );
 
             Ok(())

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1619,9 +1619,7 @@ impl XybridModel {
             handle
                 .executor
                 .execute(&metadata, &warmup_input, None)
-                .map_err(|e| {
-                    SdkError::InferenceError(format!("Warmup execution failed: {}", e))
-                })?;
+                .map_err(|e| SdkError::InferenceError(format!("Warmup execution failed: {}", e)))?;
         }
 
         let latency_ms = start.elapsed().as_millis() as u32;

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -1261,6 +1261,164 @@ fn pipeline_streaming_fallback_emits_bounded_event_shape() {
     );
 }
 
+/// Regression guard: `XybridModel::warmup` must emit exactly one
+/// `ModelWarmup` telemetry event per warmup pass — distinct from
+/// `ModelComplete` so the Traces dashboard can render it with a
+/// `warmup` badge and default-filter it out of cost-attribution
+/// rollups. Carries the same attribution fields (`stage_name`,
+/// `target`, `latency_ms`) as a real inference's completion event.
+///
+/// Before this contract landed, `warmup` delegated to `self.run`,
+/// which emitted `ModelComplete` — making warmups indistinguishable
+/// from real inferences on the wire and inflating cost-attribution
+/// rollups with synthetic warmup runs.
+#[cfg(feature = "llm-llamacpp")]
+#[test]
+fn xybrid_model_warmup_emits_one_model_warmup_event() {
+    use xybrid_core::execution::listener;
+
+    let _serial = listener_test_lock();
+
+    let Some(model_dir) = model_fixtures::model_or_skip("qwen2.5-0.5b-instruct") else {
+        return;
+    };
+
+    let (tx, rx) = mpsc::channel::<TelemetryEvent>();
+    register_telemetry_sender(tx);
+
+    listener::set_execution_listener(|event| {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let telemetry_event = match event {
+            xybrid_sdk::ExecutionEvent::Started { model_id, method } => TelemetryEvent {
+                event_type: "ExecutionStarted".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: None,
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Completed {
+                model_id,
+                method,
+                latency_ms,
+            } => TelemetryEvent {
+                event_type: "ExecutionCompleted".to_string(),
+                stage_name: Some(method),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: None,
+                data: Some(format!(r#"{{"model":"{}"}}"#, model_id)),
+                timestamp_ms,
+            },
+            xybrid_sdk::ExecutionEvent::Failed {
+                model_id,
+                method,
+                latency_ms,
+                error,
+            } => TelemetryEvent {
+                event_type: "ExecutionFailed".to_string(),
+                stage_name: Some(model_id.clone()),
+                target: Some("device".to_string()),
+                latency_ms: Some(latency_ms as u32),
+                error: Some(error),
+                data: Some(format!(
+                    r#"{{"model":"{}","method":"{}"}}"#,
+                    model_id, method
+                )),
+                timestamp_ms,
+            },
+        };
+
+        publish_telemetry_event(telemetry_event);
+    });
+
+    let model = xybrid_sdk::ModelLoader::from_directory(&model_dir)
+        .expect("loader should build from directory")
+        .load()
+        .expect("qwen2.5-0.5b-instruct should load");
+
+    model.warmup().expect("warmup should succeed");
+
+    std::thread::sleep(Duration::from_millis(100));
+    listener::clear_execution_listener();
+
+    let mut collected: Vec<TelemetryEvent> = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        collected.push(ev);
+    }
+
+    let warmups: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| e.event_type == "ModelWarmup")
+        .collect();
+    assert_eq!(
+        warmups.len(),
+        1,
+        "XybridModel::warmup must emit exactly one ModelWarmup per call. \
+         Captured {} total events: {:#?}",
+        collected.len(),
+        collected
+    );
+    let warmup = warmups[0];
+    assert_eq!(
+        warmup.stage_name.as_deref(),
+        Some("qwen2.5-0.5b-instruct"),
+        "ModelWarmup stage_name should be the model id; got {:?}",
+        warmup.stage_name
+    );
+    assert_eq!(
+        warmup.target.as_deref(),
+        Some("local"),
+        "ModelWarmup target should be `local`; got {:?}",
+        warmup.target
+    );
+    assert!(
+        warmup.latency_ms.is_some_and(|ms| ms > 0),
+        "ModelWarmup must carry positive latency_ms; got {:?}",
+        warmup.latency_ms
+    );
+
+    // No `ModelComplete` should fire on a warmup pass — the warmup is a
+    // distinct event category, not a real inference completion.
+    let model_completes: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| e.event_type == "ModelComplete")
+        .collect();
+    assert!(
+        model_completes.is_empty(),
+        "warmup must NOT emit ModelComplete — that would inflate \
+         cost-attribution rollups with synthetic warmup runs. Leaked: {:#?}",
+        model_completes
+    );
+
+    // No outer-span or pipeline-frame leakage either.
+    let leaked_outer: Vec<&TelemetryEvent> = collected
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.event_type.as_str(),
+                "ExecutionStarted"
+                    | "ExecutionCompleted"
+                    | "PipelineStart"
+                    | "PipelineComplete"
+                    | "StageStart"
+                    | "StageComplete"
+            )
+        })
+        .collect();
+    assert!(
+        leaked_outer.is_empty(),
+        "warmup must not emit outer-span Started/Completed or pipeline-frame \
+         events alongside the ModelWarmup. Leaked: {:#?}",
+        leaked_outer
+    );
+}
+
 /// Smoke test: MNIST inference works without telemetry (no env vars needed).
 /// Ensures the model fixture is valid and the execution pipeline doesn't panic.
 #[test]


### PR DESCRIPTION
## Summary

- `XybridModel::warmup` (sync + async) no longer delegates to `self.run`. Run the warmup inference inline through the executor and publish a single `ModelWarmup` telemetry event with measured latency. Same attribution fields (`stage_name`, `target`, `latency_ms`) as `ModelComplete`, but the distinct `event_type` lets the platform render with a `warmup` badge and default-filter warmups out of cost-attribution rollups.
- `XybridModel::warmup_async` previously published no wire event at all — fix that too while we're here, emit `ModelWarmup` consistently.
- `crates/xybrid-cli/src/commands/repl.rs:warmup_models` switches from `orchestrator.execute_pipeline` to constructing an `XybridModel` per stage with a `bundle_path` and calling `.warmup()` on each. Goes directly through the executor; the orchestrator's pipeline-frame event chain no longer fires for warmup.

### Why

The CLI REPL produced two phantom 0-ms `LLM` rows on the Traces dashboard at startup alongside the real chat turns. Cause: `warmup_models` invoked `orchestrator.execute_pipeline` with `"Hi"`. The orchestrator emits a full pipeline-execution event chain. The SDK→wire bridge filter (landed in the row-fanout cleanup) drops the pipeline-frame events but legitimately lets `PolicyEvaluated` + `RoutingDecided` through. On a real inference those events sit behind a completion row; on a warmup pass there's no completion to anchor them, so they render as phantoms.

Bypassing the orchestrator for warmup (going straight through `XybridModel::warmup → executor`) eliminates the orchestrator-event noise entirely. Publishing a distinct `ModelWarmup` event keeps the warmup observable to billing / perf debugging without conflating it with a real inference.

### Wire-shape change per warmup invocation

| | Before | After |
|---|---|---|
| Events emitted | 2 (PolicyEvaluated + RoutingDecided) — render as phantoms with no completion behind them | 1 (`ModelWarmup`) with `stage_name`, `target=local`, positive `latency_ms` |
| Dashboard rows | 2 phantom 0-ms `LLM` rows, no `GGUF` badge, no tokens | 1 `ModelWarmup` row per local stage with measured latency |

## Test plan

- [x] New `xybrid_model_warmup_emits_one_model_warmup_event` integration test — asserts exactly one `ModelWarmup` per call, positive latency, no `ModelComplete` (warmups must not inflate cost-attribution rollups), no outer-span / pipeline-frame leakage. Skips gracefully via `model_or_skip("qwen2.5-0.5b-instruct")`.
- [x] `cargo test -p xybrid-sdk --features platform-macos --test telemetry_integration` — 12 pass, 1 ignored
- [x] `cargo test -p xybrid-sdk --features platform-macos --lib` — 331 pass
- [x] `cargo clippy --workspace --tests --benches --features platform-macos -- -D warnings` — clean
- [ ] On-device verify: re-run CLI REPL with three chat turns — dashboard should show exactly three real `LLM/GGUF` rows + one `ModelWarmup` row (no phantoms).

## Notes

- `Pipeline::warmup` and `Pipeline::warmup_async` (the SDK convenience wrappers) still delegate to the pipeline-level run path which goes through the orchestrator. They're a deliberately secondary path used by callers who already hold a `Pipeline` (vs. `XybridModel`) and want a one-call "warm + ready" gesture. Updating them to also emit `ModelWarmup` would require either a similar refactor or piggybacking on the orchestrator's events. Out of scope here — only the REPL path is fixed, which is where the user-visible phantom rows surfaced. Tracked as the remaining piece of the follow-up epic.
- Platform-side hoist + dashboard rendering of the `warmup` badge is a separate follow-up. Currently `ModelWarmup` reaches the wire but the dashboard renders it generically. That platform-side piece is the next step after this PR lands.