### PR TITLE
fix(release): include bindings/flutter/rust/Cargo.toml in version-sync.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -670,15 +670,15 @@ checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "csbindgen"
-version = "1.9.7"
+version = "1.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710604f525e7b68070458083252602c2bf2afe255dfe019e83bd57bdfa50bdb4"
+checksum = "950f59b281d7e20f050b4efd56d7c36c0deb853bf9ea1f20b985a75ae5b03b34"
 dependencies = [
  "regex",
  "syn 2.0.117",
@@ -1534,9 +1534,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "ena"
@@ -2335,7 +2335,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2443,7 +2443,7 @@ checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs 6.0.0",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "indicatif 0.18.4",
  "libc",
  "log",
@@ -2495,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2521,7 +2521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -2532,7 +2532,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2618,7 +2618,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -2634,7 +2634,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper 1.9.0",
  "hyper-util",
  "rustls",
@@ -2682,7 +2682,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "ipnet",
@@ -3054,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3208,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 dependencies = [
  "value-bag",
 ]
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "lzma-rust2"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -3596,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3851,9 +3851,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3882,9 +3882,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -4641,7 +4641,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -4941,9 +4941,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5314,9 +5314,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5679,14 +5679,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -6122,7 +6122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -6250,9 +6250,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6263,9 +6263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6273,9 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6283,9 +6283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6296,9 +6296,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -6352,9 +6352,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7112,7 +7112,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.1.0-rc1"
+version = "0.1.0-rc3"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.1.0-rc1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.1.0-rc3"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/tools/scripts/version-sync.sh
+++ b/tools/scripts/version-sync.sh
@@ -15,6 +15,12 @@ CARGO_WORKSPACE="$REPO_ROOT/Cargo.toml"
 FLUTTER_PUBSPEC="$REPO_ROOT/bindings/flutter/pubspec.yaml"
 UNITY_PACKAGE="$REPO_ROOT/bindings/unity/package.json"
 KOTLIN_GRADLE="$REPO_ROOT/bindings/kotlin/build.gradle.kts"
+# bindings/flutter/rust hardcodes `version = "..."` instead of inheriting
+# `version.workspace = true` because cargokit hashes this file's bytes to
+# decide whether the precompiled Flutter binaries need rebuilding. Without
+# a hardcoded version, every workspace bump would leave the precompiled
+# cache pointing at an out-of-date hash.
+FLUTTER_RUST_CARGO="$REPO_ROOT/bindings/flutter/rust/Cargo.toml"
 # Root SPM manifest. `let sdkVersion = "..."` drives the GitHub release-asset
 # URL for SPM consumers in remote mode and MUST match the cargo workspace
 # version.
@@ -41,6 +47,12 @@ get_unity_version() {
 # Extract version from Kotlin build.gradle.kts
 get_kotlin_version() {
     grep '^version = ' "$KOTLIN_GRADLE" | sed 's/version = "\(.*\)"/\1/'
+}
+
+# Extract version from bindings/flutter/rust/Cargo.toml (the hardcoded line —
+# strip any trailing inline comment).
+get_flutter_rust_version() {
+    grep '^version = ' "$FLUTTER_RUST_CARGO" | head -1 | sed 's/version = "\(.*\)".*/\1/'
 }
 
 # Extract sdkVersion from root Package.swift
@@ -83,6 +95,17 @@ set_kotlin_version() {
     rm -f "$KOTLIN_GRADLE.bak"
 }
 
+# Set version in bindings/flutter/rust/Cargo.toml. The `^version = "..."`
+# anchor matches only the line under [package] (dependency entries in
+# [dependencies] use `name = { version = "..." }` syntax and start with a
+# crate name, not "version"). The trailing inline comment is preserved
+# because the `".*"` capture stops at the closing quote.
+set_flutter_rust_version() {
+    local version="$1"
+    sed -i.bak "s/^version = \".*\"/version = \"$version\"/" "$FLUTTER_RUST_CARGO"
+    rm -f "$FLUTTER_RUST_CARGO.bak"
+}
+
 # Set sdkVersion in root Package.swift. Leaves useLocalNatives and
 # xybridFFIChecksum untouched — those are managed independently
 # (set-natives-mode.sh / sync-spm-checksum.sh).
@@ -101,7 +124,7 @@ check_versions() {
     echo "Cargo workspace version: $cargo_version"
     echo ""
 
-    for name_func in "Flutter:get_flutter_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version"; do
+    for name_func in "Flutter:get_flutter_version" "Flutter rust crate:get_flutter_rust_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version"; do
         local name="${name_func%%:*}"
         local func="${name_func##*:}"
         local version
@@ -134,6 +157,7 @@ case "${1:-}" in
         VERSION="$(get_cargo_version)"
         echo "Syncing all packages to version: $VERSION"
         set_flutter_version "$VERSION"
+        set_flutter_rust_version "$VERSION"
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
         set_swift_version "$VERSION"
@@ -153,6 +177,7 @@ case "${1:-}" in
         echo "Setting all packages to version: $VERSION"
         set_cargo_version "$VERSION"
         set_flutter_version "$VERSION"
+        set_flutter_rust_version "$VERSION"
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
         set_swift_version "$VERSION"


### PR DESCRIPTION
## Summary

`just bump-version` was silently leaving `bindings/flutter/rust/Cargo.toml` behind on every release. Fixes that, and brings master's Flutter rust crate back in sync with the rest of the workspace (was at 0.1.0-rc1, everything else at 0.1.0-rc3).

## How we found it

The 0.1.0-rc4-dryrun branch (validating the new release-prep flow from #169) tripped `release-dryrun.yml`'s `check-version-branch`:

```
Target:              0.1.0-rc4-dryrun
Cargo workspace:     0.1.0-rc4-dryrun
Flutter pubspec:     0.1.0-rc4-dryrun
Flutter rust crate:  0.1.0-rc1            ← MISMATCH
Unity package:       0.1.0-rc4-dryrun
Kotlin gradle:       0.1.0-rc4-dryrun
ERROR: 0.1.0-rc1 != 0.1.0-rc4-dryrun
```

Root cause: `bindings/flutter/rust/Cargo.toml` hardcodes its `version = "..."` line instead of using `version.workspace = true` (the line's inline comment explains why: *"cargokit hashes this file to detect changes"*). `version-sync.sh` didn't know about it. So every release since 0.1.0-rc1 left this one file stale. `release-dryrun.yml`'s check just hadn't been exercised on a real release-bump branch until now.

## Fix

**`tools/scripts/version-sync.sh`:**

- New `FLUTTER_RUST_CARGO` constant with a comment explaining the cargokit invariant.
- `get_flutter_rust_version()` reads the hardcoded version line, stripping any trailing inline comment.
- `set_flutter_rust_version()` rewrites it via the same portable `sed -i.bak ... ; rm -f .bak` pattern the script uses for the other files. The `^version = "..."` anchor matches only the `[package]` line — dependency entries in `[dependencies]` use `name = { version = "..." }` syntax and start with the crate name, not `version`.
- Wired into both the bulk-set loop and the `--check` loop.

**`bindings/flutter/rust/Cargo.toml`:**

- Bumped from 0.1.0-rc1 → 0.1.0-rc3 so master is internally consistent. Cargokit will see a "changed" version on the next build and recompile once — one-time cache miss, harmless.
- `Cargo.lock` regenerated (it's a workspace member, so the lock had the same drift).

## Verification

Locally on this branch:

```
$ ./tools/scripts/version-sync.sh --check
Cargo workspace version: 0.1.0-rc3

  Flutter: 0.1.0-rc3 ✓
  Flutter rust crate: 0.1.0-rc3 ✓
  Unity: 0.1.0-rc3 ✓
  Kotlin: 0.1.0-rc3 ✓
  Swift: 0.1.0-rc3 ✓

All versions in sync.
```

(Before this PR, `--check` would have flagged the Flutter rust crate as out of sync — try it on master to confirm.)

## Why this is also helpful for the new release-branch flow

In the release-prep + release-publish flow from #169, the maintainer runs `just bump-version <V>` locally on a `release/v<V>` branch. After this PR, that one command brings every version file to `<V>`, so `release-dryrun.yml`'s check-version-branch passes on the first push. Before this PR, the maintainer would have had to manually fix `bindings/flutter/rust/Cargo.toml` after every bump — a footgun.

## Test plan

- [ ] Existing CI still green (the script change is additive; no behavior changed for already-correct files)
- [ ] After merge, `just bump-version 0.1.0-rc4` on a future release branch produces a clean diff that touches all six version files (Cargo.toml, pubspec.yaml, package.json, build.gradle.kts, Package.swift, bindings/flutter/rust/Cargo.toml)
- [ ] `./tools/scripts/version-sync.sh --check` returns "All versions in sync." on master after merge