### PR TITLE
fix(core): recover from poisoned telemetry-session lock instead of panicking

### DIFF
--- a/crates/xybrid-core/src/telemetry/session.rs
+++ b/crates/xybrid-core/src/telemetry/session.rs
@@ -430,12 +430,22 @@ impl SessionManager {
         }
     }
 
+    /// Acquire the session lock, recovering from poisoning.
+    ///
+    /// A `std::sync::Mutex` stays poisoned permanently once a thread panics
+    /// while holding it, so every accessor must recover the guard via
+    /// `into_inner` rather than bail on `Err`. Otherwise a single panic would
+    /// permanently silence all telemetry — including the `record_*` methods —
+    /// even after `start_session`/`reset` install a fresh, consistent session.
+    fn lock_session(&self) -> std::sync::MutexGuard<'_, Option<SessionMetrics>> {
+        self.current_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
     /// Start a new session.
     pub fn start_session(&self) -> String {
-        let mut session = self
-            .current_session
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let mut session = self.lock_session();
         let new_session = SessionMetrics::new(self.device_id.clone());
         let session_id = new_session.session_id.clone();
         *session = Some(new_session);
@@ -444,46 +454,36 @@ impl SessionManager {
 
     /// Get current session metrics (clone).
     pub fn get_session(&self) -> Option<SessionMetrics> {
-        let session = self
-            .current_session
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        session.clone()
+        self.lock_session().clone()
     }
 
     /// Record an inference call.
     pub fn record_inference(&self, model_id: &str, version: &str, latency_ms: u64) {
-        if let Ok(mut session) = self.current_session.lock() {
-            if let Some(ref mut s) = *session {
-                s.record_inference(model_id, version, latency_ms);
-            }
+        let mut session = self.lock_session();
+        if let Some(ref mut s) = *session {
+            s.record_inference(model_id, version, latency_ms);
         }
     }
 
     /// Record an error.
     pub fn record_error(&self, model_id: Option<&str>, error: &str) {
-        if let Ok(mut session) = self.current_session.lock() {
-            if let Some(ref mut s) = *session {
-                s.record_error(model_id, error);
-            }
+        let mut session = self.lock_session();
+        if let Some(ref mut s) = *session {
+            s.record_error(model_id, error);
         }
     }
 
     /// Set hardware capabilities for current session.
     pub fn set_hardware_capabilities(&self, caps: HardwareCapabilities) {
-        if let Ok(mut session) = self.current_session.lock() {
-            if let Some(ref mut s) = *session {
-                s.set_hardware_capabilities(caps);
-            }
+        let mut session = self.lock_session();
+        if let Some(ref mut s) = *session {
+            s.set_hardware_capabilities(caps);
         }
     }
 
     /// End current session and return export.
     pub fn end_session(&self) -> Option<TelemetryExport> {
-        let mut session = self
-            .current_session
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let mut session = self.lock_session();
         if let Some(ref mut s) = *session {
             s.end_session();
             Some(TelemetryExport::from_session(s))
@@ -494,20 +494,14 @@ impl SessionManager {
 
     /// Export current session without ending it.
     pub fn export_session(&self) -> Option<TelemetryExport> {
-        let session = self
-            .current_session
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        session.as_ref().map(TelemetryExport::from_session)
+        self.lock_session()
+            .as_ref()
+            .map(TelemetryExport::from_session)
     }
 
     /// Reset session (start fresh).
     pub fn reset(&self) {
-        let mut session = self
-            .current_session
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        *session = Some(SessionMetrics::new(self.device_id.clone()));
+        *self.lock_session() = Some(SessionMetrics::new(self.device_id.clone()));
     }
 }
 

--- a/crates/xybrid-core/src/telemetry/session.rs
+++ b/crates/xybrid-core/src/telemetry/session.rs
@@ -432,7 +432,10 @@ impl SessionManager {
 
     /// Start a new session.
     pub fn start_session(&self) -> String {
-        let mut session = self.current_session.lock().unwrap();
+        let mut session = self
+            .current_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let new_session = SessionMetrics::new(self.device_id.clone());
         let session_id = new_session.session_id.clone();
         *session = Some(new_session);
@@ -441,7 +444,10 @@ impl SessionManager {
 
     /// Get current session metrics (clone).
     pub fn get_session(&self) -> Option<SessionMetrics> {
-        let session = self.current_session.lock().unwrap();
+        let session = self
+            .current_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         session.clone()
     }
 
@@ -474,7 +480,10 @@ impl SessionManager {
 
     /// End current session and return export.
     pub fn end_session(&self) -> Option<TelemetryExport> {
-        let mut session = self.current_session.lock().unwrap();
+        let mut session = self
+            .current_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         if let Some(ref mut s) = *session {
             s.end_session();
             Some(TelemetryExport::from_session(s))
@@ -485,13 +494,19 @@ impl SessionManager {
 
     /// Export current session without ending it.
     pub fn export_session(&self) -> Option<TelemetryExport> {
-        let session = self.current_session.lock().unwrap();
+        let session = self
+            .current_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         session.as_ref().map(TelemetryExport::from_session)
     }
 
     /// Reset session (start fresh).
     pub fn reset(&self) {
-        let mut session = self.current_session.lock().unwrap();
+        let mut session = self
+            .current_session
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         *session = Some(SessionMetrics::new(self.device_id.clone()));
     }
 }


### PR DESCRIPTION
## What

`TelemetrySession` guards `current_session` (`Mutex<Option<SessionMetrics>>`) with `.lock().unwrap()` in 5 methods (`start_session`, `get_session`, `end_session`, `export_session`, `reset`) — while **3 sibling methods on the same mutex** (`record_inference`, `record_error`, `set_hardware_capabilities`) already degrade gracefully via `if let Ok(...)`. Switched the 5 to `unwrap_or_else(|p| p.into_inner())`.

## Why it matters

Same-file inconsistency: a panic while holding `current_session` poisons it, and the 5 `.unwrap()` methods then crash — telemetry session bookkeeping taking down the caller — even though the other 3 methods on the same lock keep working. Telemetry should degrade, not crash inference. Recovery is lossless (the guarded value is in-memory session metrics).

## Scope

Mechanical, single file, **no API change**. Completes the **production lock-poison sweep** surfaced by the audit:
- `local.rs:536` routing — #228 (merged)
- `event_bus.rs` ×8 — #233
- SDK `telemetry.rs` ×6 — #234 (merged)
- **`telemetry/session.rs` ×5 — this PR**

A workspace re-scan confirms no other *production* `.lock()/.read()/.write().unwrap()` sites remain on the default feature set (the rest were `#[cfg(test)]` mocks).

## Testing

- `cargo test -p xybrid-core --lib telemetry::session` — 8 pass
- `cargo clippy -p xybrid-core --lib --features ort-download -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean