### PR TITLE
fix(sdk): recover from poisoned telemetry locks instead of panicking

### DIFF
--- a/crates/xybrid-sdk/src/telemetry.rs
+++ b/crates/xybrid-sdk/src/telemetry.rs
@@ -587,7 +587,10 @@ impl HttpTelemetryExporter {
 
     /// Add an event to the buffer
     pub fn push(&self, event: TelemetryEvent) {
-        let mut buffer = self.buffer.lock().unwrap();
+        // Telemetry is a background concern that must degrade, not crash the
+        // inference path: recover from a poisoned buffer/queue lock instead of
+        // panicking (matches `register_telemetry_sender`'s graceful handling).
+        let mut buffer = self.buffer.lock().unwrap_or_else(|p| p.into_inner());
         buffer.push(event);
         self.ingested.fetch_add(1, Ordering::Release);
 
@@ -707,7 +710,7 @@ impl HttpTelemetryExporter {
 
         thread::spawn(move || {
             for event in rx {
-                let mut buf = buffer.lock().unwrap();
+                let mut buf = buffer.lock().unwrap_or_else(|p| p.into_inner());
                 buf.push(event);
                 ingested.fetch_add(1, Ordering::Release);
 
@@ -754,7 +757,7 @@ fn flush_buffer_with_retry(
     dropped_count: &Arc<AtomicU32>,
 ) {
     let events: Vec<TelemetryEvent> = {
-        let mut buf = buffer.lock().unwrap();
+        let mut buf = buffer.lock().unwrap_or_else(|p| p.into_inner());
         buf.drain(..).collect()
     };
 
@@ -916,7 +919,7 @@ fn queue_failed_events(
     failed_queue: &Arc<Mutex<VecDeque<PlatformEvent>>>,
     dropped_count: &Arc<AtomicU32>,
 ) {
-    let mut queue = failed_queue.lock().unwrap();
+    let mut queue = failed_queue.lock().unwrap_or_else(|p| p.into_inner());
 
     for event in events {
         if queue.len() >= MAX_FAILED_QUEUE_SIZE {
@@ -943,7 +946,7 @@ fn retry_failed_events(
 
     // Take a batch of events from the queue
     let events: Vec<PlatformEvent> = {
-        let mut queue = failed_queue.lock().unwrap();
+        let mut queue = failed_queue.lock().unwrap_or_else(|p| p.into_inner());
         let batch_size = config.batch_size.min(queue.len());
         queue.drain(..batch_size).collect()
     };
@@ -955,7 +958,7 @@ fn retry_failed_events(
     // Try to send the batch
     if let Err(failed_events) = send_batch_inner(&events, config, agent, circuit, retry_policy) {
         // Put them back at the front of the queue
-        let mut queue = failed_queue.lock().unwrap();
+        let mut queue = failed_queue.lock().unwrap_or_else(|p| p.into_inner());
         for event in failed_events.into_iter().rev() {
             queue.push_front(event);
         }


### PR DESCRIPTION
## What

The `HttpTelemetryExporter` event **buffer** (`Mutex<Vec<…>>`) and failed-send **retry queue** (`Mutex<VecDeque<…>>`) were locked with `.lock().unwrap()` at all 6 production sites (`push`, the sender thread's drain, `flush`'s drain, and the failed-queue enqueue/batch/requeue). Switched to `unwrap_or_else(|p| p.into_inner())`.

## Why it matters

`push()` runs on the **inference publish path**. If any thread panics while holding the buffer or queue mutex, it poisons, and **every subsequent telemetry publish then panics** — a background, best-effort concern taking down the inference thread. Telemetry should degrade silently, never crash the caller.

Both mutexes guard **pure in-memory bookkeeping** (an event `Vec`, a `VecDeque` retry queue), so recovering the guard and continuing is correct and lossless. It also matches the graceful handling `register_telemetry_sender` already uses in this same file.

## Scope

Mechanical, single file, **no API change**. Surfaced by the slice-3f audit; same lock-poison consistency theme as `local.rs:536` (#228) and `event_bus.rs` (#233).

## Testing

- `cargo test -p xybrid-sdk --features ort-download --lib telemetry` — 82 pass
- `cargo clippy -p xybrid-sdk --lib --features ort-download -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean