### PR TITLE
feat(kotlin): add apiKey/telemetry to Xybrid.init()

### DIFF
--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -22,12 +22,19 @@ import java.io.File
  * Main entry point for the Xybrid SDK.
  *
  * Call [Xybrid.init] once before using any other Xybrid functionality.
+ * Inference runs on-device whether or not you authenticate; pass an
+ * `apiKey` to start the telemetry exporter and see your runs on the
+ * dashboard. Get a free key at https://dashboard.xybrid.dev.
  *
  * ```kotlin
  * class MyApplication : Application() {
  *     override fun onCreate() {
  *         super.onCreate()
+ *         // Anonymous — local inference, telemetry disabled
  *         Xybrid.init(this)
+ *
+ *         // Authenticated — telemetry flows to the dashboard
+ *         Xybrid.init(this, apiKey = BuildConfig.XYBRID_API_KEY)
  *     }
  * }
  * ```
@@ -44,6 +51,15 @@ object Xybrid {
      *
      * Typically called from `Application.onCreate()` or `Activity.onCreate()`.
      *
+     * All parameters except [context] are optional. Without an [apiKey], the
+     * SDK runs fully on-device and telemetry is disabled — the first
+     * inference logs a one-shot hint pointing at the dashboard (suppress
+     * with the `XYBRID_QUIET=1` environment variable). Pass [apiKey] to
+     * start the platform telemetry exporter; [ingestUrl] overrides the
+     * destination for a self-hosted dashboard, and [gatewayUrl] overrides
+     * the LLM gateway. Configuration is applied on the first call; because
+     * `init` is idempotent, a later call with different arguments is a no-op.
+     *
      * Also subscribes to OS-level battery and thermal notifications and
      * forwards each value through the SDK's push-state surface so the
      * routing engine has live telemetry without consumer apps writing
@@ -57,15 +73,25 @@ object Xybrid {
      * (treated as "no signal" rather than an optimistic default).
      *
      * @param context Android context (application or activity).
+     * @param apiKey Xybrid API key. When set, starts the telemetry exporter.
+     * @param gatewayUrl Optional override for the LLM gateway URL.
+     * @param ingestUrl Optional override for the telemetry ingest URL.
      */
     @JvmStatic
-    fun init(context: Context) {
+    @JvmOverloads
+    fun init(
+        context: Context,
+        apiKey: String? = null,
+        gatewayUrl: String? = null,
+        ingestUrl: String? = null,
+    ) {
         if (initialized) return
         synchronized(this) {
             if (initialized) return
             setBinding("kotlin")
             val cacheDir = File(context.filesDir, "xybrid/models")
             initSdkCacheDir(cacheDir.absolutePath)
+            configureRuntime(apiKey = apiKey, gatewayUrl = gatewayUrl, ingestUrl = ingestUrl)
             registerPlatformObservers(context.applicationContext)
             initialized = true
         }

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/uniffi/xybrid_uniffi/xybrid_uniffi.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/uniffi/xybrid_uniffi/xybrid_uniffi.kt
@@ -415,6 +415,8 @@ internal interface _UniFFILib : Library {
     ): Unit
     fun uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_configure_runtime(`apiKey`: RustBuffer.ByValue,`gatewayUrl`: RustBuffer.ByValue,`ingestUrl`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(`cacheDir`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
     fun uniffi_xybrid_uniffi_fn_func_set_battery_level(`percent`: Byte,_uniffi_out_err: RustCallStatus, 
@@ -541,6 +543,8 @@ internal interface _UniFFILib : Library {
     ): Short
     fun uniffi_xybrid_uniffi_checksum_func_clear_thermal_state(
     ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_configure_runtime(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(
     ): Short
     fun uniffi_xybrid_uniffi_checksum_func_set_battery_level(
@@ -592,6 +596,9 @@ private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_xybrid_uniffi_checksum_func_clear_thermal_state() != 36495.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_configure_runtime() != 13785.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -622,7 +629,7 @@ private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_xybrid_uniffi_checksum_method_xybridmodelloader_load() != 43654.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_bundle() != 7105.toShort()) {
+    if (lib.uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_bundle() != 38159.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_directory() != 8635.toShort()) {
@@ -1211,7 +1218,7 @@ class XybridModelLoader(
     companion object {
         fun `fromBundle`(`path`: String): XybridModelLoader =
             XybridModelLoader(
-    rustCall() { _status ->
+    rustCallWithError(XybridException) { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_constructor_xybridmodelloader_from_bundle(FfiConverterString.lower(`path`),_status)
 })
         fun `fromDirectory`(`path`: String): XybridModelLoader =
@@ -2354,6 +2361,14 @@ fun `clearThermalState`() =
     
     rustCall() { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_status)
+}
+
+
+
+fun `configureRuntime`(`apiKey`: String?, `gatewayUrl`: String?, `ingestUrl`: String?) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_configure_runtime(FfiConverterOptionalString.lower(`apiKey`),FfiConverterOptionalString.lower(`gatewayUrl`),FfiConverterOptionalString.lower(`ingestUrl`),_status)
 }
 
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/xybrid_uniffi.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/xybrid_uniffi.kt
@@ -415,6 +415,8 @@ internal interface _UniFFILib : Library {
     ): Unit
     fun uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_uniffi_out_err: RustCallStatus, 
     ): Unit
+    fun uniffi_xybrid_uniffi_fn_func_configure_runtime(`apiKey`: RustBuffer.ByValue,`gatewayUrl`: RustBuffer.ByValue,`ingestUrl`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
+    ): Unit
     fun uniffi_xybrid_uniffi_fn_func_init_sdk_cache_dir(`cacheDir`: RustBuffer.ByValue,_uniffi_out_err: RustCallStatus, 
     ): Unit
     fun uniffi_xybrid_uniffi_fn_func_set_battery_level(`percent`: Byte,_uniffi_out_err: RustCallStatus, 
@@ -541,6 +543,8 @@ internal interface _UniFFILib : Library {
     ): Short
     fun uniffi_xybrid_uniffi_checksum_func_clear_thermal_state(
     ): Short
+    fun uniffi_xybrid_uniffi_checksum_func_configure_runtime(
+    ): Short
     fun uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir(
     ): Short
     fun uniffi_xybrid_uniffi_checksum_func_set_battery_level(
@@ -592,6 +596,9 @@ private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_xybrid_uniffi_checksum_func_clear_thermal_state() != 36495.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_xybrid_uniffi_checksum_func_configure_runtime() != 13785.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_xybrid_uniffi_checksum_func_init_sdk_cache_dir() != 59754.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -622,7 +629,7 @@ private fun uniffiCheckApiChecksums(lib: _UniFFILib) {
     if (lib.uniffi_xybrid_uniffi_checksum_method_xybridmodelloader_load() != 43654.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_bundle() != 7105.toShort()) {
+    if (lib.uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_bundle() != 38159.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_xybrid_uniffi_checksum_constructor_xybridmodelloader_from_directory() != 8635.toShort()) {
@@ -1211,7 +1218,7 @@ class XybridModelLoader(
     companion object {
         fun `fromBundle`(`path`: String): XybridModelLoader =
             XybridModelLoader(
-    rustCall() { _status ->
+    rustCallWithError(XybridException) { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_constructor_xybridmodelloader_from_bundle(FfiConverterString.lower(`path`),_status)
 })
         fun `fromDirectory`(`path`: String): XybridModelLoader =
@@ -2354,6 +2361,14 @@ fun `clearThermalState`() =
     
     rustCall() { _status ->
     _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_clear_thermal_state(_status)
+}
+
+
+
+fun `configureRuntime`(`apiKey`: String?, `gatewayUrl`: String?, `ingestUrl`: String?) =
+    
+    rustCall() { _status ->
+    _UniFFILib.INSTANCE.uniffi_xybrid_uniffi_fn_func_configure_runtime(FfiConverterOptionalString.lower(`apiKey`),FfiConverterOptionalString.lower(`gatewayUrl`),FfiConverterOptionalString.lower(`ingestUrl`),_status)
 }
 
 

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -44,6 +44,16 @@ if (result.success) {
 
 `Xybrid.init(context)` also registers `BatteryManager` and (on API 29+) `PowerManager.OnThermalStatusChangedListener` observers, forwarding readings to the routing engine. See [Host Integration](/docs/internals/host-integration) for what's wired automatically and the override surface.
 
+## Initialization
+
+Inference runs entirely on-device whether or not you authenticate. Pass an `apiKey` to light up the [dashboard](https://dashboard.xybrid.dev) — that single call starts the telemetry exporter, and your `model.run(...)` calls automatically emit execution traces:
+
+```kotlin
+Xybrid.init(this, apiKey = BuildConfig.XYBRID_API_KEY)
+```
+
+Without a key, telemetry is disabled and the first inference logs a one-shot hint pointing at the dashboard (suppress with the `XYBRID_QUIET=1` environment variable). Get a free key at [dashboard.xybrid.dev](https://dashboard.xybrid.dev). For a self-hosted dashboard, also pass `ingestUrl`.
+
 ---
 
 ## Model Loading

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -35,6 +35,16 @@ if (result.success) {
 }
 ```
 
+## 初始化
+
+无论是否鉴权，推理都完全在本地运行。传入 `apiKey` 即可点亮[控制台](https://dashboard.xybrid.dev)——这一次调用会启动遥测导出器，你的 `model.run(...)` 调用便会自动上报执行轨迹：
+
+```kotlin
+Xybrid.init(this, apiKey = BuildConfig.XYBRID_API_KEY)
+```
+
+未提供密钥时，遥测处于禁用状态，首次推理会打印一条一次性提示指向控制台（可通过环境变量 `XYBRID_QUIET=1` 关闭）。在 [dashboard.xybrid.dev](https://dashboard.xybrid.dev) 免费获取密钥。若使用自托管控制台，请额外传入 `ingestUrl`。
+
 ---
 
 ## 模型加载

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -99,6 +99,10 @@ dependencies {
 ```kotlin
 import ai.xybrid.*
 
+// Runs locally as-is. Add a free key from dashboard.xybrid.dev to see
+// your inference traces: Xybrid.init(context, apiKey = "...")
+Xybrid.init(context)
+
 // Load a model from the registry
 val loader = XybridModelLoader.fromRegistry("kokoro-82m")
 val model = loader.load()

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -98,6 +98,10 @@ dependencies {
 import ai.xybrid.XybridModelLoader
 import ai.xybrid.XybridEnvelope
 
+// 默认即可本地运行。在 dashboard.xybrid.dev 免费获取密钥即可查看
+// 推理轨迹：Xybrid.init(context, apiKey = "...")
+Xybrid.init(context)
+
 // 从注册表加载模型
 val loader = XybridModelLoader.fromRegistry("kokoro-82m")
 val model = loader.load()

--- a/examples/android/app/src/main/java/ai/xybrid/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/ai/xybrid/example/MainActivity.kt
@@ -22,6 +22,8 @@ import ai.xybrid.example.ui.theme.XybridExampleTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Runs locally as-is. Add a free key from dashboard.xybrid.dev to see
+        // your inference traces: Xybrid.init(this, apiKey = "xy_live_...")
         Xybrid.init(this)
         setContent {
             XybridExampleTheme {


### PR DESCRIPTION
## Summary

Extends the Android `Xybrid.init(context)` with optional `apiKey` / `gatewayUrl` / `ingestUrl` params (with `@JvmOverloads` so existing Java `Xybrid.init(context)` calls keep working), delegating to the shared `configureRuntime` UniFFI export added in #196. Passing an `apiKey` starts the telemetry exporter; anonymous use runs fully on-device and the first inference nudges toward the dashboard — matching the Swift `initialize(apiKey:)` surface from #196 and the Rust builder from #188. Also documents it in the Android example, integration page, and Kotlin quickstart tab (EN + ZH). PR 4 of the init-clarification series.

Regenerating the Kotlin bindings (`cargo xtask generate-bindings --language kotlin`) also corrected pre-existing drift: `fromBundle` now routes through `rustCallWithError(XybridException)` to match the Rust `from_bundle -> Result` signature. The Kotlin public API is unchanged (exceptions are unchecked), so no caller breaks.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — no Rust change in this PR; the `configure_runtime` export landed in #196. Kotlin compiles in CI's `build-android` job (no local Android SDK).
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (Android page + quickstart, EN + ZH)
- [x] No breaking changes — `init(context)` preserved via `@JvmOverloads`; regenerated `fromBundle` keeps the same public signature