### PR TITLE
refactor(sdk): share one blocking body across pipeline run/run_async

### DIFF
--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -1149,140 +1149,14 @@ impl Pipeline {
             self.load_models()?;
         }
 
-        let handle = self
-            .handle
-            .read()
-            .map_err(|_| SdkError::PipelineError("Failed to acquire pipeline lock".to_string()))?;
-
-        // Clone stage descriptors and set bundle_path on each
-        let mut stage_descriptors = handle.stage_descriptors.clone();
-        for desc in &mut stage_descriptors {
-            if let Some(bundle_path) = handle.bundle_paths.get(&desc.name) {
-                desc.bundle_path = Some(bundle_path.to_string_lossy().to_string());
-            }
-        }
-        let availability_map: HashMap<String, bool> = stage_descriptors
-            .iter()
-            .map(|stage| (stage.name.clone(), stage.is_locally_runnable()))
-            .collect();
-        drop(handle);
-
-        // Collect runtime metrics from caller options when provided.
-        let metrics = pipeline_metrics(options);
-
-        // Install per-call pipeline context. The RAII guard clears on
-        // every exit (success, `?` error, panic) so we don't leak the
-        // global `trace_id` onto later unrelated telemetry — replaces
-        // the manual `set_telemetry_pipeline_context(None, None)` calls
-        // that previously had to be threaded through every exit.
-        let trace_id = uuid::Uuid::new_v4();
-        let pipeline_id = self
-            .name
-            .as_ref()
-            .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
-        let _context_guard =
-            crate::telemetry::TelemetryPipelineContextGuard::install(pipeline_id, Some(trace_id));
-
-        let mut orchestrator = Orchestrator::new();
-        // Subscribe after construction: bootstrap events emitted by
-        // `Orchestrator::new()` are constructor-local, while execution events
-        // below must be drained before this short-lived orchestrator returns.
-        let bridge = crate::telemetry::bridge_orchestrator_events(&orchestrator);
-        // No need to set registry config - executor uses bundle_path from stage descriptors
-
-        let availability_fn = move |stage: &str| -> LocalAvailability {
-            let exists = availability_map.get(stage).copied().unwrap_or(false);
-            LocalAvailability::new(exists)
-        };
-
-        let start_time = std::time::Instant::now();
-        let resource_guard = crate::telemetry::begin_resource_run();
-        let execution_result =
-            orchestrator.execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn);
-        drop(orchestrator);
-        bridge.join().map_err(|e| {
-            SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e))
-        })?;
-        let results: Vec<StageExecutionResult> = execution_result
-            .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
-        let total_latency_ms = start_time.elapsed().as_millis() as u32;
-
-        let stages: Vec<StageTiming> = results
-            .iter()
-            .map(|result| StageTiming {
-                name: result.stage.clone(),
-                latency_ms: result.latency_ms,
-                target: result.routing_decision.target.to_string(),
-                reason: result.routing_decision.reason.clone(),
-            })
-            .collect();
-
-        let (output_type, output) = if let Some(last) = results.last() {
-            let output_type = match &last.output.kind {
-                EnvelopeKind::Text(_) => OutputType::Text,
-                EnvelopeKind::Audio(_) => OutputType::Audio,
-                EnvelopeKind::Embedding(_) => OutputType::Embedding,
-            };
-            (output_type, last.output.clone())
-        } else {
-            (
-                OutputType::Unknown,
-                Envelope::new(EnvelopeKind::Text(String::new())),
-            )
-        };
-
-        // Emit telemetry event. LLM metrics ride on the separate
-        // `PlatformEvent.stages[].spans[].metadata` path (populated
-        // via `xybrid_core::tracing::add_metadata` in the LLM
-        // adapter), so we intentionally keep this `data` blob compact
-        // — only the fields that already crossed the wire before
-        // llm_metrics existed.
-        // For single-stage pipelines, attribute the `PipelineComplete`
-        // row to the inner stage so the Traces dashboard reads
-        // `pipeline / <stage>` (with a real `target`) instead of the
-        // less-informative `pipeline / <pipeline-name>` with `target:
-        // None`. Multi-stage pipelines keep the pipeline-level naming
-        // so ASR → LLM → TTS legs still collapse under one row via the
-        // shared `trace_id`.
-        let (event_stage_name, event_target) = if results.len() == 1 {
-            let only = &results[0];
-            (
-                Some(only.stage.clone()),
-                Some(only.routing_decision.target.to_string()),
-            )
-        } else {
-            (self.name.clone(), None)
-        };
-        let event = crate::telemetry::TelemetryEvent {
-            event_type: "PipelineComplete".to_string(),
-            stage_name: event_stage_name,
-            target: event_target,
-            latency_ms: Some(total_latency_ms),
-            error: None,
-            data: Some(pipeline_complete_data(
-                &stages,
-                &output_type,
-                options.correlation_id.as_deref(),
-            )),
-            timestamp_ms: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0),
-        };
-        crate::telemetry::publish_with_resource_summary_in_context(
-            event,
-            resource_guard,
-            pipeline_id,
-            Some(trace_id),
-        );
-
-        Ok(PipelineExecutionResult {
-            name: self.name.clone(),
-            stages,
-            total_latency_ms,
-            output_type,
-            output,
-        })
+        let (stage_descriptors, availability_map) = self.resolve_run_inputs();
+        execute_blocking(
+            self.name.clone(),
+            stage_descriptors,
+            availability_map,
+            envelope,
+            options,
+        )
     }
 
     /// Run inference asynchronously.
