### PR TITLE
docs: add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 [![License][license-shield]][license-url]
 [![Build][build-shield]][build-url]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
+[![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
 [![Stars][stars-shield]][stars-url]
 [![Release][release-shield]][release-url]
 [![Release Date][release-date-shield]][release-url]
@@ -61,6 +62,8 @@
 [build-url]: https://github.com/xybrid-ai/xybrid/actions
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/xybrid-ai/xybrid/badge
 [scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/xybrid-ai/xybrid
+[bestpractices-shield]: https://www.bestpractices.dev/projects/13041/badge
+[bestpractices-url]: https://www.bestpractices.dev/projects/13041
 [stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat
 [stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
 [release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat&sort=semver


### PR DESCRIPTION
## Summary

Adds the OpenSSF Best Practices badge (bestpractices.dev project 13041) to the README, next to the existing OpenSSF Scorecard badge, using the same reference-style links. The Scorecard `CII-Best-Practices` check reads this badge by repository URL, so surfacing it complements the badge-completion work and that check will reflect on the next scan.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A, README-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)