### PR TITLE
fix(telemetry): drain span collector on ModelWarmup so warmup spans don't leak into the next event

### DIFF
--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1000,16 +1000,22 @@ fn convert_to_platform_event(
     // Span-bearing event types: completion-family events publish a final
     // ModelComplete/PipelineComplete that drains the collector, AND the
     // cloud-fallback flow publishes LocalAborted/CloudRetry as terminal
-    // markers for each leg without ever firing a *Complete. Both kinds
-    // need their flamegraph attached at the wire layer or the dashboard
-    // sees an empty trace detail. Adding LocalAborted/CloudRetry here is
-    // the symmetric counterpart of the same addition in
-    // `snapshot_spans_into_event` — both gates must agree, otherwise the
-    // SDK attaches spans to event.data["spans"] but `convert_to_platform_event`
-    // strips them again before the wire.
+    // markers for each leg without ever firing a *Complete, AND
+    // ModelWarmup is its own completion category (XybridModel::warmup
+    // opens executor spans then publishes a single ModelWarmup —
+    // distinct from ModelComplete so the dashboard can filter warmups
+    // out of cost-attribution rollups). All four kinds need their
+    // flamegraph attached at the wire layer or the dashboard sees an
+    // empty trace detail. This list MUST match `snapshot_spans_into_event`
+    // above; otherwise the SDK attaches spans to event.data["spans"]
+    // but `convert_to_platform_event` strips them again before the wire.
     let stages = if matches!(
         event.event_type.as_str(),
-        "PipelineComplete" | "ModelComplete" | "LocalAborted" | "CloudRetry"
+        "PipelineComplete"
+            | "ModelComplete"
+            | "ModelWarmup"
+            | "LocalAborted"
+            | "CloudRetry"
     ) && core_tracing::is_tracing_enabled()
     {
         let embedded_spans: Option<serde_json::Value> = payload
@@ -2265,9 +2271,22 @@ fn snapshot_spans_into_event(event: TelemetryEvent) -> TelemetryEvent {
     // so without these the cloud-leg `SpanGuard`s in
     // `runtime_adapter/cloud/mod.rs` get stranded in the global collector
     // and the dashboard's flamegraph stays empty.
+    //
+    // `ModelWarmup` follows the same shape: `XybridModel::warmup` opens
+    // `execute:<model>` + `llm_inference` spans via the executor before
+    // publishing. Without this entry those spans would (a) never reach
+    // the warmup event's payload — the dashboard falls back to a
+    // synthesized placeholder flamegraph — and (b) leak into the next
+    // event's snapshot (typically the first real inference of the
+    // session), giving that inference's trace two stray spans it
+    // didn't generate.
     let is_span_bearing = matches!(
         event.event_type.as_str(),
-        "PipelineComplete" | "ModelComplete" | "LocalAborted" | "CloudRetry"
+        "PipelineComplete"
+            | "ModelComplete"
+            | "ModelWarmup"
+            | "LocalAborted"
+            | "CloudRetry"
     );
     if !is_span_bearing || !core_tracing::is_tracing_enabled() {
         return event;

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1011,11 +1011,7 @@ fn convert_to_platform_event(
     // but `convert_to_platform_event` strips them again before the wire.
     let stages = if matches!(
         event.event_type.as_str(),
-        "PipelineComplete"
-            | "ModelComplete"
-            | "ModelWarmup"
-            | "LocalAborted"
-            | "CloudRetry"
+        "PipelineComplete" | "ModelComplete" | "ModelWarmup" | "LocalAborted" | "CloudRetry"
     ) && core_tracing::is_tracing_enabled()
     {
         let embedded_spans: Option<serde_json::Value> = payload
@@ -2282,11 +2278,7 @@ fn snapshot_spans_into_event(event: TelemetryEvent) -> TelemetryEvent {
     // didn't generate.
     let is_span_bearing = matches!(
         event.event_type.as_str(),
-        "PipelineComplete"
-            | "ModelComplete"
-            | "ModelWarmup"
-            | "LocalAborted"
-            | "CloudRetry"
+        "PipelineComplete" | "ModelComplete" | "ModelWarmup" | "LocalAborted" | "CloudRetry"
     );
     if !is_span_bearing || !core_tracing::is_tracing_enabled() {
         return event;

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -1477,8 +1477,7 @@ fn xybrid_model_warmup_drains_span_collector_to_avoid_leak_into_next_event() {
         "global span collector must be drained after `XybridModel::warmup` publishes \
          its `ModelWarmup` event — leftover spans leak into the next event's \
          snapshot. Got {} stranded spans: {}",
-        leftover_spans,
-        after
+        leftover_spans, after
     );
 
     core_tracing::reset_tracing();

--- a/crates/xybrid-sdk/tests/telemetry_integration.rs
+++ b/crates/xybrid-sdk/tests/telemetry_integration.rs
@@ -1419,6 +1419,71 @@ fn xybrid_model_warmup_emits_one_model_warmup_event() {
     );
 }
 
+/// Regression guard: `XybridModel::warmup` must drain the global span
+/// collector when it publishes — otherwise the executor spans opened
+/// during warmup (`execute:<model>`, `llm_inference`) stay in the
+/// collector and leak into the snapshot of the next event the SDK
+/// publishes. On a real CLI REPL session that means the first chat
+/// turn's `ModelComplete` snapshot captures three spans (two leaked
+/// warmup spans + one real chat span) and the warmup's own
+/// `ModelWarmup` event reaches the dashboard with no real spans —
+/// the dashboard falls back to its synthesized placeholder
+/// flamegraph.
+///
+/// The fix is that `ModelWarmup` is in the span-bearing event-type
+/// list inside `publish_telemetry_event::snapshot_spans_into_event`
+/// (and the matching gate in `convert_to_platform_event`). This test
+/// asserts the observable consequence: the global collector is empty
+/// after `model.warmup()` returns.
+#[cfg(feature = "llm-llamacpp")]
+#[test]
+fn xybrid_model_warmup_drains_span_collector_to_avoid_leak_into_next_event() {
+    use xybrid_core::tracing as core_tracing;
+
+    let _serial = listener_test_lock();
+
+    let Some(model_dir) = model_fixtures::model_or_skip("qwen2.5-0.5b-instruct") else {
+        return;
+    };
+
+    // Need tracing enabled for the executor's SpanGuards to actually
+    // open spans, and for `snapshot_spans_into_event` to consider this
+    // event span-bearing. Reset first so leftover spans from earlier
+    // tests don't pollute the assertion.
+    core_tracing::init_tracing(true);
+    core_tracing::reset_tracing();
+
+    let (tx, _rx) = mpsc::channel::<TelemetryEvent>();
+    register_telemetry_sender(tx);
+
+    let model = xybrid_sdk::ModelLoader::from_directory(&model_dir)
+        .expect("loader should build from directory")
+        .load()
+        .expect("qwen2.5-0.5b-instruct should load");
+
+    model.warmup().expect("warmup should succeed");
+
+    // After publish, the collector must be empty. Any leftover span
+    // here would attach to whatever event publishes next, polluting
+    // its trace detail on the dashboard.
+    let after = core_tracing::get_stages_json();
+    let leftover_spans = after
+        .get("spans")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert_eq!(
+        leftover_spans, 0,
+        "global span collector must be drained after `XybridModel::warmup` publishes \
+         its `ModelWarmup` event — leftover spans leak into the next event's \
+         snapshot. Got {} stranded spans: {}",
+        leftover_spans,
+        after
+    );
+
+    core_tracing::reset_tracing();
+}
+
 /// Smoke test: MNIST inference works without telemetry (no env vars needed).
 /// Ensures the model fixture is valid and the execution pipeline doesn't panic.
 #[test]


### PR DESCRIPTION
## Summary

`XybridModel::warmup` opens `execute:<model>` + `llm_inference` spans via the executor before publishing a `ModelWarmup` event. Two gates in `crates/xybrid-sdk/src/telemetry.rs` decide whether an event triggers the span-snapshot + collector-reset path:

- `snapshot_spans_into_event` at the SDK publish boundary
- `convert_to_platform_event` at the SDK→wire conversion

Both listed `PipelineComplete`, `ModelComplete`, `LocalAborted`, `CloudRetry` — but NOT `ModelWarmup` (added in a prior PR). One-list-entry change in each gate fixes both symptoms.

## Symptoms (both fixed by this change)

| # | What the user sees | Why |
|---|---|---|
| 1 | Warmup row's trace detail renders the **synthesized placeholder** flamegraph (POST /v1/chat, auth · validate key, cache · lookup, …) instead of the real `execute:<model>` + `llm_inference` spans | `snapshot_spans_into_event` skipped on `ModelWarmup` → warmup's spans never embedded → dashboard falls back to `buildSpansFor` placeholder |
| 2 | First chat turn after warmup shows **3 spans on its trace detail**: 2 stray `execute:<model>` + `llm_inference` it didn't generate, plus its own real `llm_inference_streaming_with_messages` | Collector never reset on warmup publish → warmup's spans stay live → next event's snapshot captures them |

Both surfaced on a real REPL session — warmup row had a 7-span synthesized fallback; chat turn 1 had 3 spans (2 leaked + 1 real); chat turns 2 + 3 had 1 span (correct, because chat turn 1's snapshot drained the collector).

## Test plan

- [x] New `xybrid_model_warmup_drains_span_collector_to_avoid_leak_into_next_event` asserts the observable consequence: `core_tracing::get_stages_json()["spans"]` is empty after `model.warmup()` returns
- [x] Existing `xybrid_model_warmup_emits_one_model_warmup_event` + `xybrid_model_run_streaming_emits_one_model_complete_event` still pass
- [x] `cargo test -p xybrid-sdk --features platform-macos --test telemetry_integration` — 13 pass, 1 ignored
- [x] `cargo test -p xybrid-sdk --features platform-macos --lib` — 333 pass
- [x] `cargo clippy --workspace --tests --benches --features platform-macos -- -D warnings` — clean
- [ ] On-device verify: re-run CLI REPL streaming → warmup row should render a real flamegraph (no "synthesized" tag); chat turn rows should only show their own spans

## Notes

- The two match lists at telemetry.rs:1010-1013 and telemetry.rs:2268-2271 must always agree — the comment block at convert_to_platform_event already warned about this. Both updated symmetrically.
- This is the cleanup follow-up to the `ModelWarmup` event type itself (introduced via the warmup-folding work).