### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.1] - 2026-05-30
+
+First patch on the 0.1.0 line. Headline is the new `Xybrid.init()` entry point —
+anonymous-by-default telemetry wired up uniformly across every binding — plus a
+round of FFI soundness/safety hardening across the C ABI.
+
+### Added
+
+- **`Xybrid.init()` builder with anonymous-by-default telemetry** (#188): a single
+  SDK entry point that starts telemetry from an API key, anonymous unless configured
+  otherwise. Brought to every binding in lockstep: Swift `Xybrid.initialize()` (#196),
+  Kotlin `Xybrid.init()` (#201), Unity `XybridClient.Initialize()` (#202), and the
+  Flutter bundled `init()` (#195, which also marks the old `initTelemetry` legacy).
+- **Error retryability across bindings**: inherent `SdkError::is_retryable` /
+  `retry_after` (#198), surfaced to Swift and Kotlin through UniFFI (#200).
+- **Typed `XybridOutputType` enum** for the result output kind in the C FFI (#194).
+- **Telemetry stamps `sdk_version` and `binding`** on every `PlatformEvent` (#183),
+  so events are attributable to the SDK build and language binding that emitted them.
+
+### Changed
+
+- **SDK**: one shared blocking body backs pipeline `run` / `run_async` (#210);
+  platform detection deduplicated to a single `cfg` ladder (#206).
+- **FFI**: handle-lifecycle helpers consolidated behind a macro (#192).
+- **Docs**: READMEs and reference docs aligned with the bundled `init()` telemetry
+  (#204); the Flutter example reads `XYBRID_API_KEY` at init (#207); SAFETY comments
+  added to every `llama_cpp` unsafe block and impl (#191).
+- **CI**: workflow token permissions scoped to least privilege (#211); native build
+  workflows skipped on markdown-only changes (#208); docs deploy only when `docs/`
+  changes (#186); apple release-prep jobs parallelized, NDK cached (#184); verify-release
+  SPM + Flutter version parsing tightened (#182).
+
+### Fixed
+
+- **Redact Xybrid's own api-key prefix in telemetry** (#209): the SDK no longer leaks
+  the leading bytes of its own key into emitted events.
+- **Cache TTL clock handling is now panic-safe** (#203): a backwards clock no longer
+  panics the cache layer.
+- **FFI soundness and panic-safety**:
+  - removed the unsound `unsafe impl Sync` from `StreamCallbackCtx` (#187);
+  - every `extern "C"` body now guards against panics unwinding across the C ABI (#185);
+  - accessor strings are cached in handle state to fix a use-after-free contract (#189).
+
+### Known issues
+
+- **iOS Simulator slice still missing from the published xcframework**
+  ([#179](https://github.com/xybrid-ai/xybrid/issues/179)): unchanged from 0.1.0.
+  Swift consumers building against the iOS Simulator on Apple Silicon still need the
+  `useLocalNatives = true` workaround after vendoring the ORT iOS simulator slice.
+
+### Consumer install lines
+
+```swift
+// Swift Package Manager
+.package(url: "https://github.com/xybrid-ai/xybrid", from: "0.1.1")
+```
+
+```yaml
+# Flutter / pub.dev
+xybrid_flutter: ^0.1.1
+```
+
+---
+
 ## [0.1.0] - 2026-05-27
 
 Production release of the 0.1.0 line. No code changes since rc4 — this release closes the rc series and finalizes the release toolchain that was iterated through rc1 → rc4.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2609,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2635,7 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
  "tokio",
@@ -2664,7 +2664,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2684,12 +2684,12 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3388,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -4644,7 +4644,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -5030,9 +5030,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5101,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5563,7 +5563,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5810,9 +5810,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -6159,9 +6159,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6943,7 +6943,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -6958,14 +6958,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6992,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -7056,7 +7056,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -7067,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7076,7 +7076,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-uniffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde_json",
  "thiserror 1.0.69",
@@ -7112,7 +7112,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",
@@ -7181,18 +7181,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.1.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "3b80b834cafcf134fa6a22dbc889c51bca107b85964466be5416d7d5b6b42043"
+let xybridFFIChecksum = "a22fe3e6f4bf19ad1113c9b63e7fc78a6e754dbe68a1b9605055a43a0322d62b"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.1.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "a22fe3e6f4bf19ad1113c9b63e7fc78a6e754dbe68a1b9605055a43a0322d62b"
+let xybridFFIChecksum = "ca6fd9ae0a17538335ef683d24a761dadf22a0dcf7c9ef972795cf268453ffac"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.1.0"
+let sdkVersion = "0.1.1"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.1
+
+* New bundled `init()` entry point starts anonymous-by-default telemetry from an API key; the standalone `initTelemetry` is now legacy (xybrid-ai/xybrid#188, #195)
+* `PlatformEvent` payloads now carry `sdk_version` and `binding`, so telemetry is attributable to the SDK build and the Flutter binding that emitted it (xybrid-ai/xybrid#183)
+* Fixed: the SDK no longer leaks the leading bytes of its own API key into emitted telemetry (xybrid-ai/xybrid#209)
+* Fixed: cache TTL handling is panic-safe — a backwards system clock no longer panics the cache layer (xybrid-ai/xybrid#203)
+* Example app now reads `XYBRID_API_KEY` from the environment at init (xybrid-ai/xybrid#207)
+
 ## 0.1.0
 
 Production release of the 0.1.0 line. No Flutter-binding code changes since rc4 — closes the rc series.

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.1.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.1.1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.1.0"
+version = "0.1.1"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary

Prepares the **0.1.1** patch release. Bumps the workspace version to `0.1.1` across every package manifest (Cargo workspace, Flutter `pubspec.yaml` + hardcoded rust crate, Unity `package.json`, Kotlin `build.gradle.kts`, Swift `sdkVersion`) plus `Cargo.lock`, and adds the `0.1.1` CHANGELOG entries to both the root and Flutter-binding changelogs — covering the new `Xybrid.init()` anonymous-by-default telemetry builder wired across all bindings, the FFI soundness/panic-safety hardening, and the telemetry api-key redaction + panic-safe cache TTL fixes. `Package.swift`'s `xybridFFIChecksum` is pinned to the freshly built xcframework (auto-committed by `release-prep`). Merging this PR triggers `release-publish.yml` to tag `v0.1.1`, publish the draft release, and push to crates.io / pub.dev / Maven Central.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (release: version bump + changelog for 0.1.1)

## Checklist

- [x] Tests pass (`cargo test`) — green on master at the release commit; release-prep build matrix passing
- [x] Code follows project style
- [x] Documentation updated (CHANGELOG.md + Flutter CHANGELOG.md)
- [x] No breaking changes (patch release; additive only)