### PR TITLE
feat(swift): start telemetry from apiKey in Xybrid.initialize()

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -19,9 +19,16 @@ import UIKit
 /// It registers the binding identifier so registry calls are attributed to the
 /// Swift SDK, and is safe to call multiple times — subsequent calls are no-ops.
 ///
+/// Inference runs on-device whether or not you authenticate. Pass an `apiKey`
+/// to start the telemetry exporter and see your runs on the dashboard — get a
+/// free key at https://dashboard.xybrid.dev.
+///
 /// ```swift
-/// // Application entry point
+/// // Anonymous — local inference, telemetry disabled
 /// Xybrid.initialize()
+///
+/// // Authenticated — telemetry flows to the dashboard
+/// Xybrid.initialize(apiKey: ProcessInfo.processInfo.environment["XYBRID_API_KEY"])
 /// ```
 public enum Xybrid {
     private static let initLock = NSLock()
@@ -40,6 +47,17 @@ public enum Xybrid {
     /// `X-Xybrid-Client` header on registry HTTP calls reports
     /// `binding=swift`. Idempotent and thread-safe.
     ///
+    /// All parameters are optional. Without an `apiKey`, the SDK runs fully
+    /// on-device and telemetry is disabled — the first inference logs a
+    /// one-shot hint pointing at the dashboard (suppress with the
+    /// `XYBRID_QUIET=1` environment variable). Pass `apiKey` to start the
+    /// platform telemetry exporter; `ingestUrl` overrides the destination
+    /// for a self-hosted dashboard, and `gatewayUrl` overrides the LLM
+    /// gateway. Get a free key at https://dashboard.xybrid.dev.
+    ///
+    /// Configuration is applied on the first call; because `initialize()` is
+    /// idempotent, a later call with different arguments is a no-op.
+    ///
     /// On iOS, also enables `UIDevice` battery monitoring and subscribes
     /// to `UIDevice.batteryLevelDidChangeNotification`, forwarding each
     /// reading through the SDK's push-state surface so the routing
@@ -48,11 +66,21 @@ public enum Xybrid {
     /// in `xybrid-core` (no host wiring needed). On macOS, both
     /// battery (IOKit) and thermal (NSProcessInfo) are in-Rust, so
     /// nothing extra is registered here.
-    public static func initialize() {
+    ///
+    /// - Parameters:
+    ///   - apiKey: Xybrid API key. When set, starts the telemetry exporter.
+    ///   - gatewayUrl: Optional override for the LLM gateway URL.
+    ///   - ingestUrl: Optional override for the telemetry ingest URL.
+    public static func initialize(
+        apiKey: String? = nil,
+        gatewayUrl: String? = nil,
+        ingestUrl: String? = nil
+    ) {
         initLock.lock()
         defer { initLock.unlock() }
         if initialized { return }
         setBinding(binding: "swift")
+        configureRuntime(apiKey: apiKey, gatewayUrl: gatewayUrl, ingestUrl: ingestUrl)
         registerPlatformObservers()
         initialized = true
     }

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -81,7 +81,17 @@ public enum Xybrid {
         if initialized { return }
         setBinding(binding: "swift")
         configureRuntime(apiKey: apiKey, gatewayUrl: gatewayUrl, ingestUrl: ingestUrl)
-        registerPlatformObservers()
+        // `registerPlatformObservers()` touches UIKit (`UIDevice.current`,
+        // `isBatteryMonitoringEnabled`) on iOS, which is main-thread-only.
+        // `initialize()` is documented as callable from any thread (apps
+        // commonly call it inside a `Task`), so hop to main when needed.
+        // The `initialized` guard ensures only one caller ever reaches here,
+        // so the deferred registration runs exactly once.
+        if Thread.isMainThread {
+            registerPlatformObservers()
+        } else {
+            DispatchQueue.main.async { registerPlatformObservers() }
+        }
         initialized = true
     }
 

--- a/bindings/apple/Sources/Xybrid/xybrid_uniffi.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_uniffi.swift
@@ -591,8 +591,8 @@ public class XybridModelLoader: XybridModelLoaderProtocol {
 
     
 
-    public static func fromBundle(path: String)  -> XybridModelLoader {
-        return XybridModelLoader(unsafeFromRawPointer: try! rustCall() {
+    public static func fromBundle(path: String) throws -> XybridModelLoader {
+        return XybridModelLoader(unsafeFromRawPointer: try rustCallWithError(FfiConverterTypeXybridError.lift) {
     uniffi_xybrid_uniffi_fn_constructor_xybridmodelloader_from_bundle(
         FfiConverterString.lower(path),$0)
 })
@@ -1795,6 +1795,17 @@ public func clearThermalState()  {
 
 
 
+public func configureRuntime(apiKey: String?, gatewayUrl: String?, ingestUrl: String?)  {
+    try! rustCall() {
+    uniffi_xybrid_uniffi_fn_func_configure_runtime(
+        FfiConverterOptionString.lower(apiKey),
+        FfiConverterOptionString.lower(gatewayUrl),
+        FfiConverterOptionString.lower(ingestUrl),$0)
+}
+}
+
+
+
 public func initSdkCacheDir(cacheDir: String)  {
     try! rustCall() {
     uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(
@@ -1852,6 +1863,9 @@ private var initializationResult: InitializationResult {
     if (uniffi_xybrid_uniffi_checksum_func_clear_thermal_state() != 36495) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_xybrid_uniffi_checksum_func_configure_runtime() != 13785) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -1882,7 +1896,7 @@ private var initializationResult: InitializationResult {
     if (uniffi_xybrid_uniffi_checksum_method_xybridmodelloader_load() != 43654) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_bundle() != 7105) {
+    if (uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_bundle() != 38159) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_directory() != 8635) {

--- a/bindings/apple/Sources/xybrid_uniffiFFI/include/xybrid_uniffiFFI.h
+++ b/bindings/apple/Sources/xybrid_uniffiFFI/include/xybrid_uniffiFFI.h
@@ -93,6 +93,8 @@ void uniffi_xybrid_uniffi_fn_func_clear_battery_level(RustCallStatus *_Nonnull o
 void uniffi_xybrid_uniffi_fn_func_clear_thermal_state(RustCallStatus *_Nonnull out_status
     
 );
+void uniffi_xybrid_uniffi_fn_func_configure_runtime(RustBuffer api_key, RustBuffer gateway_url, RustBuffer ingest_url, RustCallStatus *_Nonnull out_status
+);
 void uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(RustBuffer cache_dir, RustCallStatus *_Nonnull out_status
 );
 void uniffi_xybrid_uniffi_fn_func_set_battery_level(uint8_t percent, RustCallStatus *_Nonnull out_status
@@ -219,6 +221,9 @@ uint16_t uniffi_xybrid_uniffi_checksum_func_clear_battery_level(void
     
 );
 uint16_t uniffi_xybrid_uniffi_checksum_func_clear_thermal_state(void
+    
+);
+uint16_t uniffi_xybrid_uniffi_checksum_func_configure_runtime(void
     
 );
 uint16_t uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(void

--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -59,6 +59,50 @@ fn resolve_binding(binding: &str) -> &'static str {
     }
 }
 
+/// Apply optional runtime configuration during host SDK initialization.
+///
+/// The Swift `Xybrid.initialize(...)` and Kotlin `Xybrid.init(...)` wrappers
+/// call this once, after [`set_binding`], to thread through whatever the host
+/// app passed. Every argument is optional:
+///
+/// - `api_key` — when present and non-blank, starts the platform telemetry
+///   exporter so inference traces reach the dashboard. Omit it to run
+///   anonymously (local inference only); the first inference then logs a
+///   one-shot hint pointing at the dashboard.
+/// - `gateway_url` — overrides the LLM gateway URL.
+/// - `ingest_url` — overrides the telemetry ingest endpoint (self-hosted
+///   dashboards). When omitted, the exporter targets the production default.
+///
+/// Delegates entirely to the [`xybrid_sdk::init`] builder, so the
+/// API-key-gating and ingest-URL defaulting rules match every other binding.
+/// Blank strings are treated as absent so hosts can pass empty
+/// `String.fromEnvironment`-style values without accidentally configuring
+/// anything.
+#[uniffi::export]
+fn configure_runtime(
+    api_key: Option<String>,
+    gateway_url: Option<String>,
+    ingest_url: Option<String>,
+) {
+    let non_blank = |value: Option<String>| {
+        value
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    };
+
+    let mut builder = xybrid_sdk::init();
+    if let Some(key) = non_blank(api_key) {
+        builder = builder.api_key(key);
+    }
+    if let Some(gateway) = non_blank(gateway_url) {
+        builder = builder.gateway_url(gateway);
+    }
+    if let Some(ingest) = non_blank(ingest_url) {
+        builder = builder.ingest_url(ingest);
+    }
+    builder.run();
+}
+
 // -- Platform-state push API --
 //
 // Mobile telemetry APIs (`UIDevice.batteryLevel` on iOS,

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -56,6 +56,18 @@ if result.success {
 
 On iOS, `Xybrid.initialize()` enables `UIDevice` battery monitoring and subscribes to `UIDevice.batteryLevelDidChangeNotification`, forwarding readings to the routing engine. Thermal state on Apple platforms is sourced from `NSProcessInfo.thermalState` directly in `xybrid-core`. See [Host Integration](/docs/internals/host-integration) for the per-platform picture.
 
+## Initialization
+
+Inference runs entirely on-device whether or not you authenticate. Pass an `apiKey` to light up the [dashboard](https://dashboard.xybrid.dev) — that single call starts the telemetry exporter, and your `model.run(...)` calls automatically emit execution traces:
+
+```swift
+Xybrid.initialize(
+    apiKey: ProcessInfo.processInfo.environment["XYBRID_API_KEY"]
+)
+```
+
+Without a key, telemetry is disabled and the first inference logs a one-shot hint pointing at the dashboard (suppress with the `XYBRID_QUIET=1` environment variable). Get a free key at [dashboard.xybrid.dev](https://dashboard.xybrid.dev). For a self-hosted dashboard, also pass `ingestUrl`.
+
 ---
 
 ## Model Loading

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -48,6 +48,18 @@ if result.success {
 }
 ```
 
+## 初始化
+
+无论是否鉴权，推理都完全在本地运行。传入 `apiKey` 即可点亮[控制台](https://dashboard.xybrid.dev)——这一次调用会启动遥测导出器，你的 `model.run(...)` 调用便会自动上报执行轨迹：
+
+```swift
+Xybrid.initialize(
+    apiKey: ProcessInfo.processInfo.environment["XYBRID_API_KEY"]
+)
+```
+
+未提供密钥时，遥测处于禁用状态，首次推理会打印一条一次性提示指向控制台（可通过环境变量 `XYBRID_QUIET=1` 关闭）。在 [dashboard.xybrid.dev](https://dashboard.xybrid.dev) 免费获取密钥。若使用自托管控制台，请额外传入 `ingestUrl`。
+
 ---
 
 ## 模型加载

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -67,6 +67,10 @@ dependencies: [
 ```swift
 import Xybrid
 
+// Runs locally as-is. Add a free key from dashboard.xybrid.dev to see
+// your inference traces: Xybrid.initialize(apiKey: "...")
+Xybrid.initialize()
+
 // Load a model from the registry
 let loader = ModelLoader.fromRegistry(modelId: "kokoro-82m")
 let model = try loader.load()

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -65,6 +65,10 @@ dependencies: [
 ```swift
 import Xybrid
 
+// 默认即可本地运行。在 dashboard.xybrid.dev 免费获取密钥即可查看
+// 推理轨迹：Xybrid.initialize(apiKey: "...")
+Xybrid.initialize()
+
 // 从注册表加载模型
 let loader = XybridModelLoader.fromRegistry(modelId: "kokoro-82m")
 let model = try loader.load()

--- a/examples/ios/XybridExample/ContentView.swift
+++ b/examples/ios/XybridExample/ContentView.swift
@@ -60,6 +60,12 @@ struct ContentView: View {
             let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
                 .first!.appendingPathComponent("xybrid").path
             initSdkCacheDir(cacheDir: cacheDir)
+
+            // Initialize the runtime. Runs locally as-is; add a free key from
+            // dashboard.xybrid.dev to see inference traces:
+            //   Xybrid.initialize(apiKey: "xy_live_...")
+            Xybrid.initialize()
+
             await MainActor.run {
                 appState = .ready
             }


### PR DESCRIPTION
## Summary

Brings the anonymous-by-default telemetry model (from #188/#195) to the Swift SDK. `Xybrid.initialize()` gains optional `apiKey` / `gatewayUrl` / `ingestUrl` params; passing a key starts the platform telemetry exporter so inference traces reach the dashboard, while the no-arg call keeps running fully on-device. The Swift wrapper calls a new `configure_runtime` UniFFI export that delegates to the `xybrid_sdk::init()` builder, so api-key gating and ingest-URL defaulting are identical across bindings — no duplicated logic. Includes regenerated Swift bindings, iOS docs (EN + ZH), the quickstart Swift tab, and wires `Xybrid.initialize()` into the iOS example. `resourceTelemetry` parity is intentionally deferred (needs a typed-enum-through-UniFFI pass).

> **Heads-up for reviewers:** regenerating the Swift bindings also corrected a pre-existing drift — `XybridModelLoader.fromBundle` is now `throws` (the Rust signature already returned `Result`; the committed bindings were stale). No in-repo Swift caller is affected.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — `cargo build/clippy -p xybrid-uniffi -- -D warnings` clean; `swiftc -parse` of the wrapper exits 0
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (iOS SDK page + quickstart, EN + ZH)
- [x] No breaking changes to the public Swift init surface — new params are optional; anonymous `initialize()` is unchanged