### PR TITLE
ci(release-prep): emit SLSA build provenance for release artifacts

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -56,11 +56,13 @@ env:
 permissions:
   contents: write
   pull-requests: write
-  # SLSA build provenance attestations — `attest-build-provenance` writes
-  # signed attestations to GitHub's transparency log via Sigstore. Consumers
-  # verify with `gh attestation verify <file> --repo xybrid-ai/xybrid`.
-  id-token: write
-  attestations: write
+  # SLSA build provenance attestations (id-token + attestations) are
+  # scoped per-job on build-apple-all, build-android, and build-cli only —
+  # the jobs that actually call `attest-build-provenance`. Keeping these
+  # out of the workflow-level permissions means patch-spm-checksum,
+  # create-draft-release, open-release-pr, and the Flutter precompile
+  # jobs don't get unnecessary OIDC-issuance or attestation-write
+  # privileges.
 
 jobs:
   # =========================================================================
@@ -129,6 +131,10 @@ jobs:
     name: Build Apple (all)
     needs: [check-release-branch]
     runs-on: macos-14
+    permissions:
+      contents: read       # actions/checkout
+      id-token: write      # Sigstore OIDC for attest-build-provenance
+      attestations: write  # GitHub attestations API
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -181,7 +187,7 @@ jobs:
           zip -r ../../../dist/XybridFFI-${TAG}.xcframework.zip XybridFFI.xcframework
 
       - name: Attest XCFramework provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: dist/XybridFFI-${{ needs.check-release-branch.outputs.tag }}.xcframework.zip
 
@@ -226,7 +232,7 @@ jobs:
           chmod +x dist-cli/xybrid-${TAG}-macos-arm64
 
       - name: Attest macOS CLI provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: dist-cli/xybrid-${{ needs.check-release-branch.outputs.tag }}-macos-arm64
 
@@ -243,6 +249,10 @@ jobs:
     name: Build Android
     needs: [check-release-branch]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # actions/checkout
+      id-token: write      # Sigstore OIDC for attest-build-provenance
+      attestations: write  # GitHub attestations API
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -300,7 +310,7 @@ jobs:
           zip -r ../../../dist/xybrid-android-${TAG}.zip .
 
       - name: Attest Android artifact provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: dist/xybrid-android-${{ needs.check-release-branch.outputs.tag }}.zip
 
@@ -463,6 +473,10 @@ jobs:
     name: Build CLI (${{ matrix.name }})
     needs: [check-release-branch]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read       # actions/checkout
+      id-token: write      # Sigstore OIDC for attest-build-provenance
+      attestations: write  # GitHub attestations API
     strategy:
       fail-fast: false
       matrix:
@@ -515,22 +529,25 @@ jobs:
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact }}
 
       - name: Prepare artifact
+        id: prepare
         shell: bash
         env:
           TAG: ${{ needs.check-release-branch.outputs.tag }}
         run: |
           mkdir -p dist
           if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/xybrid-${TAG}-${{ matrix.name }}.exe
+            ARTIFACT="dist/xybrid-${TAG}-${{ matrix.name }}.exe"
           else
-            cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/xybrid-${TAG}-${{ matrix.name }}
-            chmod +x dist/xybrid-${TAG}-${{ matrix.name }}
+            ARTIFACT="dist/xybrid-${TAG}-${{ matrix.name }}"
           fi
