### PR TITLE
fix(core): handle non-contiguous ONNX output tensors without panicking

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
@@ -465,25 +465,20 @@ impl ONNXSession {
             // Try to extract as f32 first, then as i64 if that fails
             // This handles models with mixed output types
             let array_d = if let Ok(output_array) = output_value.try_extract_array::<f32>() {
-                // Convert ndarray view to owned ArrayD
-                let shape = output_array.shape();
-                let dims: Vec<usize> = shape.to_vec();
-                let owned_array = output_array.to_owned();
-                let data: Vec<f32> = owned_array.as_slice().unwrap().to_vec();
+                // Collect in logical (row-major) order, which matches the
+                // `from_shape_vec` interpretation below. Iterating avoids
+                // `as_slice().unwrap()`, which panics when ORT hands back a
+                // non-standard-layout (e.g. transposed) output view.
+                let dims: Vec<usize> = output_array.shape().to_vec();
+                let data: Vec<f32> = output_array.iter().copied().collect();
                 ArrayD::from_shape_vec(IxDyn(&dims), data).map_err(|e| {
                     AdapterError::RuntimeError(format!("Failed to convert output to ArrayD: {}", e))
                 })?
             } else if let Ok(output_array) = output_value.try_extract_array::<i64>() {
-                // Convert i64 to f32 for uniform handling
-                let shape = output_array.shape();
-                let dims: Vec<usize> = shape.to_vec();
-                let owned_array = output_array.to_owned();
-                let data: Vec<f32> = owned_array
-                    .as_slice()
-                    .unwrap()
-                    .iter()
-                    .map(|&x| x as f32)
-                    .collect();
+                // Convert i64 to f32 for uniform handling (same layout-safe
+                // iteration as the f32 arm above).
+                let dims: Vec<usize> = output_array.shape().to_vec();
+                let data: Vec<f32> = output_array.iter().map(|&x| x as f32).collect();
                 ArrayD::from_shape_vec(IxDyn(&dims), data).map_err(|e| {
                     AdapterError::RuntimeError(format!("Failed to convert output to ArrayD: {}", e))
                 })?

--- a/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
+++ b/crates/xybrid-core/src/runtime_adapter/onnx/session.rs
@@ -465,20 +465,27 @@ impl ONNXSession {
             // Try to extract as f32 first, then as i64 if that fails
             // This handles models with mixed output types
             let array_d = if let Ok(output_array) = output_value.try_extract_array::<f32>() {
-                // Collect in logical (row-major) order, which matches the
-                // `from_shape_vec` interpretation below. Iterating avoids
-                // `as_slice().unwrap()`, which panics when ORT hands back a
-                // non-standard-layout (e.g. transposed) output view.
+                // Fast path: a standard-layout output is one contiguous slice
+                // (a memcpy). Fall back to logical-order iteration only when the
+                // output is non-contiguous (e.g. transposed) — which `as_slice`
+                // reports as `None`, where the old `as_slice().unwrap()` panicked.
+                // Either way the data is row-major, matching `from_shape_vec`.
                 let dims: Vec<usize> = output_array.shape().to_vec();
-                let data: Vec<f32> = output_array.iter().copied().collect();
+                let data: Vec<f32> = match output_array.as_slice() {
+                    Some(slice) => slice.to_vec(),
+                    None => output_array.iter().copied().collect(),
+                };
                 ArrayD::from_shape_vec(IxDyn(&dims), data).map_err(|e| {
                     AdapterError::RuntimeError(format!("Failed to convert output to ArrayD: {}", e))
                 })?
             } else if let Ok(output_array) = output_value.try_extract_array::<i64>() {
-                // Convert i64 to f32 for uniform handling (same layout-safe
-                // iteration as the f32 arm above).
+                // Convert i64 to f32 for uniform handling, same fast/safe split
+                // as the f32 arm above.
                 let dims: Vec<usize> = output_array.shape().to_vec();
-                let data: Vec<f32> = output_array.iter().map(|&x| x as f32).collect();
+                let data: Vec<f32> = match output_array.as_slice() {
+                    Some(slice) => slice.iter().map(|&x| x as f32).collect(),
+                    None => output_array.iter().map(|&x| x as f32).collect(),
+                };
                 ArrayD::from_shape_vec(IxDyn(&dims), data).map_err(|e| {
                     AdapterError::RuntimeError(format!("Failed to convert output to ArrayD: {}", e))
                 })?


### PR DESCRIPTION
## What

ONNX output extraction did `owned_array.as_slice().unwrap()` for both the f32 and i64 arms. `as_slice()` returns `None` (→ panic) when the array is **not standard (C-contiguous) layout** — e.g. a transposed/F-order tensor, whose layout `to_owned()` preserves.

## Why it matters

ONNX Runtime outputs are usually contiguous, so it's rare — but a model that emits a non-contiguous output would **panic mid-inference** instead of returning a result. On the default-feature inference path.

## Fix

Collect via `.iter()` — which yields elements in logical (row-major) order, exactly the order `from_shape_vec(IxDyn(dims), data)` expects — for both arms. This is layout-independent (no panic) and produces identical results for the normal contiguous case. Also drops the now-unnecessary `to_owned()` clone.

```rust
let dims: Vec<usize> = output_array.shape().to_vec();
let data: Vec<f32> = output_array.iter().copied().collect();          // f32 arm
let data: Vec<f32> = output_array.iter().map(|&x| x as f32).collect(); // i64 arm
```

## Testing

- `cargo test -p xybrid-core --lib runtime_adapter::onnx` — 46 pass, **including the real MNIST inference test** (confirms the iterated extraction yields correct output)
- `cargo clippy -p xybrid-core --lib --features ort-download -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

From the slice-4e audit. No API change.