### PR TITLE
docs: align READMEs + reference docs with bundled init() telemetry

### DIFF
--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -41,6 +41,9 @@ import 'package:xybrid_flutter/xybrid_flutter.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Runs locally with no key. Pass an apiKey to light up the dashboard:
+  //   await Xybrid.init(apiKey: const String.fromEnvironment('XYBRID_API_KEY'));
   await Xybrid.init();
 
   // Load a TTS model from the registry
@@ -51,6 +54,11 @@ Future<void> main() async {
   print('Audio: ${result.audioBytes?.length} bytes');
 }
 ```
+
+Inference runs entirely on-device whether or not you authenticate. Without an
+`apiKey`, telemetry is disabled and the first inference logs a one-shot hint
+pointing at the dashboard (suppress with `XYBRID_QUIET=1`). Get a free key at
+[dashboard.xybrid.dev](https://dashboard.xybrid.dev).
 
 ## Features
 

--- a/bindings/flutter/example/example.md
+++ b/bindings/flutter/example/example.md
@@ -6,7 +6,9 @@
 import 'package:xybrid_flutter/xybrid_flutter.dart';
 
 Future<void> main() async {
-  // Initialize the SDK (call once at app startup)
+  // Initialize the SDK (call once at app startup). Runs locally with no
+  // key; pass an apiKey to light up the dashboard:
+  //   await Xybrid.init(apiKey: const String.fromEnvironment('XYBRID_API_KEY'));
   await Xybrid.init();
 
   // Load a TTS model from the registry

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -90,7 +90,8 @@ public class XybridExample : MonoBehaviour
 
     void Start()
     {
-        // Initialize the SDK
+        // Runs locally with no key. Pass an apiKey to light up the
+        // dashboard: XybridClient.Initialize(apiKey: "xy_live_...")
         XybridClient.Initialize();
 
         // Load a model from the registry

--- a/crates/xybrid-sdk/README.md
+++ b/crates/xybrid-sdk/README.md
@@ -6,6 +6,28 @@ Developer-facing API for hybrid cloud-edge AI inference with declarative routing
 
 The Xybrid SDK provides high-level abstractions and macros for building hybrid inference pipelines. It allows developers to annotate functions with `#[hybrid::route]` to enable automatic orchestrator-based routing between local and cloud execution.
 
+## Initialization
+
+Configure the SDK in one call with the `init()` builder. Inference runs
+on-device whether or not you authenticate; passing an API key starts the
+platform telemetry exporter so your runs show up on the dashboard.
+
+```rust
+// Anonymous — local inference, telemetry disabled
+xybrid_sdk::init().run();
+
+// Authenticated — telemetry exporter starts automatically
+xybrid_sdk::init()
+    .api_key("xy_live_...")
+    .run();
+```
+
+Without a key, the first inference logs a one-shot hint pointing at the
+dashboard (suppress with `XYBRID_QUIET=1`). Get a free key at
+<https://dashboard.xybrid.dev>. The builder also takes `.cache_dir(...)`,
+`.gateway_url(...)`, `.ingest_url(...)` (self-hosted dashboards), and
+`.resource_telemetry(...)`.
+
 ## Usage
 
 ### Basic Example
@@ -55,14 +77,19 @@ Future versions of the macro will:
 
 ## Telemetry
 
