### PR TITLE
docs(examples): inject apiKey + ingestUrl via platform-native env vars

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -49,7 +49,37 @@ Or build from the command line:
 ./gradlew assembleDebug
 ```
 
-### 3. Obtain Model Files
+### 3. Set your API key (optional)
+
+The app reads `XYBRID_API_KEY` (and optionally `XYBRID_PLATFORM_URL`, the
+telemetry ingest endpoint) through `BuildConfig`, wired in
+`app/build.gradle.kts` from one of three sources (first one wins) — so neither
+lands in the repo:
+
+| Source | Best for | How |
+|--------|----------|-----|
+| `local.properties` | Android Studio (just press Run) | `xybrid.apiKey=sk_test_...` / `xybrid.platformUrl=https://...` |
+| Gradle property | one-liner / CI | `-PXYBRID_API_KEY=sk_test_...` / `-PXYBRID_PLATFORM_URL=https://...` |
+| Env variable | shells / CI | `export XYBRID_API_KEY=sk_test_...` / `export XYBRID_PLATFORM_URL=https://...` |
+
+The Gradle-property form is the Android analog of Flutter's
+`flutter run --dart-define=...`:
+
+```bash
+./gradlew installDebug \
+  -PXYBRID_API_KEY=sk_test_... \
+  -PXYBRID_PLATFORM_URL=https://your-platform.example.com
+```
+
+For Android Studio, copy
+[`local.properties.example`](local.properties.example) to `local.properties`
+(already gitignored) and fill in your values. Both are optional: without a key
+the app runs anonymously (on-device inference, telemetry disabled); without a
+platform URL it uses the default Xybrid endpoint (`XYBRID_PLATFORM_URL` is
+handy for pointing a debug build at a self-hosted or tunneled platform). Get a
+free key at [dashboard.xybrid.dev](https://dashboard.xybrid.dev).
+
+### 4. Obtain Model Files
 
 The app loads models from the device filesystem. You need to place model files on the device before running inference.
 
@@ -88,7 +118,7 @@ The app defaults to `<app-files-dir>/models/kokoro-82m` — you can edit the pat
 - `tokens.txt` — Phoneme token vocabulary
 - `voices.bin` — Voice embeddings
 
-### 4. Run the App
+### 5. Run the App
 
 1. Select a device or emulator (API 28+)
 2. Click **Run** (Shift+F10)

--- a/examples/android/app/build.gradle.kts
+++ b/examples/android/app/build.gradle.kts
@@ -16,7 +16,7 @@ val localProperties = Properties().apply {
 }
 
 fun resolveConfig(name: String, localPropKey: String): String =
-    (project.findProperty(name) as String?)
+    project.findProperty(name)?.toString()
         ?: System.getenv(name)
         ?: localProperties.getProperty(localPropKey)
         ?: ""

--- a/examples/android/app/build.gradle.kts
+++ b/examples/android/app/build.gradle.kts
@@ -1,7 +1,28 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
 }
