### PR TITLE
fix(core): don't panic in with_retry when the circuit is open for all attempts

### DIFF
--- a/crates/xybrid-core/src/cloud/error.rs
+++ b/crates/xybrid-core/src/cloud/error.rs
@@ -136,4 +136,11 @@ impl RetryableError for CloudError {
             _ => None,
         }
     }
+
+    fn circuit_open() -> Self {
+        CloudError::CircuitOpen(
+            "gateway circuit breaker stayed open for the entire retry window; no request was sent"
+                .to_string(),
+        )
+    }
 }

--- a/crates/xybrid-core/src/http/mod.rs
+++ b/crates/xybrid-core/src/http/mod.rs
@@ -17,6 +17,7 @@
 //! impl RetryableError for MyError {
 //!     fn is_retryable(&self) -> bool { true }
 //!     fn retry_after(&self) -> Option<Duration> { None }
+//!     fn circuit_open() -> Self { MyError }
 //! }
 //!
 //! let policy = RetryPolicy::default();

--- a/crates/xybrid-core/src/http/retry.rs
+++ b/crates/xybrid-core/src/http/retry.rs
@@ -155,6 +155,15 @@ pub trait RetryableError {
     ///
     /// This is typically parsed from the `Retry-After` HTTP header.
     fn retry_after(&self) -> Option<Duration>;
+
+    /// Construct the error to report when a circuit breaker stayed open for the
+    /// entire attempt budget, so no real attempt ever ran.
+    ///
+    /// [`with_retry`] returns this — rather than panicking — when every
+    /// iteration is skipped because the circuit is open.
+    fn circuit_open() -> Self
+    where
+        Self: Sized;
 }
 
 /// Execute an operation with automatic retry on failure.
@@ -181,6 +190,7 @@ pub trait RetryableError {
 /// impl RetryableError for MyError {
 ///     fn is_retryable(&self) -> bool { true }
 ///     fn retry_after(&self) -> Option<Duration> { None }
+///     fn circuit_open() -> Self { MyError }
 /// }
 ///
 /// # fn make_http_request() -> Result<String, MyError> { Ok("ok".into()) }
@@ -255,9 +265,11 @@ where
         }
     }
 
-    // All attempts exhausted
+    // All attempts exhausted. `last_error` is `None` only if every iteration
+    // was skipped by an open circuit breaker (no operation ever ran) — report
+    // that as a circuit-open error instead of panicking.
     RetryResult::Exhausted {
-        last_error: last_error.expect("at least one attempt should have been made"),
+        last_error: last_error.unwrap_or_else(E::circuit_open),
         attempts: policy.max_attempts,
     }
 }
@@ -306,6 +318,43 @@ mod tests {
         fn retry_after(&self) -> Option<Duration> {
             self.retry_after
         }
+
+        fn circuit_open() -> Self {
+            TestError {
+                retryable: false,
+                retry_after: None,
+            }
+        }
+    }
+
+    #[test]
+    fn circuit_open_for_all_attempts_returns_error_not_panic() {
+        use crate::http::CircuitConfig;
+
+        // Open the breaker by exceeding its failure threshold up front.
+        let breaker = CircuitBreaker::new(CircuitConfig::default());
+        for _ in 0..10 {
+            breaker.record_failure();
+        }
+        assert!(breaker.is_open(), "breaker should be open before the call");
+
+        // Short attempt budget so the per-skip 100ms wait stays quick.
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            ..RetryPolicy::default()
+        };
+
+        let mut calls = 0;
+        let result: RetryResult<&str, TestError> = with_retry(&policy, Some(&breaker), || {
+            calls += 1;
+            Ok("unreachable while the circuit is open")
+        });
+
+        // The operation never ran, and we got a graceful error — previously
+        // this path panicked via `last_error.expect(...)`.
+        assert_eq!(calls, 0, "operation must not run while the circuit is open");
+        assert!(matches!(result, RetryResult::Exhausted { .. }));
+        assert!(result.into_result().is_err());
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -258,6 +258,13 @@ impl xybrid_core::http::RetryableError for SdkError {
     fn retry_after(&self) -> Option<std::time::Duration> {
         SdkError::retry_after(self)
     }
+
+    fn circuit_open() -> Self {
+        SdkError::CircuitOpen(
+            "circuit breaker stayed open for the entire retry window; no request was sent"
+                .to_string(),
+        )
+    }
 }
 
 fn streaming_execution_error(error: xybrid_core::runtime_adapter::AdapterError) -> SdkError {


### PR DESCRIPTION
## The bug

`with_retry`'s circuit-open branch `continue`s **without setting `last_error`**:

```rust
if !cb.can_execute() {
    std::thread::sleep(Duration::from_millis(100));
    continue;            // <-- no last_error recorded
}
...
// after the loop:
RetryResult::Exhausted {
    last_error: last_error.expect("at least one attempt should have been made"), // 💥
    ...
}
```

If the circuit is open on **every** iteration of the attempt budget, the loop exits with `last_error == None` and the `.expect(...)` **panics** — a crash in the one primitive whose entire job is to degrade gracefully under failure, triggered *precisely when the system is already degraded* (circuit open = recent repeated failures).

Reachability: the sole production caller (`cloud/client.rs`) pre-checks `can_execute()`, but (a) `with_retry` is **`pub`** API with no such contract for other/future callers, and (b) the breaker is `Arc`-shared and can be opened by a racing thread *between* the caller's pre-check and the loop — then stay open for all attempts → panic, under exactly the concurrent-failure load the breaker exists to absorb.

## The fix

Add a `RetryableError::circuit_open()` constructor and return `Exhausted { last_error: circuit_open(), .. }` instead of the `expect`:

```rust
last_error: last_error.unwrap_or_else(E::circuit_open),
```

When every attempt was skipped by an open circuit, the reported error *is* "circuit open" — semantically correct and panic-free. Implemented for the two `RetryableError` impls in the repo — `CloudError` and `SdkError` — both of which already have a `CircuitOpen` variant that maps cleanly.

## Notes

- `RetryableError` is public (`xybrid_core::http`, also re-exported from the SDK). Adding a required method is a minor breaking change for external implementors, but there are none in-repo and this is alpha (`0.1.x`). No default is possible (you can't construct an arbitrary `Self` generically).
- Regression test (`circuit_open_for_all_attempts_returns_error_not_panic`) opens a breaker up front, runs it through `with_retry`, and asserts the operation never runs and a graceful error is returned (no panic).

## Testing

- `cargo test -p xybrid-core --lib http::retry` — 10 pass (incl. new test)
- `cargo test -p xybrid-core --doc` — 106 pass (both updated trait-impl examples compile)
- `cargo test -p xybrid-sdk --features ort-download --lib` — 356 pass
- `cargo clippy` (core + sdk, lib/tests) `-D warnings` — clean
- `cargo fmt --all -- --check` — clean

From the slice-4b audit.