### PR TITLE
fix: pin XYBRID_VERSION in install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -29,9 +29,9 @@ if (-not $Version) {
 }
 
 # --- Download ---
-
-$Artifact = "$BinaryName-$Version-$Platform.exe"
-$Url = "https://github.com/$Repo/releases/download/$Version/$Artifact"
+$XybridVersion = if ($env:XYBRID_VERSION) { $env:XYBRID_VERSION } else { "0.1.0-rc3" }
+$Artifact = "$BinaryName-$XybridVersion-$Platform.exe"
+$Url = "https://github.com/$Repo/releases/download/$XybridVersion/$Artifact"
 
 $InstallDir = "$env:USERPROFILE\.xybrid\bin"
 if (-not (Test-Path $InstallDir)) {
@@ -40,7 +40,7 @@ if (-not (Test-Path $InstallDir)) {
 
 $Dest = Join-Path $InstallDir "$BinaryName.exe"
 
-Write-Host "==> Downloading xybrid $Version for $Platform..." -ForegroundColor Blue
+Write-Host "==> Downloading xybrid $XybridVersion for $Platform..." -ForegroundColor Blue
 
 try {
     Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing

--- a/install.sh
+++ b/install.sh
@@ -104,11 +104,12 @@ choose_install_dir() {
 # --- Download and install ---
 
 download_and_install() {
-  URL="https://github.com/$REPO/releases/download/${VERSION}/${ARTIFACT}"
+  XYBRID_VERSION="${XYBRID_VERSION:-0.1.0-rc3}"
+  URL="https://github.com/$REPO/releases/download/${XYBRID_VERSION}/${ARTIFACT}"
   TMPDIR=$(mktemp -d)
   TMPFILE="$TMPDIR/$BINARY_NAME"
 
-  info "Downloading xybrid ${VERSION} for ${PLATFORM}-${ARCH}..."
+  info "Downloading xybrid ${XYBRID_VERSION} for ${PLATFORM}-${ARCH}..."
 
   if command -v curl >/dev/null 2>&1; then
     HTTP_CODE=$(curl -sL -w "%{http_code}" -o "$TMPFILE" "$URL")


### PR DESCRIPTION
## Summary
- Add `XYBRID_VERSION` variable to `install.sh` and `install.ps1`
- Defaults to `0.1.0-rc3`, overridable via env var
- Prevents silent breakage when a new release ships