### PR TITLE
feat(uniffi): expose error retryability to Swift/Kotlin

### DIFF
--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -207,7 +207,7 @@ impl XybridError {
     /// Kotlin callers reach this via the exported
     /// [`xybrid_error_is_retryable`] free function rather than
     /// pattern-matching on variants that may shift between releases.
-    fn is_retryable(&self) -> bool {
+    pub fn is_retryable(&self) -> bool {
         match self {
             XybridError::NetworkError { .. }
             | XybridError::RateLimited { .. }
@@ -234,10 +234,29 @@ impl XybridError {
     /// carries a server-specified backoff; every other variant returns
     /// `None`. Exposed to Swift / Kotlin via
     /// [`xybrid_error_retry_after_secs`].
-    fn retry_after_secs(&self) -> Option<u64> {
+    ///
+    /// Matched exhaustively (rather than `_ => None`) so a future variant
+    /// that should carry a retry delay is compile-forced to be handled
+    /// here — same discipline as [`Self::is_retryable`].
+    pub fn retry_after_secs(&self) -> Option<u64> {
         match self {
             XybridError::RateLimited { retry_after_secs } => Some(*retry_after_secs),
-            _ => None,
+
+            XybridError::ModelNotFound { .. }
+            | XybridError::DirectoryNotFound { .. }
+            | XybridError::MetadataNotFound { .. }
+            | XybridError::MetadataInvalid { .. }
+            | XybridError::LoadError { .. }
+            | XybridError::InferenceError { .. }
+            | XybridError::StreamingNotSupported
+            | XybridError::NotLoaded
+            | XybridError::ConfigError { .. }
+            | XybridError::NetworkError { .. }
+            | XybridError::IoError { .. }
+            | XybridError::CacheError { .. }
+            | XybridError::PipelineError { .. }
+            | XybridError::CircuitOpen { .. }
+            | XybridError::Timeout { .. } => None,
         }
     }
 }

--- a/crates/xybrid-uniffi/src/lib.rs
+++ b/crates/xybrid-uniffi/src/lib.rs
@@ -195,6 +195,77 @@ pub enum XybridError {
     Timeout { timeout_ms: u64 },
 }
 
+impl XybridError {
+    /// Whether retrying the operation that produced this error could
+    /// succeed without the caller changing anything.
+    ///
+    /// Mirrors the Rust SDK's `SdkError::is_retryable` contract across
+    /// the UniFFI boundary: `NetworkError`, `RateLimited`, and `Timeout`
+    /// are retryable; everything else is not. (`SdkError::Offline`, also
+    /// retryable on the Rust side, is collapsed into `NetworkError` by
+    /// the `From` impl below, so its retryability is preserved.) Swift /
+    /// Kotlin callers reach this via the exported
+    /// [`xybrid_error_is_retryable`] free function rather than
+    /// pattern-matching on variants that may shift between releases.
+    fn is_retryable(&self) -> bool {
+        match self {
+            XybridError::NetworkError { .. }
+            | XybridError::RateLimited { .. }
+            | XybridError::Timeout { .. } => true,
+
+            XybridError::ModelNotFound { .. }
+            | XybridError::DirectoryNotFound { .. }
+            | XybridError::MetadataNotFound { .. }
+            | XybridError::MetadataInvalid { .. }
+            | XybridError::LoadError { .. }
+            | XybridError::InferenceError { .. }
+            | XybridError::StreamingNotSupported
+            | XybridError::NotLoaded
+            | XybridError::ConfigError { .. }
+            | XybridError::IoError { .. }
+            | XybridError::CacheError { .. }
+            | XybridError::PipelineError { .. }
+            | XybridError::CircuitOpen { .. } => false,
+        }
+    }
+
+    /// The minimum delay (in seconds) a caller should wait before
+    /// retrying, when the error itself dictates one. Only `RateLimited`
+    /// carries a server-specified backoff; every other variant returns
+    /// `None`. Exposed to Swift / Kotlin via
+    /// [`xybrid_error_retry_after_secs`].
+    fn retry_after_secs(&self) -> Option<u64> {
+        match self {
+            XybridError::RateLimited { retry_after_secs } => Some(*retry_after_secs),
+            _ => None,
+        }
+    }
+}
+
+/// Whether the given error is worth retrying without changes.
+///
+/// The UniFFI-exported mirror of the Rust SDK's retryability contract.
+/// Swift / Kotlin callers should branch on this instead of switching on
+/// `XybridError` variants directly, so retry logic survives variant
+/// additions/renames between releases.
+///
+/// In Swift: `if xybridErrorIsRetryable(error: caught) { … }`
+/// In Kotlin: `if (xybridErrorIsRetryable(caught)) { … }`
+#[uniffi::export]
+fn xybrid_error_is_retryable(error: &XybridError) -> bool {
+    error.is_retryable()
+}
+
+/// Server-specified retry delay in seconds, if the error carries one.
+///
+/// Returns the `RateLimited` backoff when present; `None` for every
+/// other error (the caller picks its own backoff if
+/// [`xybrid_error_is_retryable`] returned true).
+#[uniffi::export]
+fn xybrid_error_retry_after_secs(error: &XybridError) -> Option<u64> {
+    error.retry_after_secs()
+}
+
 impl From<SdkError> for XybridError {
     fn from(e: SdkError) -> Self {
         match e {
@@ -666,6 +737,68 @@ impl XybridModelLoader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `XybridError` retryability must mirror the Rust SDK's
+    /// `SdkError::is_retryable` contract across the boundary, and the
+    /// `From<SdkError>` collapse of `Offline → NetworkError` must
+    /// preserve retryability (both are retryable). The match is
+    /// exhaustive so a new variant forces a decision here too.
+    #[test]
+    fn error_retryability_mirrors_sdk_contract() {
+        // Retryable variants.
+        assert!(XybridError::NetworkError {
+            message: "x".into()
+        }
+        .is_retryable());
+        assert!(XybridError::RateLimited {
+            retry_after_secs: 5
+        }
+        .is_retryable());
+        assert!(XybridError::Timeout { timeout_ms: 100 }.is_retryable());
+
+        // Representative non-retryable variants.
+        assert!(!XybridError::NotLoaded.is_retryable());
+        assert!(!XybridError::CircuitOpen {
+            message: "x".into()
+        }
+        .is_retryable());
+        assert!(!XybridError::InferenceError {
+            message: "x".into()
+        }
+        .is_retryable());
+
+        // SdkError::Offline collapses to NetworkError, which is retryable —
+        // so the Rust-side Offline retryability survives the boundary. This
+        // is the load-bearing cross-boundary assertion: the `From` impl
+        // must not silently demote a retryable error to a non-retryable
+        // variant.
+        let from_offline: XybridError = SdkError::Offline("down".into()).into();
+        assert!(matches!(from_offline, XybridError::NetworkError { .. }));
+        assert!(from_offline.is_retryable());
+    }
+
+    #[test]
+    fn retry_after_secs_only_on_rate_limited() {
+        assert_eq!(
+            XybridError::RateLimited {
+                retry_after_secs: 7
+            }
+            .retry_after_secs(),
+            Some(7)
+        );
+        assert_eq!(
+            XybridError::Timeout { timeout_ms: 100 }.retry_after_secs(),
+            None
+        );
+        assert_eq!(XybridError::NotLoaded.retry_after_secs(), None);
+
+        // The exported free functions delegate to the inherent methods.
+        let rl = XybridError::RateLimited {
+            retry_after_secs: 9,
+        };
+        assert!(xybrid_error_is_retryable(&rl));
+        assert_eq!(xybrid_error_retry_after_secs(&rl), Some(9));
+    }
 
     // Pure-helper tests: exercise every accepted platform without touching
     // the process-global OnceLock in xybrid-sdk. This is the only way to


### PR DESCRIPTION
## Summary

Audit **theme 8** (the last high-severity finding from the slice-1 FFI audit). `XybridError` crossed the UniFFI boundary as a thrown enum with no way for Swift/Kotlin callers to ask *"should I retry this?"* — they had to pattern-match on variants that may shift between releases, and the Rust SDK's `RetryableError` contract didn't survive the boundary at all.

Builds directly on #198 (inherent `SdkError::is_retryable`/`retry_after`), mirroring that shape one layer up:

- **Inherent `XybridError::is_retryable()` / `retry_after_secs()`** — same contract as the Rust SDK (`NetworkError` / `RateLimited` / `Timeout` retryable; everything else not). Exhaustive match → a new variant forces a decision.
- **Two `#[uniffi::export]` free functions** delegating to them:
  - `xybrid_error_is_retryable(&XybridError) -> bool`
  - `xybrid_error_retry_after_secs(&XybridError) -> Option<u64>`

## Verified end-to-end (not just Rust compile)

I regenerated **both** Swift and Kotlin bindings from the built dylib and confirmed the functions surface idiomatically:

| | Swift | Kotlin |
|---|---|---|
| retryable | `xybridErrorIsRetryable(error:) -> Bool` | `xybridErrorIsRetryable(error: XybridException): Boolean` |
| backoff | `xybridErrorRetryAfterSecs(error:) -> UInt64?` | `xybridErrorRetryAfterSecs(error: XybridException): ULong?` |

UniFFI 0.25 lowers the `&XybridError` argument to a by-value error in both bindings — I checked this empirically rather than assuming it, since error-types-as-arguments aren't a given.

## Retryability preserved across the `From<SdkError>` collapse

`SdkError::Offline` (retryable) folds into `XybridError::NetworkError` (also retryable), so offline errors stay retryable on the foreign side. New regression test asserts the collapse doesn't silently demote retryability.

## Callers

Swift / Kotlin now branch on `xybridErrorIsRetryable(error)` instead of switching on variants — retry logic survives variant additions/renames between releases (exactly the fragility the audit flagged).

## Scope notes

- **No `api-surface.yaml` change.** That file tracks customer-facing platform-binding *methods* (Dart/Kotlin/Swift wrapper classes), not raw uniffi free functions — the existing `set_battery_level` / `set_binding` exports aren't listed either. The ergonomic `error.isRetryable` convenience wrappers in the Swift/Kotlin SDK *packages* are follow-up binding-layer work.
- The **C-ABI** side (`xybrid-ffi`) is unchanged — it surfaces errors as `null` + `xybrid_last_error()` strings with no typed error, so retryability there needs the separate error-code redesign (a different audit item), not this fix.

## Test plan

- [x] `cargo build -p xybrid-uniffi` clean
- [x] `cargo test -p xybrid-uniffi --lib` — **8 passed, 0 failed** (+2 new)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p xybrid-uniffi --all-targets -- -D warnings` clean
- [x] Swift + Kotlin bindings regenerated from dylib — both functions present and idiomatic