### PR TITLE
refactor(sdk): dedup platform detection to a single cfg ladder

### DIFF
--- a/crates/xybrid-sdk/src/source.rs
+++ b/crates/xybrid-sdk/src/source.rs
@@ -304,42 +304,18 @@ impl ModelSource {
 }
 
 /// Detect the current platform for registry downloads.
+///
+/// Delegates to [`crate::platform::current_platform`] — the single source of
+/// truth for the `(target_os, target_arch)` → platform-string mapping.
+/// Previously this carried its own duplicate `#[cfg]` ladder, which risked
+/// drifting from `platform.rs`: this function feeds the registry download
+/// path (`RegistryClient::resolve`, `ModelLoader::load_from_legacy_registry`)
+/// while `platform::current_platform` feeds device telemetry, so a platform
+/// added to one ladder but not the other would make the registry request a
+/// different platform's bundle than the device reports — with no compile
+/// error. One ladder, no drift (audit slice 3c).
 pub fn detect_platform() -> String {
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    return "macos-arm64".to_string();
-
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    return "macos-x86_64".to_string();
-
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    return "linux-x86_64".to_string();
-
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    return "linux-arm64".to_string();
-
-    #[cfg(all(target_os = "ios", target_arch = "aarch64"))]
-    return "ios-arm64".to_string();
-
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
-    return "android-arm64".to_string();
-
-    #[cfg(all(target_os = "android", target_arch = "arm"))]
-    return "android-arm".to_string();
-
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    return "windows-x86_64".to_string();
-
-    #[cfg(not(any(
-        all(target_os = "macos", target_arch = "aarch64"),
-        all(target_os = "macos", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "x86_64"),
-        all(target_os = "linux", target_arch = "aarch64"),
-        all(target_os = "ios", target_arch = "aarch64"),
-        all(target_os = "android", target_arch = "aarch64"),
-        all(target_os = "android", target_arch = "arm"),
-        all(target_os = "windows", target_arch = "x86_64"),
-    )))]
-    return "unknown".to_string();
+    crate::platform::current_platform().to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Audit slice 3c. `source::detect_platform()` carried its own `#[cfg(target_os/target_arch)]` ladder that duplicated `platform::detect_platform()` — same combinations, same output strings.

The two fed **different subsystems**: `source::detect_platform` drives the registry download path (`RegistryClient::resolve`, `ModelLoader::load_from_legacy_registry`), while `platform::current_platform` drives device telemetry. That's a latent correctness-drift bug — add a new platform (e.g. `windows-arm64`) to one ladder but not the other, and the device reports one platform string while the registry requests a different platform's bundle, with no compile error.

## Fix

`source::detect_platform` now delegates to `crate::platform::current_platform().to_string()` — single source of truth. The public signature (`pub fn detect_platform() -> String`) is unchanged, so both call sites are untouched.

**No behaviour change** — the deleted ladder produced byte-identical strings to `current_platform()` for every `(os, arch)` combination (verified by reading both ladders during the audit). Net −24 lines.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p xybrid-sdk --all-targets -- -D warnings` clean
- [x] `cargo test -p xybrid-sdk --lib` source (11) + platform (4) — all pass