### PR TITLE
docs(example): read XYBRID_API_KEY in the Flutter example init

### DIFF
--- a/examples/flutter/lib/main.dart
+++ b/examples/flutter/lib/main.dart
@@ -65,7 +65,12 @@ class _SdkInitializationScreenState extends State<SdkInitializationScreen> {
   /// Initialize the Xybrid SDK.
   Future<void> _initializeSdk() async {
     try {
-      await Xybrid.init();
+      // Pass the key at compile time with
+      //   flutter run --dart-define=XYBRID_API_KEY=xy_live_...
+      // Unset resolves to "", which the SDK treats as anonymous (local only).
+      await Xybrid.init(
+        apiKey: const String.fromEnvironment('XYBRID_API_KEY'),
+      );
       if (mounted) {
         setState(() {
           _initState = _InitState.ready;


### PR DESCRIPTION
## Summary

Wires the Flutter example's `Xybrid.init()` to `const String.fromEnvironment('XYBRID_API_KEY')` so it can be run with telemetry via `flutter run --dart-define=XYBRID_API_KEY=...`. When the define is unset it resolves to `""`, which the SDK already treats as anonymous (local-only), so the default behavior is unchanged. This is a small follow-up to the init-clarification series (#188/#195/#196/#201/#202/#204) — the one example that still called bare `init()`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — N/A, Flutter example-only change (no Rust touched)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (example demonstrates the apiKey path)
- [x] No breaking changes — unset define resolves to "", treated as anonymous