### PR TITLE
fix(repl): route cached models locally

### DIFF
--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -10,13 +10,59 @@ use xybrid_core::conversation::ConversationContext;
 use xybrid_core::ir::{Envelope, EnvelopeKind, MessageRole};
 use xybrid_core::orchestrator::routing_engine::LocalAvailability;
 use xybrid_core::orchestrator::Orchestrator;
-use xybrid_core::pipeline_config::PipelineConfig;
+use xybrid_core::pipeline::ExecutionTarget;
+use xybrid_core::pipeline_config::{PipelineConfig, StageConfig};
 use xybrid_sdk::model::ModelLoader;
 use xybrid_sdk::registry_client::RegistryClient;
 
 use colored::Colorize;
 
 use crate::ui;
+
+fn parse_repl_target(target: Option<&str>) -> Result<Option<ExecutionTarget>> {
+    target
+        .map(|value| {
+            value
+                .parse::<ExecutionTarget>()
+                .map_err(|err| anyhow::anyhow!(err))
+        })
+        .transpose()
+}
+
+fn target_allows_local(target: Option<&ExecutionTarget>) -> bool {
+    match target {
+        Some(target) => target.allows_local(),
+        None => true,
+    }
+}
+
+fn stage_is_locally_available(stage: &StageDescriptor) -> bool {
+    stage.is_locally_runnable()
+}
+
+fn stage_config_allows_local_cache(
+    stage_config: &StageConfig,
+    target: Option<&ExecutionTarget>,
+) -> bool {
+    match target {
+        Some(target) => target_allows_local(Some(target)),
+        None => !stage_config.is_cloud_stage(),
+    }
+}
+
+fn parse_stage_config_target(stage_config: &StageConfig) -> Option<ExecutionTarget> {
+    let value = stage_config.target()?;
+    match value.parse::<ExecutionTarget>() {
+        Ok(target) => Some(target),
+        Err(err) => {
+            ui::warning(&format!(
+                "Ignoring invalid stage target '{}': {}",
+                value, err
+            ));
+            None
+        }
+    }
+}
 
 /// Interactive REPL mode - keeps models loaded for fast repeated inference.
 pub(crate) fn handle_repl_command(
@@ -25,7 +71,7 @@ pub(crate) fn handle_repl_command(
     model_file: Option<PathBuf>,
     huggingface: Option<String>,
     voice: Option<String>,
-    _target: Option<String>,
+    target: Option<String>,
     stream: bool,
     system_prompt: Option<String>,
     verbose: u8,
@@ -38,6 +84,10 @@ pub(crate) fn handle_repl_command(
     ui::hint("Type 'quit' or 'exit' to exit. Type 'help' for commands.");
 
     print_streaming_status(stream);
+    let execution_target = parse_repl_target(target.as_deref())?;
+    if let Some(target) = &execution_target {
+        ui::kv("Target", target.as_str());
+    }
     println!();
 
     // --huggingface: load from HuggingFace repo
@@ -62,6 +112,7 @@ pub(crate) fn handle_repl_command(
 
         let mut stage = StageDescriptor::new(_model.model_id());
         stage.bundle_path = Some(cache_dir.to_string_lossy().to_string());
+        stage.target = execution_target.clone();
         vec![stage]
     } else if let Some(ref gguf_path) = model_file {
         // --model-file: load a bare GGUF file with auto-generated metadata
@@ -102,6 +153,7 @@ pub(crate) fn handle_repl_command(
 
         let mut stage = StageDescriptor::new(metadata.model_id.clone());
         stage.bundle_path = Some(parent_dir.to_string_lossy().to_string());
+        stage.target = execution_target.clone();
         vec![stage]
     } else {
         let client = RegistryClient::from_env().context("Failed to initialize registry client")?;
@@ -124,14 +176,19 @@ pub(crate) fn handle_repl_command(
             None
         };
 
-        load_stages(&client, &pipeline_config, &model_id)?
+        load_stages(
+            &client,
+            &pipeline_config,
+            &model_id,
+            execution_target.as_ref(),
+        )?
     };
 
     let mut conversation_context: Option<ConversationContext> = None;
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
     let mut loaded_model: Option<xybrid_sdk::model::XybridModel> = None;
 
-    if stages.len() == 1 && stages[0].bundle_path.is_some() {
+    if stages.len() == 1 && stage_is_locally_available(&stages[0]) {
         let bundle_path = PathBuf::from(stages[0].bundle_path.as_ref().unwrap());
         let model_result = if bundle_path.extension().is_some_and(|ext| ext == "xyb") {
             ModelLoader::from_bundle(&bundle_path).and_then(|loader| loader.load())
@@ -166,7 +223,7 @@ pub(crate) fn handle_repl_command(
 
     let stage_bundle_paths: std::collections::HashMap<String, bool> = stages
         .iter()
-        .map(|s| (s.name.clone(), s.bundle_path.is_some()))
+        .map(|s| (s.name.clone(), stage_is_locally_available(s)))
         .collect();
     let availability_fn = move |stage: &str| -> LocalAvailability {
         LocalAvailability::new(stage_bundle_paths.get(stage).copied().unwrap_or(false))
@@ -226,7 +283,7 @@ pub(crate) fn handle_repl_command(
         // Try streaming execution
         #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
         let use_streaming = {
-            let can_stream = stream && stages.len() == 1 && stages[0].bundle_path.is_some();
+            let can_stream = stream && stages.len() == 1 && stage_is_locally_available(&stages[0]);
             if stream && !can_stream {
                 ui::warning("Streaming conditions not met");
                 if verbose > 0 {
@@ -302,6 +359,7 @@ fn load_stages(
     client: &RegistryClient,
     pipeline_config: &Option<PipelineConfig>,
     model_id: &Option<String>,
+    execution_target: Option<&ExecutionTarget>,
 ) -> Result<Vec<StageDescriptor>> {
     let mut stages = Vec::new();
 
@@ -311,8 +369,10 @@ fn load_stages(
         for stage_config in &config.stages {
             let model_id = stage_config.model_id();
             let mut desc = StageDescriptor::new(&model_id);
+            let configured_target = parse_stage_config_target(stage_config);
+            desc.target = execution_target.cloned().or(configured_target);
 
-            if !stage_config.is_cloud_stage() {
+            if stage_config_allows_local_cache(stage_config, desc.target.as_ref()) {
                 ensure_model_cached(&mut desc, &model_id, client)?;
             }
             stages.push(desc);
@@ -320,7 +380,10 @@ fn load_stages(
     } else if let Some(ref model_id) = model_id {
         ui::kv("Model", model_id);
         let mut desc = StageDescriptor::new(model_id);
-        ensure_model_cached(&mut desc, model_id, client)?;
+        desc.target = execution_target.cloned();
+        if target_allows_local(desc.target.as_ref()) {
+            ensure_model_cached(&mut desc, model_id, client)?;
+        }
         stages.push(desc);
     }
 
@@ -385,6 +448,10 @@ fn warmup_models(stages: &[StageDescriptor]) {
     let mut failed: Vec<(String, String)> = Vec::new();
 
     for stage in stages {
+        if !target_allows_local(stage.target.as_ref()) {
+            continue;
+        }
+
         let Some(bundle_path_str) = stage.bundle_path.as_ref() else {
             // Remote / integration stage — nothing to warm locally.
             continue;
@@ -710,5 +777,114 @@ fn execute_batch(
         Err(e) => {
             ui::err(&format!("{}", e));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_targets_do_not_allow_local_runtime() {
+        assert!(!target_allows_local(Some(&ExecutionTarget::Cloud)));
+        assert!(!target_allows_local(Some(&ExecutionTarget::Server)));
+    }
+
+    #[test]
+    fn local_and_auto_targets_allow_local_runtime() {
+        assert!(target_allows_local(None));
+        assert!(target_allows_local(Some(&ExecutionTarget::Device)));
+        assert!(target_allows_local(Some(&ExecutionTarget::Auto)));
+    }
+
+    #[test]
+    fn network_target_with_bundle_path_is_not_local_available() {
+        let stage = StageDescriptor::new("test-model")
+            .with_bundle_path("/tmp/test-model")
+            .with_target(ExecutionTarget::Cloud);
+
+        assert!(!stage_is_locally_available(&stage));
+    }
+
+    #[test]
+    fn server_config_stage_skips_local_cache() {
+        let config = PipelineConfig::from_yaml(
+            r#"
+name: test
+stages:
+  - id: llm
+    model: test-model
+    target: server
+"#,
+        )
+        .unwrap();
+
+        assert!(!stage_config_allows_local_cache(
+            &config.stages[0],
+            Some(&ExecutionTarget::Server)
+        ));
+    }
+
+    #[test]
+    fn direct_model_network_target_skips_registry_cache_lookup() {
+        for target in [ExecutionTarget::Cloud, ExecutionTarget::Server] {
+            let client = RegistryClient::with_url("http://127.0.0.1:9").unwrap();
+
+            let stages = load_stages(
+                &client,
+                &None,
+                &Some("test-model".to_string()),
+                Some(&target),
+            )
+            .unwrap();
+
+            assert_eq!(stages.len(), 1);
+            assert_eq!(stages[0].target.as_ref(), Some(&target));
+            assert!(stages[0].bundle_path.is_none());
+        }
+    }
+
+    #[test]
+    fn invalid_yaml_target_is_ignored_without_hard_failure() {
+        let config = PipelineConfig::from_yaml(
+            r#"
+name: test
+stages:
+  - id: llm
+    model: test-model
+    target: clod
+    provider: openai
+"#,
+        )
+        .unwrap();
+        let client = RegistryClient::with_url("http://127.0.0.1:9").unwrap();
+
+        let stages = load_stages(&client, &Some(config), &None, None).unwrap();
+
+        assert_eq!(stages.len(), 1);
+        assert_eq!(stages[0].target, None);
+        assert!(stages[0].bundle_path.is_none());
+    }
+
+    #[test]
+    fn repl_target_accepts_local_execution_aliases() {
+        assert_eq!(
+            parse_repl_target(Some("local")).unwrap(),
+            Some(ExecutionTarget::Device)
+        );
+        assert_eq!(
+            parse_repl_target(Some("device")).unwrap(),
+            Some(ExecutionTarget::Device)
+        );
+    }
+
+    #[test]
+    fn repl_target_rejects_model_format_values() {
+        let err = parse_repl_target(Some("onnx")).unwrap_err();
+
+        assert!(
+            err.to_string().contains("Unknown execution target"),
+            "{err}"
+        );
     }
 }

--- a/crates/xybrid-cli/src/main.rs
+++ b/crates/xybrid-cli/src/main.rs
@@ -232,7 +232,7 @@ enum Commands {
         #[arg(long, value_name = "VOICE")]
         voice: Option<String>,
 
-        /// Target format for model resolution (onnx, coreml, tflite)
+        /// Execution target for REPL inference (auto, local/device, cloud, server)
         #[arg(long, value_name = "TARGET")]
         target: Option<String>,
 

--- a/crates/xybrid-core/examples/authority_demo.rs
+++ b/crates/xybrid-core/examples/authority_demo.rs
@@ -157,6 +157,7 @@ fn demo_single_model(authority: &LocalAuthority, model_id: &str, metrics: &Devic
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: None, // Let authority decide
+        local_availability: None,
         device_class: None,
         device_class_schema_version: None,
     };
@@ -213,6 +214,7 @@ fn demo_pipeline(authority: &LocalAuthority, metrics: &DeviceMetrics) {
             metrics: metrics.clone(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         };
@@ -257,6 +259,7 @@ fn demo_explicit_target(authority: &LocalAuthority, metrics: &DeviceMetrics) {
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: None, // Auto-routing
+        local_availability: None,
         device_class: None,
         device_class_schema_version: None,
     };
@@ -273,6 +276,7 @@ fn demo_explicit_target(authority: &LocalAuthority, metrics: &DeviceMetrics) {
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: Some(ExecutionTarget::Device), // Force on-device
+        local_availability: None,
         device_class: None,
         device_class_schema_version: None,
     };

--- a/crates/xybrid-core/src/context.rs
+++ b/crates/xybrid-core/src/context.rs
@@ -169,6 +169,16 @@ impl StageDescriptor {
         self
     }
 
+    /// Derive whether this stage is currently runnable through the local executor.
+    pub fn is_locally_runnable(&self) -> bool {
+        let allows_local = self
+            .target
+            .as_ref()
+            .map(ExecutionTarget::allows_local)
+            .unwrap_or(true);
+        self.bundle_path.is_some() && allows_local
+    }
+
     /// Check if this stage is a cloud stage (uses third-party cloud API).
     pub fn is_cloud(&self) -> bool {
         matches!(self.target, Some(ExecutionTarget::Cloud)) || self.provider.is_some()
@@ -190,6 +200,31 @@ mod tests {
         let metrics = DeviceMetrics::default();
 
         assert_eq!(metrics.resource.memory_pressure, MemoryPressure::Unknown);
+    }
+
+    #[test]
+    fn stage_local_runnability_requires_bundle_path() {
+        let stage = StageDescriptor::new("test-model");
+
+        assert!(!stage.is_locally_runnable());
+    }
+
+    #[test]
+    fn stage_local_runnability_respects_network_target() {
+        let stage = StageDescriptor::new("test-model")
+            .with_bundle_path("/tmp/test-model")
+            .with_target(ExecutionTarget::Cloud);
+
+        assert!(!stage.is_locally_runnable());
+    }
+
+    #[test]
+    fn stage_local_runnability_allows_auto_with_bundle_path() {
+        let stage = StageDescriptor::new("test-model")
+            .with_bundle_path("/tmp/test-model")
+            .with_target(ExecutionTarget::Auto);
+
+        assert!(stage.is_locally_runnable());
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -299,7 +299,7 @@ impl Orchestrator {
         stage: &StageDescriptor,
         input: &Envelope,
         metrics: &DeviceMetrics,
-        _availability: &LocalAvailability,
+        availability: &LocalAvailability,
     ) -> OrchestratorResult<StageExecutionResult> {
         let _start_time = std::time::Instant::now();
 
@@ -348,6 +348,7 @@ impl Orchestrator {
             metrics: metrics.clone(),
             resource_monitor: self.resource_monitor.clone(),
             explicit_target: stage.target.clone(),
+            local_availability: Some(availability.clone()),
             device_class: Some(metrics.canonical_device_class()),
             device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
         };
@@ -547,7 +548,7 @@ impl Orchestrator {
         stage: &StageDescriptor,
         input: &Envelope,
         metrics: &DeviceMetrics,
-        _availability: &LocalAvailability,
+        availability: &LocalAvailability,
     ) -> OrchestratorResult<StageExecutionResult> {
         // Emit stage start event (consistent with sync execute_stage)
         self.event_bus.publish(OrchestratorEvent::StageStart {
@@ -593,6 +594,7 @@ impl Orchestrator {
             metrics: metrics.clone(),
             resource_monitor: self.resource_monitor.clone(),
             explicit_target: stage.target.clone(),
+            local_availability: Some(availability.clone()),
             device_class: Some(metrics.canonical_device_class()),
             device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
         };
@@ -1086,6 +1088,7 @@ mod tests {
             metrics: DeviceMetrics::default(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         }
@@ -1118,13 +1121,16 @@ mod tests {
         let stage = StageDescriptor::new("test_stage");
         let input = text_envelope("Text");
         let metrics = DeviceMetrics::default();
-        let availability = LocalAvailability::new(true);
+        // This test exercises the cloud/mock execution path; the model is
+        // intentionally not advertised as locally runnable.
+        let availability = LocalAvailability::new(false);
 
         let result = orchestrator.execute_stage(&stage, &input, &metrics, &availability);
 
         assert!(result.is_ok());
         let exec_result = result.unwrap();
         assert_eq!(exec_result.stage, "test_stage");
+        assert_eq!(exec_result.routing_decision.target.as_str(), "cloud");
         match &exec_result.output.kind {
             EnvelopeKind::Text(text) => assert!(text.contains("output")),
             other => panic!("expected text output, got {:?}", other),
@@ -1172,7 +1178,7 @@ mod tests {
         let stage = StageDescriptor::new("test_stage");
         let input = audio_envelope(&[9, 9, 9, 9]);
         let metrics = DeviceMetrics::default();
-        let availability = LocalAvailability::new(true);
+        let availability = LocalAvailability::new(false);
 
         let result = orchestrator.execute_stage(&stage, &input, &metrics, &availability);
 
@@ -1184,6 +1190,39 @@ mod tests {
             .routing_decision
             .reason
             .contains("model_unavailable"));
+    }
+
+    #[test]
+    fn test_execute_stage_uses_local_availability_hint() {
+        let mut orchestrator = orchestrator_with_mock_adapter(ExecutionMode::Batch);
+        let stage = StageDescriptor::new("test_stage");
+        let input = text_envelope("hello");
+        let metrics = DeviceMetrics::default();
+        let availability = LocalAvailability::new(true);
+
+        let result = orchestrator
+            .execute_stage(&stage, &input, &metrics, &availability)
+            .unwrap();
+
+        assert_eq!(result.routing_decision.target.as_str(), "local");
+    }
+
+    #[test]
+    fn test_execute_stage_ignores_bundle_path_when_local_availability_is_false() {
+        let mut orchestrator = orchestrator_with_mock_adapter(ExecutionMode::Batch);
+        let model_dir = tempfile::tempdir().unwrap();
+        let stage = StageDescriptor::new("test_stage")
+            .with_bundle_path(model_dir.path().to_string_lossy().to_string());
+        let input = text_envelope("hello");
+        let metrics = DeviceMetrics::default();
+        let availability = LocalAvailability::new(false);
+
+        let result = orchestrator
+            .execute_stage(&stage, &input, &metrics, &availability)
+            .unwrap();
+
+        assert_eq!(result.routing_decision.target.as_str(), "cloud");
+        assert!(result.routing_decision.reason.contains("model_unavailable"));
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator/authority/local.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/local.rs
@@ -321,37 +321,10 @@ impl OrchestrationAuthority for LocalAuthority {
     }
 
     fn resolve_target_with_feedback(&self, context: &StageContext) -> TargetResolution {
-        // If explicit target specified in pipeline, use it
-        if let Some(explicit) = &context.explicit_target {
-            let target = match explicit {
-                ExecutionTarget::Device => ResolvedTarget::Device,
-                ExecutionTarget::Server => ResolvedTarget::Server {
-                    endpoint: "https://api.xybrid.dev".to_string(),
-                },
-                ExecutionTarget::Cloud => ResolvedTarget::Cloud {
-                    provider: "xybrid".to_string(),
-                },
-                ExecutionTarget::Auto => {
-                    // Fall through to routing engine
-                    return self.resolve_with_routing_engine(context);
-                }
-            };
-
-            let metrics = self.routing_metrics(context);
-            return TargetResolution::new(
-                AuthorityDecision {
-                    result: target,
-                    reason: format!("Explicit target from pipeline YAML: {:?}", explicit),
-                    source: DecisionSource::Local,
-                    confidence: 1.0,
-                    timestamp_ms: now_ms(),
-                },
-                context.model_id.clone(),
-                Some(SignalContext::from_metrics(&metrics)),
-            );
+        if let Some(resolution) = self.explicit_target_resolution(context) {
+            return resolution;
         }
 
-        // Otherwise, use routing engine heuristics
         self.resolve_with_routing_engine(context)
     }
 
@@ -467,12 +440,47 @@ impl LocalAuthority {
         }
     }
 
-    /// Internal: resolve target using the routing engine.
-    fn resolve_with_routing_engine(&self, context: &StageContext) -> TargetResolution {
-        let availability = LocalAvailability {
-            local_model_exists: self.check_model_exists(&context.model_id),
+    fn explicit_target_resolution(&self, context: &StageContext) -> Option<TargetResolution> {
+        let explicit = context.explicit_target.as_ref()?;
+        let target = match explicit {
+            ExecutionTarget::Device => ResolvedTarget::Device,
+            ExecutionTarget::Server => ResolvedTarget::Server {
+                endpoint: "https://api.xybrid.dev".to_string(),
+            },
+            ExecutionTarget::Cloud => ResolvedTarget::Cloud {
+                provider: "xybrid".to_string(),
+            },
+            ExecutionTarget::Auto => return None,
         };
 
+        let metrics = self.routing_metrics(context);
+        Some(TargetResolution::new(
+            AuthorityDecision {
+                result: target,
+                reason: format!("Explicit target from pipeline YAML: {:?}", explicit),
+                source: DecisionSource::Local,
+                confidence: 1.0,
+                timestamp_ms: now_ms(),
+            },
+            context.model_id.clone(),
+            Some(SignalContext::from_metrics(&metrics)),
+        ))
+    }
+
+    /// Internal: resolve target using the routing engine.
+    fn resolve_with_routing_engine(&self, context: &StageContext) -> TargetResolution {
+        let availability = context
+            .local_availability
+            .clone()
+            .unwrap_or_else(|| LocalAvailability::new(self.check_model_exists(&context.model_id)));
+        self.resolve_with_routing_engine_and_availability(context, availability)
+    }
+
+    fn resolve_with_routing_engine_and_availability(
+        &self,
+        context: &StageContext,
+        availability: LocalAvailability,
+    ) -> TargetResolution {
         // Create a minimal envelope for policy check
         let envelope = Envelope::new(context.input_kind.clone());
         let live_metrics = self.routing_metrics(context);
@@ -634,6 +642,7 @@ signature: "test-deny-all"
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         }
@@ -672,6 +681,7 @@ signature: "test-deny-all"
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: Some(ExecutionTarget::Device),
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         };
@@ -691,12 +701,25 @@ signature: "test-deny-all"
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: Some(ExecutionTarget::Cloud),
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         };
 
         let decision = authority.resolve_target(&context);
         assert!(matches!(decision.result, ResolvedTarget::Cloud { .. }));
+    }
+
+    #[test]
+    fn caller_local_availability_overrides_cache_provider() {
+        let authority = LocalAuthority::with_cache_provider(Arc::new(CachedProvider));
+        let mut context = text_context();
+        context.local_availability = Some(LocalAvailability::new(false));
+
+        let decision = authority.resolve_target(&context);
+
+        assert!(matches!(decision.result, ResolvedTarget::Cloud { .. }));
+        assert!(decision.reason.contains("model_unavailable"));
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator/authority/mod.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/mod.rs
@@ -182,6 +182,7 @@ mod tests {
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: Some(crate::pipeline::ExecutionTarget::Device),
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         };

--- a/crates/xybrid-core/src/orchestrator/authority/remote.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/remote.rs
@@ -211,7 +211,7 @@ impl RemoteAuthority {
 
     fn target_cache_key(context: &StageContext, metrics: &DeviceMetrics) -> String {
         format!(
-            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             context.stage_id,
             context.model_id,
             context.input_kind.as_str(),
@@ -229,7 +229,12 @@ impl RemoteAuthority {
                 .explicit_target
                 .as_ref()
                 .map(|target| target.to_string())
-                .unwrap_or_else(|| "auto".to_string())
+                .unwrap_or_else(|| "auto".to_string()),
+            context
+                .local_availability
+                .as_ref()
+                .map(|availability| availability.local_model_exists.to_string())
+                .unwrap_or_else(|| "unknown-local".to_string())
         )
     }
 
@@ -259,6 +264,12 @@ impl RemoteAuthority {
             }
             if let Some(explicit_target) = &context.explicit_target {
                 qp.append_pair("explicit_target", &explicit_target.to_string());
+            }
+            if let Some(availability) = &context.local_availability {
+                qp.append_pair(
+                    "local_model_exists",
+                    &availability.local_model_exists.to_string(),
+                );
             }
         }
         Some(url.to_string())
@@ -425,6 +436,7 @@ mod tests {
     use crate::context::DeviceMetrics;
     use crate::device::ResourceMonitor;
     use crate::ir::{Envelope, EnvelopeKind};
+    use crate::orchestrator::routing_engine::LocalAvailability;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::mpsc;
@@ -446,6 +458,7 @@ mod tests {
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
+            local_availability: None,
             device_class: None,
             device_class_schema_version: None,
         }
@@ -642,6 +655,18 @@ mod tests {
     }
 
     #[test]
+    fn target_advice_url_includes_local_availability_when_known() {
+        let authority = RemoteAuthority::new("https://api.xybrid.dev");
+        let mut context = default_context("available");
+        context.local_availability = Some(LocalAvailability::new(false));
+        let url = authority
+            .target_advice_url(&context, &context.metrics)
+            .expect("routing advice url");
+
+        assert!(url.contains("local_model_exists=false"), "{url}");
+    }
+
+    #[test]
     fn target_cache_key_differs_by_device_class_and_schema() {
         let a = context_with_device_class("cached-class", "iphone-15-pro");
         let b = context_with_device_class("cached-class", "iphone-15");
@@ -768,6 +793,19 @@ mod tests {
         let cloud_key = RemoteAuthority::target_cache_key(&cloud_context, &cloud_context.metrics);
 
         assert_ne!(auto_key, cloud_key);
+    }
+
+    #[test]
+    fn target_cache_key_differs_by_local_availability() {
+        let mut available = context_with_device_class("cached-availability", "iphone-15-pro");
+        available.local_availability = Some(LocalAvailability::new(true));
+        let mut unavailable = available.clone();
+        unavailable.local_availability = Some(LocalAvailability::new(false));
+
+        let available_key = RemoteAuthority::target_cache_key(&available, &available.metrics);
+        let unavailable_key = RemoteAuthority::target_cache_key(&unavailable, &unavailable.metrics);
+
+        assert_ne!(available_key, unavailable_key);
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator/authority/types.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/types.rs
@@ -7,7 +7,7 @@ pub use crate::abort::AbortReason;
 use crate::context::DeviceMetrics;
 use crate::device::{MemoryPressure, ResourceMonitor, ThermalState};
 use crate::ir::{Envelope, EnvelopeKind};
-use crate::orchestrator::routing_engine::LocalReliabilityHint;
+use crate::orchestrator::routing_engine::{LocalAvailability, LocalReliabilityHint};
 use crate::pipeline::ExecutionTarget;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -30,6 +30,12 @@ pub struct StageContext {
     pub resource_monitor: Arc<ResourceMonitor>,
     /// Explicit target from pipeline YAML (if specified).
     pub explicit_target: Option<ExecutionTarget>,
+    /// Caller-computed local model availability, when known.
+    ///
+    /// `Some(false)` means the caller already determined the model is not
+    /// locally executable. `None` means the authority may consult its own cache
+    /// provider fallback.
+    pub local_availability: Option<LocalAvailability>,
     /// Canonical stable hardware-family bucket used by fleet reliability.
     pub device_class: Option<String>,
     /// Schema version for `device_class`.

--- a/crates/xybrid-core/src/pipeline/target.rs
+++ b/crates/xybrid-core/src/pipeline/target.rs
@@ -42,6 +42,11 @@ impl ExecutionTarget {
         matches!(self, ExecutionTarget::Server | ExecutionTarget::Cloud)
     }
 
+    /// Returns true if this target allows local execution.
+    pub fn allows_local(&self) -> bool {
+        !self.requires_network()
+    }
+
     /// Returns true if this target can work offline.
     pub fn supports_offline(&self) -> bool {
         matches!(self, ExecutionTarget::Device)
@@ -141,6 +146,14 @@ mod tests {
         assert!(ExecutionTarget::Server.requires_network());
         assert!(ExecutionTarget::Cloud.requires_network());
         assert!(!ExecutionTarget::Auto.requires_network()); // Auto doesn't inherently require network
+    }
+
+    #[test]
+    fn test_allows_local() {
+        assert!(ExecutionTarget::Device.allows_local());
+        assert!(!ExecutionTarget::Server.allows_local());
+        assert!(!ExecutionTarget::Cloud.allows_local());
+        assert!(ExecutionTarget::Auto.allows_local());
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -662,12 +662,17 @@ pub fn run_pipeline(config_path: &str) -> Result<PipelineResult, PipelineConfigE
     // Create device metrics
     let metrics = DeviceMetrics::default();
 
-    // Create availability function from config
-    let availability_map = config.availability.clone();
-    let availability_fn = move |stage: &str| -> LocalAvailability {
-        let exists = availability_map.get(stage).copied().unwrap_or(false);
-        LocalAvailability::new(exists)
-    };
+    // Ignore legacy availability hints because these configs have no resolved
+    // bundle paths. Without a bundle path or preloaded adapter, local execution
+    // is not runnable.
+    if !config.availability.is_empty() {
+        log::warn!(
+            target: "xybrid_sdk",
+            "Legacy pipeline availability hints are ignored; use PipelineRef::load() and load_models() for local execution"
+        );
+    }
+    let availability_fn =
+        move |_stage: &str| -> LocalAvailability { LocalAvailability::new(false) };
 
     // Create orchestrator
     let mut orchestrator = Orchestrator::new();
@@ -773,12 +778,17 @@ pub async fn run_pipeline_async(config_path: &str) -> Result<PipelineResult, Pip
     // Create device metrics
     let metrics = DeviceMetrics::default();
 
-    // Create availability function from config
-    let availability_map = config.availability.clone();
-    let availability_fn = move |stage: &str| -> LocalAvailability {
-        let exists = availability_map.get(stage).copied().unwrap_or(false);
-        LocalAvailability::new(exists)
-    };
+    // Ignore legacy availability hints because these configs have no resolved
+    // bundle paths. Without a bundle path or preloaded adapter, local execution
+    // is not runnable.
+    if !config.availability.is_empty() {
+        log::warn!(
+            target: "xybrid_sdk",
+            "Legacy pipeline availability hints are ignored; use PipelineRef::load() and load_models() for local execution"
+        );
+    }
+    let availability_fn =
+        move |_stage: &str| -> LocalAvailability { LocalAvailability::new(false) };
 
     // Create orchestrator
     let mut orchestrator = Orchestrator::new();

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -291,6 +291,7 @@ fn local_reliability_hint_after_abort(
         metrics: metrics.clone(),
         resource_monitor: xybrid_core::device::ResourceMonitor::global(),
         explicit_target: None,
+        local_availability: None,
         device_class: Some(metrics.canonical_device_class()),
         device_class_schema_version: Some(xybrid_core::context::DEVICE_CLASS_SCHEMA_VERSION),
     };

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -60,6 +60,8 @@ use crate::result::OutputType;
 use crate::run_options::RunOptions;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
@@ -358,6 +360,16 @@ impl CacheProvider for StreamingFastPathCacheProvider {
 }
 
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn stage_descriptor_with_bundle_path(
+    stage_descriptor: &StageDescriptor,
+    bundle_path: &Path,
+) -> StageDescriptor {
+    let mut stage_descriptor = stage_descriptor.clone();
+    stage_descriptor.bundle_path = Some(bundle_path.to_string_lossy().to_string());
+    stage_descriptor
+}
+
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 #[derive(Debug, Clone)]
 struct StreamingFastPathRoute {
     policy_allowed: bool,
@@ -393,6 +405,7 @@ fn resolve_streaming_fast_path_route(
         metrics: metrics.clone(),
         resource_monitor: ResourceMonitor::global(),
         explicit_target: stage.target.clone(),
+        local_availability: Some(LocalAvailability::new(stage.is_locally_runnable())),
         device_class: Some(metrics.canonical_device_class()),
         device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
     };
@@ -405,6 +418,7 @@ fn resolve_streaming_fast_path_route(
     let hint = resolution.local_reliability_hint.unwrap_or_default();
     let can_stream_locally = policy_allowed
         && matches!(resolution.decision.result, ResolvedTarget::Device)
+        && stage.is_locally_runnable()
         && !policy_transform;
 
     StreamingFastPathRoute {
@@ -853,7 +867,7 @@ impl Pipeline {
             .stages
             .iter()
             .enumerate()
-            .filter(|(_, s)| matches!(s.status, StageStatus::NeedsDownload))
+            .filter(|(_, s)| matches!(s.status, StageStatus::Cached | StageStatus::NeedsDownload))
             .filter_map(|(idx, s)| {
                 s.model_id.as_ref().map(|m| {
                     (
@@ -862,17 +876,35 @@ impl Pipeline {
                         m.clone(),
                         s.download_bytes.unwrap_or(0),
                         s.target.clone(),
+                        s.status.clone(),
                     )
                 })
             })
             .collect();
 
-        let total_stages = stages_to_fetch.len();
+        let total_stages = stages_to_fetch
+            .iter()
+            .filter(|(_, _, _, _, _, status)| matches!(status, StageStatus::NeedsDownload))
+            .count();
         let mut skipped_count = 0;
 
-        for (stage_idx, (_, stage_id, model_id, total_bytes, stage_target)) in
-            stages_to_fetch.into_iter().enumerate()
-        {
+        let mut download_stage_idx = 0;
+        for (_, stage_id, model_id, total_bytes, stage_target, stage_status) in stages_to_fetch {
+            if matches!(stage_status, StageStatus::Cached) {
+                let model_dir = client.fetch_extracted(&model_id, None, |_| {})?;
+                let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+                handle.availability_map.insert(model_id.clone(), true);
+                handle.availability_map.insert(stage_id.clone(), true);
+                handle
+                    .bundle_paths
+                    .insert(stage_id.clone(), model_dir.clone());
+                handle.bundle_paths.insert(model_id, model_dir);
+                continue;
+            }
+
+            let stage_idx = download_stage_idx;
+            download_stage_idx += 1;
+
             // Convert StageTarget to ExecutionTarget for authority
             // - Device: user explicitly wants local, authority should respect it
             // - Auto: let authority decide based on device conditions
@@ -892,6 +924,7 @@ impl Pipeline {
                 metrics: metrics.clone(),
                 resource_monitor: ResourceMonitor::global(),
                 explicit_target,
+                local_availability: None,
                 device_class: Some(metrics.canonical_device_class()),
                 device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
             };
@@ -1088,7 +1121,10 @@ impl Pipeline {
                 desc.bundle_path = Some(bundle_path.to_string_lossy().to_string());
             }
         }
-        let availability_map = handle.availability_map.clone();
+        let availability_map: HashMap<String, bool> = stage_descriptors
+            .iter()
+            .map(|stage| (stage.name.clone(), stage.is_locally_runnable()))
+            .collect();
         drop(handle);
 
         // Collect runtime metrics from caller options when provided.
@@ -1237,7 +1273,12 @@ impl Pipeline {
                 }
             }
 
-            (descriptors, handle.availability_map.clone())
+            let availability_map: HashMap<String, bool> = descriptors
+                .iter()
+                .map(|stage| (stage.name.clone(), stage.is_locally_runnable()))
+                .collect();
+
+            (descriptors, availability_map)
         };
 
         let envelope_clone = envelope.clone();
@@ -1494,10 +1535,11 @@ impl Xybrid {
         // For streaming, we need to identify if there's an LLM stage and execute it with streaming
         // For now, support single-stage LLM pipelines
         if handle.stage_descriptors.len() == 1 {
-            let stage_descriptor = handle.stage_descriptors[0].clone();
-            let stage_name = stage_descriptor.name.clone();
+            let stage_name = handle.stage_descriptors[0].name.clone();
             if let Some(bundle_path) = handle.bundle_paths.get(&stage_name) {
                 let bundle_path = bundle_path.clone(); // Clone to avoid borrow issues
+                let stage_descriptor =
+                    stage_descriptor_with_bundle_path(&handle.stage_descriptors[0], &bundle_path);
                 let metadata_path = bundle_path.join("model_metadata.json");
                 if metadata_path.exists() {
                     let metadata_str = std::fs::read_to_string(&metadata_path).map_err(|e| {
@@ -1735,6 +1777,7 @@ stages:
         ));
         let stage = StageDescriptor::new("llm")
             .with_model(model_id)
+            .with_bundle_path(tempdir.path().to_string_lossy().to_string())
             .with_target(ExecutionTarget::Device);
         let envelope = Envelope::new(EnvelopeKind::Text("prompt".to_string()));
         let metrics = DeviceMetrics::default();
@@ -1747,6 +1790,43 @@ stages:
         assert_eq!(route.target, "local");
         assert_eq!(route.sample_size, 0);
         assert!(route.reason.contains("Explicit target"));
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_descriptor_uses_loaded_bundle_path() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let stage = StageDescriptor::new("llm")
+            .with_model("streaming-local-model")
+            .with_target(ExecutionTarget::Device);
+
+        assert!(!stage.is_locally_runnable());
+
+        let stage = stage_descriptor_with_bundle_path(&stage, tempdir.path());
+
+        assert!(stage.is_locally_runnable());
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_network_target_disables_local_streaming() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let model_id = "streaming-cloud-model";
+        let authority = LocalAuthority::with_cache_provider(Arc::new(
+            StreamingFastPathCacheProvider::new(model_id, tempdir.path().to_path_buf()),
+        ));
+        let stage = StageDescriptor::new("llm")
+            .with_model(model_id)
+            .with_bundle_path(tempdir.path().to_string_lossy().to_string())
+            .with_target(ExecutionTarget::Cloud);
+        let envelope = Envelope::new(EnvelopeKind::Text("prompt".to_string()));
+        let metrics = DeviceMetrics::default();
+
+        let route =
+            resolve_streaming_fast_path_route(&authority, &stage, model_id, &envelope, &metrics);
+
+        assert!(!route.can_stream_locally);
+        assert_eq!(route.target, "cloud");
     }
 
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]


### PR DESCRIPTION
## Summary
- centralize the local-runnability rule on `StageDescriptor::is_locally_runnable()` and thread the existing `LocalAvailability` hint into authority without routing-time filesystem checks
- make `xybrid repl --target cloud|server` skip local cache lookup, warmup, and availability advertising while warning and continuing on invalid YAML stage targets
- keep SDK regular and streaming pipeline routing aligned with loaded bundle paths, including warm-cache materialization before run/streaming and a legacy-config warning when old availability hints cannot imply runnable local execution

## Verification
- `cargo fmt --check`
- `cargo test -p xybrid-core --test system_validation test_sdk_pipeline_execution -- --nocapture`
- `cargo test -p xybrid-sdk --features llm-llamacpp streaming_fast_path -- --nocapture`
- `cargo test -p xybrid-core --features llm-llamacpp stage_local_runnability -- --nocapture`
- `cargo test --workspace --features ort-download --lib --bins --tests`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download --doc`
- `git diff --check`