### PR TITLE
refactor(core): consolidate resolve_file_path into execution::path

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -1759,14 +1759,7 @@ impl TemplateExecutor {
 
     /// Resolve a file path relative to base_path.
     pub fn resolve_file_path(&self, file: &str) -> String {
-        if self.base_path.is_empty() {
-            file.to_string()
-        } else {
-            Path::new(&self.base_path)
-                .join(file)
-                .to_string_lossy()
-                .to_string()
-        }
+        super::path::resolve_file_path(&self.base_path, file)
     }
 
     /// Break words used as secondary split points for center-break chunking.

--- a/crates/xybrid-core/src/execution/mod.rs
+++ b/crates/xybrid-core/src/execution/mod.rs
@@ -86,6 +86,9 @@ pub(crate) mod session_factory;
 #[allow(unused_imports)]
 pub(crate) use session_factory::{InferenceSession, OnnxSessionFactory, SessionFactory};
 
+// Base-path file resolution (internal)
+pub(crate) mod path;
+
 // Main executor
 mod executor;
 pub use executor::TemplateExecutor;

--- a/crates/xybrid-core/src/execution/path.rs
+++ b/crates/xybrid-core/src/execution/path.rs
@@ -1,0 +1,38 @@
+//! Resolves a model file path relative to a base path.
+//!
+//! Shared by the executor and the pre/post-processing pipelines so the
+//! empty-base-path fallback behaves identically across all three call sites.
+
+use std::path::Path;
+
+/// Resolves `file` against `base_path`.
+///
+/// Returns `file` unchanged when `base_path` is empty; otherwise joins them
+/// and returns the lossy UTF-8 form of the resulting path.
+pub(crate) fn resolve_file_path(base_path: &str, file: &str) -> String {
+    if base_path.is_empty() {
+        file.to_string()
+    } else {
+        Path::new(base_path)
+            .join(file)
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_base_returns_file_unchanged() {
+        assert_eq!(resolve_file_path("", "encoder.onnx"), "encoder.onnx");
+    }
+
+    #[test]
+    fn non_empty_base_is_joined() {
+        let resolved = resolve_file_path("/models", "encoder.onnx");
+        assert!(resolved.contains("encoder.onnx"));
+        assert!(resolved.contains("models"));
+    }
+}

--- a/crates/xybrid-core/src/execution/postprocessing/mod.rs
+++ b/crates/xybrid-core/src/execution/postprocessing/mod.rs
@@ -14,6 +14,7 @@ pub mod codec;
 pub mod decode;
 pub mod tensor_ops;
 
+use super::path::resolve_file_path;
 use super::types::{ExecutorResult, RawOutputs};
 use crate::execution::template::PostprocessingStep;
 
@@ -86,17 +87,5 @@ pub fn apply_postprocessing_step(
                 "CodecDecode is handled by CodecTtsStrategy, not the generic postprocessing dispatcher".into(),
             ),
         ),
-    }
-}
-
-/// Resolve a file path relative to base_path.
-fn resolve_file_path(base_path: &str, file: &str) -> String {
-    if base_path.is_empty() {
-        file.to_string()
-    } else {
-        std::path::Path::new(base_path)
-            .join(file)
-            .to_string_lossy()
-            .to_string()
     }
 }

--- a/crates/xybrid-core/src/execution/preprocessing/mod.rs
+++ b/crates/xybrid-core/src/execution/preprocessing/mod.rs
@@ -108,4 +108,3 @@ pub fn apply_preprocessing_step(
         } => image::resize_step(data, *width, *height, interpolation),
     }
 }
-

--- a/crates/xybrid-core/src/execution/preprocessing/mod.rs
+++ b/crates/xybrid-core/src/execution/preprocessing/mod.rs
@@ -16,6 +16,7 @@ pub mod image;
 pub mod tensor;
 pub mod text;
 
+use super::path::resolve_file_path;
 use super::types::{ExecutorResult, PreprocessedData};
 use crate::execution::template::PreprocessingStep;
 use crate::ir::Envelope;
@@ -108,14 +109,3 @@ pub fn apply_preprocessing_step(
     }
 }
 
-/// Resolve a file path relative to base_path.
-fn resolve_file_path(base_path: &str, file: &str) -> String {
-    if base_path.is_empty() {
-        file.to_string()
-    } else {
-        std::path::Path::new(base_path)
-            .join(file)
-            .to_string_lossy()
-            .to_string()
-    }
-}


### PR DESCRIPTION
## Summary

Consolidates the empty-base file-resolution helper that was duplicated byte-for-byte across the executor, preprocessing, and postprocessing modules into a single `pub(crate) execution::path::resolve_file_path` free function with module docs and unit tests. `TemplateExecutor::resolve_file_path` keeps its public signature and now delegates; preprocessing and postprocessing import the shared function. This is the first behavior-preserving increment of the `execution/executor.rs` god-file cleanup, following the Microsoft Pragmatic Rust guidance (`M-REGULAR-FN`, `M-SMALLER-CRATES`). No behavior change; all 904 `xybrid-core` lib tests pass and `clippy --lib --tests -D warnings` is clean.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)