### PR TITLE
fix(spm): backport v0.1.0-rc3 XybridFFI checksum to master

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.1.0-rc3"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "7a395ce792a136bec78a375b413ea76a62ad42854ccfd8100827088b59154772"
+let xybridFFIChecksum = "03bd2024645ee99681d266717431f2ea9c297fcae0de414e52cbdc83be463285"
 
 let package = Package(
     name: "Xybrid",


### PR DESCRIPTION
## Summary

Unblocks SPM consumers tracking `branch: "master"` — they currently hit a checksum mismatch because master's `Package.swift` still has the placeholder `xybridFFIChecksum` that predates the v0.1.0-rc3 release run.

## Why master is stale

The release workflow (`.github/workflows/release.yml` — *"Patch Package.swift checksum and force-move tag"*, lines 223-262) builds the xcframework, computes its SHA-256, patches `Package.swift`, commits, and **force-moves the tag** onto that patched commit. The patch never lands on master — so:

- `exact: "0.1.0-rc3"` / `from: "0.1.0-rc3"` ✅ works (tag resolves to `cfa0d58`, which carries the correct checksum)
- `branch: "swift"` ✅ works (auto-generated by `publish-swift`)
- `branch: "master"` ❌ fails with `checksum does not match` against the actual release zip

## What this PR changes

One line in `Package.swift`:

```diff
-let xybridFFIChecksum = "7a395ce792a136bec78a375b413ea76a62ad42854ccfd8100827088b59154772"
+let xybridFFIChecksum = "03bd2024645ee99681d266717431f2ea9c297fcae0de414e52cbdc83be463285"
```

The new value is the SHA-256 of the public v0.1.0-rc3 release asset, verified two ways:

```
$ curl -fsSL -o /tmp/x.zip https://github.com/xybrid-ai/xybrid/releases/download/v0.1.0-rc3/XybridFFI-v0.1.0-rc3.xcframework.zip
$ shasum -a 256 /tmp/x.zip
03bd2024645ee99681d266717431f2ea9c297fcae0de414e52cbdc83be463285  /tmp/x.zip

$ ./bindings/apple/scripts/sync-spm-checksum.sh --check /tmp/x.zip
Checksum already up to date.
```

## Follow-up (separate PR)

The underlying workflow design is what keeps biting us — tag-driven release with no back-PR to master. Drafts of a replacement (release-branch + draft-release flow that opens a PR to master before tagging) are staged in `.context/release-workflows/`. That's the durable fix; this PR is just the unblock.

## Test plan

- [ ] SPM resolves cleanly with `.package(url: "https://github.com/xybrid-ai/xybrid", branch: "master")` against this branch's tip
- [ ] Existing `.package(url: ..., exact: "0.1.0-rc3")` consumers are unaffected (the tag commit is untouched)