### PR TITLE
fix(release): publish llama-cpp-sys + xybrid-llama to crates.io

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -247,6 +247,8 @@ jobs:
           }
 
           publish_crate xybrid-macros
+          publish_crate llama-cpp-sys
+          publish_crate xybrid-llama
           publish_crate xybrid-core
           publish_crate xybrid-sdk
           publish_crate xybrid

--- a/crates/llama-cpp-sys/Cargo.toml
+++ b/crates/llama-cpp-sys/Cargo.toml
@@ -3,8 +3,8 @@ name = "llama-cpp-sys"
 version.workspace = true
 edition.workspace = true
 license = "MIT"
+repository.workspace = true
 description = "Raw FFI bindings to llama.cpp. Build-time clones + cmake-compiles the pinned upstream commit; first-party C++ shim lives in wrapper.cpp."
-publish = false
 
 # The llama.cpp source tree (~180MB) is fetched via the workspace-level
 # submodule consumed by build.rs (`vendor/llama-cpp/`). This path does not live under this

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `llama-cpp-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-llama-cpp-sys = { path = "../llama-cpp-sys", optional = true }
-xybrid-llama = { path = "../xybrid-llama", optional = true }
+llama-cpp-sys = { path = "../llama-cpp-sys", version = "0.1.2", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.1.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -3,8 +3,8 @@ name = "xybrid-llama"
 version.workspace = true
 edition.workspace = true
 license = "MIT"
+repository.workspace = true
 description = "Safe Rust wrappers over llama-cpp-sys: RAII model/context handles, streaming trampoline, typed errors. Zero `unsafe` on the public surface."
-publish = false
 
 [lib]
 name = "xybrid_llama"
@@ -20,6 +20,6 @@ default = []
 bindings = ["llama-cpp-sys/bindings"]
 
 [dependencies]
-llama-cpp-sys = { path = "../llama-cpp-sys" }
+llama-cpp-sys = { path = "../llama-cpp-sys", version = "0.1.2" }
 thiserror = { workspace = true }
 tracing = "0.1"


### PR DESCRIPTION
## Problem

The #166 llama.cpp crate split broke crates.io publishing as of **v0.1.2**. `xybrid-core` now depends on the new `llama-cpp-sys` + `xybrid-llama` crates via **optional, path-only deps with no version**, and both new crates are marked `publish = false`. `cargo publish` rejects this:

```
all dependencies must have a version requirement specified when publishing.
dependency `llama-cpp-sys` does not specify a version
```

The v0.1.2 release-publish run died on `xybrid-core` — only `xybrid-macros@0.1.2` made it to crates.io; `xybrid-core`/`xybrid-sdk`/`xybrid` are missing, and pub.dev got skipped as a downstream `needs` (since recovered separately). GitHub release, Maven, and the swift branch published fine.

## Fix

- Drop `publish = false` from `llama-cpp-sys` and `xybrid-llama`. Their `build.rs` already supports crates.io consumers (pinned-commit fallback clone when the submodule isn't present), so they were designed to be publishable — the flag was an oversight. The ~180MB llama.cpp source lives at workspace `vendor/llama-cpp/`, outside these crates' manifest dirs, so it is **not** bundled into the tarballs (llama-cpp-sys packages to ~23KiB).
- Add `version` requirements to the three regular path deps (`xybrid-core` → both, `xybrid-llama` → `llama-cpp-sys`).
- Publish the two crates in dependency order (after `xybrid-macros`, before `xybrid-core`) in `release-publish.yml`.

## Validation

`cargo publish --dry-run`: `llama-cpp-sys` packages cleanly; `xybrid-llama`/`xybrid-core` now fail **only** on `llama-cpp-sys` not being on crates.io *yet* (the original "does not specify a version" error is gone). The real flow publishes in order with an index-wait between crates, so each dep exists before the next.

## Shipping

This unblocks crates.io for **0.1.3+** via the normal flow. Finishing crates.io **at 0.1.2** needs a `crates_only` dispatch mode + publishing from this fixed commit (master is still at version 0.1.2) — separate follow-up, pending the 0.1.2-hotfix vs 0.1.3 decision.