### PR TITLE
feat(unity): start telemetry from apiKey in XybridClient.Initialize()

### DIFF
--- a/bindings/unity/Runtime/Api/XybridClient.cs
+++ b/bindings/unity/Runtime/Api/XybridClient.cs
@@ -47,13 +47,25 @@ namespace Xybrid
         /// <summary>
         /// Initializes the Xybrid SDK.
         /// </summary>
+        /// <param name="apiKey">
+        /// Optional Xybrid API key. When provided, the platform telemetry exporter
+        /// starts automatically and your inference runs show up on the dashboard.
+        /// Omit it to run anonymously — inference still runs fully on-device, and
+        /// the first inference logs a one-shot hint pointing at the dashboard
+        /// (suppress with the <c>XYBRID_QUIET=1</c> environment variable). Get a
+        /// free key at https://dashboard.xybrid.dev.
+        /// </param>
+        /// <param name="ingestUrl">
+        /// Optional override for the telemetry ingest URL (for a self-hosted
+        /// dashboard). Ignored when <paramref name="apiKey"/> is null or blank.
+        /// </param>
         /// <remarks>
         /// This method should be called once at application startup, before using
         /// any other SDK features. It is safe to call multiple times - subsequent
-        /// calls are no-ops.
+        /// calls are no-ops, so configuration is applied on the first call only.
         /// </remarks>
         /// <exception cref="XybridException">Thrown if initialization fails.</exception>
-        public static unsafe void Initialize()
+        public static unsafe void Initialize(string apiKey = null, string ingestUrl = null)
         {
             lock (_lock)
             {
@@ -75,6 +87,23 @@ namespace Xybrid
                 }
 
                 _initialized = true;
+            }
+
+            // Fold telemetry into init: a non-blank API key starts the exporter,
+            // mirroring the Swift initialize(apiKey:) / Kotlin init(apiKey =)
+            // surfaces. The standalone InitializeTelemetry(TelemetryConfig) path
+            // remains available for advanced configuration (batch size, device
+            // attributes, flush interval). TelemetryConfig defaults the endpoint
+            // to the production ingest URL, so apiKey alone is enough.
+            if (!string.IsNullOrWhiteSpace(apiKey) && !_telemetryInitialized)
+            {
+                var config = new TelemetryConfig(apiKey);
+                if (!string.IsNullOrWhiteSpace(ingestUrl))
+                {
+                    config.WithEndpoint(ingestUrl);
+                }
+
+                InitializeTelemetry(config);
             }
         }
 
@@ -159,6 +188,12 @@ namespace Xybrid
         /// </exception>
         /// <exception cref="XybridException">Thrown if native telemetry initialization fails.</exception>
         /// <remarks>
+        /// Advanced entry point. For the common case, pass an <c>apiKey</c> to
+        /// <see cref="Initialize(string, string)"/> instead — that starts the
+        /// exporter as part of SDK init. Use this overload only when you need the
+        /// extra knobs on <see cref="TelemetryConfig"/> (batch size, flush
+        /// interval, device label/attributes); both paths share the same
+        /// process-wide once-guard.
         /// Thread-safe: serialized via the SDK's initialization lock. Call
         /// <see cref="ShutdownTelemetry"/> before re-initializing.
         /// </remarks>

--- a/bindings/unity/Runtime/Api/XybridClient.cs
+++ b/bindings/unity/Runtime/Api/XybridClient.cs
@@ -87,23 +87,31 @@ namespace Xybrid
                 }
 
                 _initialized = true;
-            }
 
-            // Fold telemetry into init: a non-blank API key starts the exporter,
-            // mirroring the Swift initialize(apiKey:) / Kotlin init(apiKey =)
-            // surfaces. The standalone InitializeTelemetry(TelemetryConfig) path
-            // remains available for advanced configuration (batch size, device
-            // attributes, flush interval). TelemetryConfig defaults the endpoint
-            // to the production ingest URL, so apiKey alone is enough.
-            if (!string.IsNullOrWhiteSpace(apiKey) && !_telemetryInitialized)
-            {
-                var config = new TelemetryConfig(apiKey);
-                if (!string.IsNullOrWhiteSpace(ingestUrl))
+                // Fold telemetry into init: a non-blank API key starts the
+                // exporter, mirroring the Swift initialize(apiKey:) / Kotlin
+                // init(apiKey =) surfaces. The standalone
+                // InitializeTelemetry(TelemetryConfig) path remains available for
+                // advanced configuration (batch size, device attributes, flush
+                // interval). TelemetryConfig defaults the endpoint to the
+                // production ingest URL, so apiKey alone is enough.
+                //
+                // Kept inside the lock so a concurrent caller that observes
+                // _initialized == true (and returns) is guaranteed the exporter
+                // is already running — and so the _telemetryInitialized read
+                // here has the same visibility as InitializeTelemetry's write.
+                // C# locks are reentrant, so InitializeTelemetry re-taking _lock
+                // is safe.
+                if (!string.IsNullOrWhiteSpace(apiKey) && !_telemetryInitialized)
                 {
-                    config.WithEndpoint(ingestUrl);
-                }
+                    var config = new TelemetryConfig(apiKey);
+                    if (!string.IsNullOrWhiteSpace(ingestUrl))
+                    {
+                        config.WithEndpoint(ingestUrl);
+                    }
 
-                InitializeTelemetry(config);
+                    InitializeTelemetry(config);
+                }
             }
         }
 

