### PR TITLE
docs: add Kotlin ASR microphone setup

### DIFF
--- a/docs/content/docs/(integration)/sdks/kotlin.mdx
+++ b/docs/content/docs/(integration)/sdks/kotlin.mdx
@@ -60,6 +60,73 @@ class InferenceRepository {
 }
 ```
 
+
+## Microphone Permissions for ASR
+
+Android speech-recognition flows need microphone permission before creating an audio envelope. Add the permission to your app manifest:
+
+```xml title="AndroidManifest.xml"
+<manifest ...>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <application ...>
+        ...
+    </application>
+</manifest>
+```
+
+Request `RECORD_AUDIO` at runtime before recording. This example uses the standard Activity Result API from a `ComponentActivity`:
+
+```kotlin
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
+class MainActivity : ComponentActivity() {
+    private val requestAudioPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            startRecordingForAsr()
+        } else {
+            showMicrophonePermissionMessage()
+        }
+    }
+
+    fun ensureMicrophonePermission() {
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (granted) {
+            startRecordingForAsr()
+        } else {
+            requestAudioPermission.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+}
+```
+
+After permission is granted, capture mono PCM at 16 kHz and pass the bytes to a Whisper model:
+
+```kotlin
+suspend fun transcribeRecordedAudio(audioBytes: ByteArray): String =
+    withContext(Dispatchers.IO) {
+        val model = XybridModelLoader.fromRegistry("whisper-tiny").load()
+        val envelope = Envelope.audio(
+            bytes = audioBytes,
+            sampleRate = 16000u,
+            channels = 1u,
+        )
+        val result = model.run(envelope)
+
+        result.text ?: error(result.error ?: "ASR produced no text")
+    }
+```
+
 ## Jetpack Compose Integration
 
 ```kotlin

--- a/docs/content/docs/(integration)/sdks/kotlin.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/kotlin.zh.mdx
@@ -60,6 +60,73 @@ class InferenceRepository {
 }
 ```
 
+
+## ASR 麦克风权限
+
+Android 语音识别流程在创建音频 envelope 前需要麦克风权限。先在应用清单中添加权限：
+
+```xml title="AndroidManifest.xml"
+<manifest ...>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <application ...>
+        ...
+    </application>
+</manifest>
+```
+
+录音前使用标准 Activity Result API 请求 `RECORD_AUDIO` 运行时权限。下面示例基于 `ComponentActivity`：
+
+```kotlin
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
+class MainActivity : ComponentActivity() {
+    private val requestAudioPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            startRecordingForAsr()
+        } else {
+            showMicrophonePermissionMessage()
+        }
+    }
+
+    fun ensureMicrophonePermission() {
+        val granted = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (granted) {
+            startRecordingForAsr()
+        } else {
+            requestAudioPermission.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+}
+```
+
+权限授予后，采集 16 kHz 单声道 PCM，并将字节传给 Whisper 模型：
+
+```kotlin
+suspend fun transcribeRecordedAudio(audioBytes: ByteArray): String =
+    withContext(Dispatchers.IO) {
+        val model = XybridModelLoader.fromRegistry("whisper-tiny").load()
+        val envelope = Envelope.audio(
+            bytes = audioBytes,
+            sampleRate = 16000u,
+            channels = 1u,
+        )
+        val result = model.run(envelope)
+
+        result.text ?: error(result.error ?: "ASR did not produce text")
+    }
+```
+
 ## Jetpack Compose 集成
 
 ```kotlin


### PR DESCRIPTION
## Problem
Kotlin SDK docs mention audio envelopes but do not show the Android microphone permission setup needed for real ASR flows. Issue #153 asks for manifest, runtime permission, and ASR examples in both English and Chinese Kotlin docs.

## Solution
- Added `RECORD_AUDIO` manifest snippets.
- Added Activity Result API runtime permission examples.
- Added a compact Whisper ASR transcription example using `Envelope.audio`.
- Mirrored the content in `kotlin.zh.mdx`.

Closes #153.

## Validation
- `npm install --ignore-scripts` in `docs/`
- `npm run types:check` in `docs/`
- `git diff --check`

## Confidence
Score: 82/100
Category: docs/examples