### PR TITLE
docs(core): make all doctest examples compile under no_run

### DIFF
--- a/crates/xybrid-core/src/audio/envelope.rs
+++ b/crates/xybrid-core/src/audio/envelope.rs
@@ -26,7 +26,7 @@ use super::format::AudioFormat;
 ///
 /// ## Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::audio::AudioEnvelope;
 ///
 /// // Load from WAV file

--- a/crates/xybrid-core/src/audio/mel/mod.rs
+++ b/crates/xybrid-core/src/audio/mel/mod.rs
@@ -29,9 +29,11 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
-//! use xybrid_core::audio::mel::{compute_mel_spectrogram, MelConfig};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_core::audio::mel::{compute_mel_spectrogram, MelConfig, MelScale};
 //!
+//! # let samples: Vec<f32> = Vec::new();
 //! // Using preset for Whisper
 //! let config = MelConfig::whisper();
 //! let mel = compute_mel_spectrogram(&samples, &config)?;
@@ -43,6 +45,9 @@
 //!     ..Default::default()
 //! };
 //! let mel = compute_mel_spectrogram(&samples, &config)?;
+//! # let _ = mel;
+//! # Ok(())
+//! # }
 //! ```
 //!
 pub mod common;

--- a/crates/xybrid-core/src/audio/mod.rs
+++ b/crates/xybrid-core/src/audio/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::audio::{AudioEnvelope, AudioFormat};
 //!
 //! // Create from WAV bytes

--- a/crates/xybrid-core/src/audio/vad.rs
+++ b/crates/xybrid-core/src/audio/vad.rs
@@ -13,19 +13,22 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::audio::vad::{VadSession, VadConfig};
 //!
 //! let config = VadConfig::default();
 //! let mut vad = VadSession::new("/path/to/silero-vad", config)?;
 //!
-//! // Process audio frames
+//! # let audio_chunks: Vec<Vec<f32>> = Vec::new();
 //! for chunk in audio_chunks {
-//!     let prob = vad.process(&chunk)?;
-//!     if prob > 0.5 {
+//!     let frame = vad.process_frame(&chunk)?;
+//!     if frame.is_speech {
 //!         println!("Speech detected!");
 //!     }
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 use ort::session::{builder::GraphOptimizationLevel, Session};

--- a/crates/xybrid-core/src/bundler.rs
+++ b/crates/xybrid-core/src/bundler.rs
@@ -6,7 +6,8 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::bundler::XyBundle;
 //!
 //! // Create a new bundle
@@ -22,6 +23,8 @@
 //! // Load an existing bundle
 //! let loaded = XyBundle::load("my-model-1.0.0.xyb")?;
 //! println!("Model ID: {}", loaded.manifest().model_id);
+//! # Ok(())
+//! # }
 //! ```
 
 use serde::{Deserialize, Serialize};
@@ -89,10 +92,11 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// use xybrid_core::bundler::XyBundle;
     ///
     /// let bundle = XyBundle::new("whisper-tiny", "1.2.0", "x86_64-linux");
