### PR TITLE
feat(sdk): add Xybrid.init() builder with anonymous-by-default telemetry

### DIFF
--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -25,6 +25,25 @@
 //!
 //! # Quick Start
 //!
+//! ## Initialization
+//!
+//! Anonymous use works out of the box — every inference path runs locally.
+//! Provide an API key to light up the platform dashboard:
+//!
+//! ```no_run
+//! // Anonymous — local inference, telemetry disabled
+//! xybrid_sdk::init().run();
+//!
+//! // Authenticated — telemetry exporter starts automatically
+//! xybrid_sdk::init()
+//!     .api_key("xy_live_...")
+//!     .run();
+//! ```
+//!
+//! Get a free key at <https://dashboard.xybrid.dev>. The first inference
+//! call without a key emits a one-shot info log nudging the developer
+//! toward the dashboard; set `XYBRID_QUIET=1` to suppress it.
+//!
 //! ## Batch Inference
 //!
 //! ```no_run
@@ -479,6 +498,156 @@ pub fn has_api_key() -> bool {
     std::env::var("XYBRID_API_KEY").is_ok()
 }
 
+// ============================================================================
+// XybridInit — one-stop builder for SDK initialization
+// ============================================================================
+
+/// Start configuring the SDK. Call `.run()` to apply.
+///
+/// See [`XybridInit`] for the full builder surface.
+pub fn init() -> XybridInit {
+    XybridInit::default()
+}
+
+/// Builder that bundles SDK initialization into a single call.
+///
+/// Replaces the older multi-step setup (`init_sdk_cache_dir` →
+/// `set_api_key` → `init_platform_telemetry`) for host apps that want one
+/// entry point. The legacy free functions stay public for callers that
+/// need finer control.
+///
+/// # Anonymous use
+///
+/// Omitting [`api_key`](Self::api_key) is supported: every inference path
+/// still runs locally. The platform telemetry exporter is not started, and
+/// the first inference logs a one-shot info-level hint pointing at the
+/// dashboard. Set `XYBRID_QUIET=1` to suppress the hint.
+///
+/// # Examples
+///
+/// Anonymous, default cache directory:
+///
+/// ```no_run
+/// xybrid_sdk::init().run();
+/// ```
+///
+/// Authenticated; telemetry defaults to the production ingest URL:
+///
+/// ```no_run
+/// xybrid_sdk::init()
+///     .api_key("xy_live_...")
+///     .run();
+/// ```
+///
+/// Full configuration — self-hosted dashboard with resource sampling on:
+///
+/// ```no_run
+/// use xybrid_sdk::ResourceTelemetryMode;
+///
+/// xybrid_sdk::init()
+///     .api_key("xy_live_...")
+///     .ingest_url("http://192.168.1.78:8081")
+///     .resource_telemetry(ResourceTelemetryMode::Summary { interval_ms: 5000 })
+///     .run();
+/// ```
+#[derive(Debug, Clone, Default)]
+#[must_use = "call .run() to apply the configuration"]
+pub struct XybridInit {
+    api_key: Option<String>,
+    cache_dir: Option<std::path::PathBuf>,
+    gateway_url: Option<String>,
+    ingest_url: Option<String>,
+    resource_telemetry: Option<xybrid_core::device::ResourceTelemetryMode>,
+    binding: Option<&'static str>,
+}
+
+impl XybridInit {
+    /// Set the Xybrid API key. With a key, the platform telemetry exporter
+    /// starts on `.run()` and inference traces flow to the dashboard.
+    ///
+    /// Skip this call to run anonymously.
+    pub fn api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
+    /// Override the model cache directory. Required on Android (where
+    /// `dirs::cache_dir()` returns `None`); optional elsewhere.
+    pub fn cache_dir(mut self, dir: impl Into<std::path::PathBuf>) -> Self {
+        self.cache_dir = Some(dir.into());
+        self
+    }
+
+    /// Override the LLM gateway URL. Defaults to the production gateway
+    /// or to `XYBRID_GATEWAY_URL` / `XYBRID_PLATFORM_URL` if set.
+    pub fn gateway_url(mut self, url: impl Into<String>) -> Self {
+        self.gateway_url = Some(url.into());
+        self
+    }
+
+    /// Override the telemetry ingest URL. Defaults to
+    /// [`telemetry::DEFAULT_INGEST_URL`] when an API key is set. Use this
+    /// for self-hosted dashboards or on-device dev consoles.
+    pub fn ingest_url(mut self, url: impl Into<String>) -> Self {
+        self.ingest_url = Some(url.into());
+        self
+    }
+
+    /// Configure resource-telemetry sampling. Defaults to `Off`.
+    pub fn resource_telemetry(mut self, mode: xybrid_core::device::ResourceTelemetryMode) -> Self {
+        self.resource_telemetry = Some(mode);
+        self
+    }
+
+    /// Register the binding identifier for this process (e.g. `"flutter"`,
+    /// `"kotlin"`, `"swift"`, `"unity"`). Bindings call this; host apps
+    /// rarely need to.
+    pub fn binding(mut self, binding: &'static str) -> Self {
+        self.binding = Some(binding);
+        self
+    }
+
+    /// Apply the configuration. Cache dir, gateway URL, API key, and
+    /// telemetry exporter are wired up in the order other code in the SDK
+    /// expects them.
+    ///
+    /// Idempotent for the cache dir and binding (first-set-wins via
+    /// `OnceLock`). The telemetry exporter has its own process-wide
+    /// once-guard at the binding layer; a second `.run()` does not spawn a
+    /// second exporter.
+    pub fn run(self) {
+        if let Some(binding) = self.binding {
+            set_binding(binding);
+        }
+        if let Some(dir) = self.cache_dir {
+            init_sdk_cache_dir(dir);
+        }
+        if let Some(url) = self.gateway_url.as_deref() {
+            set_gateway_url(url);
+        }
+        if let Some(key) = self.api_key.as_deref() {
+            set_api_key(key);
+        }
+
+        if let Some(key) = self.api_key.as_deref() {
+            let endpoint = self
+                .ingest_url
+                .as_deref()
+                .unwrap_or(telemetry::DEFAULT_INGEST_URL);
+            let mut config = telemetry::TelemetryConfig::new(endpoint, key);
+            if let Some(mode) = self.resource_telemetry {
+                config = config.with_resource_telemetry(mode);
+            }
+            telemetry::init_platform_telemetry(config);
+        } else if self.ingest_url.is_some() {
+            log::warn!(
+                target: "xybrid_sdk",
+                "ingest_url set without api_key; telemetry exporter not started"
+            );
+        }
+    }
+}
+
 /// Re-export common types for convenience
 pub mod prelude {
     pub use xybrid_core::context::{DeviceMetrics, StageDescriptor};
@@ -886,5 +1055,69 @@ mod sdk_config_tests {
             cfg.cache_dir.as_deref(),
             Some(std::path::Path::new("/tmp/xybrid-cache"))
         );
+    }
+}
+
+#[cfg(test)]
+mod xybrid_init_tests {
+    use super::{init, XybridInit};
+    use xybrid_core::device::ResourceTelemetryMode;
+
+    #[test]
+    fn init_returns_default_anonymous_builder() {
+        let builder = init();
+        let default = XybridInit::default();
+        // Default builder carries no configuration — the anonymous path.
+        assert_eq!(format!("{:?}", builder), format!("{:?}", default));
+    }
+
+    #[test]
+    fn api_key_setter_stores_value() {
+        let builder = init().api_key("xy_test_123");
+        let dbg = format!("{:?}", builder);
+        assert!(dbg.contains("xy_test_123"), "debug = {}", dbg);
+    }
+
+    #[test]
+    fn cache_dir_setter_stores_path() {
+        let builder = init().cache_dir("/tmp/xybrid-test-cache");
+        let dbg = format!("{:?}", builder);
+        assert!(
+            dbg.contains("xybrid-test-cache"),
+            "cache_dir not stored, debug = {}",
+            dbg
+        );
+    }
+
+    #[test]
+    fn ingest_url_setter_stores_value() {
+        let builder = init().ingest_url("http://192.168.1.78:8081");
+        let dbg = format!("{:?}", builder);
+        assert!(dbg.contains("192.168.1.78"), "debug = {}", dbg);
+    }
+
+    #[test]
+    fn gateway_url_setter_stores_value() {
+        let builder = init().gateway_url("https://gateway.example/v1");
+        let dbg = format!("{:?}", builder);
+        assert!(dbg.contains("gateway.example"), "debug = {}", dbg);
+    }
+
+    #[test]
+    fn resource_telemetry_setter_stores_mode() {
+        let builder = init().resource_telemetry(ResourceTelemetryMode::Boundary);
+        let dbg = format!("{:?}", builder);
+        assert!(dbg.contains("Boundary"), "debug = {}", dbg);
+    }
+
+    #[test]
+    fn builder_is_chainable() {
+        let _builder = init()
+            .api_key("xy_test")
+            .cache_dir("/tmp/x")
+            .gateway_url("https://gateway")
+            .ingest_url("https://ingest")
+            .resource_telemetry(ResourceTelemetryMode::Off)
+            .binding("rust");
     }
 }

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1897,6 +1897,7 @@ impl XybridModel {
         envelope: &Envelope,
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
+        crate::telemetry::maybe_emit_dev_nudge();
         let start = Instant::now();
         // Begin a resource-telemetry scope for this run. When
         // `resource_telemetry_mode()` is `Off` the guard is a no-op; otherwise
@@ -2747,6 +2748,7 @@ impl XybridModel {
         envelope: &Envelope,
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
+        crate::telemetry::maybe_emit_dev_nudge();
         let handle = self.handle.clone();
         let model_id = self.model_id.clone();
         let version = self.version.clone();

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1861,6 +1861,91 @@ pub fn init_platform_telemetry_from_env() -> bool {
     }
 }
 
+// ============================================================================
+// First-inference dev nudge
+// ============================================================================
+
+/// URL printed in the dev-nudge log. Hard-coded rather than wired through
+/// config because the nudge fires when no config has been provided.
+const DASHBOARD_URL: &str = "https://dashboard.xybrid.dev";
+
+/// Once-guard for [`maybe_emit_dev_nudge`].
+static DEV_NUDGE: std::sync::Once = std::sync::Once::new();
+
+/// Emit a one-shot info-level hint when the host app runs inference
+/// without configuring an API key. Subsequent calls are no-ops via
+/// [`std::sync::Once`].
+///
+/// Hooked into [`crate::model::XybridModel::run`] and
+/// [`crate::model::XybridModel::run_async`] so the nudge surfaces on first
+/// use rather than at init time — a host app that initializes the SDK far
+/// from where it runs inference still sees the hint.
+///
+/// Suppressed when `XYBRID_QUIET=1`.
+pub(crate) fn maybe_emit_dev_nudge() {
+    DEV_NUDGE.call_once(|| {
+        let api_key = std::env::var("XYBRID_API_KEY").ok();
+        let quiet = std::env::var("XYBRID_QUIET").ok();
+        if !should_emit_dev_nudge(api_key.as_deref(), quiet.as_deref()) {
+            return;
+        }
+        log::info!(
+            target: "xybrid_sdk",
+            "telemetry disabled (no XYBRID_API_KEY set). Get a free key at {} to see your inference traces.",
+            DASHBOARD_URL,
+        );
+    });
+}
+
+/// Pure predicate that decides whether the dev-nudge should print. Split
+/// out so unit tests can exercise the rule without poking process
+/// environment variables.
+fn should_emit_dev_nudge(api_key: Option<&str>, quiet: Option<&str>) -> bool {
+    if quiet == Some("1") {
+        return false;
+    }
+    let has_key = api_key.map(|k| !k.is_empty()).unwrap_or(false);
+    !has_key
+}
+
+#[cfg(test)]
+mod dev_nudge_tests {
+    use super::should_emit_dev_nudge;
+
+    #[test]
+    fn emits_when_no_api_key_and_not_quiet() {
+        assert!(should_emit_dev_nudge(None, None));
+    }
+
+    #[test]
+    fn suppressed_when_quiet_flag_set() {
+        assert!(!should_emit_dev_nudge(None, Some("1")));
+    }
+
+    #[test]
+    fn suppressed_when_api_key_present() {
+        assert!(!should_emit_dev_nudge(Some("xy_live_abc"), None));
+    }
+
+    #[test]
+    fn empty_api_key_treated_as_unset() {
+        assert!(should_emit_dev_nudge(Some(""), None));
+    }
+
+    #[test]
+    fn quiet_takes_priority_over_missing_key() {
+        assert!(!should_emit_dev_nudge(None, Some("1")));
+    }
+
+    #[test]
+    fn quiet_other_value_not_suppressive() {
+        // Only "1" suppresses. "true" / "yes" don't — keeps the env-flag
+        // contract narrow.
+        assert!(should_emit_dev_nudge(None, Some("true")));
+        assert!(should_emit_dev_nudge(None, Some("0")));
+    }
+}
+
 /// Set pipeline context for event enrichment
 pub fn set_telemetry_pipeline_context(pipeline_id: Option<Uuid>, trace_id: Option<Uuid>) {
     let mut event_context = xybrid_core::event_bus::EventContext::current();


### PR DESCRIPTION
## Summary

Adds `xybrid_sdk::init() -> XybridInit`, a single chainable builder that bundles the four current setup steps (cache dir, API key, gateway URL, telemetry exporter) into one call. Anonymous use is fully supported — telemetry is a silent no-op until an API key is set, and the first inference call emits a one-shot `log::info!` pointing at `https://dashboard.xybrid.dev` (suppress with `XYBRID_QUIET=1`). This is PR 1 of a series; the language bindings (Dart/Swift/Kotlin/C#) and docs site updates ship in follow-ups.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test -p xybrid-sdk --lib --features ort-download` — 343 passed, 13 new; doctests 86 passed)
- [x] Code follows project style (`cargo fmt`, `cargo clippy --features ort-download -- -D warnings` clean)
- [x] Documentation updated (crate-level Quick Start adds an `Initialization` section)
- [x] No breaking changes — legacy free fns (`init_sdk_cache_dir`, `set_api_key`, `init_platform_telemetry`, …) stay public and unchanged