### PR TITLE
docs(sdk): make all doctest examples compile under no_run

### DIFF
--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -6,7 +6,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_sdk::CacheManager;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -455,10 +455,16 @@ impl CacheManager {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::CacheManager;
+    /// # use std::path::PathBuf;
+    /// # let xyb_path = PathBuf::from("model.xyb");
     /// let cache = CacheManager::new()?;
     /// let model_dir = cache.ensure_extracted(&xyb_path)?;
     /// // model_dir now contains: model_metadata.json, model.gguf, etc.
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn ensure_extracted(&self, xyb_path: &Path) -> Result<PathBuf, SdkError> {
         use xybrid_core::execution::ModelMetadata;

--- a/crates/xybrid-sdk/src/cache/cache_provider.rs
+++ b/crates/xybrid-sdk/src/cache/cache_provider.rs
@@ -5,16 +5,21 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_sdk::SdkCacheProvider;
-//! use xybrid_core::orchestrator::LocalAuthority;
+//! use xybrid_sdk::orchestrator::LocalAuthority;
+//! use std::path::PathBuf;
 //! use std::sync::Arc;
 //!
 //! // Create SDK cache provider
-//! let provider = Arc::new(SdkCacheProvider::new()?);
+//! let provider = Arc::new(SdkCacheProvider::with_dir(PathBuf::from("/tmp/cache"))?);
 //!
 //! // Inject into LocalAuthority
 //! let authority = LocalAuthority::with_cache_provider(provider);
+//! # let _ = authority;
+//! # Ok(())
+//! # }
 //! ```
 
 use std::path::{Path, PathBuf};
@@ -38,13 +43,17 @@ use crate::model::SdkError;
 ///
 /// ## Example
 ///
-/// ```rust,ignore
-/// use xybrid_sdk::SdkCacheProvider;
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use xybrid_sdk::{CacheProvider, SdkCacheProvider};
+/// use std::path::PathBuf;
 ///
-/// let provider = SdkCacheProvider::new()?;
+/// let provider = SdkCacheProvider::with_dir(PathBuf::from("/tmp/cache"))?;
 /// if provider.is_model_cached("kokoro-82m") {
 ///     println!("Model is available locally");
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub struct SdkCacheProvider {
     cache: CacheManager,

--- a/crates/xybrid-sdk/src/cache/mod.rs
+++ b/crates/xybrid-sdk/src/cache/mod.rs
@@ -15,8 +15,10 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
-//! use xybrid_sdk::{CacheManager, SdkCacheProvider};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_sdk::{CacheManager, CacheProvider, SdkCacheProvider};
+//! use std::path::PathBuf;
 //!
 //! // Direct cache management
 //! let cache = CacheManager::new()?;
@@ -24,10 +26,12 @@
 //! println!("Cached models: {}", status.total_models);
 //!
 //! // As a provider for the orchestrator
-//! let provider = SdkCacheProvider::new()?;
+//! let provider = SdkCacheProvider::with_dir(PathBuf::from("/tmp/xybrid-cache"))?;
 //! if provider.is_model_cached("kokoro-82m") {
 //!     println!("Model available locally");
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 mod cache_manager;

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -27,37 +27,48 @@
 //!
 //! ## Batch Inference
 //!
-//! ```rust,ignore
-//! use xybrid_sdk::{ModelLoader, Envelope};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_sdk::ModelLoader;
+//! use xybrid_sdk::ir::{Envelope, EnvelopeKind};
 //!
 //! // Load model from registry
-//! let loader = ModelLoader::from_registry("http://localhost:8080", "whisper-tiny", "1.0");
+//! let loader = ModelLoader::from_registry("whisper-tiny");
 //! let model = loader.load()?;
 //!
 //! // Run inference
-//! let result = model.run(&Envelope::audio(audio_bytes))?;
+//! let audio_bytes: Vec<u8> = vec![];
+//! let envelope = Envelope::new(EnvelopeKind::Audio(audio_bytes));
+//! let result = model.run(&envelope, None)?;
 //! println!("Transcription: {}", result.unwrap_text());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Streaming ASR
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_sdk::{ModelLoader, StreamConfig};
 //!
 //! let model = ModelLoader::from_directory("/path/to/whisper-model")?.load()?;
 //! let stream = model.stream(StreamConfig::with_vad())?;
 //!
 //! // Feed audio chunks
+//! let audio_samples: Vec<f32> = vec![];
 //! stream.feed(&audio_samples)?;
 //!
 //! // Get final transcript
 //! let result = stream.flush()?;
 //! println!("Transcript: {}", result.text);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Pipelines
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_sdk::run_pipeline;
 //!
 //! let result = run_pipeline("examples/pipeline.yaml")?;
@@ -65,31 +76,40 @@
 //! for stage in &result.stages {
 //!     println!("  {}: {}ms ({})", stage.name, stage.latency_ms, stage.target);
 //! }
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Model Warmup (for LLM and other large models)
 //!
 //! Pre-load models at app startup for fast first inference:
 //!
-//! ```rust,ignore
-//! use xybrid_sdk::{ModelLoader, PipelineRef, Envelope};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_sdk::{ModelLoader, PipelineRef};
+//! use xybrid_sdk::ir::{Envelope, EnvelopeKind};
 //!
 //! // Option 1: Warmup a single model
-//! let model = ModelLoader::from_registry("gemma-3-1b").load()?;
+//! let loader = ModelLoader::from_registry("gemma-3-1b");
+//! let model = loader.load()?;
 //! model.warmup()?;  // Pre-loads model weights, compiles shaders
-//! let result = model.run(&Envelope::text("Hello"))?;  // Fast!
+//! let envelope = Envelope::new(EnvelopeKind::Text("Hello".into()));
+//! let result = model.run(&envelope, None)?;  // Fast!
 //!
 //! // Option 2: Warmup a pipeline
+//! let yaml = "stages: []";
 //! let pipeline = PipelineRef::from_yaml(yaml)?.load()?;
 //! pipeline.load_models()?;  // Download models
 //! pipeline.warmup()?;       // Pre-load into memory
-//! let result = pipeline.run(&Envelope::text("Hello"))?;  // Fast!
+//! let result = pipeline.run(&envelope)?;  // Fast!
 //!
 //! // Option 3: Async warmup for background loading
 //! let model = loader.load()?;
 //! tokio::spawn(async move {
 //!     model.warmup_async().await
 //! });
+//! # Ok(())
+//! # }
 //! ```
 
 use anyhow::Result;
@@ -523,7 +543,7 @@ pub mod hybrid {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// use xybrid_sdk::hybrid;
     ///
     /// #[hybrid::route]
@@ -613,7 +633,7 @@ pub enum PipelineConfigError {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_sdk::run_pipeline;
 ///
 /// match run_pipeline("examples/hiiipe.yaml") {
@@ -729,7 +749,7 @@ pub fn run_pipeline(config_path: &str) -> Result<PipelineResult, PipelineConfigE
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_sdk::run_pipeline_async;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -621,20 +621,30 @@ struct ModelHandle {
 ///
 /// # Example (Recommended - Registry-based)
 ///
-/// ```ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// # use xybrid_sdk::ModelLoader;
+/// # use xybrid_sdk::ir::Envelope;
+/// # let envelope: Envelope = unimplemented!();
 /// // Load using registry (recommended - auto-resolves to best variant)
 /// let loader = ModelLoader::from_registry("kokoro-82m");
 /// let model = loader.load()?;
-/// let result = model.run(&envelope)?;
+/// let result = model.run(&envelope, None)?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Example (With progress callback)
 ///
-/// ```ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// # use xybrid_sdk::ModelLoader;
 /// let loader = ModelLoader::from_registry("kokoro-82m");
 /// let model = loader.load_with_progress(|progress| {
 ///     println!("Download: {:.1}%", progress * 100.0);
 /// })?;
+/// # Ok(())
+/// # }
 /// ```
 /// GGUF quantization preference order for automatic selection.
 /// Q4_K_M is the default — best quality/size tradeoff for edge devices.
@@ -692,9 +702,13 @@ impl ModelLoader {
     /// caching and SHA256 verification.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
     /// let loader = ModelLoader::from_registry("kokoro-82m");
     /// let model = loader.load()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_registry(id: &str) -> Self {
         Self {
@@ -707,9 +721,13 @@ impl ModelLoader {
     /// Create loader from registry with explicit platform.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
     /// let loader = ModelLoader::from_registry_with_platform("kokoro-82m", "macos-arm64");
     /// let model = loader.load()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_registry_with_platform(id: &str, platform: &str) -> Self {
         Self {
@@ -816,9 +834,13 @@ impl ModelLoader {
     /// `SdkError::ConfigError` if the feature is not enabled.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
     /// let loader = ModelLoader::from_huggingface("xybrid-ai/kokoro-82m");
     /// let model = loader.load()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_huggingface(repo: &str) -> Self {
         Self {
@@ -831,9 +853,13 @@ impl ModelLoader {
     /// Create loader from a HuggingFace Hub repository with explicit revision.
     ///
     /// # Example
-    /// ```ignore
-    /// let loader = ModelLoader::from_huggingface_with_revision("xybrid-ai/kokoro-82m", "v1.0")?;
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
+    /// let loader = ModelLoader::from_huggingface_with_revision("xybrid-ai/kokoro-82m", "v1.0");
     /// let model = loader.load()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_huggingface_with_revision(repo: &str, revision: &str) -> Self {
         Self {
@@ -849,9 +875,13 @@ impl ModelLoader {
     /// Without a variant, defaults to Q4_K_M for GGUF repos.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
     /// let loader = ModelLoader::from_huggingface_parsed("LiquidAI/LFM2.5-350M-GGUF:Q8_0");
     /// let model = loader.load()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_huggingface_parsed(input: &str) -> Self {
         let source = ModelSource::parse_huggingface(input);
@@ -898,10 +928,15 @@ impl ModelLoader {
     /// Only applies to registry-based loading (downloads from HuggingFace).
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
+    /// # let loader: ModelLoader = unimplemented!();
     /// let model = loader.load_with_progress(|progress| {
     ///     println!("Download: {:.1}%", progress * 100.0);
     /// })?;
+    /// # Ok(())
+    /// # }
     /// ```
     #[allow(deprecated)]
     pub fn load_with_progress<F>(&self, progress_callback: F) -> SdkResult<XybridModel>
@@ -1408,11 +1443,17 @@ impl ModelLoader {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// # use xybrid_sdk::{ModelLoader, StreamConfig};
+/// # use xybrid_sdk::ir::Envelope;
+/// # let loader: ModelLoader = unimplemented!();
+/// # let audio_envelope: Envelope = unimplemented!();
+/// # let samples: Vec<f32> = vec![];
 /// let model = loader.load()?;
 ///
 /// // Batch inference
-/// let result = model.run(&audio_envelope)?;
+/// let result = model.run(&audio_envelope, None)?;
 /// println!("Transcription: {}", result.unwrap_text());
 ///
 /// // Streaming inference (if supported)
@@ -1424,6 +1465,8 @@ impl ModelLoader {
 ///
 /// // Cleanup
 /// model.unload()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct XybridModel {
     handle: Arc<RwLock<ModelHandle>>,
@@ -1466,13 +1509,18 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::{ModelLoader, ConversationContext};
+    /// # let loader: ModelLoader = unimplemented!();
     /// let model = loader.load()?;
     /// if model.is_llm() {
     ///     // Create conversation context for multi-turn chat
     ///     let mut ctx = ConversationContext::new();
     ///     // ... manage conversation history
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_llm(&self) -> bool {
         self.handle
@@ -1507,7 +1555,9 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use xybrid_sdk::XybridModel;
+    /// # let model: XybridModel = unimplemented!();
     /// if let Some(voices) = model.voices() {
     ///     for voice in voices {
     ///         println!("{}: {} ({})", voice.id, voice.name, voice.language.unwrap_or_default());
@@ -1560,12 +1610,19 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
+    /// # use xybrid_sdk::ir::Envelope;
+    /// # let loader: ModelLoader = unimplemented!();
+    /// # let envelope: Envelope = unimplemented!();
     /// let model = loader.load()?;
     /// model.warmup()?;  // Pre-load model
     ///
     /// // First inference is now fast
-    /// let result = model.run(&envelope)?;
+    /// let result = model.run(&envelope, None)?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn warmup(&self) -> SdkResult<()> {
         use xybrid_core::ir::EnvelopeKind;
@@ -1673,7 +1730,10 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # async fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::ModelLoader;
+    /// # let loader: ModelLoader = unimplemented!();
     /// let model = loader.load()?;
     ///
     /// // Start warmup in background
@@ -1685,6 +1745,8 @@ impl XybridModel {
     ///
     /// // Wait for warmup if needed
     /// warmup_handle.await??;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn warmup_async(&self) -> SdkResult<()> {
         let handle = self.handle.clone();
@@ -1929,10 +1991,12 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// use xybrid_sdk::{ModelLoader, ConversationContext, Envelope, EnvelopeKind, MessageRole};
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_sdk::{ModelLoader, ConversationContext};
+    /// use xybrid_sdk::ir::{Envelope, EnvelopeKind, MessageRole};
     ///
-    /// let model = ModelLoader::from_registry("gemma-3-1b")?.load()?;
+    /// let model = ModelLoader::from_registry("gemma-3-1b").load()?;
     /// let mut ctx = ConversationContext::new();
     ///
     /// // Add user message to context
@@ -1941,12 +2005,14 @@ impl XybridModel {
     /// ctx.push(user_input.clone());
     ///
     /// // Run with context (model sees the full history)
-    /// let result = model.run_with_context(&user_input, &ctx)?;
+    /// let result = model.run_with_context(&user_input, &ctx, None)?;
     ///
     /// // Add assistant response to context
     /// ctx.push(result.envelope().clone());
     ///
     /// println!("{}", result.text().unwrap_or_default());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn run_with_context(
         &self,
@@ -2043,7 +2109,11 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::{XybridModel, ConversationContext};
+    /// # use xybrid_sdk::ir::{Envelope, EnvelopeKind, MessageRole};
+    /// # let model: XybridModel = unimplemented!();
     /// let mut ctx = ConversationContext::new();
     ///
     /// // Add user message and run with streaming
@@ -2051,7 +2121,7 @@ impl XybridModel {
     ///     .with_role(MessageRole::User);
     /// ctx.push(input.clone());
     ///
-    /// let result = model.run_streaming_with_context(&input, &ctx, |token| {
+    /// let result = model.run_streaming_with_context(&input, &ctx, None, |token| {
     ///     print!("{}", token.token);
     ///     std::io::Write::flush(&mut std::io::stdout())?;
     ///     Ok(())
@@ -2059,6 +2129,8 @@ impl XybridModel {
     ///
     /// // Add assistant response to context
     /// ctx.push(result.envelope().clone());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn run_streaming_with_context<F>(
         &self,
@@ -2221,13 +2293,20 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::XybridModel;
+    /// # use xybrid_sdk::ir::Envelope;
+    /// # let model: XybridModel = unimplemented!();
+    /// # let envelope: Envelope = unimplemented!();
     /// // Works for both LLM and non-LLM models
-    /// let result = model.run_streaming(&envelope, |token| {
+    /// let result = model.run_streaming(&envelope, None, |token| {
     ///     print!("{}", token.token);
     ///     std::io::Write::flush(&mut std::io::stdout())?;
     ///     Ok(())
     /// })?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn run_streaming<F>(
         &self,
@@ -2475,10 +2554,15 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # async fn _example() {
+    /// # use xybrid_sdk::{XybridModel, StreamEvent};
+    /// # use xybrid_sdk::ir::Envelope;
+    /// # let model: XybridModel = unimplemented!();
+    /// # let envelope: Envelope = unimplemented!();
     /// use tokio_stream::StreamExt;
     ///
-    /// let mut stream = model.run_stream(envelope);
+    /// let mut stream = model.run_stream(envelope, None);
     /// while let Some(event) = stream.next().await {
     ///     match event {
     ///         StreamEvent::Token(token) => print!("{}", token.token),
@@ -2486,6 +2570,7 @@ impl XybridModel {
     ///         StreamEvent::Error(e) => eprintln!("Error: {}", e),
     ///     }
     /// }
+    /// # }
     /// ```
     pub fn run_stream(
         &self,
@@ -2734,7 +2819,11 @@ impl XybridModel {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::{XybridModel, StreamConfig};
+    /// # let model: XybridModel = unimplemented!();
+    /// # let audio_samples: Vec<f32> = vec![];
     /// let stream = model.stream(StreamConfig::with_vad())?;
     ///
     /// // Feed audio chunks
@@ -2747,6 +2836,8 @@ impl XybridModel {
     ///
     /// // Get final transcript
     /// let transcript = stream.flush()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn stream(&self, config: StreamConfig) -> SdkResult<XybridStream> {
         if !self.supports_streaming {

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -6,21 +6,32 @@
 //!
 //! # Example (Simple - just run)
 //!
-//! ```rust,ignore
-//! use xybrid_sdk::{PipelineRef, Envelope};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_sdk::PipelineRef;
+//! use xybrid_sdk::ir::{Envelope, EnvelopeKind};
 //!
+//! # let yaml_content = "stages: []";
+//! # let audio_bytes: Vec<u8> = vec![];
 //! // Load and run in a few lines
 //! let pipeline = PipelineRef::from_yaml(yaml_content)?.load()?;
 //! pipeline.load_models()?;  // Optional: explicit preloading
-//! let result = pipeline.run(&Envelope::audio(audio_bytes))?;
+//! let envelope = Envelope::new(EnvelopeKind::Audio(audio_bytes));
+//! let result = pipeline.run(&envelope)?;
 //! println!("Pipeline completed in {}ms", result.total_latency_ms);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Example (Staged - inspect and preload)
 //!
-//! ```rust,ignore
-//! use xybrid_sdk::{PipelineRef, Envelope};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_sdk::PipelineRef;
+//! use xybrid_sdk::ir::{Envelope, EnvelopeKind};
 //!
+//! # let yaml_content = "stages: []";
+//! # let audio_bytes: Vec<u8> = vec![];
 //! // Step 1: Parse YAML (instant, no network)
 //! let ref_ = PipelineRef::from_yaml(yaml_content)?;
 //! println!("Stages: {:?}", ref_.stage_ids());
@@ -35,7 +46,11 @@
 //! })?;
 //!
 //! // Step 4: Run
-//! let result = pipeline.run(&Envelope::audio(audio_bytes))?;
+//! let envelope = Envelope::new(EnvelopeKind::Audio(audio_bytes));
+//! let result = pipeline.run(&envelope)?;
+//! # let _ = result;
+//! # Ok(())
+//! # }
 //! ```
 
 // ============================================================================
@@ -95,14 +110,19 @@ pub type PipelineResult<T> = Result<T, SdkError>;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 /// use xybrid_sdk::PipelineRef;
 ///
+/// # let yaml = "stages: []";
 /// let ref_ = PipelineRef::from_yaml(yaml)?;
 /// println!("Pipeline: {:?}", ref_.name());
 /// println!("Stages: {:?}", ref_.stage_ids());
 ///
 /// let pipeline = ref_.load()?;
+/// # let _ = pipeline;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct PipelineRef {
@@ -530,9 +550,13 @@ struct PipelineHandle {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use xybrid_sdk::{PipelineRef, Envelope};
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use xybrid_sdk::PipelineRef;
+/// use xybrid_sdk::ir::{Envelope, EnvelopeKind};
 ///
+/// # let yaml = "stages: []";
+/// # let audio_bytes: Vec<u8> = vec![];
 /// let pipeline = PipelineRef::from_yaml(yaml)?.load()?;
 ///
 /// // Inspect the pipeline
@@ -544,7 +568,10 @@ struct PipelineHandle {
 /// pipeline.load_models()?;
 ///
 /// // Run inference
-/// let result = pipeline.run(&Envelope::audio(audio_bytes))?;
+/// let result = pipeline.run(&Envelope::new(EnvelopeKind::Audio(audio_bytes)))?;
+/// # let _ = result;
+/// # Ok(())
+/// # }
 /// ```
 pub struct Pipeline {
     name: Option<String>,
@@ -1001,13 +1028,21 @@ impl Pipeline {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::PipelineRef;
+    /// # use xybrid_sdk::ir::{Envelope, EnvelopeKind};
+    /// # let yaml = "stages: []";
     /// let pipeline = PipelineRef::from_yaml(yaml)?.load()?;
     /// pipeline.load_models()?;  // Download models
     /// pipeline.warmup()?;       // Pre-load into memory
     ///
     /// // First inference is now fast
-    /// let result = pipeline.run(&Envelope::text("Hello"))?;
+    /// let envelope = Envelope::new(EnvelopeKind::Text("Hello".into()));
+    /// let result = pipeline.run(&envelope)?;
+    /// # let _ = result;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn warmup(&self) -> PipelineResult<()> {
         log::info!(target: "xybrid_sdk", "Warming up pipeline: {:?}", self.name);
@@ -1044,7 +1079,10 @@ impl Pipeline {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # async fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::PipelineRef;
+    /// # let yaml = "stages: []";
     /// let pipeline = PipelineRef::from_yaml(yaml)?.load()?;
     /// pipeline.load_models()?;
     ///
@@ -1058,6 +1096,8 @@ impl Pipeline {
     ///
     /// // Wait for warmup if needed
     /// warmup_handle.await??;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn warmup_async(&self) -> PipelineResult<()> {
         log::info!(target: "xybrid_sdk", "Warming up pipeline (async): {:?}", self.name);
@@ -1433,11 +1473,18 @@ impl Xybrid {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// use xybrid_sdk::{Xybrid, Envelope};
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_sdk::Xybrid;
+    /// use xybrid_sdk::ir::{Envelope, EnvelopeKind};
     ///
-    /// let result = Xybrid::run_pipeline(yaml_content, &Envelope::audio(audio_bytes))?;
+    /// # let yaml_content = "stages: []";
+    /// # let audio_bytes: Vec<u8> = vec![];
+    /// let envelope = Envelope::new(EnvelopeKind::Audio(audio_bytes));
+    /// let result = Xybrid::run_pipeline(yaml_content, &envelope)?;
     /// println!("Output: {:?}", result.text());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn run_pipeline(
         yaml: &str,
@@ -1477,19 +1524,27 @@ impl Xybrid {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// use xybrid_sdk::{Xybrid, Envelope, PartialToken};
+    /// ```no_run
+    /// # #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_sdk::{Xybrid, PartialToken};
+    /// use xybrid_sdk::ir::{Envelope, EnvelopeKind};
     /// use std::io::Write;
     ///
+    /// # let yaml_content = "stages: []";
+    /// let envelope = Envelope::new(EnvelopeKind::Text("Hello, how are you?".into()));
     /// let result = Xybrid::run_pipeline_streaming(
     ///     yaml_content,
-    ///     &Envelope::text("Hello, how are you?"),
+    ///     &envelope,
     ///     Box::new(|token: PartialToken| {
     ///         print!("{}", token.token);
     ///         std::io::stdout().flush()?;
     ///         Ok(())
     ///     }),
     /// )?;
+    /// # let _ = result;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Note

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -11,7 +11,8 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_sdk::registry_client::RegistryClient;
 //!
 //! let client = RegistryClient::default_client()?;
@@ -30,6 +31,8 @@
 //! let bundle_path = client.fetch("kokoro-82m", None, |progress| {
 //!     println!("Downloaded: {:.1}%", progress * 100.0);
 //! })?;
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::cache::CacheManager;
@@ -758,7 +761,9 @@ impl RegistryClient {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_sdk::RegistryClient;
     /// let client = RegistryClient::default_client()?;
     /// let model_dir = client.fetch_extracted("kokoro-82m", None, |p| {
     ///     println!("Downloaded: {:.1}%", p * 100.0);
@@ -766,6 +771,8 @@ impl RegistryClient {
     ///
     /// // model_dir now contains model_metadata.json and all model files
     /// let metadata_path = model_dir.join("model_metadata.json");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn fetch_extracted<F>(
         &self,

--- a/crates/xybrid-sdk/src/result.rs
+++ b/crates/xybrid-sdk/src/result.rs
@@ -109,8 +109,12 @@ impl std::fmt::Display for OutputType {
 ///
 /// # Example
 ///
-/// ```ignore
-/// let result = model.run(&envelope)?;
+/// ```no_run
+/// # use xybrid_sdk::{XybridModel, ir::Envelope, result::OutputType};
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let model: XybridModel = unimplemented!();
+/// # let envelope: Envelope = unimplemented!();
+/// let result = model.run(&envelope, None)?;
 ///
 /// // Check output type
 /// match result.output_type() {
@@ -124,6 +128,8 @@ impl std::fmt::Display for OutputType {
 /// if let Some(text) = result.text() {
 ///     println!("Transcription: {}", text);
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct InferenceResult {

--- a/crates/xybrid-sdk/src/source.rs
+++ b/crates/xybrid-sdk/src/source.rs
@@ -21,11 +21,12 @@ pub enum ModelSource {
     /// SHA256 verification.
     ///
     /// # Example
-    /// ```ignore
-    /// ModelSource::Registry {
+    /// ```no_run
+    /// # use xybrid_sdk::ModelSource;
+    /// let _ = ModelSource::Registry {
     ///     id: "kokoro-82m".to_string(),
     ///     platform: None, // Auto-detect
-    /// }
+    /// };
     /// ```
     Registry {
         /// Model ID (e.g., "kokoro-82m", "whisper-tiny")
@@ -41,13 +42,15 @@ pub enum ModelSource {
     /// which is less flexible than registry API resolution.
     ///
     /// # Example
-    /// ```ignore
-    /// ModelSource::LegacyRegistry {
+    /// ```no_run
+    /// # #![allow(deprecated)]
+    /// # use xybrid_sdk::ModelSource;
+    /// let _ = ModelSource::LegacyRegistry {
     ///     url: "http://localhost:8080".to_string(),
     ///     model_id: "whisper-tiny".to_string(),
     ///     version: "1.0".to_string(),
     ///     platform: None, // Auto-detect
-    /// }
+    /// };
     /// ```
     #[deprecated(since = "0.0.17", note = "Use ModelSource::Registry instead")]
     LegacyRegistry {
@@ -64,10 +67,12 @@ pub enum ModelSource {
     /// Load from local .xyb bundle file.
     ///
     /// # Example
-    /// ```ignore
-    /// ModelSource::Bundle {
+    /// ```no_run
+    /// # use xybrid_sdk::ModelSource;
+    /// # use std::path::PathBuf;
+    /// let _ = ModelSource::Bundle {
     ///     path: PathBuf::from("models/whisper-tiny.xyb"),
-    /// }
+    /// };
     /// ```
     Bundle {
         /// Path to the .xyb bundle file
@@ -79,10 +84,12 @@ pub enum ModelSource {
     /// The directory must contain `model_metadata.json` and model files.
     ///
     /// # Example
-    /// ```ignore
-    /// ModelSource::Directory {
+    /// ```no_run
+    /// # use xybrid_sdk::ModelSource;
+    /// # use std::path::PathBuf;
+    /// let _ = ModelSource::Directory {
     ///     path: PathBuf::from("/path/to/whisper-model"),
-    /// }
+    /// };
     /// ```
     Directory {
         /// Path to model directory containing model_metadata.json
@@ -98,12 +105,13 @@ pub enum ModelSource {
     /// auto-generated in a future version.
     ///
     /// # Example
-    /// ```ignore
-    /// ModelSource::HuggingFace {
+    /// ```no_run
+    /// # use xybrid_sdk::ModelSource;
+    /// let _ = ModelSource::HuggingFace {
     ///     repo: "xybrid-ai/kokoro-82m".to_string(),
     ///     revision: None, // Uses default branch
     ///     variant: None, // Auto-selects Q4_K_M for GGUF repos
-    /// }
+    /// };
     /// ```
     HuggingFace {
         /// HuggingFace repository ID (e.g., "xybrid-ai/kokoro-82m")
@@ -123,7 +131,8 @@ impl ModelSource {
     /// for the current platform.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use xybrid_sdk::ModelSource;
     /// let source = ModelSource::registry("kokoro-82m");
     /// ```
     pub fn registry(id: impl Into<String>) -> Self {
@@ -136,7 +145,8 @@ impl ModelSource {
     /// Create a registry source with explicit platform.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
+    /// # use xybrid_sdk::ModelSource;
     /// let source = ModelSource::registry_with_platform("kokoro-82m", "macos-arm64");
     /// ```
     pub fn registry_with_platform(id: impl Into<String>, platform: impl Into<String>) -> Self {

--- a/crates/xybrid-sdk/src/stream.rs
+++ b/crates/xybrid-sdk/src/stream.rs
@@ -116,7 +116,12 @@ struct StreamHandle {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # use xybrid_sdk::{XybridModel, StreamConfig};
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let model: XybridModel = unimplemented!();
+/// # let audio_chunk_1: Vec<f32> = vec![];
+/// # let audio_chunk_2: Vec<f32> = vec![];
 /// let stream = model.stream(StreamConfig::with_vad())?;
 ///
 /// // Feed audio samples (16kHz mono f32)
@@ -134,6 +139,8 @@ struct StreamHandle {
 ///
 /// // Reset for new utterance
 /// stream.reset()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct XybridStream {
     handle: Arc<RwLock<StreamHandle>>,

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1368,7 +1368,7 @@ static PLATFORM_EXPORTER: RwLock<Option<HttpTelemetryExporter>> = RwLock::new(No
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_sdk::telemetry::{init_platform_telemetry, TelemetryConfig};
 ///
 /// let config = TelemetryConfig::new("https://ingest.xybrid.dev", "your-api-key")


### PR DESCRIPTION
## Summary

- All xybrid-sdk doctests were marked `ignore` or `rust,ignore`, so they were never compile-checked and had drifted from the real API. This converts them to `no_run` and brings them in sync with the actual signatures — CI will now catch future drift.
- Net result: `cargo test --doc -p xybrid-sdk` goes from 50 ignored to **82 passing, 0 failed, 0 ignored**.
- Closes the "Fix SDK doctest examples" pre-release checklist item for v0.1.0.

## API drift fixed along the way

- `XybridModel::run` is `(envelope, Option<&GenerationConfig>)`; docs showed `model.run(&envelope)`.
- `run_streaming` / `run_with_context` / `run_streaming_with_context` / `run_stream` all carry the same `Option<&GenerationConfig>` slot the examples were missing.
- `ModelLoader::from_registry` takes a single id; the top-level example still showed the pre-registry `(url, model_id, version)` signature.
- `Envelope::audio(...)` / `Envelope::text(...)` don't exist — switched to `Envelope::new(EnvelopeKind::Audio(...))` etc.
- `SdkCacheProvider::new()` is commented out; example now uses `SdkCacheProvider::with_dir(...)`, which is the real public API.

## Approach

Each block gets a hidden `# fn _example() -> Result<(), …>` wrapper plus `unimplemented!()` stub bindings for inputs like `model` / `envelope`, so the rendered docs stay focused on the API surface while still type-checking against real signatures.

xybrid-core doctests were intentionally left out of this PR — the same audit there exposes ~60 cases of similar drift that need careful per-example fixing. Will follow up in a separate PR so this one can land cleanly for the v0.1.0 cut.

## Test plan

- [x] `cargo test --doc -p xybrid-sdk` — 82 passed, 0 failed, 0 ignored
- [x] `cargo clippy -p xybrid-sdk --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean