### PR TITLE
feat(telemetry): stamp sdk_version and binding on every PlatformEvent

### DIFF
--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -255,6 +255,15 @@ static BINDING: OnceLock<&'static str> = OnceLock::new();
 /// so registry calls can be attributed correctly.
 pub const DEFAULT_BINDING: &str = "rust";
 
+/// SDK crate version, stamped onto every telemetry event as `sdk_version` and
+/// used in the `X-Xybrid-Client` registry header.
+///
+/// Sourced from `CARGO_PKG_VERSION` at compile time so the value tracks the
+/// `xybrid-sdk` crate's own `Cargo.toml` without manual sync. The `xybrid-core`
+/// version is exposed separately as [`xybrid_core::VERSION`]; the two can
+/// diverge across releases.
+pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Register the binding identifier for this process.
 ///
 /// Each platform binding (Flutter, Kotlin, Swift, Unity) calls this once at

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -37,7 +37,7 @@ use crate::model::SdkError;
 use crate::platform::current_platform;
 use crate::source::detect_platform;
 use crate::telemetry_optout::is_telemetry_opted_out;
-use crate::{get_binding, DEFAULT_BINDING};
+use crate::{get_binding, DEFAULT_BINDING, SDK_VERSION};
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -94,7 +94,7 @@ fn build_client_header_with_optout(binding: &str, opted_out: bool) -> Option<Str
     Some(format!(
         "binding={}; sdk_version={}; core_version={}; platform={}; backends={}",
         safe_binding,
-        env!("CARGO_PKG_VERSION"),
+        SDK_VERSION,
         xybrid_core::VERSION,
         current_platform(),
         backends,

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -332,6 +332,15 @@ struct PlatformEvent {
     session_id: Uuid,
     event_type: String,
     payload: serde_json::Value,
+    // SDK self-identification. Always present so the backend can slice
+    // telemetry by SDK version (regression analysis) and by binding
+    // (adoption / per-platform performance). `sdk_version` is the
+    // `xybrid-sdk` crate version (compile-time `CARGO_PKG_VERSION`);
+    // `binding` is the process-global identifier set by the platform
+    // binding at init (`flutter`/`swift`/`kotlin`/`unity`), defaulting
+    // to `rust` when no binding has called `set_binding`.
+    sdk_version: String,
+    binding: String,
     // `device_id` honors the opt-out contract: when the SDK clears it
     // because the caller opted out of hardware detection without supplying
     // an explicit id, the wire event omits the field entirely rather than
@@ -1133,6 +1142,8 @@ fn convert_to_platform_event(
         session_id: config.session_id,
         event_type: event.event_type.clone(),
         payload,
+        sdk_version: crate::SDK_VERSION.to_string(),
+        binding: crate::get_binding().to_string(),
         device_id: config.device_id.clone(),
         device_label: config.device_label.clone(),
         platform: config.platform.clone(),
@@ -2734,6 +2745,50 @@ mod tests {
     }
 
     #[test]
+    fn platform_event_stamps_sdk_version_and_binding() {
+        // Invariant: every PlatformEvent that leaves the SDK carries
+        // `sdk_version` (= crate::SDK_VERSION) and `binding`
+        // (= crate::get_binding()). The assertion compares against the
+        // SDK's own view of itself rather than hardcoded strings so the
+        // test is hermetic regardless of `set_binding(...)` calls made by
+        // other tests sharing this process (BINDING is a OnceLock).
+        let event = TelemetryEvent {
+            event_type: "ModelComplete".to_string(),
+            stage_name: Some("test_stage".to_string()),
+            target: Some("local".to_string()),
+            latency_ms: Some(10),
+            error: None,
+            data: None,
+            timestamp_ms: 1_700_000_000_000,
+        };
+        let config = TelemetryConfig::new("https://ingest.example.test", "sk_test_abc");
+        let platform = convert_to_platform_event(&event, &config, None, None, None);
+
+        assert_eq!(platform.sdk_version, crate::SDK_VERSION);
+        assert_eq!(platform.binding, crate::get_binding());
+        assert!(
+            !platform.sdk_version.is_empty(),
+            "sdk_version must not be empty"
+        );
+        assert!(!platform.binding.is_empty(), "binding must not be empty");
+
+        // Wire format: serialize and confirm the exact JSON keys land
+        // on the payload. Guards against an accidental `#[serde(rename)]`
+        // drift that would silently break the backend ingest contract.
+        let json = serde_json::to_value(&platform).unwrap();
+        assert_eq!(
+            json["sdk_version"].as_str(),
+            Some(crate::SDK_VERSION),
+            "wire key `sdk_version` missing or mismatched: {json}"
+        );
+        assert_eq!(
+            json["binding"].as_str(),
+            Some(crate::get_binding()),
+            "wire key `binding` missing or mismatched: {json}"
+        );
+    }
+
+    #[test]
     fn resource_summary_attaches_and_hoists_through_convert() {
         // End-to-end happy path: attach_resource_summary()
         // edits event.data, then convert_to_platform_event hoists
@@ -3768,6 +3823,8 @@ mod tests {
             session_id: Uuid::new_v4(),
             event_type: "Test".to_string(),
             payload: serde_json::json!({}),
+            sdk_version: crate::SDK_VERSION.to_string(),
+            binding: crate::get_binding().to_string(),
             device_id: None,
             device_label: None,
             platform: None,


### PR DESCRIPTION
## Summary

Adds two always-present fields to the `PlatformEvent` wire schema so the backend can slice telemetry by SDK release (regression analysis) and by platform binding (adoption / per-platform performance). `sdk_version` comes from a new `pub const SDK_VERSION = env!(\"CARGO_PKG_VERSION\")` in `xybrid-sdk`, which also replaces the inline `env!` in `registry_client::build_client_header_with_optout` so the registry header and telemetry event share a single source of truth. `binding` is read from the existing process-global `get_binding()`, matching how `RegistryClient` resolves it. A hermetic unit test asserts both the struct fields and the serialized JSON keys land on the wire.

## Type of Change

- [x] New feature

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)