### PR TITLE
ci(vercel): only deploy docs when docs/ changes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- docs/"
 }


### PR DESCRIPTION
## Summary

The previous `vercel.json` ignoreCommand checked `VERCEL_GIT_COMMIT_REF != "main"`, but the default branch is `master` — so the gate never matched and Vercel registered a status check on every PR. Replaced it with a path-based filter so Vercel only builds when files under `docs/` (the only thing actually deployed) change.

Non-maintainer PR gating is intentionally not handled here — it belongs in the Vercel dashboard (Settings → Git → require team-member authorization for outside collaborators) since `vercel.json` can't see GitHub permission state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — n/a, config-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable) — n/a
- [x] No breaking changes (or breaking changes documented)