### PR TITLE
fix(core): avoid panic on poisoned context lock in llama.cpp is_loaded

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -514,7 +514,13 @@ impl LlmBackend for LlamaCppBackend {
     }
 
     fn is_loaded(&self) -> bool {
-        self.model.is_some() && self.context.lock().unwrap().is_some()
+        // A poisoned context lock means an interrupted `llama_decode` may have
+        // left the `LlamaContext` inconsistent, so treat it as "not safely
+        // loaded" rather than panicking on `unwrap`. Matches the graceful
+        // `.ok()` degradation used elsewhere in this backend (e.g.
+        // `last_cached_prefix_len`) instead of `into_inner()` recovery, because
+        // the guarded context must not be reused once poisoned.
+        self.model.is_some() && self.context.lock().map(|c| c.is_some()).unwrap_or(false)
     }
 
     fn unload(&mut self) -> LlmResult<()> {


### PR DESCRIPTION
## What

`LlamaCppBackend::is_loaded()` unwrapped the context mutex:

```rust
self.model.is_some() && self.context.lock().unwrap().is_some()
```

A poisoned lock — left behind when an `llama_decode` on another thread panics mid-mutation — would make `is_loaded()` itself panic instead of reporting load state. This is the same class of bug as the recently-merged poisoned-lock sweep (#231, #233–#236).

## Fix

Treat a poisoned context lock as **"not safely loaded"** and return `false`:

```rust
self.model.is_some() && self.context.lock().map(|c| c.is_some()).unwrap_or(false)
```

This matches the graceful `.ok()` degradation already used in `last_cached_prefix_len` (and `clear_cached_prefix_state`).

### Why not `into_inner()` recovery?

The event-bus/telemetry fixes recovered the poisoned guard via `unwrap_or_else(|p| p.into_inner())` because their state was benign in-memory bookkeeping. That's **not** safe here: a poisoned context guard may protect a `LlamaContext` left inconsistent by the interrupted `llama_decode`, so the guarded value must not be reused. Reporting "not loaded" is the conservative, correct behaviour.

## Scope

Audited every `.lock()` site in `llama_cpp/mod.rs`. All other production sites already handle poisoning (`map_err` → `AdapterError::RuntimeError`, or `.ok()`); the remaining `.unwrap()`s are inside `#[cfg(test)]`. This was the last production `.lock().unwrap()` in the backend.

## Test

- `cargo clippy -p xybrid-core --lib --features llm-llamacpp -- -D warnings` — clean
- `cargo test -p xybrid-core --lib --features llm-llamacpp runtime_adapter::llama_cpp` — 9 passed