### PR TITLE
ci(scorecard): use a PAT for full Branch-Protection scoring

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,12 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # The default GITHUB_TOKEN cannot read branch-protection settings, so
+          # the Branch-Protection check errors out. Supply a PAT with
+          # Administration:read (secret SCORECARD_TOKEN) to score it fully.
+          # Falls back to the default token when the secret is absent, so this
+          # is safe to land before the secret exists.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary

The Scorecard Branch-Protection check currently reports **-1 (internal error)** because the default `GITHUB_TOKEN` cannot read branch-protection settings — not because protection is misconfigured. Per OSSF guidance, the fix is to give the scorecard action a token with `Administration: read`. This passes `repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}` — it prefers the PAT secret and **falls back to the default token when the secret is absent**, so it's safe to merge before the secret exists and auto-upgrades once it does.

## ⚠️ Action required to take effect (maintainer)
This PR alone changes nothing until the secret is created:
1. Create a **fine-grained PAT** (GitHub → Settings → Developer settings → Fine-grained tokens), scoped to **`xybrid-ai/xybrid`**, with **Repository permissions → Administration: Read-only** (and Metadata: Read-only, which is implied).
2. Add it as a repo secret named **`SCORECARD_TOKEN`** (repo → Settings → Secrets and variables → Actions).
3. Re-run the Scorecard workflow (Actions → Scorecard → Run workflow) — Branch-Protection should score correctly (~8) instead of -1.

> Classic PAT with `repo` scope works too if your org restricts fine-grained PATs, but fine-grained least-privilege is preferred.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (CI / security tooling)

## Checklist

- [x] YAML validated; falls back to `github.token` so the scheduled scan can't break if the secret is missing
- [x] No breaking changes