### PR TITLE
feat(sdk): expose inherent SdkError::is_retryable / retry_after

### DIFF
--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -211,6 +211,11 @@ pub use model::{
 pub use platform::current_platform;
 pub use registry_client::{CacheStats, ModelSummary, RegistryClient, ResolvedVariant};
 pub use run_options::{AbortPolicy, AbortReason, AbortSignal, CancellationToken, RunOptions};
+// Re-exported so callers can use the trait form of `SdkError::is_retryable`
+// / `retry_after` (e.g. in generic retry helpers) without naming
+// `xybrid_core`. The inherent methods on `SdkError` cover the common case
+// without any import.
+pub use xybrid_core::http::RetryableError;
 // Pipeline API (PipelineRef → Pipeline)
 pub use pipeline::{
     // Config types for FFI bindings (Flutter, Kotlin, Swift)

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -116,8 +116,23 @@ pub enum SdkError {
 /// Result type for SDK operations.
 pub type SdkResult<T> = Result<T, SdkError>;
 
-impl xybrid_core::http::RetryableError for SdkError {
-    fn is_retryable(&self) -> bool {
+impl SdkError {
+    /// Whether retrying the operation that produced this error could
+    /// succeed without the caller changing anything.
+    ///
+    /// Transient failures (`NetworkError`, `RateLimited`, `Timeout`,
+    /// `Offline`) are retryable; everything else — including
+    /// `CircuitOpen`, `ConfigError`, `ModelNotFound`, `LoadError`,
+    /// `InferenceError`, and `AbortedForCloudFallback` — is not. `Offline`
+    /// is retryable only across *different* registry URLs (a fallback
+    /// registry may be reachable when the primary isn't); within a single
+    /// URL the retry loop short-circuits (see `registry_client`).
+    ///
+    /// This is the inherent form of the [`xybrid_core::http::RetryableError`]
+    /// trait method, exposed directly on `SdkError` so callers (and the
+    /// FFI / UniFFI layers) can query retryability without importing the
+    /// trait. The trait impl forwards here.
+    pub fn is_retryable(&self) -> bool {
         match self {
             // Retryable errors (transient failures)
             SdkError::NetworkError(_) => true,
@@ -148,13 +163,30 @@ impl xybrid_core::http::RetryableError for SdkError {
         }
     }
 
-    fn retry_after(&self) -> Option<std::time::Duration> {
+    /// The minimum delay a caller should wait before retrying, when the
+    /// error itself dictates one. Only `RateLimited` carries a
+    /// server-specified backoff; every other variant returns `None`
+    /// (the caller picks its own backoff if [`Self::is_retryable`]).
+    ///
+    /// Inherent form of [`xybrid_core::http::RetryableError::retry_after`];
+    /// the trait impl forwards here.
+    pub fn retry_after(&self) -> Option<std::time::Duration> {
         match self {
             SdkError::RateLimited { retry_after_secs } => {
                 Some(std::time::Duration::from_secs(*retry_after_secs))
             }
             _ => None,
         }
+    }
+}
+
+impl xybrid_core::http::RetryableError for SdkError {
+    fn is_retryable(&self) -> bool {
+        SdkError::is_retryable(self)
+    }
+
+    fn retry_after(&self) -> Option<std::time::Duration> {
+        SdkError::retry_after(self)
     }
 }
 
@@ -2899,6 +2931,47 @@ impl Clone for XybridModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The inherent `SdkError::is_retryable` / `retry_after` accessors and
+    /// the `RetryableError` trait impl must agree for every variant — the
+    /// trait forwards to the inherent methods, so a divergence would be a
+    /// refactor slip. Covers the four retryable variants, a representative
+    /// non-retryable one, and the `RateLimited` retry-after passthrough.
+    #[test]
+    fn inherent_and_trait_retryability_agree() {
+        use xybrid_core::http::RetryableError;
+
+        let cases = [
+            (SdkError::NetworkError("x".into()), true),
+            (
+                SdkError::RateLimited {
+                    retry_after_secs: 5,
+                },
+                true,
+            ),
+            (SdkError::Timeout { timeout_ms: 100 }, true),
+            (SdkError::Offline("x".into()), true),
+            (SdkError::CircuitOpen("x".into()), false),
+            (SdkError::NotLoaded, false),
+            (SdkError::ConfigError("x".into()), false),
+        ];
+        for (err, expected) in &cases {
+            assert_eq!(err.is_retryable(), *expected, "inherent for {err:?}");
+            assert_eq!(
+                RetryableError::is_retryable(err),
+                *expected,
+                "trait for {err:?}"
+            );
+        }
+
+        // Only RateLimited carries a server-specified backoff.
+        let rl = SdkError::RateLimited {
+            retry_after_secs: 7,
+        };
+        assert_eq!(rl.retry_after(), Some(std::time::Duration::from_secs(7)));
+        assert_eq!(rl.retry_after(), RetryableError::retry_after(&rl));
+        assert_eq!(SdkError::NotLoaded.retry_after(), None);
+    }
 
     #[test]
     fn streaming_execution_error_preserves_typed_cloud_fallback_abort() {

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -50,7 +50,7 @@ use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy, RetryableError};
+use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy};
 
 pub const DEFAULT_REGISTRY_URL: &str = "https://registry.xybrid.dev";
 pub const FALLBACK_REGISTRY_URL: &str = "https://r2.xybrid.dev";


### PR DESCRIPTION
## Summary

Audit **slice 3a, finding 1** (the first sub-slice of the xybrid-sdk audit). `is_retryable()` / `retry_after()` existed only as impls of the `xybrid_core::http::RetryableError` trait — the most important behavioural query on the SDK's public error type was invisible from `SdkError`'s docs/autocomplete and required consumers to discover and `use xybrid_core::http::RetryableError` (a deep path in a *different* crate) before calling it.

This moves the logic onto inherent `impl SdkError { pub fn is_retryable / retry_after }` methods and has the `RetryableError` trait impl forward to them (`M-ESSENTIAL-FN-INHERENT`). The trait is re-exported from `xybrid_sdk` so generic retry helpers can name it without reaching into `xybrid_core`.

## Why now

This is the **prerequisite for FFI audit theme 8** — surfacing retryability across the FFI / UniFFI boundary. Those layers can now forward `SdkError::is_retryable()` directly instead of importing a foreign-crate trait.

## Knock-on cleanup

`registry_client.rs` imported `RetryableError` solely to call `.is_retryable()` on an `SdkError`. With the inherent method present, method resolution picks it and the trait import is dead — removed. (Good sign the fix achieves its goal: callers stop needing the trait.)

## Behaviour unchanged

- Same retryable set: `NetworkError`, `RateLimited`, `Timeout`, `Offline`; everything else non-retryable.
- Match stays exhaustive — a new `SdkError` variant still forces a retryability decision (CLAUDE.md contract).
- New test `inherent_and_trait_retryability_agree` locks inherent/trait parity + the `RateLimited` retry-after passthrough.

## Scope: finding 2 deferred (deliberately)

Audit slice 3a's **second** finding — `SdkError` variants stringize their causes (`format!("…: {}", e)`) instead of `#[source]`-chaining — is **not** here. That's a crate-wide breaking reshape of every variant *and* every construction/match site, warranting a dedicated PR + `api-contract-check.sh` run. Bundling it with this additive change would make an unreviewable diff. Tracked for a follow-up.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p xybrid-sdk --all-targets -- -D warnings` clean
- [x] `cargo test -p xybrid-sdk --lib` — **345 passed, 0 failed** (+1 new)