+
+// Resolve Xybrid config without committing it to the repo. Precedence:
+//   1. -P<name>=... on the Gradle command line (CI / one-liner)
+//   2. <name> environment variable
+//   3. <localPropKey> in local.properties (gitignored — best for Android Studio)
+// Unset resolves to "", which the SDK treats as anonymous / default platform.
+val localProperties = Properties().apply {
+    val f = rootProject.file("local.properties")
+    if (f.exists()) f.inputStream().use { load(it) }
+}
+
+fun resolveConfig(name: String, localPropKey: String): String =
+    (project.findProperty(name) as String?)
+        ?: System.getenv(name)
+        ?: localProperties.getProperty(localPropKey)
+        ?: ""
+
+val xybridApiKey = resolveConfig("XYBRID_API_KEY", "xybrid.apiKey")
+val xybridPlatformUrl = resolveConfig("XYBRID_PLATFORM_URL", "xybrid.platformUrl")
 
 android {
     namespace = "ai.xybrid.example"
@@ -15,6 +36,10 @@ android {
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // Surfaced to the app as BuildConfig.XYBRID_API_KEY / XYBRID_PLATFORM_URL.
+        buildConfigField("String", "XYBRID_API_KEY", "\"$xybridApiKey\"")
+        buildConfigField("String", "XYBRID_PLATFORM_URL", "\"$xybridPlatformUrl\"")
 
         vectorDrawables {
             useSupportLibrary = true
@@ -42,6 +67,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {

--- a/examples/android/app/src/main/java/ai/xybrid/example/MainActivity.kt
+++ b/examples/android/app/src/main/java/ai/xybrid/example/MainActivity.kt
@@ -22,9 +22,16 @@ import ai.xybrid.example.ui.theme.XybridExampleTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Runs locally as-is. Add a free key from dashboard.xybrid.dev to see
-        // your inference traces: Xybrid.init(this, apiKey = "xy_live_...")
-        Xybrid.init(this)
+        // The key and platform URL come from BuildConfig, wired in
+        // app/build.gradle.kts from local.properties (xybrid.apiKey /
+        // xybrid.platformUrl), -PXYBRID_API_KEY / -PXYBRID_PLATFORM_URL, or the
+        // matching env vars — never committed. Blank resolves to anonymous,
+        // local-only init against the default platform. See README.
+        Xybrid.init(
+            this,
+            apiKey = BuildConfig.XYBRID_API_KEY.ifBlank { null },
+            ingestUrl = BuildConfig.XYBRID_PLATFORM_URL.ifBlank { null },
+        )
         setContent {
             XybridExampleTheme {
                 Surface(

--- a/examples/android/local.properties.example
+++ b/examples/android/local.properties.example
@@ -1,0 +1,12 @@
+# Copy this file to `local.properties` and fill in your key.
+# `local.properties` is gitignored, so your key never lands in the repo.
+#
+# Android Studio reads it automatically — just press Run.
+# Get a free key at https://dashboard.xybrid.dev.
+#
+# Leave it unset to run anonymously (on-device inference, telemetry disabled).
+xybrid.apiKey=xy_live_xxxxxxxxxxxxxxxxxxxxxxxx
+
+# Optional: point telemetry at a self-hosted / tunneled platform (ingest URL).
+# Leave unset to use the default Xybrid platform endpoint.
+xybrid.platformUrl=https://your-platform.example.com

--- a/examples/flutter/README.md
+++ b/examples/flutter/README.md
@@ -53,6 +53,25 @@ flutter run -d ios
 flutter run -d android
 ```
 
+### Setting your API key (optional)
+
+The app reads `XYBRID_API_KEY` (and optionally `XYBRID_PLATFORM_URL`, the
+telemetry ingest endpoint) via `--dart-define`, so neither lands in the repo:
+
+```bash
+flutter run \
+  --dart-define=XYBRID_API_KEY=sk_test_... \
+  --dart-define=XYBRID_PLATFORM_URL=https://your-platform.example.com
+```
+
+Both are optional. Without a key the app runs anonymously (on-device inference,
+telemetry disabled); without a platform URL it uses the default Xybrid
+endpoint. `XYBRID_PLATFORM_URL` is handy for pointing a debug build at a
+self-hosted or tunneled (e.g. ngrok) platform. Get a free key at
+[dashboard.xybrid.dev](https://dashboard.xybrid.dev). The iOS and Android
+native examples use the equivalent Xcode scheme / Gradle `BuildConfig`
+mechanisms — see their READMEs.
+
 ## Project Structure
 
 ```

--- a/examples/flutter/lib/main.dart
+++ b/examples/flutter/lib/main.dart
@@ -10,6 +10,14 @@ import 'screens/model_loading_screen.dart';
 import 'screens/pipeline_demo_screen.dart';
 import 'screens/tts_demo_screen.dart';
 
+/// API key and platform (ingest) URL, injected at build time with
+///   flutter run --dart-define=XYBRID_API_KEY=sk_... \
+///               --dart-define=XYBRID_PLATFORM_URL=https://...
+/// Both are optional — unset resolves to "", which we pass as null so the SDK
+/// runs anonymously (local-only) against the default platform endpoint.
+const String _kApiKey = String.fromEnvironment('XYBRID_API_KEY');
+const String _kPlatformUrl = String.fromEnvironment('XYBRID_PLATFORM_URL');
+
 void main() {
   runApp(const XybridExampleApp());
 }
@@ -65,11 +73,9 @@ class _SdkInitializationScreenState extends State<SdkInitializationScreen> {
   /// Initialize the Xybrid SDK.
   Future<void> _initializeSdk() async {
     try {
-      // Pass the key at compile time with
-      //   flutter run --dart-define=XYBRID_API_KEY=xy_live_...
-      // Unset resolves to "", which the SDK treats as anonymous (local only).
       await Xybrid.init(
-        apiKey: const String.fromEnvironment('XYBRID_API_KEY'),
+        apiKey: _kApiKey.isEmpty ? null : _kApiKey,
+        ingestUrl: _kPlatformUrl.isEmpty ? null : _kPlatformUrl,
       );
       if (mounted) {
         setState(() {

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -43,7 +43,37 @@ In Xcode:
 3. Click **+** and add local package: `../../bindings/apple`
 4. Select **Xybrid** library
 
-### 4. Build and Run
+### 4. Set your API key (optional)
+
+The app reads `XYBRID_API_KEY` (and optionally `XYBRID_PLATFORM_URL`, the
+telemetry ingest endpoint) from the scheme's environment — the Xcode-native way
+to inject values at run time without committing them. This is the iOS analog of
+Flutter's `flutter run --dart-define=...`.
+
+1. **Product → Scheme → Edit Scheme…** (or `Cmd+<`)
+2. Select **Run** → **Arguments** tab
+3. Under **Environment Variables**, add:
+   - `XYBRID_API_KEY` = `sk_test_...`
+   - `XYBRID_PLATFORM_URL` = `https://your-platform.example.com` *(optional)*
+
+The values are saved in your *user* scheme under `xcuserdata/`, which is
+gitignored — so they never land in the repo. Leave **Shared** unchecked
+(the default) to keep it that way. Both are optional: without a key the app
+runs anonymously (on-device inference, telemetry disabled); without a platform
+URL it uses the default Xybrid endpoint (`XYBRID_PLATFORM_URL` is handy for
+pointing a debug build at a self-hosted or tunneled platform). Get a free key
+at [dashboard.xybrid.dev](https://dashboard.xybrid.dev).
+
+To inject them from the command line on a Simulator instead, prefix the
+launch environment:
+
+```bash
+SIMCTL_CHILD_XYBRID_API_KEY=sk_test_... \
+SIMCTL_CHILD_XYBRID_PLATFORM_URL=https://your-platform.example.com \
+  xcrun simctl launch --console booted ai.xybrid.example
+```
+
+### 5. Build and Run
 
 1. Select an iOS device (arm64) — simulator requires separate ORT build
 2. Press **Cmd+R** to build and run
@@ -81,9 +111,15 @@ let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMa
     .first!.appendingPathComponent("xybrid").path
 initSdkCacheDir(cacheDir: cacheDir)
 
-// Runs locally with no key. Pass an apiKey to light up the dashboard:
-//   Xybrid.initialize(apiKey: ProcessInfo.processInfo.environment["XYBRID_API_KEY"])
-Xybrid.initialize()
+// Reads the key and platform URL from scheme environment variables (see
+// "Set your API key" above). Empty/unset → anonymous, local-only init.
+let env = ProcessInfo.processInfo.environment
+let apiKey = env["XYBRID_API_KEY"]
+let platformUrl = env["XYBRID_PLATFORM_URL"]
+Xybrid.initialize(
+    apiKey: apiKey?.isEmpty == false ? apiKey : nil,
+    ingestUrl: platformUrl?.isEmpty == false ? platformUrl : nil
+)
 ```
 
 ### Load Model

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -117,8 +117,8 @@ let env = ProcessInfo.processInfo.environment
 let apiKey = env["XYBRID_API_KEY"]
 let platformUrl = env["XYBRID_PLATFORM_URL"]
 Xybrid.initialize(
-    apiKey: apiKey?.isEmpty == false ? apiKey : nil,
-    ingestUrl: platformUrl?.isEmpty == false ? platformUrl : nil
+    apiKey: (apiKey ?? "").isEmpty ? nil : apiKey,
+    ingestUrl: (platformUrl ?? "").isEmpty ? nil : platformUrl
 )
 ```
 

--- a/examples/ios/XybridExample/ContentView.swift
+++ b/examples/ios/XybridExample/ContentView.swift
@@ -61,10 +61,19 @@ struct ContentView: View {
                 .first!.appendingPathComponent("xybrid").path
             initSdkCacheDir(cacheDir: cacheDir)
 
-            // Initialize the runtime. Runs locally as-is; add a free key from
-            // dashboard.xybrid.dev to see inference traces:
-            //   Xybrid.initialize(apiKey: "xy_live_...")
-            Xybrid.initialize()
+            // The key and platform URL come from the XYBRID_API_KEY and
+            // XYBRID_PLATFORM_URL scheme environment variables (Product →
+            // Scheme → Edit Scheme → Run → Arguments), so they never land in
+            // the repo. Empty/unset resolves to anonymous, local-only init
+            // against the default platform. Get a free key at
+            // dashboard.xybrid.dev. See README.
+            let env = ProcessInfo.processInfo.environment
+            let apiKey = env["XYBRID_API_KEY"]
+            let platformUrl = env["XYBRID_PLATFORM_URL"]
+            Xybrid.initialize(
+                apiKey: apiKey?.isEmpty == false ? apiKey : nil,
+                ingestUrl: platformUrl?.isEmpty == false ? platformUrl : nil
+            )
 
             await MainActor.run {
                 appState = .ready

--- a/examples/ios/XybridExample/ContentView.swift
+++ b/examples/ios/XybridExample/ContentView.swift
@@ -71,8 +71,8 @@ struct ContentView: View {
             let apiKey = env["XYBRID_API_KEY"]
             let platformUrl = env["XYBRID_PLATFORM_URL"]
             Xybrid.initialize(
-                apiKey: apiKey?.isEmpty == false ? apiKey : nil,
-                ingestUrl: platformUrl?.isEmpty == false ? platformUrl : nil
+                apiKey: (apiKey ?? "").isEmpty ? nil : apiKey,
+                ingestUrl: (platformUrl ?? "").isEmpty ? nil : platformUrl
             )
 
             await MainActor.run {


### PR DESCRIPTION
## Summary

Wires the iOS, Android, and Flutter example apps to read `XYBRID_API_KEY` and `XYBRID_PLATFORM_URL` (mapped to the SDK's `ingestUrl`) at run time, each via its platform-native, repo-safe mechanism — Xcode scheme environment variables (`ProcessInfo`), `local.properties`/`-P`/env → `BuildConfig`, and `--dart-define` respectively — so neither value is ever committed. Previously the iOS and Android examples called `init` with no key at all, and none exposed the ingest URL. Adds a gitignored `local.properties.example` scaffold and documents the run flow (including pointing a debug build at a self-hosted or tunneled platform) in each example README.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — example-app/docs only; native toolchains (XCFramework, Android NDK, Flutter) not set up locally, so builds were reviewed by hand, not run
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)