+    /// # let _ = bundle;
     /// ```
     pub fn new(
         model_id: impl Into<String>,
@@ -120,9 +124,13 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
     /// let mut bundle = XyBundle::new("my-model", "1.0.0", "x86_64-linux");
     /// bundle.add_file("model.onnx")?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn add_file(&mut self, path: impl AsRef<Path>) -> BundlerResult<()> {
         let path = path.as_ref();
@@ -177,9 +185,13 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
     /// let mut bundle = XyBundle::new("my-model", "1.0.0", "x86_64-linux");
     /// bundle.add_file_with_relative_path("/full/path/to/misaki/us_gold.json", "misaki/us_gold.json")?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn add_file_with_relative_path(
         &mut self,
@@ -261,10 +273,14 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
     /// let mut bundle = XyBundle::new("my-model", "1.0.0", "x86_64-linux");
     /// bundle.add_file("model.onnx")?;
     /// bundle.write("my-model-1.0.0.xyb")?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn write(&mut self, path: impl AsRef<Path>) -> BundlerResult<()> {
         let path = path.as_ref();
@@ -338,9 +354,13 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
     /// let bundle = XyBundle::load("my-model-1.0.0.xyb")?;
     /// println!("Model: {}", bundle.manifest().model_id);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn load(path: impl AsRef<Path>) -> BundlerResult<Self> {
         let path = path.as_ref();
@@ -422,10 +442,14 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let bytes = download_bundle_bytes("http://registry.example.com/bundle.xyb");
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
+    /// # let bytes: Vec<u8> = vec![]; // e.g., fetched over HTTP
     /// let bundle = XyBundle::load_from_bytes(&bytes)?;
     /// println!("Model: {}", bundle.manifest().model_id);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn load_from_bytes(bytes: &[u8]) -> BundlerResult<Self> {
         use std::io::Cursor;
@@ -502,9 +526,13 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
     /// let bundle = XyBundle::load("my-model-1.0.0.xyb")?;
     /// bundle.extract_to("/tmp/extracted")?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn extract_to(&self, output_dir: impl AsRef<Path>) -> BundlerResult<()> {
         let output_dir = output_dir.as_ref();
@@ -533,11 +561,15 @@ impl XyBundle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::bundler::XyBundle;
     /// let bundle = XyBundle::load("my-model-1.0.0.xyb")?;
     /// if let Some(metadata_json) = bundle.get_metadata_json()? {
     ///     println!("Metadata: {}", metadata_json);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn get_metadata_json(&self) -> BundlerResult<Option<String>> {
         if let Some(contents) = self.files.get("model_metadata.json") {

--- a/crates/xybrid-core/src/cache_provider.rs
+++ b/crates/xybrid-core/src/cache_provider.rs
@@ -15,17 +15,20 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
-//! use xybrid_core::CacheProvider;
+//! ```no_run
+//! # fn _example() {
+//! # use std::sync::Arc;
+//! use xybrid_core::cache_provider::{CacheProvider, NoopCacheProvider};
 //!
-//! // SDK provides this at bootstrap time
-//! let provider: Arc<dyn CacheProvider> = Arc::new(SdkCacheProvider::new());
-//! let orchestrator = Orchestrator::with_cache_provider(provider);
+//! // SDK provides this at bootstrap time (NoopCacheProvider stands in for
+//! // the real SdkCacheProvider that lives in xybrid-sdk).
+//! let provider: Arc<dyn CacheProvider> = Arc::new(NoopCacheProvider);
 //!
 //! // Core uses it for routing decisions
 //! if provider.is_model_cached("kokoro-82m") {
-//!     route_to_device();
+//!     // route to local device
 //! }
+//! # }
 //! ```
 
 use std::path::{Path, PathBuf};

--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -29,12 +29,15 @@ const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 10_000;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 /// use xybrid_core::cloud::Cloud;
 ///
 /// let cloud = Cloud::new()?;
 /// let response = cloud.prompt("Hello, world!")?;
 /// println!("Response: {}", response);
+/// # Ok(())
+/// # }
 /// ```
 pub struct Cloud {
     config: CloudConfig,

--- a/crates/xybrid-core/src/cloud/mod.rs
+++ b/crates/xybrid-core/src/cloud/mod.rs
@@ -28,7 +28,8 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::cloud::{Cloud, CompletionRequest};
 //!
 //! // Create client (routes through gateway by default)
@@ -44,6 +45,9 @@
 //!         .with_system("You are a helpful programming tutor.")
 //!         .with_max_tokens(100)
 //! )?;
+//! # let _ = response;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Note

--- a/crates/xybrid-core/src/cloud_llm/mod.rs
+++ b/crates/xybrid-core/src/cloud_llm/mod.rs
@@ -11,10 +11,14 @@
 //!
 //! ## Example
 //!
-//! ```rust,ignore
-//! use xybrid_core::cloud_llm::{LlmClient, LlmRequest, LlmProvider};
+//! This module is crate-private (`pub(crate)`) — the snippet below is for
+//! internal reference only and is not compiled as a doctest.
 //!
-//! let client = LlmClient::new(LlmProvider::OpenAI)?;
+//! ```text
+//! use xybrid_core::cloud_llm::{LlmClient, LlmRequest};
+//! use xybrid_core::pipeline::IntegrationProvider;
+//!
+//! let client = LlmClient::new(IntegrationProvider::OpenAI)?;
 //! let response = client.complete(LlmRequest {
 //!     prompt: "Hello, world!".to_string(),
 //!     system: Some("You are a helpful assistant.".to_string()),

--- a/crates/xybrid-core/src/device/capabilities.rs
+++ b/crates/xybrid-core/src/device/capabilities.rs
@@ -19,7 +19,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::device::capabilities::{HardwareCapabilities, detect_capabilities};
 //!
 //! let capabilities = detect_capabilities();

--- a/crates/xybrid-core/src/device/mod.rs
+++ b/crates/xybrid-core/src/device/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::device::{detect_capabilities, HardwareCapabilities};
 //!
 //! let capabilities = detect_capabilities();

--- a/crates/xybrid-core/src/error.rs
+++ b/crates/xybrid-core/src/error.rs
@@ -18,7 +18,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::error::{XybridError, XybridResult};
 //!
 //! fn load_and_run() -> XybridResult<String> {

--- a/crates/xybrid-core/src/execution/chat_template.rs
+++ b/crates/xybrid-core/src/execution/chat_template.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::execution::chat_template::{ChatTemplateFormat, ChatTemplateFormatter};
 //! use xybrid_core::ir::{Envelope, EnvelopeKind, MessageRole};
 //!

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -8,14 +8,21 @@
 //!
 //! The executor supports dependency injection for testability:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() {
+//! use std::collections::HashMap;
+//! use xybrid_core::execution::TemplateExecutor;
+//! use xybrid_core::runtime_adapter::ModelRuntime;
+//! use xybrid_core::testing::mocks::MockRuntime;
+//!
 //! // Default: uses ONNX (and Candle if feature-enabled)
 //! let executor = TemplateExecutor::new("models/");
 //!
 //! // Custom runtime injection for testing:
-//! let runtimes = HashMap::new();
-//! runtimes.insert("mock".to_string(), Box::new(MockRuntime::new()));
+//! let mut runtimes: HashMap<String, Box<dyn ModelRuntime>> = HashMap::new();
+//! runtimes.insert("mock".to_string(), Box::new(MockRuntime::with_text("hi")));
 //! let executor = TemplateExecutor::with_runtimes("models/", runtimes);
+//! # }
 //! ```
 
 use log::{debug, info, warn};
@@ -134,16 +141,27 @@ use super::voice_loader::TtsVoiceLoader;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::collections::HashMap;
+/// use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+/// use xybrid_core::ir::{Envelope, EnvelopeKind};
+/// use xybrid_core::runtime_adapter::ModelRuntime;
+/// use xybrid_core::testing::mocks::MockRuntime;
+///
+/// # let metadata: ModelMetadata = unimplemented!();
+/// # let input = Envelope::new(EnvelopeKind::Text("hi".into()));
 /// // Default usage (recommended)
 /// let mut executor = TemplateExecutor::new("models/whisper");
-/// let output = executor.execute(&metadata, &input)?;
+/// let output = executor.execute(&metadata, &input, None)?;
 ///
 /// // Testing with mock runtime
-/// use std::collections::HashMap;
 /// let mut runtimes: HashMap<String, Box<dyn ModelRuntime>> = HashMap::new();
-/// runtimes.insert("mock".to_string(), Box::new(MockRuntime::new()));
+/// runtimes.insert("mock".to_string(), Box::new(MockRuntime::with_text("hi")));
 /// let executor = TemplateExecutor::with_runtimes("models/", runtimes);
+/// # let _ = (output, executor);
+/// # Ok(())
+/// # }
 /// ```
 pub struct TemplateExecutor {
     /// Configured runtimes (e.g., "onnx", "candle")
@@ -191,14 +209,18 @@ impl TemplateExecutor {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() {
     /// use std::collections::HashMap;
+    /// use xybrid_core::execution::TemplateExecutor;
     /// use xybrid_core::runtime_adapter::ModelRuntime;
+    /// use xybrid_core::testing::mocks::MockRuntime;
     ///
     /// // Inject a mock runtime for testing
     /// let mut runtimes: HashMap<String, Box<dyn ModelRuntime>> = HashMap::new();
-    /// runtimes.insert("onnx".to_string(), Box::new(MockRuntime::new()));
+    /// runtimes.insert("onnx".to_string(), Box::new(MockRuntime::with_text("hi")));
     /// let executor = TemplateExecutor::with_runtimes("models/", runtimes);
+    /// # }
     /// ```
     pub fn with_runtimes(
         base_path: &str,
@@ -537,28 +559,41 @@ impl TemplateExecutor {
     /// The input is automatically appended to the context when building the prompt.
     /// Push both input and result to context **after** execution for the next turn:
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+    /// # use xybrid_core::conversation::ConversationContext;
+    /// # use xybrid_core::ir::{Envelope, EnvelopeKind, MessageRole};
+    /// # let metadata: ModelMetadata = unimplemented!();
+    /// # let mut executor = TemplateExecutor::new("models/");
+    /// # let mut ctx = ConversationContext::new();
     /// // CORRECT: Push AFTER execution
     /// let input = Envelope::new(EnvelopeKind::Text("Hello".into()))
     ///     .with_role(MessageRole::User);
-    /// let result = executor.execute_with_context(&metadata, &input, &ctx)?;
-    /// ctx.push(input);   // Push for next turn
+    /// let result = executor.execute_with_context(&metadata, &input, &ctx, None)?;
+    /// ctx.push(input.clone());   // Push for next turn
     /// ctx.push(result);  // Push for next turn
     ///
     /// // WRONG: Pushing before causes duplicate messages!
     /// ctx.push(input.clone());  // DON'T DO THIS
-    /// let result = executor.execute_with_context(&metadata, &input, &ctx)?;
+    /// let result = executor.execute_with_context(&metadata, &input, &ctx, None)?;
+    /// # let _ = result;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// A runtime warning is logged if the input is already in context (detected by local_id).
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// use xybrid_core::execution::TemplateExecutor;
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
     /// use xybrid_core::conversation::ConversationContext;
     /// use xybrid_core::ir::{Envelope, EnvelopeKind, MessageRole};
     ///
+    /// # let metadata: ModelMetadata = unimplemented!();
+    /// # let mut executor = TemplateExecutor::new("models/");
     /// let mut ctx = ConversationContext::new()
     ///     .with_system(Envelope::new(EnvelopeKind::Text("You are helpful.".into()))
     ///         .with_role(MessageRole::System));
@@ -573,12 +608,14 @@ impl TemplateExecutor {
     /// let input = Envelope::new(EnvelopeKind::Text("How are you?".into()))
     ///     .with_role(MessageRole::User);
     ///
-    /// let result = executor.execute_with_context(&metadata, &input, &ctx)?;
+    /// let result = executor.execute_with_context(&metadata, &input, &ctx, None)?;
     /// assert!(result.is_assistant_message());
     ///
     /// // Update context for next turn
     /// ctx.push(input);
     /// ctx.push(result);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn execute_with_context(
         &mut self,
@@ -724,12 +761,21 @@ impl TemplateExecutor {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use std::io::Write;
+    /// # use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+    /// # use xybrid_core::ir::{Envelope, EnvelopeKind};
+    /// # let metadata: ModelMetadata = unimplemented!();
+    /// # let input = Envelope::new(EnvelopeKind::Text("hi".into()));
+    /// # let mut executor = TemplateExecutor::new("models/");
     /// executor.execute_streaming(&metadata, &input, Box::new(|token| {
     ///     print!("{}", token.token);
-    ///     std::io::stdout().flush()?;
+    ///     std::io::stdout().flush().ok();
     ///     Ok(())
-    /// }))?;
+    /// }), None)?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn execute_streaming(
         &mut self,
@@ -821,15 +867,25 @@ impl TemplateExecutor {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use std::io::Write;
+    /// # use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+    /// # use xybrid_core::conversation::ConversationContext;
+    /// # use xybrid_core::ir::{Envelope, EnvelopeKind, MessageRole};
+    /// # let metadata: ModelMetadata = unimplemented!();
+    /// # let input = Envelope::new(EnvelopeKind::Text("hi".into()));
+    /// # let mut executor = TemplateExecutor::new("models/");
     /// let mut ctx = ConversationContext::new();
     /// ctx.push(Envelope::new(EnvelopeKind::Text("Hello!".into())).with_role(MessageRole::User));
     ///
     /// executor.execute_streaming_with_context(&metadata, &input, &ctx, Box::new(|token| {
     ///     print!("{}", token.token);
-    ///     std::io::stdout().flush()?;
+    ///     std::io::stdout().flush().ok();
     ///     Ok(())
-    /// }))?;
+    /// }), None)?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn execute_streaming_with_context(
         &mut self,

--- a/crates/xybrid-core/src/execution/listener.rs
+++ b/crates/xybrid-core/src/execution/listener.rs
@@ -7,7 +7,7 @@
 //!
 //! # Usage
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::execution::listener::{set_execution_listener, ExecutionEvent};
 //!
 //! set_execution_listener(|event| {

--- a/crates/xybrid-core/src/execution/mod.rs
+++ b/crates/xybrid-core/src/execution/mod.rs
@@ -41,15 +41,21 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::execution::{TemplateExecutor, template::ModelMetadata};
 //! use xybrid_core::ir::{Envelope, EnvelopeKind};
 //!
-//! let metadata: ModelMetadata = serde_json::from_str(&config_json)?;
+//! # let config_json = "{}";
+//! # let audio_bytes: Vec<u8> = vec![];
+//! let metadata: ModelMetadata = serde_json::from_str(config_json)?;
 //! let mut executor = TemplateExecutor::with_base_path("/path/to/model-dir");
 //!
 //! let input = Envelope::new(EnvelopeKind::Audio(audio_bytes));
-//! let output = executor.execute(&metadata, &input)?;
+//! let output = executor.execute(&metadata, &input, None)?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
 //! ```
 
 // Template types (model_metadata.json schema)

--- a/crates/xybrid-core/src/executor.rs
+++ b/crates/xybrid-core/src/executor.rs
@@ -145,7 +145,7 @@ impl Executor {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// use xybrid_core::executor::Executor;
     /// use xybrid_core::runtime_adapter::OnnxRuntimeAdapter;
     /// use std::sync::Arc;
@@ -192,16 +192,20 @@ impl Executor {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
     /// use xybrid_core::executor::Executor;
     /// use xybrid_core::context::StageDescriptor;
     /// use xybrid_core::ir::{Envelope, EnvelopeKind};
     ///
-    /// let executor = Executor::new();
+    /// let mut executor = Executor::new();
     /// let stage = StageDescriptor::new("asr");
     /// let input = Envelope::new(EnvelopeKind::Audio(vec![0u8; 1024]));
     ///
     /// let (output, metadata) = executor.execute_stage(&stage, &input, "local")?;
+    /// # let _ = (output, metadata);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn execute_stage(
         &mut self,
@@ -411,17 +415,18 @@ impl Executor {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # async fn _example() -> Result<(), Box<dyn std::error::Error>> {
     /// use xybrid_core::executor::Executor;
     /// use xybrid_core::context::StageDescriptor;
     /// use xybrid_core::ir::{Envelope, EnvelopeKind};
     ///
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let executor = Executor::new();
+    /// let mut executor = Executor::new();
     /// let stage = StageDescriptor::new("asr");
     /// let input = Envelope::new(EnvelopeKind::Audio(vec![0u8; 1024]));
     ///
     /// let (output, metadata) = executor.execute_stage_async(&stage, &input, "local").await?;
+    /// # let _ = (output, metadata);
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/xybrid-core/src/http/mod.rs
+++ b/crates/xybrid-core/src/http/mod.rs
@@ -7,23 +7,34 @@
 //!
 //! Use [`RetryPolicy`] to configure automatic retries with exponential backoff:
 //!
-//! ```rust,ignore
-//! use xybrid_core::http::{RetryPolicy, with_retry};
+//! ```no_run
+//! # fn _example() {
+//! use std::time::Duration;
+//! use xybrid_core::http::{RetryPolicy, with_retry, RetryableError};
+//!
+//! #[derive(Debug)]
+//! struct MyError;
+//! impl RetryableError for MyError {
+//!     fn is_retryable(&self) -> bool { true }
+//!     fn retry_after(&self) -> Option<Duration> { None }
+//! }
 //!
 //! let policy = RetryPolicy::default();
 //! let result = with_retry(&policy, None, || {
-//!     // Your HTTP operation here
 //!     Ok::<_, MyError>("success")
 //! });
+//! # let _ = result;
+//! # }
 //! ```
 //!
 //! ## Circuit Breaker
 //!
 //! Use [`CircuitBreaker`] to prevent hammering failing endpoints:
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::http::{CircuitBreaker, CircuitConfig};
 //!
+//! # fn make_request() -> Result<(), Box<dyn std::error::Error>> { Ok(()) }
 //! let circuit = CircuitBreaker::new(CircuitConfig::default());
 //!
 //! if circuit.can_execute() {

--- a/crates/xybrid-core/src/http/retry.rs
+++ b/crates/xybrid-core/src/http/retry.rs
@@ -171,9 +171,19 @@ pub trait RetryableError {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use std::time::Duration;
 /// use xybrid_core::http::{RetryPolicy, with_retry, RetryableError};
 ///
+/// #[derive(Debug)]
+/// struct MyError;
+/// impl RetryableError for MyError {
+///     fn is_retryable(&self) -> bool { true }
+///     fn retry_after(&self) -> Option<Duration> { None }
+/// }
+///
+/// # fn make_http_request() -> Result<String, MyError> { Ok("ok".into()) }
 /// let policy = RetryPolicy::default();
 /// let result = with_retry(&policy, None, || {
 ///     make_http_request()
@@ -183,6 +193,7 @@ pub trait RetryableError {
 ///     Ok(response) => println!("Success: {:?}", response),
 ///     Err(e) => eprintln!("Failed: {:?}", e),
 /// }
+/// # }
 /// ```
 pub fn with_retry<T, E, F>(
     policy: &RetryPolicy,

--- a/crates/xybrid-core/src/ir/envelope.rs
+++ b/crates/xybrid-core/src/ir/envelope.rs
@@ -12,7 +12,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::ir::{Envelope, EnvelopeKind};
 //! use std::collections::HashMap;
 //!

--- a/crates/xybrid-core/src/lib.rs
+++ b/crates/xybrid-core/src/lib.rs
@@ -21,13 +21,19 @@
 //!
 //! Use the [`prelude`] module for common imports:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::prelude::*;
 //!
+//! # let audio_bytes: Vec<u8> = vec![];
+//! # let metadata: xybrid_core::execution::ModelMetadata = unimplemented!();
 //! // Create an executor and run inference
 //! let mut executor = TemplateExecutor::with_base_path("models/whisper");
-//! let input = Envelope::from_audio(audio_bytes);
-//! let output = executor.execute(&metadata, &input)?;
+//! let input = Envelope::new(EnvelopeKind::Audio(audio_bytes));
+//! let output = executor.execute(&metadata, &input, None)?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Module Organization
@@ -150,7 +156,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::prelude::*;
 /// ```
 pub mod prelude;
@@ -164,11 +170,12 @@ pub mod prelude;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::error::{XybridError, XybridResult};
 ///
 /// fn run_model() -> XybridResult<String> {
 ///     // ...
+///     # Err(XybridError::NotFound("stub".into()))
 /// }
 /// ```
 pub mod error;

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -112,7 +112,7 @@ pub enum ExecutionMode {
 /// For smarter decisions based on fleet-wide data, configure a `RemoteAuthority` which
 /// will automatically fall back to `LocalAuthority` when the backend is unavailable.
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::orchestrator::{Orchestrator, RemoteAuthority};
 ///
 /// // Default: LocalAuthority (fully offline)
@@ -213,7 +213,7 @@ impl Orchestrator {
     ///
     /// Use this to configure smart routing via `RemoteAuthority`:
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// use xybrid_core::orchestrator::{Orchestrator, RemoteAuthority};
     ///
     /// // RemoteAuthority automatically falls back to LocalAuthority

--- a/crates/xybrid-core/src/orchestrator/authority/local.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/local.rs
@@ -55,12 +55,15 @@ const MAX_RELIABILITY_KEYS: usize = 256;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
 /// use xybrid_core::orchestrator::authority::{LocalAuthority, OrchestrationAuthority, PolicyRequest};
 ///
+/// # let request: PolicyRequest = unimplemented!();
 /// let authority = LocalAuthority::new();
 /// let decision = authority.apply_policy(&request);
 /// println!("Decision: {:?} ({})", decision.result, decision.reason);
+/// # }
 /// ```
 pub struct LocalAuthority {
     policy_engine: DefaultPolicyEngine,

--- a/crates/xybrid-core/src/orchestrator/authority/mod.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/mod.rs
@@ -46,7 +46,7 @@ pub use types::*;
 /// Works completely offline. Uses device metrics and simple heuristics.
 /// You can inspect the source - no magic, no phone-home.
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::orchestrator::authority::{LocalAuthority, OrchestrationAuthority};
 ///
 /// let authority = LocalAuthority::new();
@@ -58,7 +58,7 @@ pub use types::*;
 /// Delegates to xybrid backend for smarter decisions based on fleet data.
 /// Returns the same explainable decisions, just with more intelligence.
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::orchestrator::authority::{RemoteAuthority, OrchestrationAuthority};
 ///
 /// let authority = RemoteAuthority::new("https://api.xybrid.dev");

--- a/crates/xybrid-core/src/orchestrator/authority/remote.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/remote.rs
@@ -46,12 +46,17 @@ const TARGET_ADVICE_CACHE_CAPACITY: usize = 256;
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use xybrid_core::orchestrator::authority::{RemoteAuthority, OrchestrationAuthority};
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::orchestrator::authority::{
+///     RemoteAuthority, OrchestrationAuthority, PolicyRequest,
+/// };
 ///
+/// # let request: PolicyRequest = unimplemented!();
 /// let authority = RemoteAuthority::new("https://api.xybrid.dev");
-/// // Falls back to local if network unavailable
 /// let decision = authority.apply_policy(&request);
+/// # let _ = decision;
+/// # }
 /// ```
 pub struct RemoteAuthority {
     /// Backend endpoint URL.

--- a/crates/xybrid-core/src/orchestrator/bootstrap.rs
+++ b/crates/xybrid-core/src/orchestrator/bootstrap.rs
@@ -6,11 +6,14 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::orchestrator::Orchestrator;
 //!
 //! let orchestrator = Orchestrator::bootstrap(None)?;
-//! // orchestrator is ready to execute pipelines
+//! # let _ = orchestrator;
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::context::DeviceMetrics;
@@ -91,14 +94,19 @@ impl Orchestrator {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::path::Path;
     /// use xybrid_core::orchestrator::Orchestrator;
     ///
     /// // Bootstrap with defaults
     /// let orchestrator = Orchestrator::bootstrap(None)?;
     ///
     /// // Bootstrap with configuration file
-    /// let orchestrator = Orchestrator::bootstrap(Some("config/hiiipe.yml"))?;
+    /// let orchestrator = Orchestrator::bootstrap(Some(Path::new("config/hiiipe.yml")))?;
+    /// # let _ = orchestrator;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn bootstrap(config_path: Option<&Path>) -> Result<Self, OrchestratorError> {
         // Emit bootstrap start event

--- a/crates/xybrid-core/src/prelude.rs
+++ b/crates/xybrid-core/src/prelude.rs
@@ -5,13 +5,18 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::prelude::*;
 //!
+//! # let metadata: xybrid_core::execution::ModelMetadata = unimplemented!();
 //! // Now you have access to common types
-//! let input = Envelope::from_text("Hello, world!");
+//! let input = Envelope::new(EnvelopeKind::Text("Hello, world!".into()));
 //! let mut executor = TemplateExecutor::with_base_path("models/tts");
-//! let output = executor.execute(&metadata, &input)?;
+//! let output = executor.execute(&metadata, &input, None)?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # What's Included

--- a/crates/xybrid-core/src/preprocessing/mel_spectrogram.rs
+++ b/crates/xybrid-core/src/preprocessing/mel_spectrogram.rs
@@ -9,12 +9,16 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
-//! use xybrid_core::preprocessing::mel_spectrogram::{audio_bytes_to_whisper_mel};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_core::preprocessing::mel_spectrogram::audio_bytes_to_whisper_mel;
 //!
-//! let wav_bytes = std::fs::read("audio.wav").unwrap();
+//! let wav_bytes = std::fs::read("audio.wav")?;
 //! let mel_tensor = audio_bytes_to_whisper_mel(&wav_bytes)?;
 //! // mel_tensor has shape [1, 80, 3000]
+//! # let _ = mel_tensor;
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::audio::mel::whisper::{compute_whisper_mel, WhisperMelConfig};

--- a/crates/xybrid-core/src/runtime_adapter/candle/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/adapter.rs
@@ -22,6 +22,7 @@ use candle_core::Device;
 /// # Example
 ///
 /// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 /// use xybrid_core::runtime_adapter::candle::CandleRuntimeAdapter;
 /// use xybrid_core::runtime_adapter::RuntimeAdapter;
 /// use xybrid_core::ir::{Envelope, EnvelopeKind};
@@ -32,6 +33,9 @@ use candle_core::Device;
 /// let audio_bytes = std::fs::read("audio.wav")?;
 /// let input = Envelope::new(EnvelopeKind::Audio(audio_bytes));
 /// let output = adapter.execute(&input)?;
+/// # let _ = output;
+/// # Ok(())
+/// # }
 /// ```
 pub struct CandleRuntimeAdapter {
     /// Loaded models (model_id -> WhisperModel)

--- a/crates/xybrid-core/src/runtime_adapter/candle/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/adapter.rs
@@ -21,7 +21,7 @@ use candle_core::Device;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::runtime_adapter::candle::CandleRuntimeAdapter;
 /// use xybrid_core::runtime_adapter::RuntimeAdapter;
 /// use xybrid_core::ir::{Envelope, EnvelopeKind};

--- a/crates/xybrid-core/src/runtime_adapter/candle/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/mod.rs
@@ -20,12 +20,18 @@
 //! # Example
 //!
 //! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::runtime_adapter::candle::CandleRuntimeAdapter;
 //! use xybrid_core::runtime_adapter::RuntimeAdapter;
+//! use xybrid_core::ir::{Envelope, EnvelopeKind};
 //!
 //! let mut adapter = CandleRuntimeAdapter::new()?;
 //! adapter.load_model("/path/to/whisper-tiny")?;
+//! # let audio_envelope = Envelope::new(EnvelopeKind::Audio(vec![]));
 //! let output = adapter.execute(&audio_envelope)?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
 //! ```
 
 mod adapter;

--- a/crates/xybrid-core/src/runtime_adapter/candle/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::runtime_adapter::candle::CandleRuntimeAdapter;
 //! use xybrid_core::runtime_adapter::RuntimeAdapter;
 //!

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::runtime_adapter::CloudRuntimeAdapter;
 //!
 //! let adapter = CloudRuntimeAdapter::new();

--- a/crates/xybrid-core/src/runtime_adapter/coreml/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/coreml/adapter.rs
@@ -8,12 +8,15 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
-//! use xybrid_core::runtime_adapter::coreml::CoreMLRuntimeAdapter;
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_core::runtime_adapter::CoreMLRuntimeAdapter;
 //! use xybrid_core::runtime_adapter::RuntimeAdapter;
 //!
 //! let mut adapter = CoreMLRuntimeAdapter::new();
 //! adapter.load_model("/path/to/model.mlpackage")?;
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::ir::{Envelope, EnvelopeKind};

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -69,11 +69,14 @@ static BACKEND_INIT: Once = Once::new();
 /// # Example
 ///
 /// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 /// use xybrid_core::runtime_adapter::llama_cpp::LlamaCppBackend;
 /// use xybrid_core::runtime_adapter::llm::{LlmBackend, LlmConfig};
 ///
 /// let mut backend = LlamaCppBackend::new()?;
 /// backend.load(&LlmConfig::new("model.gguf"))?;
+/// # Ok(())
+/// # }
 /// ```
 #[cfg(feature = "llm-llamacpp")]
 pub struct LlamaCppBackend {

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -68,7 +68,7 @@ static BACKEND_INIT: Once = Once::new();
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::runtime_adapter::llama_cpp::LlamaCppBackend;
 /// use xybrid_core::runtime_adapter::llm::{LlmBackend, LlmConfig};
 ///

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -173,7 +173,7 @@ pub trait LlmBackend: Send + Sync {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// backend.generate_streaming(&messages, &config, Box::new(|token| {
     ///     print!("{}", token.token);
     ///     std::io::stdout().flush()?;

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -174,11 +174,20 @@ pub trait LlmBackend: Send + Sync {
     /// # Example
     ///
     /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::io::Write;
+    /// use xybrid_core::runtime_adapter::llm::{ChatMessage, GenerationConfig, LlmBackend};
+    ///
+    /// # let backend: &dyn LlmBackend = unimplemented!();
+    /// # let messages: Vec<ChatMessage> = vec![];
+    /// # let config = GenerationConfig::default();
     /// backend.generate_streaming(&messages, &config, Box::new(|token| {
     ///     print!("{}", token.token);
-    ///     std::io::stdout().flush()?;
+    ///     std::io::stdout().flush().ok();
     ///     Ok(())
     /// }))?;
+    /// # Ok(())
+    /// # }
     /// ```
     fn generate_streaming(
         &self,

--- a/crates/xybrid-core/src/runtime_adapter/metadata_driven.rs
+++ b/crates/xybrid-core/src/runtime_adapter/metadata_driven.rs
@@ -51,11 +51,13 @@ impl MetadataDrivenAdapter {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// # use xybrid_core::runtime_adapter::metadata_driven::MetadataDrivenAdapter;
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_core::runtime_adapter::MetadataDrivenAdapter;
     /// let mut adapter = MetadataDrivenAdapter::new();
     /// adapter.load_metadata("models/whisper-tiny/model_metadata.json")?;
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn load_metadata(&mut self, metadata_path: impl AsRef<Path>) -> AdapterResult<()> {
         let path = metadata_path.as_ref();

--- a/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mistral/mod.rs
@@ -216,7 +216,7 @@ fn emit_final_token_if_needed(
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// use xybrid_core::runtime_adapter::mistral::MistralBackend;
 /// use xybrid_core::runtime_adapter::llm::{LlmBackend, LlmConfig};
 ///

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -22,8 +22,10 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
-//! use xybrid_core::runtime_adapter::{RuntimeAdapter, OnnxRuntimeAdapter};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_core::runtime_adapter::RuntimeAdapter;
+//! use xybrid_core::runtime_adapter::onnx::OnnxRuntimeAdapter;
 //! use xybrid_core::ir::{Envelope, EnvelopeKind};
 //!
 //! // Create adapter
@@ -35,6 +37,9 @@
 //! // Run inference
 //! let input = Envelope::new(EnvelopeKind::Text("hello world".to_string()));
 //! let output = adapter.execute(&input)?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::ir::Envelope;
@@ -244,11 +249,19 @@ pub trait RuntimeAdapter: Send + Sync {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_core::ir::{Envelope, EnvelopeKind};
+    /// use xybrid_core::runtime_adapter::{OnnxRuntimeAdapter, RuntimeAdapter};
+    ///
     /// let mut adapter = OnnxRuntimeAdapter::new();
     /// adapter.load_model("model.onnx")?;
     /// adapter.warmup()?;  // Optional: trigger GPU initialization
+    /// # let input = Envelope::new(EnvelopeKind::Text("probe".into()));
     /// let output = adapter.execute(&input)?;  // First inference is now fast
+    /// # let _ = output;
+    /// # Ok(())
+    /// # }
     /// ```
     fn warmup(&mut self) -> AdapterResult<()> {
         Ok(())

--- a/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
@@ -77,11 +77,16 @@ impl OnnxRuntimeAdapter {
     ///
     /// // CPU execution
     /// let adapter = OnnxRuntimeAdapter::with_execution_provider(ExecutionProviderKind::Cpu);
+    /// ```
     ///
-    /// // CoreML with Neural Engine (requires ort-coreml feature)
-    /// #[cfg(feature = "ort-coreml")]
+    /// With the `ort-coreml` feature, additionally:
+    ///
+    /// ```ignore
+    /// use xybrid_core::runtime_adapter::onnx::{
+    ///     CoreMLConfig, ExecutionProviderKind, OnnxRuntimeAdapter,
+    /// };
     /// let adapter = OnnxRuntimeAdapter::with_execution_provider(
-    ///     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine())
+    ///     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine()),
     /// );
     /// ```
     pub fn with_execution_provider(execution_provider: ExecutionProviderKind) -> Self {

--- a/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/adapter.rs
@@ -6,19 +6,19 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
-//! use xybrid_core::runtime_adapter::onnx::{OnnxRuntimeAdapter, ExecutionProviderKind};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_core::runtime_adapter::onnx::OnnxRuntimeAdapter;
 //! use xybrid_core::runtime_adapter::RuntimeAdapter;
 //!
 //! // CPU execution (default)
 //! let mut adapter = OnnxRuntimeAdapter::new();
 //! adapter.load_model("/path/to/model.onnx")?;
 //!
-//! // CoreML execution (macOS/iOS, requires ort-coreml feature)
-//! #[cfg(feature = "ort-coreml")]
-//! let mut adapter = OnnxRuntimeAdapter::with_execution_provider(
-//!     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine())
-//! );
+//! // CoreML execution (macOS/iOS, requires `ort-coreml` feature) is gated by cfg —
+//! // see `with_execution_provider` for the typed entry point.
+//! # Ok(())
+//! # }
 //! ```
 
 use super::execution_provider::ExecutionProviderKind;
@@ -72,7 +72,7 @@ impl OnnxRuntimeAdapter {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// use xybrid_core::runtime_adapter::onnx::{OnnxRuntimeAdapter, ExecutionProviderKind};
     ///
     /// // CPU execution
@@ -113,7 +113,7 @@ impl OnnxRuntimeAdapter {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
     /// use xybrid_core::runtime_adapter::onnx::{OnnxRuntimeAdapter, ModelHints};
     ///
     /// let hints = ModelHints {

--- a/crates/xybrid-core/src/runtime_adapter/onnx/execution_provider.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/execution_provider.rs
@@ -13,17 +13,16 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
-//! use xybrid_core::runtime_adapter::onnx::{ExecutionProviderKind, CoreMLConfig, CoreMLComputeUnits};
+//! ```no_run
+//! # fn _example() {
+//! use xybrid_core::runtime_adapter::onnx::ExecutionProviderKind;
 //!
 //! // Use CPU (default)
 //! let cpu_provider = ExecutionProviderKind::Cpu;
 //!
-//! // Use CoreML with Neural Engine
-//! let coreml_provider = ExecutionProviderKind::CoreML(CoreMLConfig {
-//!     compute_units: CoreMLComputeUnits::CpuAndNeuralEngine,
-//!     ..Default::default()
-//! });
+//! // CoreML variant (macOS/iOS, requires `ort-coreml` feature) is gated behind cfg.
+//! # let _ = cpu_provider;
+//! # }
 //! ```
 
 use std::fmt;

--- a/crates/xybrid-core/src/runtime_adapter/onnx/mobile.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/mobile.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::runtime_adapter::onnx::ONNXMobileRuntimeAdapter;
 //! use xybrid_core::runtime_adapter::RuntimeAdapter;
 //!

--- a/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
@@ -16,7 +16,10 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::collections::HashMap;
+//! use ndarray::ArrayD;
 //! use xybrid_core::runtime_adapter::onnx::{ONNXSession, ExecutionProviderKind, SessionOptions};
 //!
 //! // CPU execution, no profiling overhead
@@ -26,16 +29,13 @@
 //!     SessionOptions::default(),
 //! )?;
 //!
-//! // CoreML execution with resolved-EP capture (requires ort-coreml feature)
-//! #[cfg(feature = "ort-coreml")]
-//! let session = ONNXSession::build(
-//!     "/path/to/model.onnx",
-//!     ExecutionProviderKind::CoreML(CoreMLConfig::with_neural_engine()),
-//!     SessionOptions { capture_resolved_ep: true },
-//! )?;
+//! // CoreML execution with resolved-EP capture is gated by the `ort-coreml` cfg.
 //!
-//! let inputs = /* prepare inputs */;
+//! let inputs: HashMap<String, ArrayD<f32>> = HashMap::new();
 //! let outputs = session.run(inputs)?;
+//! # let _ = outputs;
+//! # Ok(())
+//! # }
 //! ```
 
 use super::execution_provider::ExecutionProviderKind;
@@ -165,7 +165,8 @@ impl ONNXSession {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
     /// use xybrid_core::runtime_adapter::onnx::{ONNXSession, ExecutionProviderKind, SessionOptions};
     ///
     /// // Cheap path — no profiling overhead, no tempdir
@@ -176,11 +177,16 @@ impl ONNXSession {
     /// )?;
     ///
     /// // Opt in to resolved-EP capture for telemetry callers
+    /// let mut opts = SessionOptions::default();
+    /// opts.capture_resolved_ep = true;
     /// let session = ONNXSession::build(
     ///     "model.onnx",
     ///     ExecutionProviderKind::Cpu,
-    ///     SessionOptions { capture_resolved_ep: true },
+    ///     opts,
     /// )?;
+    /// # let _ = session;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build(
         model_path: &str,

--- a/crates/xybrid-core/src/streaming/mod.rs
+++ b/crates/xybrid-core/src/streaming/mod.rs
@@ -23,9 +23,12 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::streaming::{StreamSession, StreamConfig};
 //!
+//! # let audio_chunk_1: Vec<f32> = vec![];
+//! # let audio_chunk_2: Vec<f32> = vec![];
 //! // Create session - backend auto-detected from model_metadata.json
 //! let config = StreamConfig::default();
 //! let mut session = StreamSession::new("/path/to/whisper-model", config)?;
@@ -42,6 +45,8 @@
 //! // Flush to get final transcription
 //! let final_result = session.flush()?;
 //! println!("Final: {}", final_result);
+//! # Ok(())
+//! # }
 //! ```
 
 mod audio_buffer;

--- a/crates/xybrid-core/src/streaming/session.rs
+++ b/crates/xybrid-core/src/streaming/session.rs
@@ -220,18 +220,21 @@ impl TranscriptAccumulator {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 /// use xybrid_core::streaming::{StreamSession, StreamConfig};
 ///
 /// // Create session from model directory (backend auto-detected)
 /// let config = StreamConfig::default();
 /// let mut session = StreamSession::new("/path/to/whisper-model", config)?;
 ///
-/// // Feed audio chunks
+/// # let audio_samples: Vec<f32> = Vec::new();
 /// session.feed(&audio_samples)?;
 ///
-/// // Get final transcript
 /// let transcript = session.flush()?;
+/// # let _ = transcript;
+/// # Ok(())
+/// # }
 /// ```
 pub struct StreamSession {
     /// Model directory path
@@ -274,12 +277,19 @@ impl StreamSession {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use xybrid_core::streaming::{StreamSession, StreamConfig};
+    ///
+    /// let config = StreamConfig::default();
     /// // Whisper model (Candle backend, auto-detected)
-    /// let session = StreamSession::new("/path/to/whisper-model", config)?;
+    /// let session = StreamSession::new("/path/to/whisper-model", config.clone())?;
     ///
     /// // Wav2Vec2 model (ONNX backend, auto-detected)
     /// let session = StreamSession::new("/path/to/wav2vec2-model", config)?;
+    /// # let _ = session;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new<P: AsRef<Path>>(model_dir: P, config: StreamConfig) -> StreamResult<Self> {
         let model_dir = model_dir.as_ref().to_path_buf();

--- a/crates/xybrid-core/src/testing/mocks.rs
+++ b/crates/xybrid-core/src/testing/mocks.rs
@@ -8,7 +8,8 @@
 //! Use `MockRuntimeAdapter` when testing the `Executor` - it implements
 //! the `RuntimeAdapter` trait and doesn't require real ONNX files.
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() {
 //! use xybrid_core::testing::mocks::MockRuntimeAdapter;
 //! use xybrid_core::executor::Executor;
 //! use std::sync::Arc;
@@ -16,6 +17,7 @@
 //! let mut executor = Executor::new();
 //! let adapter = MockRuntimeAdapter::with_text_output("transcribed text");
 //! executor.register_adapter(Arc::new(adapter));
+//! # }
 //! ```
 
 use crate::ir::{Envelope, EnvelopeKind};
@@ -34,12 +36,19 @@ use std::sync::Mutex;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use xybrid_core::ir::{Envelope, EnvelopeKind};
+/// use xybrid_core::runtime_adapter::ModelRuntime;
 /// use xybrid_core::testing::mocks::MockRuntime;
 ///
 /// let mut runtime = MockRuntime::with_embedding(vec![0.1, 0.2, 0.3]);
-/// let output = runtime.execute(&input_envelope)?;
+/// let input = Envelope::new(EnvelopeKind::Text("probe".into()));
+/// let output = runtime.execute(&input)?;
 /// assert_eq!(runtime.call_count(), 1);
+/// # let _ = output;
+/// # Ok(())
+/// # }
 /// ```
 pub struct MockRuntime {
     /// Output to return from execute()
@@ -217,9 +226,11 @@ impl MockOnnxOutputs {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
 /// use xybrid_core::testing::mocks::MockRuntimeAdapter;
 /// use xybrid_core::executor::Executor;
+/// use xybrid_core::runtime_adapter::RuntimeAdapter;
 /// use std::sync::Arc;
 ///
 /// let mut executor = Executor::new();
@@ -228,6 +239,7 @@ impl MockOnnxOutputs {
 /// executor.register_adapter(Arc::new(adapter));
 ///
 /// // Now execute_stage will use the mock adapter
+/// # }
 /// ```
 pub struct MockRuntimeAdapter {
     /// The output to return from execute()

--- a/crates/xybrid-core/src/testing/mod.rs
+++ b/crates/xybrid-core/src/testing/mod.rs
@@ -5,11 +5,12 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() {
 //! use xybrid_core::testing::{fixtures, mocks, model_fixtures};
 //!
 //! // Create a mock runtime that returns fixed outputs
-//! let mock_runtime = mocks::MockRuntime::with_output(vec![0.1, 0.2, 0.3]);
+//! let mock_runtime = mocks::MockRuntime::with_embedding(vec![0.1, 0.2, 0.3]);
 //!
 //! // Use test fixtures for common inputs
 //! let audio = fixtures::sample_audio_16khz(1.0); // 1 second of silence
@@ -17,13 +18,16 @@
 //!
 //! // Get path to downloaded test models
 //! let model_dir = model_fixtures::require_model("kokoro-82m");
+//! # let _ = (mock_runtime, audio, envelope, model_dir);
+//! # }
 //! ```
 //!
 //! ## Model Fixtures
 //!
 //! The `model_fixtures` module provides utilities for locating test models:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() {
 //! use xybrid_core::testing::model_fixtures;
 //!
 //! // Get model path (panics if not found)
@@ -38,6 +42,8 @@
 //! let Some(model_dir) = model_fixtures::model_or_skip("kokoro-82m") else {
 //!     return; // Test skipped
 //! };
+//! # let _ = model_dir;
+//! # }
 //! ```
 
 pub mod fixtures;

--- a/crates/xybrid-core/src/testing/model_fixtures.rs
+++ b/crates/xybrid-core/src/testing/model_fixtures.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use xybrid_core::testing::model_fixtures;
 //!
 //! // Get model path (panics if not found)
@@ -95,10 +95,13 @@ pub fn models_dir() -> Option<&'static PathBuf> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::testing::model_fixtures;
 /// if let Some(path) = model_fixtures::model_path("kokoro-82m") {
 ///     let metadata = path.join("model_metadata.json");
 /// }
+/// # }
 /// ```
 pub fn model_path(model_name: &str) -> Option<PathBuf> {
     let models = models_dir()?;
@@ -133,12 +136,15 @@ fn has_model_binaries(dir: &Path) -> bool {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::testing::model_fixtures;
 /// if model_fixtures::model_available("kokoro-82m") {
 ///     // Run integration test
 /// } else {
 ///     eprintln!("Skipping: kokoro-82m not downloaded");
 /// }
+/// # }
 /// ```
 pub fn model_available(model_name: &str) -> bool {
     model_path(model_name)
@@ -156,9 +162,13 @@ pub fn model_available(model_name: &str) -> bool {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::testing::model_fixtures;
 /// let model_dir = model_fixtures::require_model("kokoro-82m");
 /// let metadata_path = model_dir.join("model_metadata.json");
+/// # let _ = metadata_path;
+/// # }
 /// ```
 pub fn require_model(model_name: &str) -> PathBuf {
     if let Some(path) = model_path(model_name) {
@@ -196,7 +206,7 @@ You can also set XYBRID_TEST_MODELS environment variable to a custom path.
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
 /// #[test]
 /// fn test_tts_inference() {
 ///     let Some(model_dir) = model_fixtures::model_or_skip("kokoro-82m") else {
@@ -225,10 +235,13 @@ pub fn model_or_skip(model_name: &str) -> Option<PathBuf> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::testing::model_fixtures;
 /// if let Some(fixtures) = model_fixtures::fixtures_dir() {
 ///     let test_audio = fixtures.join("input/test_audio.wav");
 /// }
+/// # }
 /// ```
 pub fn fixtures_dir() -> Option<PathBuf> {
     models_dir().and_then(|m| m.parent().map(|p| p.to_path_buf()))
@@ -262,10 +275,13 @@ pub fn list_available_models() -> Vec<String> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::testing::model_fixtures;
 /// if let Some(input_dir) = model_fixtures::input_dir() {
 ///     let test_audio = input_dir.join("test_audio.wav");
 /// }
+/// # }
 /// ```
 pub fn input_dir() -> Option<PathBuf> {
     fixtures_dir().map(|f| f.join("input"))
@@ -275,10 +291,15 @@ pub fn input_dir() -> Option<PathBuf> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use xybrid_core::testing::model_fixtures;
 /// if let Some(audio_path) = model_fixtures::test_audio("test_audio.wav") {
 ///     let audio_bytes = std::fs::read(&audio_path)?;
+///     let _ = audio_bytes;
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub fn test_audio(filename: &str) -> Option<PathBuf> {
     input_dir().map(|d| d.join(filename)).filter(|p| p.exists())
@@ -288,9 +309,13 @@ pub fn test_audio(filename: &str) -> Option<PathBuf> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() {
+/// use xybrid_core::testing::model_fixtures;
 /// let audio_path = model_fixtures::default_test_audio()
 ///     .expect("test_audio.wav should exist");
+/// # let _ = audio_path;
+/// # }
 /// ```
 pub fn default_test_audio() -> Option<PathBuf> {
     test_audio("test_audio.wav")
@@ -300,10 +325,15 @@ pub fn default_test_audio() -> Option<PathBuf> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use xybrid_core::testing::model_fixtures;
 /// if let Some(text_path) = model_fixtures::test_text("sample.txt") {
 ///     let text = std::fs::read_to_string(&text_path)?;
+///     let _ = text;
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub fn test_text(filename: &str) -> Option<PathBuf> {
     input_dir().map(|d| d.join(filename)).filter(|p| p.exists())
@@ -320,10 +350,15 @@ pub fn pipelines_dir() -> Option<PathBuf> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```no_run
+/// # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+/// use xybrid_core::testing::model_fixtures;
 /// if let Some(pipeline_path) = model_fixtures::pipeline("tts_pipeline.yaml") {
 ///     let yaml = std::fs::read_to_string(&pipeline_path)?;
+///     let _ = yaml;
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub fn pipeline(filename: &str) -> Option<PathBuf> {
     pipelines_dir()

--- a/crates/xybrid-core/src/tracing.rs
+++ b/crates/xybrid-core/src/tracing.rs
@@ -5,7 +5,8 @@
 //!
 //! # Usage
 //!
-//! ```ignore
+//! ```no_run
+//! # fn _example() {
 //! use xybrid_core::tracing::{SpanCollector, SpanGuard};
 //!
 //! let mut collector = SpanCollector::new();
@@ -14,11 +15,13 @@
 //! // ... do work ...
 //! collector.end_span();
 //!
-//! // Or use RAII guard:
+//! // Or use RAII guard against the global collector:
 //! {
-//!     let _guard = SpanGuard::new(&mut collector, "inference");
+//!     let _guard = SpanGuard::new("inference");
 //!     // span automatically ends when guard drops
 //! }
+//! # let _ = span_id;
+//! # }
 //! ```
 
 use serde::{Deserialize, Serialize};

--- a/crates/xybrid-core/src/tts/mod.rs
+++ b/crates/xybrid-core/src/tts/mod.rs
@@ -22,7 +22,8 @@
 //!
 //! TTS models should be executed via `TemplateExecutor`:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
 //! use xybrid_core::execution::TemplateExecutor;
 //! use xybrid_core::execution::ModelMetadata;
 //! use xybrid_core::ir::{Envelope, EnvelopeKind};
@@ -32,7 +33,10 @@
 //! )?;
 //! let mut executor = TemplateExecutor::with_base_path("models/kitten-tts");
 //! let input = Envelope::new(EnvelopeKind::Text("Hello, world!".to_string()));
-//! let output = executor.execute(&metadata, &input)?;
+//! let output = executor.execute(&metadata, &input, None)?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
 //! ```
 
 pub mod voice_embedding;

--- a/crates/xybrid-core/src/tts/voice_embedding.rs
+++ b/crates/xybrid-core/src/tts/voice_embedding.rs
@@ -7,8 +7,9 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
-//! use xybrid_core::tts::voice_embedding::{VoiceEmbeddingLoader, VoiceFormat};
+//! ```no_run
+//! # fn _example() -> Result<(), Box<dyn std::error::Error>> {
+//! use xybrid_core::tts::voice_embedding::VoiceEmbeddingLoader;
 //!
 //! // Auto-detect format and load
 //! let loader = VoiceEmbeddingLoader::new(256);
@@ -17,6 +18,9 @@
 //!
 //! // Or load all embeddings (raw format only)
 //! let all_embeddings = loader.load_all_raw("voices.bin")?;
+//! # let _ = (embedding, all_embeddings);
+//! # Ok(())
+//! # }
 //! ```
 
 use std::path::Path;


### PR DESCRIPTION
## Summary

Sibling of #168 for `xybrid-core`. After the bulk `rust,ignore` → `no_run` conversion, 45 doctests still failed to compile — they used `?` inside the synthesized `fn main()`, referenced names that weren't in scope, or used stale API signatures. This PR fixes all of them and surfaces the same kind of API drift the SDK PR did.

- `cargo test --doc -p xybrid-core --features ort-download` → **106 passed / 0 failed / 0 ignored** (was 62 / 45 / 0)
- `cargo clippy -p xybrid-core --features ort-download --lib -- -D warnings` → clean
- `cargo fmt --check` → clean

## API drift caught and fixed in the docs

- `TemplateExecutor::execute` / `execute_with_context` / `execute_streaming` / `execute_streaming_with_context` examples were missing the trailing `Option<&GenerationConfig>` arg.
- `VadSession::process` → real API is `process_frame(&samples) -> VadFrame`.
- `cloud_llm::LlmProvider::OpenAI` does not exist; the actual public type is `pipeline::IntegrationProvider`.
- `MockRuntime::with_output` does not exist; real constructors are `with_embedding` / `with_text` / `with_audio` / `with_tensor`.
- `tracing::SpanGuard::new(&mut collector, name)` was a stale signature; real form is `SpanGuard::new(name)` against a global collector.
- `runtime_adapter::{coreml, metadata_driven}` are `pub(crate)` modules; examples switched to the public re-exports at `runtime_adapter::{CoreMLRuntimeAdapter, MetadataDrivenAdapter}`.
- `SessionOptions` is `#[non_exhaustive]`, so doctests (which act as external callers) can't construct it with a struct literal — switched to `default()` + field assignment.
- ONNX `CoreML*` types are gated behind `ort-coreml`; CI tests `ort-download` only, so those examples now use CPU paths with a prose note about the cfg-gated CoreML variant.
- `Orchestrator::bootstrap` example passed `Some("path")` to `Option<&Path>`; fixed to `Some(Path::new(...))`.
- `RetryableError` impl examples were missing the `retry_after` method that the trait requires.

## Neutralized

- `cloud_llm/mod.rs` is `pub(crate)`, so the example can never compile from outside the crate — converted to a non-running ` ```text ` block.

## Test plan

- [x] `cargo test --doc -p xybrid-core --features ort-download` → 106 / 0 / 0
- [x] `cargo clippy -p xybrid-core --features ort-download --lib -- -D warnings`
- [x] `cargo fmt --check`
- [x] CI doctest + clippy jobs pass on the PR