@@ -1297,153 +1171,186 @@ impl Pipeline {
         envelope: &Envelope,
         options: &RunOptions,
     ) -> PipelineResult<PipelineExecutionResult> {
-        if !self.is_ready() {
-            self.load_models()?;
-        }
-
-        let (stage_descriptors, availability_map) = {
-            // Recover from poisoned RwLock to prevent permanent lock errors
-            let handle = self.handle.read().unwrap_or_else(|e| e.into_inner());
-
-            // Clone stage descriptors and set bundle_path on each
-            let mut descriptors = handle.stage_descriptors.clone();
-            for desc in &mut descriptors {
-                if let Some(bundle_path) = handle.bundle_paths.get(&desc.name) {
-                    desc.bundle_path = Some(bundle_path.to_string_lossy().to_string());
-                }
-            }
-
-            let availability_map: HashMap<String, bool> = descriptors
-                .iter()
-                .map(|stage| (stage.name.clone(), stage.is_locally_runnable()))
-                .collect();
-
-            (descriptors, availability_map)
-        };
-
-        let envelope_clone = envelope.clone();
-        let name = self.name.clone();
+        // `Pipeline` shares its handle via `Arc`, so a clone is a cheap
+        // `'static + Send` handle we can move into `spawn_blocking`. Running
+        // the *whole* operation — preload (a synchronous model download) and
+        // orchestration — on the blocking pool keeps both off the async
+        // executor; previously the download ran inline on the runtime worker.
+        let pipeline = self.clone();
+        let envelope = envelope.clone();
         let options = options.clone();
 
         tokio::task::spawn_blocking(move || {
-            // Collect runtime metrics from caller options when provided.
-            let metrics = pipeline_metrics(&options);
-
-            // RAII pipeline context — see sync `run` for rationale.
-            // Drops on every exit path (success, `?` error, panic) and
-            // replaces the manual `set_telemetry_pipeline_context(None, None)`
-            // cleanup the previous shape needed at every branch.
-            let trace_id = uuid::Uuid::new_v4();
-            let pipeline_id = name
-                .as_ref()
-                .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
-            let _context_guard = crate::telemetry::TelemetryPipelineContextGuard::install(
-                pipeline_id,
-                Some(trace_id),
-            );
-
-            let mut orchestrator = Orchestrator::new();
-            // Subscribe after construction; see the sync path above.
-            let bridge = crate::telemetry::bridge_orchestrator_events(&orchestrator);
-            // No need to set registry config - executor uses bundle_path from stage descriptors
-
-            let availability_fn = move |stage: &str| -> LocalAvailability {
-                let exists = availability_map.get(stage).copied().unwrap_or(false);
-                LocalAvailability::new(exists)
-            };
-
-            let start_time = std::time::Instant::now();
-            let resource_guard = crate::telemetry::begin_resource_run();
-            let execution_result = orchestrator.execute_pipeline(
-                &stage_descriptors,
-                &envelope_clone,
-                &metrics,
-                &availability_fn,
-            );
-            drop(orchestrator);
-            bridge.join().map_err(|e| {
-                SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e))
-            })?;
-            let results: Vec<StageExecutionResult> = execution_result.map_err(|e| {
-                SdkError::PipelineError(format!("Pipeline execution failed: {}", e))
-            })?;
-            let total_latency_ms = start_time.elapsed().as_millis() as u32;
-
-            let stages: Vec<StageTiming> = results
-                .iter()
-                .map(|result| StageTiming {
-                    name: result.stage.clone(),
-                    latency_ms: result.latency_ms,
-                    target: result.routing_decision.target.to_string(),
-                    reason: result.routing_decision.reason.clone(),
-                })
-                .collect();
-
-            let (output_type, output) = if let Some(last) = results.last() {
-                let output_type = match &last.output.kind {
-                    EnvelopeKind::Text(_) => OutputType::Text,
-                    EnvelopeKind::Audio(_) => OutputType::Audio,
-                    EnvelopeKind::Embedding(_) => OutputType::Embedding,
-                };
-                (output_type, last.output.clone())
-            } else {
-                (
-                    OutputType::Unknown,
-                    Envelope::new(EnvelopeKind::Text(String::new())),
-                )
-            };
-
-            // Emit PipelineComplete telemetry event. Previously absent from
-            // this async path (existed only in sync `run`); attaching now
-            // brings the two paths to parity. LLM metrics ride on span
-            // metadata (see the sync arm above for rationale), so this
-            // `data` blob stays compact.
-            // Single-stage pipelines attribute the row to the inner
-            // stage so the Traces dashboard reads `pipeline / <stage>`
-            // with a real `target`; see sync `run` above.
-            let (event_stage_name, event_target) = if results.len() == 1 {
-                let only = &results[0];
-                (
-                    Some(only.stage.clone()),
-                    Some(only.routing_decision.target.to_string()),
-                )
-            } else {
-                (name.clone(), None)
-            };
-            let event = crate::telemetry::TelemetryEvent {
-                event_type: "PipelineComplete".to_string(),
-                stage_name: event_stage_name,
-                target: event_target,
-                latency_ms: Some(total_latency_ms),
-                error: None,
-                data: Some(pipeline_complete_data(
-                    &stages,
-                    &output_type,
-                    options.correlation_id.as_deref(),
-                )),
-                timestamp_ms: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as u64)
-                    .unwrap_or(0),
-            };
-            crate::telemetry::publish_with_resource_summary_in_context(
-                event,
-                resource_guard,
-                pipeline_id,
-                Some(trace_id),
-            );
-
-            Ok(PipelineExecutionResult {
-                name,
-                stages,
-                total_latency_ms,
-                output_type,
-                output,
-            })
+            if !pipeline.is_ready() {
+                pipeline.load_models()?;
+            }
+            let (stage_descriptors, availability_map) = pipeline.resolve_run_inputs();
+            execute_blocking(
+                pipeline.name.clone(),
+                stage_descriptors,
+                availability_map,
+                &envelope,
+                &options,
+            )
         })
         .await
         .map_err(|e| SdkError::PipelineError(format!("Task join error: {}", e)))?
     }
