### PR TITLE
fix(sdk): keep the test-fixtures fallback out of release builds

### DIFF
--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -108,6 +108,12 @@ default = ["ort-download"]
 # JSON Schema generation for model_metadata.json
 schema = ["dep:schemars"]
 
+# Expose the `testing` module (mocks + model fixtures) to downstream crates.
+# No-op marker today (the module is currently always `pub`); it exists so
+# consumers can depend on `xybrid-core/test-util` now and stay correct once
+# the `testing` module is gated behind this feature (audit 4a).
+test-util = []
+
 # ONNX Runtime
 ort-download = ["ort/download-binaries", "ort/tls-native"]  # Desktop/macOS/iOS: download prebuilt binaries
 ort-dynamic = ["ort/load-dynamic"]                          # Android: load .so at runtime from AAR

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -45,6 +45,12 @@ ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 [features]
 default = []
 
+# Development/test convenience: lets SdkCacheProvider fall back to the
+# workspace's integration-test model fixtures. Off by default so shipped SDKs
+# never reference `xybrid_core::testing`. Forwards to `xybrid-core/test-util`
+# so the gate stays consistent if core later moves `testing` behind it.
+test-util = ["xybrid-core/test-util"]
+
 # HuggingFace Hub integration (download models directly from HF repos)
 huggingface = ["dep:hf-hub"]
 

--- a/crates/xybrid-sdk/src/cache/cache_provider.rs
+++ b/crates/xybrid-sdk/src/cache/cache_provider.rs
@@ -129,14 +129,15 @@ impl SdkCacheProvider {
             }
         }
 
-        // Development-only fallback: also look in the workspace's
-        // integration-tests fixtures so examples/dev runs find locally-staged
-        // models. Excluded from release builds — `models_dir()` resolves via
-        // `CARGO_MANIFEST_DIR` (the *build* machine's path) and the test
-        // fixtures, neither of which exists in a shipped SDK, so this is a
-        // no-op in production that would otherwise pull `xybrid_core::testing`
-        // (test scaffolding) into the release binary.
-        #[cfg(debug_assertions)]
+        // Development/test-only fallback: also look in the workspace's
+        // integration-tests fixtures so dev runs find locally-staged models.
+        // Gated behind the `test-util` feature (off by default) so shipped
+        // SDKs never reference `xybrid_core::testing` — `models_dir()` resolves
+        // via `CARGO_MANIFEST_DIR` / the fixtures tree, neither of which exists
+        // in a released binary, so it is a no-op in production anyway. Using a
+        // feature (not `debug_assertions`) keeps this consistent with core
+        // once `testing` is itself gated behind `xybrid-core/test-util`.
+        #[cfg(feature = "test-util")]
         if let Some(fixtures_dir) = xybrid_core::testing::model_fixtures::models_dir() {
             let fixtures_path = fixtures_dir.join(model_id);
             if fixtures_path.exists() && has_model_files(&fixtures_path) {

--- a/crates/xybrid-sdk/src/cache/cache_provider.rs
+++ b/crates/xybrid-sdk/src/cache/cache_provider.rs
@@ -129,7 +129,14 @@ impl SdkCacheProvider {
             }
         }
 
-        // Also check integration-tests fixtures for development
+        // Development-only fallback: also look in the workspace's
+        // integration-tests fixtures so examples/dev runs find locally-staged
+        // models. Excluded from release builds — `models_dir()` resolves via
+        // `CARGO_MANIFEST_DIR` (the *build* machine's path) and the test
+        // fixtures, neither of which exists in a shipped SDK, so this is a
+        // no-op in production that would otherwise pull `xybrid_core::testing`
+        // (test scaffolding) into the release binary.
+        #[cfg(debug_assertions)]
         if let Some(fixtures_dir) = xybrid_core::testing::model_fixtures::models_dir() {
             let fixtures_path = fixtures_dir.join(model_id);
             if fixtures_path.exists() && has_model_files(&fixtures_path) {


### PR DESCRIPTION
## What

`SdkCacheProvider::find_matching_dir` (`crates/xybrid-sdk/src/cache/cache_provider.rs`) fell back to `xybrid_core::testing::model_fixtures::models_dir()` on every cache miss — **production code (not `cfg(test)`) reaching into core's test scaffolding**.

## Why it's a no-op in production anyway

`models_dir()` resolves the fixtures directory via either `XYBRID_TEST_MODELS` (a test env var) or a **`CARGO_MANIFEST_DIR`-relative walk** to `integration-tests/fixtures/models`. In a shipped SDK, `CARGO_MANIFEST_DIR` is the *build machine's* path and the fixtures tree doesn't exist — so the fallback always returns `None`. It only resolves a model when a developer runs the SDK from the workspace with fixtures staged.

So in production it's a dead filesystem probe that also pulls `xybrid_core::testing` into the release dependency graph.

## Fix

Gate the fallback behind `#[cfg(debug_assertions)]`:
- **dev / examples / tests** (debug profile): keep the convenience — unchanged behavior.
- **release / shipped SDK**: drop the dead probe and the production→testing coupling.

`has_model_files` remains referenced by the ungated cache-dir scan above, so there's no dead-code warning in release.

This is also a prerequisite for the larger audit-4a item: gating core's `testing` module behind a `test-util` feature (which couldn't be done while a production SDK path referenced it).

## Testing

- `cargo clippy -p xybrid-sdk --lib --tests --features ort-download -- -D warnings` — clean
- `cargo check -p xybrid-sdk --release --features ort-download` — clean (confirms the gated path compiles out)
- `cargo test -p xybrid-sdk --features ort-download --lib cache::cache_provider` — 5 pass
- `cargo fmt --all -- --check` — clean

No public API change.