### PR TITLE
fix(core): use checked arithmetic for the voice-codes length header

### DIFF
--- a/crates/xybrid-core/src/execution/voice_loader.rs
+++ b/crates/xybrid-core/src/execution/voice_loader.rs
@@ -568,7 +568,19 @@ fn read_codes_binary(data: &[u8]) -> ExecutorResult<Vec<i32>> {
         ));
     }
     let count = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
-    let expected = 4 + count * 4;
+    // `count` is bundle-supplied (untrusted). Compute the expected size with
+    // checked arithmetic so a huge count can't overflow `usize` on 32-bit
+    // targets (e.g. armeabi-v7a Android) and silently wrap the bounds check
+    // below — which would otherwise let a tiny file through to a 16 GB
+    // `with_capacity` or an out-of-bounds index.
+    let expected = count
+        .checked_mul(4)
+        .and_then(|body| body.checked_add(4))
+        .ok_or_else(|| {
+            AdapterError::InvalidInput(format!(
+                "Voice codes count {count} overflows addressable size"
+            ))
+        })?;
     if data.len() < expected {
         return Err(AdapterError::InvalidInput(format!(
             "Voice codes file truncated: expected {} bytes for {} codes, got {}",
@@ -591,6 +603,33 @@ fn read_codes_binary(data: &[u8]) -> ExecutorResult<Vec<i32>> {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn read_codes_binary_roundtrips_valid_data() {
+        let mut data = 3u32.to_le_bytes().to_vec();
+        for v in [1i32, -2, 3] {
+            data.extend_from_slice(&v.to_le_bytes());
+        }
+        assert_eq!(read_codes_binary(&data).unwrap(), vec![1, -2, 3]);
+    }
+
+    #[test]
+    fn read_codes_binary_rejects_truncated_data() {
+        // Claims 5 codes but only carries one.
+        let mut data = 5u32.to_le_bytes().to_vec();
+        data.extend_from_slice(&7i32.to_le_bytes());
+        assert!(read_codes_binary(&data).is_err());
+    }
+
+    #[test]
+    fn read_codes_binary_rejects_overflowing_count_without_panicking() {
+        // count = u32::MAX with only a 4-byte body. The naive `4 + count * 4`
+        // overflows `usize` on 32-bit targets; checked arithmetic must turn
+        // this into a clean error rather than a wrap → OOB/OOM panic.
+        let mut data = u32::MAX.to_le_bytes().to_vec();
+        data.extend_from_slice(&[0u8; 4]);
+        assert!(read_codes_binary(&data).is_err());
+    }
 
     // ============================================================================
     // Mock Voice Source for Testing


### PR DESCRIPTION
## The bug

`read_codes_binary` (`execution/voice_loader.rs`) parses a voice-codes blob — a `u32` LE `count` followed by `count × i32`:

```rust
let count = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
let expected = 4 + count * 4;          // ⚠ unchecked
if data.len() < expected { return Err(...truncated...) }
let mut codes = Vec::with_capacity(count);
for i in 0..count {
    let offset = 4 + i * 4;
    codes.push(i32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()));
}
```

`count` is bundle-supplied (untrusted — a corrupted or malicious voice bundle). On **32-bit targets — including `armeabi-v7a` Android, a shipping platform** — `count * 4` overflows `usize` and **wraps silently in release builds**, so `expected` shrinks, the `data.len() < expected` guard passes for a tiny file, and the code then either:
- attempts `Vec::with_capacity(count)` → ~16 GB allocation → OOM/abort, or
- indexes `data[offset..offset + 4]` out of bounds → panic.

(In debug builds the multiply itself panics on overflow.) On 64-bit the bounds check happens to hold, so this is a 32-bit-only crash — but 32-bit Android ships.

## The fix

Compute `expected` with checked arithmetic:

```rust
let expected = count
    .checked_mul(4)
    .and_then(|body| body.checked_add(4))
    .ok_or_else(|| AdapterError::InvalidInput(
        format!("Voice codes count {count} overflows addressable size")))?;
```

`expected` is now exact and overflow-free on every target; the subsequent `data.len() < expected` check bounds `count` (`count ≤ (len-4)/4`), so `with_capacity` and the loop indexing are safe.

## Testing

New tests in `voice_loader`:
- `read_codes_binary_roundtrips_valid_data`
- `read_codes_binary_rejects_truncated_data`
- `read_codes_binary_rejects_overflowing_count_without_panicking` (`count = u32::MAX`, tiny body → clean `Err`, no panic/OOM)

`cargo test -p xybrid-core --lib execution::voice_loader` — 25 pass · clippy `-D warnings` clean · fmt clean.

From the slice-4e audit. The execution module (~17k LOC) has **zero `unsafe`** and serde-based metadata parsing; this hand-rolled binary parser was the only untrusted-length decode.