### PR TITLE
fix(release): rename llama-cpp-sys crate to xybrid-llama-sys

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -247,7 +247,7 @@ jobs:
           }
 
           publish_crate xybrid-macros
-          publish_crate llama-cpp-sys
+          publish_crate xybrid-llama-sys
           publish_crate xybrid-llama
           publish_crate xybrid-core
           publish_crate xybrid-sdk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,15 +3247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "llama-cpp-sys"
-version = "0.1.2"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7081,7 +7072,6 @@ dependencies = [
  "image 0.25.10",
  "lazy_static",
  "libc",
- "llama-cpp-sys",
  "log",
  "mel_spec",
  "ndarray 0.17.2",
@@ -7120,6 +7110,7 @@ dependencies = [
  "windows 0.61.3",
  "windows-sys 0.59.0",
  "xybrid-llama",
+ "xybrid-llama-sys",
  "xybrid-sdk",
  "zstd",
 ]
@@ -7139,9 +7130,18 @@ dependencies = [
 name = "xybrid-llama"
 version = "0.1.2"
 dependencies = [
- "llama-cpp-sys",
  "thiserror 1.0.69",
  "tracing",
+ "xybrid-llama-sys",
+]
+
+[[package]]
+name = "xybrid-llama-sys"
+version = "0.1.2"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
 ]
 
 [[package]]

--- a/crates/llama-cpp-sys/Cargo.toml
+++ b/crates/llama-cpp-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "llama-cpp-sys"
+name = "xybrid-llama-sys"
 version.workspace = true
 edition.workspace = true
 license = "MIT"

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 description = "Core runtime for hybrid cloud-edge AI inference: model execution, pipeline orchestration, and routing primitives."
 readme = "README.md"
 # Upstream llama backend source lives at workspace `vendor/llama-cpp/`
-# (see `.gitmodules`), consumed by the `llama-cpp-sys` crate's build
+# (see `.gitmodules`), consumed by the `xybrid-llama-sys` crate's build
 # script. No tarball-exclude needed here — the source is not under this
 # crate's manifest dir.
 
@@ -19,13 +19,13 @@ path = "src/lib.rs"
 
 [dependencies]
 # Raw FFI bindings + cmake build for llama.cpp. Gated entirely behind the
-# `llm-llamacpp` feature (which activates both `llama-cpp-sys/bindings`
+# `llm-llamacpp` feature (which activates both `xybrid-llama-sys/bindings`
 # and `xybrid-llama/bindings`) so default builds — and any consumer not
 # opting into llama.cpp — pay zero compile cost. The 3-layer shape:
-#   `llama-cpp-sys`  : raw FFI + cmake build (Phase 1)
+#   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-llama-cpp-sys = { path = "../llama-cpp-sys", version = "0.1.2", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.1.2", optional = true }
 xybrid-llama = { path = "../xybrid-llama", version = "0.1.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
@@ -136,16 +136,16 @@ llm-mistral-metal = ["llm-mistral"]
 llm-mistral-cuda = ["llm-mistral"]
 
 # llama.cpp backend. Enabling `llm-llamacpp` links the llama.cpp runtime:
-# it activates both `llama-cpp-sys/bindings` (cmake build of llama.cpp +
+# it activates both `xybrid-llama-sys/bindings` (cmake build of llama.cpp +
 # wrapper.cpp shim) and `xybrid-llama/bindings` (safe RAII wrappers).
 # All four `platform-*` presets on `xybrid-sdk` depend on it since they
 # ship runtime inference. The 3-layer crate split underneath:
-#   `llama-cpp-sys`  : raw FFI + cmake build (Phase 1)
+#   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
 llm-llamacpp = [
-    "dep:llama-cpp-sys",
-    "llama-cpp-sys/bindings",
+    "dep:xybrid-llama-sys",
+    "xybrid-llama-sys/bindings",
     "dep:xybrid-llama",
     "xybrid-llama/bindings",
 ]

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license = "MIT"
 repository.workspace = true
-description = "Safe Rust wrappers over llama-cpp-sys: RAII model/context handles, streaming trampoline, typed errors. Zero `unsafe` on the public surface."
+description = "Safe Rust wrappers over xybrid-llama-sys: RAII model/context handles, streaming trampoline, typed errors. Zero `unsafe` on the public surface."
 
 [lib]
 name = "xybrid_llama"
@@ -13,13 +13,13 @@ path = "src/lib.rs"
 [features]
 # Default: empty crate that compiles on any target. Consumers opt in to the
 # real llama.cpp-linked implementation via `bindings`, which forwards to
-# `llama-cpp-sys/bindings`. Off by default so workspace-wide `cargo check`
+# `xybrid-llama-sys/bindings`. Off by default so workspace-wide `cargo check`
 # / `cargo clippy` on lean runners (no cmake, no C++ toolchain) stays
-# green — the heavy build cost lives in `llama-cpp-sys/build.rs`.
+# green — the heavy build cost lives in `xybrid-llama-sys/build.rs`.
 default = []
-bindings = ["llama-cpp-sys/bindings"]
+bindings = ["xybrid-llama-sys/bindings"]
 
 [dependencies]
-llama-cpp-sys = { path = "../llama-cpp-sys", version = "0.1.2" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.1.2" }
 thiserror = { workspace = true }
 tracing = "0.1"


### PR DESCRIPTION
## Problem

`#246` flipped `publish = false` off so `xybrid-core` could publish, but it kept the crate name **`llama-cpp-sys`** — which is **already taken on crates.io**. crates.io normalizes `-`/`_`, so it collides with the existing [`llama_cpp_sys`](https://crates.io/crates/llama_cpp_sys) (v0.3.2). `cargo publish -p llama-cpp-sys` would be **rejected server-side** (this is exactly why the ecosystem forks use `llama-cpp-sys-2/-3/-4`). The #246 dry-run didn't catch it because `--dry-run` never uploads.

## Fix

Rename the package to **`xybrid-llama-sys`** (free; consistent with the `xybrid-` prefix of the other published crates):

- `crates/llama-cpp-sys/Cargo.toml`: `name = "xybrid-llama-sys"`. **`[lib] name = "llama_cpp_sys"` is kept**, so no Rust source changes — cargo imports a dependency by its *lib* name, not its package name (`use llama_cpp_sys` still resolves).
- Update the dependency keys + feature refs in `xybrid-llama` and `xybrid-core` (`xybrid-llama-sys = { … }`, `dep:xybrid-llama-sys`, `xybrid-llama-sys/bindings`).
- `release-publish.yml`: publish `xybrid-llama-sys` (in dependency order).
- Regenerated `Cargo.lock`. Crate **directory** stays `crates/llama-cpp-sys/` (dir name is irrelevant to cargo; left to keep the diff small).

`xybrid-llama` and the other published crate names were already free.

## Validation

- `cargo metadata` resolves the full graph (feature wiring intact).
- `cargo publish --dry-run` packages `xybrid-llama-sys@0.1.2` cleanly (23.4 KiB; the 180MB llama.cpp source lives at workspace `vendor/llama-cpp/`, outside the manifest dir).
- Source untouched; CI's `test-llm` builds the `bindings` path and exercises `use llama_cpp_sys` under the renamed package end-to-end.

Stacks on the merged #246. After this lands, the crates.io publish (local or via 0.1.3) is unblocked.