### PR TITLE
ci(release): add release-branch flow alongside the tag-driven release

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install LLVM
         run: brew install llvm
 
-      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
 
       # --- Step 1: Build XCFramework (cold compile, ~18 min) ---
       - name: Build XCFramework
@@ -332,7 +332,7 @@ jobs:
           cache-all-crates: "true"
           save-if: "true"
 
-      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
 
       - name: Install LLVM
         run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
@@ -404,7 +404,7 @@ jobs:
           cache-all-crates: "true"
           save-if: "true"
 
-      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
 
       - name: Install LLVM and NASM
         run: choco install llvm nasm
@@ -631,9 +631,24 @@ jobs:
           BRANCH: ${{ needs.check-release-branch.outputs.branch }}
         run: |
           set -euo pipefail
-          # Delete any pre-existing draft for this tag so reruns are clean.
-          # Safe: drafts have no real tag yet, so --cleanup-tag is a no-op.
-          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          # If a release already exists for this tag, clean it up *only* if
+          # it's still a draft (e.g. a previous release-prep run that never
+          # got merged). Refuse to touch published releases — a fixup push
+          # to a stale release/v* branch must not silently wipe a real
+          # release and its git tag.
+          STATE=$(gh release view "$TAG" --json isDraft -q .isDraft 2>/dev/null || echo "missing")
+          case "$STATE" in
+            true)
+              echo "::notice::Deleting pre-existing DRAFT release for ${TAG} so this run can recreate it."
+              gh release delete "$TAG" --yes --cleanup-tag
+              ;;
+            false)
+              echo "::error::Release ${TAG} is already PUBLISHED. Refusing to delete. Bump the version on this branch (or pick a new branch name) and re-push."
+              exit 1
+              ;;
+            missing)
+              ;;
+          esac
 
           PRERELEASE_FLAG=""
           case "$TAG" in

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,695 @@
+name: Release Prep
+
+# Release-branch flow, step 1 of 2. Companion: release-publish.yml.
+#
+# Trigger: push to a `release/v*` branch. The maintainer's local ritual is:
+#
+#     git switch -c release/v0.1.0-rc4 origin/master
+#     just bump-version 0.1.0-rc4          # bumps versions, scaffolds changelog
+#     /update-version-docs 0.1.0-rc4       # LLM-assisted changelog fill
+#     git add -A && git commit -m "bump: 0.1.0-rc4"
+#     git push -u origin release/v0.1.0-rc4
+#
+# Once the branch is pushed this workflow runs and:
+#
+#   1. Verifies the branch name maps to a version that matches every
+#      package manifest (Cargo workspace, pubspec.yaml, package.json,
+#      build.gradle.kts, Package.swift sdkVersion).
+#   2. Builds every release artifact on the release branch (xcframework,
+#      android .so, Flutter precompiled binaries, CLI binaries).
+#   3. Pulls the xcframework zip, computes its SHA-256, patches
+#      Package.swift's xybridFFIChecksum on the release branch, commits and
+#      pushes that patch back. Pushes by GITHUB_TOKEN do not re-trigger
+#      workflows, so this doesn't loop.
+#   4. Creates a DRAFT GitHub Release tagged v<version> with
+#      target_commitish pointing at the release branch, and uploads every
+#      artifact as a release asset. Draft asset URLs are not yet public —
+#      only repo collaborators can fetch them while the release is in draft.
+#   5. Opens a PR: release/v<version> → master.
+#
+# At this point a human reviews the PR. Nothing is published externally:
+# no public release, no crates.io / pub.dev / Maven Central publishes, no
+# git tag (drafts hold a target tag name but only materialize the tag at
+# publish time). Closing the PR without merging aborts cleanly; the draft
+# release lingers until the next release-prep run replaces it.
+#
+# Once the PR merges, release-publish.yml takes over.
+
+on:
+  push:
+    branches: ['release/v*']
+
+# Cancel in-flight runs when the maintainer pushes again to the same
+# release branch (e.g. a changelog fixup) — no point finishing a stale
+# build matrix.
+concurrency:
+  group: release-prep-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  NDK_VERSION: "26.1.10909125"
+  FLUTTER_VERSION: "3.35.7"
+  FRB_VERSION: "2.11.1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # =========================================================================
+  # Parse the branch name, verify every per-package version file matches.
+  # =========================================================================
+  check-release-branch:
+    name: Verify release branch
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.meta.outputs.branch }}
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Parse branch / version
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          case "$BRANCH" in
+            release/v*) ;;
+            *) echo "::error::Expected release/v* branch, got $BRANCH"; exit 1 ;;
+          esac
+          TAG="${BRANCH#release/}"
+          VERSION="${TAG#v}"
+          echo "branch=$BRANCH"   >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "Release branch:  $BRANCH"
+          echo "Release version: $VERSION"
+
+      - name: Check versions match release branch
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          CARGO_VERSION=$(grep -A5 '\[workspace\.package\]' Cargo.toml | grep '^version' | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+          FLUTTER_VERSION_PKG=$(grep '^version:' bindings/flutter/pubspec.yaml | sed 's/version: *//')
+          UNITY_VERSION=$(python3 -c "import json; print(json.load(open('bindings/unity/package.json'))['version'])")
+          KOTLIN_VERSION=$(grep '^version = ' bindings/kotlin/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+          SWIFT_VERSION=$(grep '^let sdkVersion = ' Package.swift | sed 's/let sdkVersion = "\(.*\)"/\1/')
+
+          echo "Cargo:   $CARGO_VERSION"
+          echo "Flutter: $FLUTTER_VERSION_PKG"
+          echo "Unity:   $UNITY_VERSION"
+          echo "Kotlin:  $KOTLIN_VERSION"
+          echo "Swift:   $SWIFT_VERSION"
+
+          FAILED=0
+          for V in "$CARGO_VERSION" "$FLUTTER_VERSION_PKG" "$UNITY_VERSION" "$KOTLIN_VERSION" "$SWIFT_VERSION"; do
+            if [ "$V" != "$VERSION" ]; then
+              echo "::error::Version mismatch — branch is $VERSION but found $V"
+              echo "Run 'just bump-version $VERSION' on the release branch and push the result."
+              FAILED=1
+            fi
+          done
+          [ "$FAILED" -eq 0 ] || exit 1
+
+  # =========================================================================
+  # Consolidated Apple build: XCFramework + Flutter darwin precompile +
+  # CLI macos-arm64. One macos-14 runner shares sccache across all three.
+  # =========================================================================
+  build-apple-all:
+    name: Build Apple (all)
+    needs: [check-release-branch]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: >-
+            aarch64-apple-ios,
+            aarch64-apple-ios-sim,
+            aarch64-apple-darwin
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "apple-xcframework"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      - name: Install LLVM
+        run: brew install llvm
+
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+
+      # --- Step 1: Build XCFramework (cold compile, ~18 min) ---
+      - name: Build XCFramework
+        run: cargo xtask build-xcframework --release
+
+      - name: Prepare XCFramework artifact
+        shell: bash
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+        run: |
+          mkdir -p dist
+          cd bindings/apple/XCFrameworks
+          zip -r ../../../dist/XybridFFI-${TAG}.xcframework.zip XybridFFI.xcframework
+
+      - name: Upload XCFramework artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: xcframework
+          path: dist/XybridFFI-*.xcframework.zip
+          if-no-files-found: error
+
+      # --- Step 2: Precompile Flutter darwin (sccache warm, ~3-5 min) ---
+      - name: Install build tool dependencies
+        working-directory: bindings/flutter/cargokit/build_tool
+        run: dart pub get
+
+      - name: Precompile and upload Flutter darwin binaries
+        working-directory: bindings/flutter/cargokit/build_tool
+        shell: bash
+        env:
+          PRIVATE_KEY: ${{ secrets.CARGOKIT_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run bin/build_tool.dart precompile-binaries \
+            --repository ${{ github.repository }} \
+            --manifest-dir ${{ github.workspace }}/bindings/flutter/rust \
+            --verbose
+
+      # --- Step 3: Build CLI macos-arm64 (sccache warm, ~1-2 min) ---
+      - name: Build CLI (macos-arm64)
+        run: cargo build --release -p xybrid-cli --target aarch64-apple-darwin --features platform-macos
+
+      - name: Strip CLI binary
+        run: strip target/aarch64-apple-darwin/release/xybrid
+
+      - name: Prepare CLI artifact
+        shell: bash
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+        run: |
+          mkdir -p dist-cli
+          cp target/aarch64-apple-darwin/release/xybrid dist-cli/xybrid-${TAG}-macos-arm64
+          chmod +x dist-cli/xybrid-${TAG}-macos-arm64
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cli-macos-arm64
+          path: dist-cli/*
+
+  # =========================================================================
+  # Android .so files build (Linux with NDK).
+  # =========================================================================
+  build-android:
+    name: Build Android
+    needs: [check-release-branch]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: >-
+            aarch64-linux-android,
+            armv7-linux-androideabi,
+            x86_64-linux-android
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "android-ndk"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      - name: Setup Android NDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install NDK
+        run: |
+          sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
+
+      - name: Install cargo-ndk
+        run: which cargo-ndk || cargo install cargo-ndk
+
+      - name: Build Android .so files
+        run: cargo xtask build-android --release
+
+      - name: Prepare artifact with version
+        shell: bash
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+        run: |
+          mkdir -p dist
+          cd bindings/kotlin/libs
+          zip -r ../../../dist/xybrid-android-${TAG}.zip .
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-libs
+          path: dist/xybrid-android-*.zip
+          if-no-files-found: error
+
+  # =========================================================================
+  # Flutter precompiled binaries — Linux (waits for build-android sccache).
+  # =========================================================================
+  precompile-flutter-linux:
+    name: Precompile Flutter (linux)
+    needs: [check-release-branch, build-android]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: >-
+            x86_64-unknown-linux-gnu,
+            aarch64-linux-android,
+            armv7-linux-androideabi,
+            x86_64-linux-android
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "flutter-linux"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+
+      - name: Install LLVM
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install Android NDK
+        run: |
+          sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
+
+      - name: Install cargo-ndk
+        run: which cargo-ndk || cargo install cargo-ndk
+
+      - name: Install build tool dependencies
+        working-directory: bindings/flutter/cargokit/build_tool
+        run: dart pub get
+
+      - name: Precompile and upload binaries
+        working-directory: bindings/flutter/cargokit/build_tool
+        shell: bash
+        env:
+          PRIVATE_KEY: ${{ secrets.CARGOKIT_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dart run bin/build_tool.dart precompile-binaries \
+            --repository ${{ github.repository }} \
+            --manifest-dir ${{ github.workspace }}/bindings/flutter/rust \
+            --verbose \
+            --android-sdk-location $ANDROID_HOME \
+            --android-ndk-version ${{ env.NDK_VERSION }} \
+            --android-min-sdk-version 28
+
+  # =========================================================================
+  # Flutter precompiled binaries — Windows.
+  # =========================================================================
+  precompile-flutter-windows:
+    name: Precompile Flutter (windows)
+    needs: [check-release-branch]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: x86_64-pc-windows-msvc
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "flutter-windows"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+
+      - name: Install LLVM and NASM
+        run: choco install llvm nasm
+
+      - name: Add NASM to PATH
+        shell: bash
+        run: echo "C:\\Program Files\\NASM" >> $GITHUB_PATH
+
+      - name: Install build tool dependencies
+        working-directory: bindings/flutter/cargokit/build_tool
+        run: dart pub get
+
+      - name: Force dynamic CRT (required for cdylib DLL linking)
+        shell: bash
+        run: |
+          echo "CFLAGS=-MD" >> $GITHUB_ENV
+          echo "CXXFLAGS=-MD" >> $GITHUB_ENV
+
+      - name: Precompile and upload binaries
+        working-directory: bindings/flutter/cargokit/build_tool
+        shell: bash
+        env:
+          PRIVATE_KEY: ${{ secrets.CARGOKIT_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MANIFEST_DIR="${GITHUB_WORKSPACE//\\//}/bindings/flutter/rust"
+          dart run bin/build_tool.dart precompile-binaries \
+            --repository ${{ github.repository }} \
+            --manifest-dir "$MANIFEST_DIR" \
+            --verbose
+
+  # =========================================================================
+  # CLI builds (Linux + Windows; macOS is built in build-apple-all).
+  # =========================================================================
+  build-cli:
+    name: Build CLI (${{ matrix.name }})
+    needs: [check-release-branch]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: xybrid
+            features: platform-desktop
+
+          - name: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: xybrid.exe
+            features: platform-desktop
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "cli-${{ matrix.name }}"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      - name: Build CLI
+        run: cargo build --release -p xybrid-cli --target ${{ matrix.target }} --features ${{ matrix.features }}
+
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        run: strip target/${{ matrix.target }}/release/${{ matrix.artifact }}
+
+      - name: Prepare artifact
+        shell: bash
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+        run: |
+          mkdir -p dist
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/xybrid-${TAG}-${{ matrix.name }}.exe
+          else
+            cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/xybrid-${TAG}-${{ matrix.name }}
+            chmod +x dist/xybrid-${TAG}-${{ matrix.name }}
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cli-${{ matrix.name }}
+          path: dist/*
+
+  # =========================================================================
+  # Patch Package.swift checksum and commit it back to the release branch.
+  #
+  # Pushes by GITHUB_TOKEN do not re-trigger workflow events
+  # (https://docs.github.com/en/actions/security-guides/automatic-token-authentication),
+  # so the checksum commit doesn't loop release-prep.
+  # =========================================================================
+  patch-spm-checksum:
+    name: Patch SPM checksum
+    needs: [check-release-branch, build-apple-all]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download xcframework artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: xcframework
+          path: dist
+
+      - name: Patch and push Package.swift checksum
+        shell: bash
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+          BRANCH: ${{ needs.check-release-branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+          ZIP="dist/XybridFFI-${TAG}.xcframework.zip"
+          ./bindings/apple/scripts/sync-spm-checksum.sh "$ZIP"
+
+          if git diff --quiet Package.swift; then
+            echo "::notice::Package.swift checksum already matches built zip — nothing to commit."
+            exit 0
+          fi
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add Package.swift
+          git commit -m "chore(release): pin XybridFFI checksum for ${TAG}"
+          git push origin "HEAD:${BRANCH}"
+
+  # =========================================================================
+  # Create the DRAFT release with every artifact attached.
+  #
+  # target_commitish = release branch. The git tag is NOT created yet —
+  # drafts hold a tag name but only materialize the tag at publish time.
+  # release-publish.yml will retarget to the merge commit and publish.
+  # =========================================================================
+  create-draft-release:
+    name: Create draft release
+    needs:
+      - check-release-branch
+      - patch-spm-checksum
+      - build-android
+      - build-cli
+      - precompile-flutter-linux
+      - precompile-flutter-windows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: find artifacts -type f | sort
+
+      - name: Generate changelog
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(git describe --tags --abbrev=0 origin/master 2>/dev/null || echo "")
+          {
+            echo "## What's Changed"
+            echo
+            if [ -n "$PREV_TAG" ]; then
+              git log "${PREV_TAG}..HEAD" --pretty=format:"- %s"
+            else
+              git log --pretty=format:"- %s" -n 20
+            fi
+            echo
+            echo
+            echo "### Artifacts"
+            echo
+            echo "**Android**"
+            echo "- \`xybrid-android-${TAG}.zip\` — Native .so files for all ABIs"
+            echo
+            echo "**Flutter**"
+            echo "- Precompiled native libraries auto-downloaded by cargokit"
+            echo
+            echo "**Unity**"
+            echo "- \`xybrid-unity-sdk-${TAG}.tar.gz\` — Native plugins (uploaded by Build Unity workflow)"
+            echo
+            echo "**Swift (iOS/macOS)**"
+            echo "- SPM: \`.package(url: \"https://github.com/${{ github.repository }}\", from: \"${TAG#v}\")\`"
+            echo "- \`XybridFFI-${TAG}.xcframework.zip\` — Pre-built XCFramework"
+            echo
+            echo "**CLI**"
+            echo "- Cross-platform binaries for macOS (arm64, x86_64), Linux (x86_64), and Windows (x86_64)"
+            echo
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+          } > CHANGELOG_RELEASE.md
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+          BRANCH: ${{ needs.check-release-branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+          # Delete any pre-existing draft for this tag so reruns are clean.
+          # Safe: drafts have no real tag yet, so --cleanup-tag is a no-op.
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+
+          PRERELEASE_FLAG=""
+          case "$TAG" in
+            *alpha*|*beta*|*rc*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+
+          gh release create "$TAG" \
+            --draft \
+            $PRERELEASE_FLAG \
+            --target "$BRANCH" \
+            --title "$TAG" \
+            --notes-file CHANGELOG_RELEASE.md \
+            artifacts/*
+
+  # =========================================================================
+  # Open the release PR (if not already open).
+  # =========================================================================
+  open-release-pr:
+    name: Open release PR
+    needs: [check-release-branch, create-draft-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Open PR (if not already open)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+          BRANCH: ${{ needs.check-release-branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh pr list --head "$BRANCH" --base master --state open --json number -q '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #${EXISTING} already open for ${BRANCH}."
+            exit 0
+          fi
+
+          BODY=$(cat <<EOF
+          Release **${TAG}**.
+
+          Artifacts are staged in a [draft release](https://github.com/${{ github.repository }}/releases/tag/${TAG}).
+
+          When this PR merges, the **Release Publish** workflow will:
+          - Tag the merge commit \`${TAG}\`
+          - Publish the draft release (asset URLs become public)
+          - Publish to crates.io, pub.dev, and Maven Central
+          - Update the \`swift\` branch
+
+          Close this PR (without merging) to abort. The draft release will
+          be cleaned up by the next \`release-prep\` run.
+          EOF
+          )
+
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "Release ${TAG}" \
+            --body "$BODY" \
+            --label release

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -208,7 +208,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.publish-release.outputs.tag }}
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+      # flutter-actions/setup-flutter is pinned to an untagged commit
+      # (mirrors the SHA the upstream pub.dev publish workflow uses; no
+      # corresponding release tag exists on flutter-actions/setup-flutter).
       - uses: flutter-actions/setup-flutter@18c66a64fb6f6d3338c63cabbc5cd6da395e7f1d
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,383 @@
+name: Release Publish
+
+# Release-branch flow, step 2 of 2. Companion: release-prep.yml.
+#
+# Trigger: a release PR (head branch `release/v*`) merges into master.
+# This workflow:
+#
+#   1. Extracts the version from the merged PR's head_ref.
+#   2. Retargets the draft release at the PR's merge commit and publishes
+#      it — GitHub atomically creates the git tag v<version> at the merge
+#      commit and flips the asset URLs from collaborator-only to public.
+#   3. Verifies the published tag's Package.swift checksum matches the
+#      now-public xcframework zip (sanity belt).
+#   4. Publishes the language packages: crates.io, pub.dev, Maven Central.
+#   5. Updates the legacy `swift` branch with the URL-based Package.swift
+#      (planned to be deprecated once consumers move to `from: "<version>"`).
+#
+# If a release PR is closed without merging, this workflow doesn't run. The
+# draft release lingers; the next release-prep run replaces it.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # =========================================================================
+  # Tag, publish the draft release. This is the irreversible step.
+  # =========================================================================
+  publish-release:
+    name: Publish GitHub release
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      merge_sha: ${{ steps.meta.outputs.merge_sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Extract release metadata
+        id: meta
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          TAG="${HEAD_REF#release/}"
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}"             >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}"     >> "$GITHUB_OUTPUT"
+          echo "merge_sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${TAG} at merge commit ${MERGE_SHA}"
+
+      - name: Verify draft release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          STATE=$(gh release view "$TAG" --json isDraft -q .isDraft 2>/dev/null || echo "missing")
+          if [ "$STATE" = "missing" ]; then
+            echo "::error::No draft release found for ${TAG}. Did release-prep run?"
+            exit 1
+          fi
+          if [ "$STATE" = "false" ]; then
+            echo "::warning::Release ${TAG} is already published — skipping publish step."
+          fi
+
+      - name: Retarget draft to merge commit and publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          MERGE_SHA: ${{ steps.meta.outputs.merge_sha }}
+        run: |
+          set -euo pipefail
+          # Drafts can be retargeted freely. The git tag is created at
+          # publish time using the (now-updated) target_commitish.
+          gh release edit "$TAG" --target "$MERGE_SHA"
+          gh release edit "$TAG" --draft=false
+          echo "::notice::Release ${TAG} published at ${MERGE_SHA}. Tag created, asset URLs are public."
+
+  # =========================================================================
+  # Sanity check: the published manifest's checksum matches the published
+  # asset. If this ever fires, something is fundamentally broken upstream.
+  # =========================================================================
+  verify-spm-checksum:
+    name: Verify SPM checksum
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.publish-release.outputs.tag }}
+
+      - name: Download published asset and verify SHA
+        env:
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/XybridFFI-${TAG}.xcframework.zip"
+          curl -fsSL -o /tmp/x.zip "$URL"
+          ./bindings/apple/scripts/sync-spm-checksum.sh --check /tmp/x.zip
+
+  # =========================================================================
+  # Publish Rust crates to crates.io.
+  #
+  # Dependency order: macros -> core -> sdk -> xybrid. Each publish waits
+  # for the new version to become visible on the sparse index before moving
+  # on. Idempotent: a re-run skips crates whose <name>@<version> is already
+  # on crates.io.
+  # =========================================================================
+  publish-crates:
+    name: Publish to crates.io
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.publish-release.outputs.tag }}
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "publish-crates"
+          save-if: "true"
+
+      - name: Publish crates in dependency order
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          VERSION: ${{ needs.publish-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Publishing version: $VERSION"
+
+          # Treat anything other than HTTP 200 as "not published yet" so
+          # transient 5xx errors don't silently skip a real publish.
+          already_published() {
+            local crate=$1
+            local status
+            status=$(curl -fsS -o /dev/null -w "%{http_code}" \
+              -A "xybrid-release-workflow/1.0 (+https://github.com/${{ github.repository }})" \
+              "https://crates.io/api/v1/crates/${crate}/${VERSION}" || echo "000")
+            [ "$status" = "200" ]
+          }
+
+          wait_for_index() {
+            local crate=$1
+            for i in $(seq 1 60); do
+              if already_published "$crate"; then
+                echo "${crate}@${VERSION} visible on crates.io after ${i} polls."
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::error::${crate}@${VERSION} did not appear on crates.io after 5 minutes"
+            return 1
+          }
+
+          publish_crate() {
+            local crate=$1
+            if already_published "$crate"; then
+              echo "::notice::${crate}@${VERSION} already published — skipping."
+              return 0
+            fi
+            echo "Publishing ${crate}@${VERSION}..."
+            cargo publish -p "$crate"
+            wait_for_index "$crate"
+          }
+
+          publish_crate xybrid-macros
+          publish_crate xybrid-core
+          publish_crate xybrid-sdk
+          publish_crate xybrid
+
+  # =========================================================================
+  # Publish Flutter to pub.dev via OIDC.
+  #
+  # Inlines the dart-lang/setup-dart publish.yml steps (rather than calling
+  # the reusable workflow) to match pub.dev's trusted-publisher binding,
+  # which expects this workflow path. pub.dev's trusted-publisher config
+  # must be updated when this workflow file is renamed.
+  # =========================================================================
+  publish-flutter:
+    name: Publish Flutter to pub.dev
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.publish-release.outputs.tag }}
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+      - uses: flutter-actions/setup-flutter@18c66a64fb6f6d3338c63cabbc5cd6da395e7f1d
+      - name: Install dependencies
+        run: dart pub get
+        working-directory: bindings/flutter
+      - name: Publish - dry run
+        run: dart pub publish --dry-run
+        working-directory: bindings/flutter
+      - name: Publish to pub.dev
+        run: dart pub publish -f
+        working-directory: bindings/flutter
+
+  # =========================================================================
+  # Publish Kotlin SDK to Maven Central.
+  #
+  # The .so files come from the just-published GitHub Release asset (the
+  # current release.yml grabs them via actions/download-artifact within a
+  # single workflow run; in the new flow they live as release assets, so
+  # we download them with gh).
+  # =========================================================================
+  publish-kotlin:
+    name: Publish Kotlin SDK
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.publish-release.outputs.tag }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Download Android .so files from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          gh release download "$TAG" \
+            --pattern "xybrid-android-*.zip" \
+            --dir artifacts
+
+      - name: Extract .so files into Kotlin libs/
+        run: |
+          mkdir -p bindings/kotlin/libs
+          cd bindings/kotlin/libs
+          unzip -o ${{ github.workspace }}/artifacts/xybrid-android-*.zip
+
+      - name: Publish to Maven Central
+        working-directory: bindings/kotlin
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+
+  # =========================================================================
+  # Update the legacy `swift` branch with the URL-based Package.swift.
+  #
+  # Planned for deprecation once consumers move to `from: "<version>"`
+  # against the main repo (which works because master's Package.swift is
+  # now always in sync with the latest release — that's the whole point of
+  # the release-branch flow).
+  # =========================================================================
+  publish-swift-branch:
+    name: Update swift branch
+    needs: [publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.publish-release.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Download XCFramework from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$TAG" \
+            --pattern "XybridFFI-*.xcframework.zip" \
+            --dir dist
+
+      - name: Compute checksum and generate Package.swift
+        shell: bash
+        env:
+          TAG: ${{ needs.publish-release.outputs.tag }}
+          VERSION: ${{ needs.publish-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          ZIPFILE=$(ls dist/XybridFFI-*.xcframework.zip)
+          CHECKSUM=$(shasum -a 256 "$ZIPFILE" | awk '{print $1}')
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/XybridFFI-${TAG}.xcframework.zip"
+
+          echo "Version: $VERSION"
+          echo "URL: $URL"
+          echo "Checksum: $CHECKSUM"
+
+          cat > Package.swift << SWIFT_EOF
+          // swift-tools-version:5.7
+          import PackageDescription
+
+          let package = Package(
+              name: "Xybrid",
+              platforms: [
+                  .iOS(.v13),
+                  .macOS(.v10_15)
+              ],
+              products: [
+                  .library(
+                      name: "Xybrid",
+                      targets: ["Xybrid"]
+                  )
+              ],
+              targets: [
+                  .target(
+                      name: "Xybrid",
+                      dependencies: ["XybridFFI"],
+                      path: "Sources/Xybrid",
+                      linkerSettings: [
+                          .linkedLibrary("c++"),
+                          .linkedFramework("Metal"),
+                          .linkedFramework("MetalPerformanceShaders"),
+                          .linkedFramework("MetalPerformanceShadersGraph"),
+                          .linkedFramework("CoreML"),
+                          .linkedFramework("Accelerate"),
+                          .linkedFramework("Security"),
+                      ]
+                  ),
+                  .binaryTarget(
+                      name: "XybridFFI",
+                      url: "$URL",
+                      checksum: "$CHECKSUM"
+                  )
+              ]
+          )
+          SWIFT_EOF
+
+      - name: Publish swift branch
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          # Stage files we want on the `swift` branch.
+          mkdir -p staging/Sources/Xybrid
+          cp Package.swift staging/
+          cp bindings/apple/Sources/Xybrid/Xybrid.swift        staging/Sources/Xybrid/
+          cp bindings/apple/Sources/Xybrid/xybrid_uniffi.swift staging/Sources/Xybrid/
+
+          git checkout --orphan swift
+          git rm -rf . 2>/dev/null || true
+          cp staging/Package.swift .
+          cp -r staging/Sources .
+          rm -rf staging
+
+          git add Package.swift Sources/
+          git commit -m "swift: update to ${TAG}"
+          git push origin swift --force


### PR DESCRIPTION
## Summary

Adds a release-branch + draft-release flow that fixes the root cause behind PR #167 (master's `Package.swift` checksum was stale because the existing tag-driven workflow patches the manifest at tag time and never lands the patch on master).

Lives alongside `release.yml` — does **not** delete or replace it yet. Once a release has gone end-to-end through the new flow, `release.yml` can be removed in a follow-up.

## The bug we're solving

SPM binary targets need `Package.swift` to contain a SHA-256 that matches the released xcframework zip. Our build is non-deterministic, so the SHA is only knowable *after* the zip is built. Today's `release.yml`:

1. Maintainer pushes tag `v0.1.0-rc3` → CI fires
2. CI builds xcframework, computes SHA, rewrites `Package.swift`, commits, **force-moves the tag** to that commit, pushes
3. Master never sees the patch

Result: `branch: "exact-tag"` works (tag points to the patched commit), `branch: "swift"` works (auto-published), `branch: "master"` is broken until someone manually backports the checksum.

## The new flow

**`release-prep.yml`** — triggered on push to `release/v*`:

```
maintainer locally:
  git switch -c release/v0.1.0-rc4 origin/master
  just bump-version 0.1.0-rc4
  /update-version-docs 0.1.0-rc4       # changelog
  git commit -am "bump: 0.1.0-rc4" && git push -u origin release/v0.1.0-rc4

CI then:
  check-release-branch     → parses version from branch name, verifies every manifest matches
  build-apple-all          → xcframework + Flutter darwin + CLI macos-arm64 (one runner, shared sccache)
  build-android            → .so files
  precompile-flutter-*     → cargokit precompiled binaries (linux + windows)
  build-cli                → matrix: linux-x86_64, windows-x86_64
  patch-spm-checksum       → SHA the xcframework zip, sync Package.swift, push back to release branch
  create-draft-release     → gh release create --draft v0.1.0-rc4 --target release/v0.1.0-rc4 artifacts/*
  open-release-pr          → gh pr create --base master --head release/v0.1.0-rc4
```

**`release-publish.yml`** — triggered when a `release/v*` PR merges:

```
  publish-release          → gh release edit --target <merge-sha> --draft=false
                             (atomic: tag created at merge commit, asset URLs flip to public)
  verify-spm-checksum      → curl the published asset, sync-spm-checksum.sh --check (sanity belt)
  publish-crates           → crates.io (macros → core → sdk → xybrid)
  publish-flutter          → pub.dev (OIDC)
  publish-kotlin           → Maven Central (downloads .so from the now-published release asset)
  publish-swift-branch     → updates the legacy `swift` branch (planned for deprecation)
```

## Properties

- **Master is never stale.** The checksum-bump commit lands on master via the release PR like any other change.
- **No force-moved tags.** The tag is created at publish time at the merge commit. It never moves again.
- **One build, one hash, one upload.** The xcframework zip is built exactly once in `build-apple-all`; its SHA is what's in `Package.swift` *and* what's served at the release asset URL.
- **Drafts are private and free.** If the release PR is closed without merging, no public trace remains (the next `release-prep` run cleans the stale draft).
- **Same maintainer ritual.** `just bump-version` + `/update-version-docs` + commit + push — only the branch name changes (`release/v*` instead of master).

## Recommended consumer line

```swift
.package(url: "https://github.com/xybrid-ai/xybrid", from: "0.1.0")
```

No more `branch: "master"` advice. `branch: "swift"` is still maintained but planned for removal in a follow-up after a deprecation notice.

## What this PR does NOT do

- Delete `release.yml` — keep both side-by-side until one release has gone end-to-end through the new flow.
- Remove the `swift` branch publish step — preserved for now, deprecated in a follow-up.
- Update README install snippets — separate doc PR.
- Update pub.dev's trusted-publisher binding — that's a maintainer action on pub.dev itself; the binding needs an additional entry for `release-publish.yml`'s workflow path before the first new-flow release can publish to pub.dev.

## Test plan

- [ ] `actionlint .github/workflows/release-{prep,publish}.yml` passes (verified locally: only the SC2086/SC2129 style suggestions that existing `release.yml` already emits — 44 vs 40 shellcheck warnings)
- [ ] Trigger `release-prep` on a throwaway `release/v0.1.0-rc4-dryrun` branch and confirm:
  - All build jobs complete on the release branch ref
  - `patch-spm-checksum` commits to the release branch without looping the workflow (GITHUB_TOKEN pushes don't re-trigger)
  - Draft release exists with all expected assets
  - `release/v*` → master PR is opened
- [ ] Close the dryrun PR without merging; verify next `release-prep` run cleans up the stale draft
- [ ] Add `release-publish.yml`'s workflow path to pub.dev trusted-publisher config
- [ ] Once green, plan first real release through the new flow; delete `release.yml` in a follow-up