+          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} "$ARTIFACT"
+          [ "${{ runner.os }}" != "Windows" ] && chmod +x "$ARTIFACT" || true
+          echo "artifact_path=$ARTIFACT" >> "$GITHUB_OUTPUT"
 
       - name: Attest CLI provenance (${{ matrix.name }})
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
-          subject-path: dist/xybrid-${{ needs.check-release-branch.outputs.tag }}-${{ matrix.name }}*
+          subject-path: ${{ steps.prepare.outputs.artifact_path }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -56,6 +56,11 @@ env:
 permissions:
   contents: write
   pull-requests: write
+  # SLSA build provenance attestations — `attest-build-provenance` writes
+  # signed attestations to GitHub's transparency log via Sigstore. Consumers
+  # verify with `gh attestation verify <file> --repo xybrid-ai/xybrid`.
+  id-token: write
+  attestations: write
 
 jobs:
   # =========================================================================
@@ -175,6 +180,11 @@ jobs:
           cd bindings/apple/XCFrameworks
           zip -r ../../../dist/XybridFFI-${TAG}.xcframework.zip XybridFFI.xcframework
 
+      - name: Attest XCFramework provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/XybridFFI-${{ needs.check-release-branch.outputs.tag }}.xcframework.zip
+
       - name: Upload XCFramework artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -214,6 +224,11 @@ jobs:
           mkdir -p dist-cli
           cp target/aarch64-apple-darwin/release/xybrid dist-cli/xybrid-${TAG}-macos-arm64
           chmod +x dist-cli/xybrid-${TAG}-macos-arm64
+
+      - name: Attest macOS CLI provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist-cli/xybrid-${{ needs.check-release-branch.outputs.tag }}-macos-arm64
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -283,6 +298,11 @@ jobs:
           mkdir -p dist
           cd bindings/kotlin/libs
           zip -r ../../../dist/xybrid-android-${TAG}.zip .
+
+      - name: Attest Android artifact provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/xybrid-android-${{ needs.check-release-branch.outputs.tag }}.zip
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -506,6 +526,11 @@ jobs:
             cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/xybrid-${TAG}-${{ matrix.name }}
             chmod +x dist/xybrid-${TAG}-${{ matrix.name }}
           fi
+
+      - name: Attest CLI provenance (${{ matrix.name }})
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/xybrid-${{ needs.check-release-branch.outputs.tag }}-${{ matrix.name }}*
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## What

Every release asset that `release-prep.yml` builds now gets a signed SLSA v1.0 build provenance attestation via [`actions/attest-build-provenance@v2`](https://github.com/actions/attest-build-provenance). Attestations land in GitHub's transparency log via Sigstore and are automatically associated with matching GitHub Release assets.

| Artifact | Job |
|---|---|
| `XybridFFI-<tag>.xcframework.zip` | `build-apple-all` |
| `xybrid-<tag>-macos-arm64` (CLI) | `build-apple-all` |
| `xybrid-android-<tag>.zip` | `build-android` |
| `xybrid-<tag>-{linux,windows}-x86_64` (CLI) | `build-cli` matrix |

## How consumers verify

```bash
gh attestation verify XybridFFI-v0.1.0.xcframework.zip --repo xybrid-ai/xybrid
```

`gh attestation verify` returns success only if the attestation:
- was generated by an Actions run in `xybrid-ai/xybrid`,
- references the exact bytes of the file being verified,
- has a valid Sigstore signature.

That's the SLSA v1.0 "binary → source repo + workflow run" link.

## Permissions

Workflow-level `permissions:` adds `id-token: write` (Sigstore OIDC) and `attestations: write` (GitHub attestations API). `contents: write` and `pull-requests: write` are unchanged.

## Out of scope (separate follow-ups if/when needed)

- **cargokit Flutter precompiled binaries** are uploaded by cargokit's own tool, not by steps we control here. Attesting those needs cooperation with cargokit's upload step (or a wrapper).
- **crates.io** has its own provenance model (Trusted Publishing via OIDC). Not yet wired — `publish-crates` still uses `CARGO_REGISTRY_TOKEN`.
- **pub.dev** is already on OIDC trusted publishing (with the env-gated binding from #176), so it records its own provenance on its side.
- **Maven Central** doesn't surface SLSA; the gradle Sigstore plugin can attach signatures separately.

## Test plan

- [ ] `actionlint .github/workflows/release-prep.yml` — passes locally, no new warnings.
- [ ] Cut `release/v0.1.0-rc5` (or `release/v0.1.0` direct) — confirm each "Attest …" step uploads an attestation. Look for "Attestation written to …" line in each job log.
- [ ] After publish, run `gh attestation verify <each-asset> --repo xybrid-ai/xybrid` on a downloaded asset. Should report `gh: ✓ Verified the artifact …`.