-The SDK includes built-in telemetry that can export events to the Xybrid Platform.
+The SDK includes built-in telemetry that exports events to the Xybrid Platform.
+For the common case you don't need anything here — just pass `.api_key(...)` to
+[`init()`](#initialization) and the exporter starts with sensible defaults
+(production ingest URL, batching, retry). The APIs below are the **advanced**
+path for callers that need explicit control over batching, device context, or
+the exporter lifecycle.
 
-### Configuration
+### Advanced configuration
 
 ```rust
 use xybrid_sdk::telemetry::{TelemetryConfig, HttpTelemetryExporter};
 
-// From environment variables (recommended)
+// From environment variables
 let exporter = HttpTelemetryExporter::from_env()?;
 
 // Manual configuration

--- a/docs/content/docs/internals/observability.mdx
+++ b/docs/content/docs/internals/observability.mdx
@@ -302,11 +302,14 @@ let telemetry = Telemetry::with_enabled(false);
 
 ### Initialize Early
 
+Pass your `apiKey` to `Xybrid.init()` at startup — that single call starts the
+platform telemetry exporter. Anonymous use (no key) runs locally with telemetry
+disabled.
+
 ```dart
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await RustLib.init();
-  initTelemetryStream();
+  await Xybrid.init(apiKey: const String.fromEnvironment('XYBRID_API_KEY'));
   runApp(MyApp());
 }
 ```

--- a/docs/content/docs/internals/observability.zh.mdx
+++ b/docs/content/docs/internals/observability.zh.mdx
@@ -294,11 +294,13 @@ let telemetry = Telemetry::with_enabled(false);
 
 ### 尽早初始化
 
+在启动时将 `apiKey` 传给 `Xybrid.init()`——这一次调用即可启动平台遥测导出器。
+匿名使用（不传密钥）则在本地运行且遥测处于禁用状态。
+
 ```dart
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await RustLib.init();
-  initTelemetryStream();
+  await Xybrid.init(apiKey: const String.fromEnvironment('XYBRID_API_KEY'));
   runApp(MyApp());
 }
 ```

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -24,7 +24,12 @@ classes:
           - { name: gatewayUrl, type: "String?" }
           - { name: ingestUrl, type: "String?" }
           - { name: resourceTelemetry, type: "String?" }
-        status: { dart: implemented, kotlin: implemented, swift: planned, csharp: implemented }
+        # apiKey-bundled init shipped across all four bindings: Dart
+        # Xybrid.init, Kotlin Xybrid.init(context, …), Swift
+        # Xybrid.initialize(apiKey:), Unity XybridClient.Initialize(apiKey:).
+        # Param coverage varies by binding (e.g. Unity omits gatewayUrl;
+        # resourceTelemetry is Dart/Rust only) — the apiKey path is universal.
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       setApiKey:
         params: [{ name: apiKey, type: String }]
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -4,7 +4,7 @@ A native iOS example app demonstrating Xybrid SDK integration using SwiftUI.
 
 ## Features
 
-- **SDK Initialization**: Cache directory setup via `initSdkCacheDir()`
+- **SDK Initialization**: Cache directory setup plus `Xybrid.initialize()` (pass an `apiKey` to enable dashboard telemetry)
 - **Model Loading**: Downloads models from the xybrid registry with async/await
 - **Text-to-Speech**: Run TTS inference with voice selection
 - **Audio Playback**: Play generated audio via AVAudioPlayer
@@ -80,6 +80,10 @@ import Xybrid
 let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
     .first!.appendingPathComponent("xybrid").path
 initSdkCacheDir(cacheDir: cacheDir)
+
+// Runs locally with no key. Pass an apiKey to light up the dashboard:
+//   Xybrid.initialize(apiKey: ProcessInfo.processInfo.environment["XYBRID_API_KEY"])
+Xybrid.initialize()
 ```
 
 ### Load Model

--- a/examples/unity/starter/README.md
+++ b/examples/unity/starter/README.md
@@ -114,6 +114,10 @@ public class XybridDemo : MonoBehaviour
 {
     async void Start()
     {
+        // Runs locally with no key. Pass an apiKey to light up the
+        // dashboard: XybridClient.Initialize(apiKey: "xy_live_...")
+        XybridClient.Initialize();
+
         // Load a model from the registry
         var loader = ModelLoader.FromRegistry("kokoro-82m");
         var model = loader.Load();


### PR DESCRIPTION
## Summary

Final docs sweep for the init-clarification series (#188 / #195 / #196 / #201 / #202). Earlier PRs updated the quickstart and per-SDK integration pages; this one catches the remaining hand-maintained docs so the `apiKey`-bundled init is the primary shown path everywhere, with the anonymous/local default and one-shot dashboard nudge framed consistently. Prose-only — no code changes.

- **`crates/xybrid-sdk/README.md`** — adds an Initialization section leading with the `init()` builder; reframes the `TelemetryConfig`/`HttpTelemetryExporter` section as the advanced path.
- **Flutter / Unity READMEs + `bindings/flutter/example/example.md`** — show the `apiKey` option and the anonymous default + `XYBRID_QUIET=1` nudge.
- **`examples/ios/README.md`, `examples/unity/starter/README.md`** — add the `Initialize()` call (the iOS README still documented only `initSdkCacheDir`).
- **`observability.mdx` (EN + ZH)** — replace the stale `initTelemetryStream()` pseudocode with `Xybrid.init(apiKey: ...)`.
- **`docs/sdk/api-surface.yaml`** — mark `Xybrid.init` as implemented on Swift now that `initialize(apiKey:)` shipped.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — N/A, documentation-only
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated — that's the whole PR
- [x] No breaking changes — `api-contract-check.sh` passes (`Xybrid.init — swift: found`; 11 warnings, no new ones; 0 errors; YAML valid)