--- a/docs/content/docs/(integration)/sdks/unity.mdx
+++ b/docs/content/docs/(integration)/sdks/unity.mdx
@@ -32,6 +32,14 @@ void Awake()
 
 `Initialize()` is thread-safe and idempotent — multiple calls are no-ops.
 
+Inference runs entirely on-device whether or not you authenticate. Pass an `apiKey` to light up the [dashboard](https://dashboard.xybrid.dev) — that single call starts the telemetry exporter, and your `model.Run(...)` calls automatically emit execution traces:
+
+```csharp
+XybridClient.Initialize(apiKey: "xy_live_...");
+```
+
+Without a key, telemetry is disabled and the first inference logs a one-shot hint pointing at the dashboard (suppress with the `XYBRID_QUIET=1` environment variable). Get a free key at [dashboard.xybrid.dev](https://dashboard.xybrid.dev). For a self-hosted dashboard, also pass `ingestUrl`. For advanced telemetry settings (batch size, flush interval, device attributes), build a `TelemetryConfig` and call `XybridClient.InitializeTelemetry` instead.
+
 ## Quick Start
 
 ```csharp

--- a/docs/content/docs/(integration)/sdks/unity.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/unity.zh.mdx
@@ -32,6 +32,14 @@ void Awake()
 
 `Initialize()` 是线程安全且幂等的——多次调用无副作用。
 
+无论是否鉴权，推理都完全在本地运行。传入 `apiKey` 即可点亮[控制台](https://dashboard.xybrid.dev)——这一次调用会启动遥测导出器，你的 `model.Run(...)` 调用便会自动上报执行轨迹：
+
+```csharp
+XybridClient.Initialize(apiKey: "xy_live_...");
+```
+
+未提供密钥时，遥测处于禁用状态，首次推理会打印一条一次性提示指向控制台（可通过环境变量 `XYBRID_QUIET=1` 关闭）。在 [dashboard.xybrid.dev](https://dashboard.xybrid.dev) 免费获取密钥。若使用自托管控制台，请额外传入 `ingestUrl`。如需高级遥测设置（批大小、刷新间隔、设备属性），请构建 `TelemetryConfig` 并改用 `XybridClient.InitializeTelemetry`。
+
 ## 快速开始
 
 ```csharp

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -137,7 +137,8 @@ https://github.com/xybrid-ai/xybrid.git#upm/v0.1.0-beta5
 using Xybrid;
 using UnityEngine;
 
-// Initialize the SDK
+// Runs locally as-is. Add a free key from dashboard.xybrid.dev to see
+// your inference traces: XybridClient.Initialize(apiKey: "...")
 XybridClient.Initialize();
 
 // Load a TTS model and generate NPC dialogue

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -136,7 +136,8 @@ https://github.com/xybrid-ai/xybrid.git#upm/v0.1.0-beta5
 using Xybrid;
 using UnityEngine;
 
-// 初始化 SDK
+// 默认即可本地运行。在 dashboard.xybrid.dev 免费获取密钥即可查看
+// 推理轨迹：XybridClient.Initialize(apiKey: "...")
 XybridClient.Initialize();
 
 // 加载 TTS 模型并生成 NPC 对话

--- a/examples/unity/Telemetry/README.md
+++ b/examples/unity/Telemetry/README.md
@@ -4,6 +4,12 @@ A minimal Unity project demonstrating end-to-end Xybrid telemetry wiring,
 including the safe mobile pause/quit lifecycle required for production
 iOS and Android integrations.
 
+> For the common case you don't need any of this — just pass your key to
+> init: `XybridClient.Initialize(apiKey: "xy_live_...")`. This example covers
+> the **advanced** path (`TelemetryConfig` + `InitializeTelemetry`) for when
+> you need batch size, flush interval, or device attributes, plus explicit
+> flush/shutdown on the mobile lifecycle.
+
 ## What this example shows
 
 The scene has **one GameObject** with a single MonoBehaviour


### PR DESCRIPTION
## Summary

Folds telemetry startup into the Unity `XybridClient.Initialize()` with optional `apiKey` / `ingestUrl` params, matching the Swift `initialize(apiKey:)` (#196) and Kotlin `init(apiKey =)` (#201) surfaces. A non-blank `apiKey` builds a `TelemetryConfig` (which already defaults the endpoint to the production ingest URL) and starts the exporter; anonymous use runs fully on-device, and the first inference nudges toward the dashboard. The standalone `InitializeTelemetry(TelemetryConfig)` / `TelemetryConfig` builder stays available for advanced settings (batch size, flush interval, device attributes) and is now documented as the advanced path. Docs updated for the Unity integration page + quickstart (EN + ZH). PR 5 of the init-clarification series.

Unlike the other bindings, this needed **no native change**: Unity's C-ABI already had the full telemetry path, so `Initialize` just orchestrates existing P/Invoke calls. No `xybrid-ffi` edit, no cbindgen/csbindgen regeneration, so `NativeMethods.g.cs` and `xybrid.h` are untouched and the build-unity drift check is unaffected.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — no Rust change in this PR (pure C# orchestration of existing FFI). Unity C# compiles in CI's `build-unity` job (no local Unity toolchain).
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (Unity page + quickstart, EN + ZH; advanced example README points to the folded path)
- [x] No breaking changes — `Initialize()` with no args is unchanged; the new params are optional and default to anonymous