+
+    /// Snapshot the stage descriptors (with bundle paths applied) and the
+    /// local-availability map from the current handle.
+    ///
+    /// Recovers from a poisoned lock (`into_inner`) rather than failing the
+    /// run, matching the write-path convention elsewhere in this module and
+    /// keeping the sync/async `run` paths consistent.
+    fn resolve_run_inputs(&self) -> (Vec<StageDescriptor>, HashMap<String, bool>) {
+        let handle = self.handle.read().unwrap_or_else(|e| e.into_inner());
+
+        // Clone stage descriptors and set bundle_path on each
+        let mut stage_descriptors = handle.stage_descriptors.clone();
+        for desc in &mut stage_descriptors {
+            if let Some(bundle_path) = handle.bundle_paths.get(&desc.name) {
+                desc.bundle_path = Some(bundle_path.to_string_lossy().to_string());
+            }
+        }
+
+        let availability_map: HashMap<String, bool> = stage_descriptors
+            .iter()
+            .map(|stage| (stage.name.clone(), stage.is_locally_runnable()))
+            .collect();
+
+        (stage_descriptors, availability_map)
+    }
+}
+
+/// Run the orchestrator on already-resolved stage descriptors and emit the
+/// `PipelineComplete` telemetry event.
+///
+/// Blocking: drives the full pipeline synchronously. Shared by sync
+/// `run_with_options` and the `spawn_blocking` body of
+/// `run_async_with_options` so the two paths can't drift — the async path
+/// previously had its own copy that, at one point, omitted the
+/// `PipelineComplete` event entirely.
+fn execute_blocking(
+    name: Option<String>,
+    stage_descriptors: Vec<StageDescriptor>,
+    availability_map: HashMap<String, bool>,
+    envelope: &Envelope,
+    options: &RunOptions,
+) -> PipelineResult<PipelineExecutionResult> {
+    // Collect runtime metrics from caller options when provided.
+    let metrics = pipeline_metrics(options);
+
+    // Install per-call pipeline context. The RAII guard clears on every exit
+    // (success, `?` error, panic) so we don't leak the global `trace_id` onto
+    // later unrelated telemetry — replaces the manual
+    // `set_telemetry_pipeline_context(None, None)` calls that previously had
+    // to be threaded through every exit.
+    let trace_id = uuid::Uuid::new_v4();
+    let pipeline_id = name
+        .as_ref()
+        .map(|n| uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, n.as_bytes()));
+    let _context_guard =
+        crate::telemetry::TelemetryPipelineContextGuard::install(pipeline_id, Some(trace_id));
+
+    let mut orchestrator = Orchestrator::new();
+    // Subscribe after construction: bootstrap events emitted by
+    // `Orchestrator::new()` are constructor-local, while execution events
+    // below must be drained before this short-lived orchestrator returns.
+    let bridge = crate::telemetry::bridge_orchestrator_events(&orchestrator);
+    // No need to set registry config - executor uses bundle_path from stage descriptors
+
+    let availability_fn = move |stage: &str| -> LocalAvailability {
+        let exists = availability_map.get(stage).copied().unwrap_or(false);
+        LocalAvailability::new(exists)
+    };
+
+    let start_time = std::time::Instant::now();
+    let resource_guard = crate::telemetry::begin_resource_run();
+    let execution_result =
+        orchestrator.execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn);
+    drop(orchestrator);
+    bridge
+        .join()
+        .map_err(|e| SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e)))?;
+    let results: Vec<StageExecutionResult> = execution_result
+        .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
+    let total_latency_ms = start_time.elapsed().as_millis() as u32;
+
+    let stages: Vec<StageTiming> = results
+        .iter()
+        .map(|result| StageTiming {
+            name: result.stage.clone(),
+            latency_ms: result.latency_ms,
+            target: result.routing_decision.target.to_string(),
+            reason: result.routing_decision.reason.clone(),
+        })
+        .collect();
+
+    let (output_type, output) = if let Some(last) = results.last() {
+        let output_type = match &last.output.kind {
+            EnvelopeKind::Text(_) => OutputType::Text,
+            EnvelopeKind::Audio(_) => OutputType::Audio,
+            EnvelopeKind::Embedding(_) => OutputType::Embedding,
+        };
+        (output_type, last.output.clone())
+    } else {
+        (
+            OutputType::Unknown,
+            Envelope::new(EnvelopeKind::Text(String::new())),
+        )
+    };
+
+    // Emit telemetry event. LLM metrics ride on the separate
+    // `PlatformEvent.stages[].spans[].metadata` path (populated via
+    // `xybrid_core::tracing::add_metadata` in the LLM adapter), so we
+    // intentionally keep this `data` blob compact — only the fields that
+    // already crossed the wire before llm_metrics existed.
+    // For single-stage pipelines, attribute the `PipelineComplete` row to the
+    // inner stage so the Traces dashboard reads `pipeline / <stage>` (with a
+    // real `target`) instead of the less-informative
+    // `pipeline / <pipeline-name>` with `target: None`. Multi-stage pipelines
+    // keep the pipeline-level naming so ASR → LLM → TTS legs still collapse
+    // under one row via the shared `trace_id`.
+    let (event_stage_name, event_target) = if results.len() == 1 {
+        let only = &results[0];
+        (
+            Some(only.stage.clone()),
+            Some(only.routing_decision.target.to_string()),
+        )
+    } else {
+        (name.clone(), None)
+    };
+    let event = crate::telemetry::TelemetryEvent {
+        event_type: "PipelineComplete".to_string(),
+        stage_name: event_stage_name,
+        target: event_target,
+        latency_ms: Some(total_latency_ms),
+        error: None,
+        data: Some(pipeline_complete_data(
+            &stages,
+            &output_type,
+            options.correlation_id.as_deref(),
+        )),
+        timestamp_ms: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+    };
+    crate::telemetry::publish_with_resource_summary_in_context(
+        event,
+        resource_guard,
+        pipeline_id,
+        Some(trace_id),
+    );
+
+    Ok(PipelineExecutionResult {
+        name,
+        stages,
+        total_latency_ms,
+        output_type,
+        output,
+    })
 }
 
 // Make Pipeline cloneable (shares the handle via Arc)

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -1186,7 +1186,7 @@ impl Pipeline {
             }
             let (stage_descriptors, availability_map) = pipeline.resolve_run_inputs();
             execute_blocking(
-                pipeline.name.clone(),
+                pipeline.name,
                 stage_descriptors,
                 availability_map,
                 &envelope,
@@ -1270,11 +1270,14 @@ fn execute_blocking(
     let execution_result =
         orchestrator.execute_pipeline(&stage_descriptors, envelope, &metrics, &availability_fn);
     drop(orchestrator);
-    bridge
-        .join()
-        .map_err(|e| SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e)))?;
+    // Join the event bridge unconditionally so its thread never leaks, but
+    // surface the *execution* error first when both fail — the pipeline
+    // failure is the root cause; a bridge-join failure is secondary noise.
+    let bridge_res = bridge.join();
     let results: Vec<StageExecutionResult> = execution_result
         .map_err(|e| SdkError::PipelineError(format!("Pipeline execution failed: {}", e)))?;
