### PR TITLE
ci(release-publish): bind publish-flutter to pub-dev-publish environment

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -238,14 +238,23 @@ jobs:
   # Publish Flutter to pub.dev via OIDC.
   #
   # Inlines the dart-lang/setup-dart publish.yml steps (rather than calling
-  # the reusable workflow) to match pub.dev's trusted-publisher binding,
-  # which expects this workflow path. pub.dev's trusted-publisher config
-  # must be updated when this workflow file is renamed.
+  # the reusable workflow) so we control the OIDC token's claims directly.
+  #
+  # pub.dev's trusted-publisher binding for xybrid_flutter is gated on the
+  # `pub-dev-publish` GitHub Actions environment (set on
+  # https://pub.dev/packages/xybrid_flutter/admin) rather than on a tag
+  # pattern. The environment claim in the OIDC token is what pub.dev
+  # validates against, so this works regardless of how the workflow was
+  # triggered — pull_request: closed, workflow_dispatch, push: tags, etc.
+  # (The old release.yml relied on the tag-ref claim because it triggered
+  # on tag push; the release-branch flow can't satisfy that since it
+  # triggers on PR-merge / dispatch, hence the move to env-based binding.)
   # =========================================================================
   publish-flutter:
     name: Publish Flutter to pub.dev
     needs: [publish-release]
     runs-on: ubuntu-latest
+    environment: pub-dev-publish
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Why

The new `release-publish.yml` triggers on `pull_request: closed` and `workflow_dispatch`, where `GITHUB_REF` is `master` — not a tag ref. pub.dev's trusted-publisher config gates the publish on `v{{version}}` matching the OIDC token's ref claim, which fails because the ref is `refs/heads/master`. End result: `publish-flutter` would OIDC-reject under the new flow.

The old `release.yml` worked because it triggered on `push: tags: ['v*']`, so the token's ref *was* the tag.

## Fix: environment-based binding

pub.dev supports gating on a GitHub Actions environment instead of (or in addition to) a tag pattern. The environment claim in the OIDC token is independent of what triggered the workflow, so the binding works regardless of trigger source.

## Setup (already done)

- GitHub: created `pub-dev-publish` environment in the repo (`gh api -X PUT repos/xybrid-ai/xybrid/environments/pub-dev-publish`). No protection rules; can add required reviewers later if you want an approval gate.
- pub.dev: `xybrid_flutter` package admin → Automated publishing → "Require GitHub Actions environment" → `pub-dev-publish`.

## What this PR changes

One line in `.github/workflows/release-publish.yml`:

```diff
   publish-flutter:
     name: Publish Flutter to pub.dev
     needs: [publish-release]
     runs-on: ubuntu-latest
+    environment: pub-dev-publish
     permissions:
       id-token: write
```

Plus updated comments above the job explaining the binding model.

## Test plan

After merge, dispatch `release-publish.yml` for `tag=v0.1.0-rc4`:

```
gh workflow run release-publish.yml --field tag=v0.1.0-rc4
```

Expected:
- `publish-release` skips its publish step (release already live from manual recovery)
- `verify-spm-checksum` passes
- `publish-flutter` now requests OIDC token *with* the environment claim → pub.dev validates → publishes successfully
- `publish-crates`, `publish-kotlin`, `publish-swift-branch` also run (unaffected by this PR)