### PR TITLE
ci(release): neuter legacy release.yml tag-push trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,21 @@
-name: Release
+name: Release (legacy tag-driven)
+
+# Break-glass for the old tag-driven release flow. The push: tags trigger
+# was removed in PR #170 because the new release-branch flow
+# (release-prep.yml + release-publish.yml) creates the v<version> tag via
+# the Releases API as part of publishing — leaving this workflow armed on
+# tag pushes would double-fire it against every new-flow release.
+#
+# To run this workflow manually (e.g. if the new flow breaks and you need
+# to ship from a tag): Actions -> Release (legacy tag-driven) -> Run
+# workflow -> choose the v<version> tag in the "Use workflow from" picker.
+# Every step below reads GITHUB_REF so the tag must already exist before
+# dispatching.
+#
+# Planned for deletion once one or two releases have shipped cleanly
+# through the new flow.
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Pre-flight for the first dryrun of the new release-branch flow (#169).

Drops `on: push: tags: ['v*']` from `release.yml`, keeps `on: workflow_dispatch` as a break-glass. Renames the workflow display name to **Release (legacy tag-driven)** so it's obvious which one is which in the Actions UI.

## Why

`release-publish.yml` creates the `v<version>` tag via the Releases API (`gh release edit --draft=false`) as part of publishing. GitHub's docs are quiet on whether tag creation through the Releases API fires `push: tags` triggers — and we don't want to find out the hard way during a real release. If both workflows fire on the same tag, the old one will try to rebuild the xcframework, force-move the tag, and re-upload assets, fighting the new flow's draft-publish.

Removing the trigger is the safest pre-flight step before the first dryrun:

- **No risk of double-fire** during new-flow releases.
- **Break-glass still works**: maintainer can push a tag and dispatch this workflow manually against that tag ref. Every existing step reads `GITHUB_REF`, so the implementation works unchanged under `workflow_dispatch` when the picker is set to a tag.
- **No code deleted** — this is a trigger change only. If the new flow goes sideways, the old flow is one click away.

Planned for full deletion in a follow-up once one or two real releases have shipped cleanly via the new flow.

## What this does NOT touch

- Any step inside `release.yml` — same checkout, same build matrix, same publish steps.
- `release-prep.yml` / `release-publish.yml` — untouched.
- The `swift` branch / `publish-swift` job — still maintained, deprecation is a separate follow-up.

## Test plan

- [ ] `actionlint .github/workflows/release.yml` passes (verified locally — no new warnings)
- [ ] After merge: confirm Actions UI shows "Release (legacy tag-driven)" with only the "Run workflow" button (no automatic runs on tag push)
- [ ] Proceed with `release/v0.1.0-rc4-dryrun` to exercise the new flow end-to-end