+    bridge_res
+        .map_err(|e| SdkError::PipelineError(format!("Orchestrator event bridge failed: {}", e)))?;
     let total_latency_ms = start_time.elapsed().as_millis() as u32;
 
     let stages: Vec<StageTiming> = results


### PR DESCRIPTION
## What

`Pipeline::run_async_with_options` ran the synchronous **preload** — a network model download via `load_models()` — *inline on the Tokio worker thread*, before the `spawn_blocking` that guarded the orchestration. On a cold cache the entire download blocked the async executor (`async-spawn-blocking` / `M-YIELD-POINTS` violation).

This PR clones the `Pipeline` (it shares its handle via `Arc`, so the clone is a cheap `'static + Send` handle) and moves the **whole** operation — preload **and** orchestration — into `spawn_blocking`, keeping all blocking work off the runtime worker.

While there, the sync and async run paths carried ~110 lines of duplicated orchestration + `PipelineComplete`-telemetry logic. That duplication had **already drifted once** — the async copy briefly emitted no completion event (its own comment notes it). Extracted the shared body into a private `execute_blocking` free fn plus a `resolve_run_inputs` helper, so both paths call one implementation.

`resolve_run_inputs` recovers from a poisoned handle (`into_inner`), matching the write paths in the same module and aligning the previously inconsistent **sync (errors on poison) vs async (recovers)** lock handling.

## Why

- **High:** async run no longer blocks the executor on cold-cache downloads.
- **Medium:** removes the duplicated run body that already caused a telemetry-drift bug.
- **Medium:** consistent lock-poison policy across sync/async run.

## Scope / non-goals

Public signatures unchanged. The broader stringly-typed `StageTarget` parsing and the `to_str().unwrap_or("")` path nits (audit 3d, low) are left for their own pass.

## Testing

- `cargo test -p xybrid-sdk --features ort-download` — 349 lib + 86 doctests pass
- `cargo clippy -p xybrid-sdk --all-targets --features ort-download -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Net −93 lines.