### PR TITLE
fix(sdk): redact Xybrid's own api-key prefix in telemetry

### DIFF
--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1700,10 +1700,15 @@ fn redact_secret_like_token(token: &str) -> String {
         || trimmed.starts_with("gho_")
         || trimmed.starts_with("xoxb-")
         || trimmed.starts_with("xoxp-")
-        // Xybrid's own key prefix (`xy_live_`, `xy_test_`, …) — the secret
-        // most likely to appear in a *xybrid* error / gateway-auth failure
-        // string, and previously the one provider key this redactor missed.
-        || trimmed.starts_with("xy_")
+        // Xybrid's own key prefixes — the secret most likely to appear in a
+        // *xybrid* error / gateway-auth failure string, and previously the one
+        // provider key this redactor missed. Matched specifically (`xy_live_`
+        // / `xy_test_`, the only two formats used across the SDK docs and
+        // bindings) rather than a bare `xy_`, which would over-redact common
+        // identifiers like `xy_coords` / `xy_axis` and corrupt legitimate
+        // error messages.
+        || trimmed.starts_with("xy_live_")
+        || trimmed.starts_with("xy_test_")
     {
         token.replacen(trimmed, "[REDACTED]", 1)
     } else {
@@ -3288,8 +3293,8 @@ mod tests {
     #[test]
     fn telemetry_error_redaction_removes_xybrid_own_key() {
         // The Xybrid key is the secret most likely to appear in a xybrid
-        // gateway-auth error; the redactor must catch its `xy_` prefix just
-        // like every other provider's.
+        // gateway-auth error; the redactor must catch its `xy_live_` /
+        // `xy_test_` prefixes just like every other provider's.
         let redacted = redact_error_for_telemetry(
             "Gateway auth failed for key xy_live_abc123def and xy_test_secret456",
         );
@@ -3302,6 +3307,19 @@ mod tests {
             "redacted = {redacted}"
         );
         assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn telemetry_error_redaction_does_not_over_redact_xy_identifiers() {
+        // The Xybrid-key match is intentionally specific (`xy_live_` /
+        // `xy_test_`), not a bare `xy_` — common identifiers like
+        // `xy_coords` must survive so error messages stay debuggable.
+        let msg = "decode failed at xy_coords=(3,4), xy_axis=z, xy_plane unset";
+        let redacted = redact_error_for_telemetry(msg);
+        assert_eq!(
+            redacted, msg,
+            "non-key xy_ identifiers must not be redacted"
+        );
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -1700,6 +1700,10 @@ fn redact_secret_like_token(token: &str) -> String {
         || trimmed.starts_with("gho_")
         || trimmed.starts_with("xoxb-")
         || trimmed.starts_with("xoxp-")
+        // Xybrid's own key prefix (`xy_live_`, `xy_test_`, …) — the secret
+        // most likely to appear in a *xybrid* error / gateway-auth failure
+        // string, and previously the one provider key this redactor missed.
+        || trimmed.starts_with("xy_")
     {
         token.replacen(trimmed, "[REDACTED]", 1)
     } else {
@@ -3279,6 +3283,25 @@ mod tests {
         assert!(redacted.contains("api_key=[REDACTED]"));
         assert!(!redacted.contains("sk_test_abc123"));
         assert!(!redacted.contains("hf_secret_xyz"));
+    }
+
+    #[test]
+    fn telemetry_error_redaction_removes_xybrid_own_key() {
+        // The Xybrid key is the secret most likely to appear in a xybrid
+        // gateway-auth error; the redactor must catch its `xy_` prefix just
+        // like every other provider's.
+        let redacted = redact_error_for_telemetry(
+            "Gateway auth failed for key xy_live_abc123def and xy_test_secret456",
+        );
+        assert!(
+            !redacted.contains("xy_live_abc123def"),
+            "redacted = {redacted}"
+        );
+        assert!(
+            !redacted.contains("xy_test_secret456"),
+            "redacted = {redacted}"
+        );
+        assert!(redacted.contains("[REDACTED]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Audit slice 3f. `redact_secret_like_token` redacted tokens prefixed `sk_` / `sk-` / `hf_` / `ghp_` / `gho_` / `xoxb-` / `xoxp-` (OpenAI, HuggingFace, GitHub, Slack) but **missed Xybrid's own key prefix `xy_`** (`xy_live_`, `xy_test_`, …).

That's the gap that matters most: the secret most likely to appear in a *xybrid* error or gateway-auth failure string is the *Xybrid* API key itself — and it was the single provider key this redactor didn't cover, so a 401 that echoed the key would ship it to the telemetry backend in cleartext.

## Fix

Adds `"xy_"` to the prefix list. **Purely additive** — it can only redact more, never less. The redactor already runs at the right boundaries (`redact_error_for_telemetry` on cloud-retry error strings and policy-deny reasons); this closes the coverage hole.

## Test plan

- [x] `cargo test -p xybrid-sdk --lib` redaction — **2 passed** (+1 new `telemetry_error_redaction_removes_xybrid_own_key`)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p xybrid-sdk --all-targets -- -D warnings` clean

## Related (not in this PR)

3f surfaced two larger findings tracked for follow-up: `init_platform_telemetry` is non-idempotent (the SDK-side root of FFI audit theme 7b — the binding `TELEMETRY_INITIALIZED` gates are workarounds for it), and the env-secrets `XYBRID_API_KEY` read sites are now fully mapped (this file lines 462 + 1898, plus `lib.rs`) so the 3b move-secrets-out-of-env fix is ready to scope.