### PR TITLE
feat(react-native): port RN binding from UniFFI to BoltFFI

### DIFF
--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -1,0 +1,173 @@
+name: Build React Native
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'bindings/react-native/**'
+      - 'bindings/apple/**'
+      - 'bindings/kotlin/**'
+      - 'crates/xybrid-bolt/**'
+      - 'crates/xybrid-ffi-facade/**'
+      - 'xtask/**'
+      - '.github/workflows/build-react-native.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # Only iOS needs per-package native staging: the pod vendors the bolt
+  # XCFramework + Swift wrapper sources. Android pulls its natives + Kotlin
+  # binding from the `ai.xybrid:xybrid-kotlin` Maven AAR (declared in
+  # android/build.gradle), so there is nothing to stage or cross-build here.
+
+  stage-ios:
+    name: Stage iOS artifacts
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: >-
+            aarch64-apple-ios,
+            aarch64-apple-ios-sim,
+            aarch64-apple-darwin
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "rn-ios"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      # boltffi CLI provides the `boltffi pack apple` that build-xcframework
+      # (invoked by stage-react-native) shells out to. `--locked` pins the
+      # 0.25.0 lib crates (see build-apple.yml for the rationale).
+      - name: Cache boltffi CLI
+        id: cache-boltffi
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/boltffi
+          key: boltffi-cli-${{ runner.os }}-0.25
+
+      - name: Install boltffi CLI
+        run: which boltffi || cargo install boltffi_cli --version 0.25.0 --locked
+
+      - name: Stage iOS artifacts
+        run: cargo xtask stage-react-native --release
+
+      - name: Verify iOS staging
+        run: |
+          set -euo pipefail
+          XCFW="bindings/react-native/ios/Frameworks/XybridFFI.xcframework"
+          [ -d "$XCFW" ] || { echo "Missing $XCFW"; exit 1; }
+          for f in Xybrid.swift xybrid_bolt.swift; do
+            [ -f "bindings/react-native/ios/XybridSwift/$f" ] \
+              || { echo "Missing bindings/react-native/ios/XybridSwift/$f"; exit 1; }
+          done
+          echo "iOS staging looks good:"
+          ls -la "$XCFW"
+          ls -la bindings/react-native/ios/XybridSwift/
+
+      - name: Upload iOS staged artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rn-ios-staged
+          path: |
+            bindings/react-native/ios/Frameworks/
+            bindings/react-native/ios/XybridSwift/
+          if-no-files-found: error
+
+  package:
+    name: Typecheck + npm pack
+    needs: stage-ios
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '20'
+
+      - name: Download iOS staged artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rn-ios-staged
+          path: bindings/react-native/ios/
+
+      - name: Install RN module deps
+        working-directory: bindings/react-native
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck
+        working-directory: bindings/react-native
+        run: npm run typecheck
+
+      - name: Build TS
+        working-directory: bindings/react-native
+        run: npm run build
+
+      - name: npm pack (dry-run)
+        working-directory: bindings/react-native
+        run: npm pack --dry-run
+
+      - name: npm pack (real)
+        working-directory: bindings/react-native
+        run: npm pack
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: react-native-xybrid-tarball
+          path: bindings/react-native/react-native-xybrid-*.tgz
+          if-no-files-found: error
+
+  smoke-ios:
+    name: Smoke build (iOS podspec lint)
+    needs: stage-ios
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download iOS staged artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rn-ios-staged
+          path: bindings/react-native/ios/
+
+      # `--quick` validates the podspec's syntax, file paths, and dependency
+      # graph — which is what this gate is for. A full lint runs xcodebuild
+      # against the spec in isolation, which fails for a RN TurboModule
+      # because the spec depends on React Native's codegen output and headers
+      # (e.g. `<React/RCTBridgeModule.h>`) that `pod lib lint` can't resolve
+      # without a host app's `use_react_native!` setup. Replace with a real
+      # `pod install` against an example app when one is added.
+      - name: Lint podspec
+        working-directory: bindings/react-native
+        run: |
+          pod lib lint react-native-xybrid.podspec \
+            --allow-warnings \
+            --quick \
+            --verbose

--- a/bindings/react-native/.gitignore
+++ b/bindings/react-native/.gitignore
@@ -1,0 +1,23 @@
+# Build outputs
+lib/
+node_modules/
+
+# iOS native artifacts staged by `cargo xtask stage-react-native`. These are
+# produced from the Rust core and should not be checked in — the published
+# npm tarball includes them (CI runs the xtask before `npm pack`), but
+# they're regenerated from source on every build, so committing would just
+# create merge friction.
+#
+# Android stages nothing: the module depends on the `ai.xybrid:xybrid-kotlin`
+# Maven AAR (it bundles the bolt .so + ORT + the Kotlin binding), so gradle
+# resolves the natives at consumer build time.
+#
+# HEADS-UP: installing this package from a git ref (e.g.
+# `react-native-xybrid: github:xybrid-ai/xybrid#some-sha`) will NOT pull
+# the iOS native artifacts — there is no `prepare` script that regenerates
+# them at install time, because doing so would force every consumer to
+# have a Rust toolchain. Install from the npm registry (or from the CI
+# tarball artifact) to get a working iOS package.
+ios/Frameworks/
+ios/XybridSwift/Xybrid.swift
+ios/XybridSwift/xybrid_bolt.swift

--- a/bindings/react-native/.npmignore
+++ b/bindings/react-native/.npmignore
@@ -1,0 +1,9 @@
+# Source/dev files we don't ship
+node_modules/
+example/
+.github/
+.editorconfig
+tsconfig.json
+tsconfig.build.json
+*.log
+.DS_Store

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -1,0 +1,118 @@
+# react-native-xybrid
+
+React Native binding for the Xybrid SDK. Wraps the same BoltFFI-generated
+Swift/Kotlin surface that powers the standalone iOS and Android SDKs, exposed
+to JavaScript through a TurboModule.
+
+## Status
+
+**Spike / pre-release.** Surface covers loader → `run()` plus voice
+introspection and platform-state push. Streaming (ASR partials, LLM token
+streams) and per-call generation config are not yet wired through — see
+"Open work" below.
+
+## Architecture
+
+```
+JS / TS
+  └── react-native-xybrid (this package)
+        ├── ios/      Swift TurboModule → bundled Xybrid.swift wrapper → XybridFFI.xcframework
+        └── android/  Kotlin TurboModule → ai.xybrid:xybrid-kotlin AAR (Maven; bundles .so + ORT)
+                                                          └── xybrid-bolt (Rust, BoltFFI)
+                                                                └── xybrid-ffi-facade (Rust)
+                                                                      └── xybrid-sdk → xybrid-core (Rust)
+```
+
+The two platforms consume the bolt core differently:
+
+- **iOS** vendors the `XybridFFI.xcframework` + the bolt Swift wrapper sources,
+  staged into this package by `cargo xtask stage-react-native` (from the same
+  `build-xcframework` output the standalone Apple SDK uses).
+- **Android** depends on the published `ai.xybrid:xybrid-kotlin` Maven AAR,
+  which bundles `libxybrid-bolt.so` + the ONNX Runtime alongside the
+  `ai.xybrid.*` Kotlin classes. Nothing is staged per-package.
+
+No new Rust code — the bridge is purely a thin layer above the bolt bindings.
+
+## Layout
+
+```
+bindings/react-native/
+├── package.json             # npm + RN codegen config
+├── react-native-xybrid.podspec
+├── src/
+│   ├── index.ts             # Public TS facade (Xybrid, ModelLoader, Model)
+│   ├── NativeXybrid.ts      # TurboModule spec (codegen input)
+│   └── types.ts
+├── ios/
+│   ├── XybridModule.{h,mm}  # ObjC++ TurboModule registration
+│   ├── XybridModuleImpl.swift  # Actual work, calls bundled Xybrid.swift
+│   ├── XybridSwift/         # ← staged by xtask: Xybrid.swift + xybrid_bolt.swift
+│   └── Frameworks/          # ← staged by xtask: XybridFFI.xcframework
+└── android/
+    ├── build.gradle         # depends on ai.xybrid:xybrid-kotlin (Maven AAR)
+    └── src/main/java/ai/xybrid/reactnative/
+        ├── XybridModule.kt  # Kotlin TurboModule → ai.xybrid.* (from the AAR)
+        └── XybridPackage.kt
+```
+
+The staged iOS paths are gitignored — they're regenerated from the Rust core
+on every build and shipped vendored inside the npm tarball. Android pulls its
+binding + natives from Maven, so there is nothing to stage there.
+
+## Local development
+
+```bash
+# 1. Stage the iOS native artifacts (XCFramework + Swift wrapper). macOS only.
+#    Android needs nothing — gradle resolves the Maven AAR.
+cargo xtask stage-react-native --release
+
+# 2. Use a yarn link or relative path in a sample app
+cd ../my-sample-rn-app
+yarn add ../xybrid/bindings/react-native
+cd ios && pod install && cd ..
+
+# 3. Wrap the app entry
+import { Xybrid, ModelLoader } from 'react-native-xybrid';
+
+await Xybrid.initialize();
+const model = await ModelLoader.fromRegistry('whisper-tiny').load();
+const result = await model.run({ kind: 'audio', bytesBase64, sampleRate: 16000, channels: 1 });
+console.log(result.text);
+await model.release();
+```
+
+> The JS `ModelLoader.fromRegistry(id).load()` facade is preserved for API
+> stability even though the native bolt layer collapsed the loader into the
+> `XybridModel` factories — `index.ts` maps the old shape onto the new calls.
+
+## Requirements
+
+- React Native ≥ 0.74 (TurboModules + codegen).
+- iOS 13+, Android API 24+ (matches xybrid-kotlin and xybrid-apple).
+- **Apple Silicon Mac for iOS development.** The staged XCFramework
+  intentionally omits `ios-x86_64-simulator` and `macos-x86_64` slices —
+  ort-sys ships no prebuilt ONNX Runtime for Intel Mac / Intel iOS
+  Simulator, so the podspec excludes those archs explicitly. Apps built
+  for real iOS devices (arm64) work everywhere; only the simulator
+  workflow is constrained.
+- New Architecture enabled (`newArchEnabled=true` in `gradle.properties`,
+  `RCT_NEW_ARCH_ENABLED=1` in the iOS Podfile env).
+
+## Open work for GA
+
+1. **Streaming.** ASR partial results and LLM token streams aren't surfaced to
+   JS yet — they need an `EventEmitter` (legacy) or a JSI `HostObject` wrapper
+   for low-jitter token delivery.
+2. **Generation config on `run`.** The bolt `XybridModel.run(envelope)` does
+   not yet accept a per-call `GenerationConfig`; the JS `config` argument is
+   currently ignored. Unblocks once the facade/bolt surface threads config
+   through `run`.
+3. **Binary payloads.** Audio bytes ride as base64 strings today. Move to
+   `ArrayBuffer` via JSI to drop the encode/decode hop on every chunk.
+4. **TypeScript codegen.** The `Spec` interface is hand-written; once the
+   surface stabilizes, generate `NativeXybrid.ts` from the same bolt `#[data]`
+   definitions the other bindings derive from, to keep them in lockstep.
+5. **Example app + automated smoke test.** No `example/` directory yet.
+   The CI workflow builds and lints the package but does not yet run a
+   sample app end-to-end.

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -1,0 +1,86 @@
+// React Native autolinking discovers this module via package.json.
+// Mirrors the layout of community modules (e.g. react-native-mmkv): the
+// module is consumable directly from a yarn install + gradle sync.
+//
+// The bolt-generated Kotlin binding and its native artifacts come from the
+// published `ai.xybrid:xybrid-kotlin` AAR on Maven Central — it bundles
+// `libxybrid-bolt.so` + the ORT runtime alongside the `ai.xybrid.*`
+// classes that `XybridModule.kt` calls into. No per-package native staging
+// is needed on Android; gradle resolves the AAR like any other dependency.
+
+buildscript {
+  ext.safeExtGet = { prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath("com.android.tools.build:gradle:8.1.1")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+  }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+def isNewArchitectureEnabled() {
+  return rootProject.hasProperty("newArchEnabled") &&
+         rootProject.getProperty("newArchEnabled") == "true"
+}
+
+android {
+  namespace "ai.xybrid.reactnative"
+  compileSdkVersion safeExtGet("compileSdkVersion", 34)
+
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 24)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
+
+    // ABIs match what `cargo xtask build-android` produces.
+    ndk {
+      abiFilters "armeabi-v7a", "arm64-v8a", "x86_64"
+    }
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+  }
+
+  buildFeatures {
+    buildConfig true
+  }
+}
+
+repositories {
+  mavenCentral()
+  google()
+}
+
+dependencies {
+  // RN core. The Maven range `[0.74.0,)` ("0.74.0 or later") matches the
+  // npm peer dependency in package.json — without it a consumer on RN 0.74
+  // or 0.75 satisfies the npm peer check but trips a gradle resolution
+  // error. Note: Gradle's `+` suffix is a prefix wildcard (`0.74.0+` would
+  // ONLY match `0.74.0.*`, not 0.75/0.76/…), which is the opposite of what
+  // a community RN module wants. Real-world resolution: host apps pin RN
+  // to a specific version, which our open range trivially satisfies, and
+  // gradle's conflict resolver picks the host's pin.
+  implementation "com.facebook.react:react-native:[0.74.0,)"
+
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
+
+  // The bolt Kotlin SDK: provides the `ai.xybrid.*` classes XybridModule.kt
+  // calls (Xybrid, XybridModel, Envelope, XybridError, …) and bundles
+  // `libxybrid-bolt.so` + the ORT runtime in the AAR. Bolt talks to the
+  // native layer over JNI directly, so there is no JNA dependency (unlike
+  // the previous uniffi binding). Keep this version in lockstep with the
+  // workspace SDK version.
+  implementation "ai.xybrid:xybrid-kotlin:0.1.2"
+}

--- a/bindings/react-native/android/src/main/AndroidManifest.xml
+++ b/bindings/react-native/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
@@ -36,9 +36,11 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.File
 import java.util.UUID
@@ -51,6 +53,17 @@ class XybridModule(reactContext: ReactApplicationContext) :
   private val models = ConcurrentHashMap<String, XybridModel>()
 
   override fun getName(): String = NAME
+
+  // Released when the RN module is torn down (fast refresh, bundle reload,
+  // host teardown). Native model weights are hundreds of MB, so failing to
+  // close them promptly OOMs the device — cancel in-flight work and free
+  // every handle here.
+  override fun invalidate() {
+    super.invalidate()
+    scope.cancel()
+    models.values.forEach { it.close() }
+    models.clear()
+  }
 
   // -- Lifecycle --
 
@@ -136,6 +149,9 @@ class XybridModule(reactContext: ReactApplicationContext) :
       } catch (e: XybridError) {
         rejectXybrid(promise, e)
       } catch (t: Throwable) {
+        // Don't swallow coroutine cancellation (e.g. scope.cancel() on
+        // module invalidation) — let it propagate so the machinery unwinds.
+        if (t is CancellationException) throw t
         promise.reject("xybrid", t.message, t)
       }
     }
@@ -196,7 +212,7 @@ class XybridModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun setThermalState(state: String, promise: Promise) {
-    val mapped = when (state.lowercase()) {
+    val mapped = when (state.lowercase(java.util.Locale.ROOT)) {
       "normal" -> XybridThermalState.NORMAL
       "warm" -> XybridThermalState.WARM
       "hot" -> XybridThermalState.HOT
@@ -228,6 +244,9 @@ class XybridModule(reactContext: ReactApplicationContext) :
       } catch (e: XybridError) {
         rejectXybrid(promise, e)
       } catch (t: Throwable) {
+        // Don't swallow coroutine cancellation (e.g. scope.cancel() on
+        // module invalidation) — let it propagate so the machinery unwinds.
+        if (t is CancellationException) throw t
         promise.reject("xybrid", t.message, t)
       }
     }
@@ -244,8 +263,8 @@ class XybridModule(reactContext: ReactApplicationContext) :
         val b64 = map.getString("bytesBase64")
           ?: throw IllegalArgumentException("audio envelope: 'bytesBase64' missing")
         val bytes = Base64.decode(b64, Base64.DEFAULT)
-        val sampleRate = if (map.hasKey("sampleRate")) map.getInt("sampleRate") else 16000
-        val channels = if (map.hasKey("channels")) map.getInt("channels") else 1
+        val sampleRate = if (map.hasKey("sampleRate") && !map.isNull("sampleRate")) map.getInt("sampleRate") else 16000
+        val channels = if (map.hasKey("channels") && !map.isNull("channels")) map.getInt("channels") else 1
         Envelope.audio(bytes, sampleRate.toUInt(), channels.toUInt())
       }
       "text" -> {

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
@@ -1,0 +1,328 @@
+package ai.xybrid.reactnative
+
+// TurboModule implementation. Forwards every JS call into the Kotlin
+// wrapper that ships at `bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt`,
+// which is itself a thin layer over the BoltFFI-generated bindings.
+//
+// Model handles are opaque string IDs (UUIDs). The native side keeps a
+// concurrent map of `id -> XybridModel`; `releaseModel` drops the entry and
+// closes the handle so the underlying Rust `Arc<XybridModel>` decrements and
+// frees.
+
+import ai.xybrid.Envelope
+import ai.xybrid.Xybrid
+import ai.xybrid.XybridEnvelope
+import ai.xybrid.XybridError
+import ai.xybrid.XybridModel
+import ai.xybrid.XybridResult
+import ai.xybrid.XybridThermalState
+import ai.xybrid.XybridVoiceInfo
+import ai.xybrid.audioBytes
+import ai.xybrid.clearBatteryLevel
+import ai.xybrid.clearThermalState
+import ai.xybrid.embedding
+import ai.xybrid.initSdkCacheDir
+import ai.xybrid.setBatteryLevel
+import ai.xybrid.setBinding
+import ai.xybrid.setThermalState
+import ai.xybrid.success
+import ai.xybrid.text
+import android.util.Base64
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class XybridModule(reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private val models = ConcurrentHashMap<String, XybridModel>()
+
+  override fun getName(): String = NAME
+
+  // -- Lifecycle --
+
+  @ReactMethod
+  fun initialize(cacheDir: String?, promise: Promise) {
+    try {
+      // Register react-native as the binding identity *before* invoking
+      // Xybrid.init, which would otherwise lock in "kotlin" via its own
+      // setBinding call. set_binding is OnceLock-guarded so the first call
+      // wins; this ordering pins the registry header to react-native.
+      setBinding("react-native")
+      Xybrid.init(reactApplicationContext)
+
+      // Override the cache dir if the JS side supplied one. Otherwise
+      // Xybrid.init has already pointed it at <filesDir>/xybrid/models.
+      if (!cacheDir.isNullOrEmpty()) {
+        File(cacheDir).mkdirs()
+        initSdkCacheDir(cacheDir)
+      }
+      promise.resolve(null)
+    } catch (t: Throwable) {
+      promise.reject("xybrid_init", t.message, t)
+    }
+  }
+
+  // -- Loaders --
+  //
+  // Bolt collapsed `XybridModelLoader.fromX(...).load()` into the
+  // `XybridModel` factories: the primary constructor loads from the registry,
+  // and `fromBundle` / `fromDirectory` / `fromHuggingface` are companion
+  // factories. Each loads eagerly (there is no separate `.load()` step).
+
+  @ReactMethod
+  fun loadFromRegistry(modelId: String, promise: Promise) {
+    runLoad(promise) { XybridModel(modelId) }
+  }
+
+  @ReactMethod
+  fun loadFromBundle(path: String, promise: Promise) {
+    runLoad(promise) { XybridModel.fromBundle(path) }
+  }
+
+  @ReactMethod
+  fun loadFromDirectory(path: String, promise: Promise) {
+    runLoad(promise) { XybridModel.fromDirectory(path) }
+  }
+
+  @ReactMethod
+  fun loadFromHuggingface(repo: String, promise: Promise) {
+    runLoad(promise) { XybridModel.fromHuggingface(repo) }
+  }
+
+  @ReactMethod
+  fun releaseModel(handle: String, promise: Promise) {
+    models.remove(handle)?.close()
+    promise.resolve(null)
+  }
+
+  // -- Inference --
+
+  @ReactMethod
+  fun run(handle: String, envelope: ReadableMap, config: ReadableMap?, promise: Promise) {
+    val model = models[handle]
+    if (model == null) {
+      promise.reject("xybrid_handle", "Unknown model handle: $handle")
+      return
+    }
+    val env = try {
+      decodeEnvelope(envelope)
+    } catch (e: IllegalArgumentException) {
+      promise.reject("xybrid_envelope", e.message, e)
+      return
+    }
+    // NOTE: bolt's `XybridModel.run(envelope)` does not yet accept a
+    // per-call generation config — config is ignored until the facade/bolt
+    // surface threads `GenerationConfig` through `run`. Tracked as a
+    // bolt-binding follow-up.
+
+    scope.launch {
+      try {
+        val result = model.run(env)
+        promise.resolve(encodeResult(result))
+      } catch (e: XybridError) {
+        rejectXybrid(promise, e)
+      } catch (t: Throwable) {
+        promise.reject("xybrid", t.message, t)
+      }
+    }
+  }
+
+  // -- TTS introspection --
+
+  @ReactMethod
+  fun voices(handle: String, promise: Promise) {
+    val model = models[handle]
+    if (model == null) {
+      promise.reject("xybrid_handle", "Unknown model handle: $handle")
+      return
+    }
+    if (!model.hasVoices()) {
+      promise.resolve(null)
+      return
+    }
+    val out = Arguments.createArray()
+    model.voices().forEach { out.pushMap(encodeVoice(it)) }
+    promise.resolve(out)
+  }
+
+  @ReactMethod
+  fun defaultVoiceId(handle: String, promise: Promise) {
+    val model = models[handle]
+    if (model == null) {
+      promise.reject("xybrid_handle", "Unknown model handle: $handle")
+      return
+    }
+    promise.resolve(model.defaultVoice()?.id)
+  }
+
+  @ReactMethod
+  fun hasVoices(handle: String, promise: Promise) {
+    val model = models[handle]
+    if (model == null) {
+      promise.reject("xybrid_handle", "Unknown model handle: $handle")
+      return
+    }
+    promise.resolve(model.hasVoices())
+  }
+
+  // -- Platform-state push --
+
+  @ReactMethod
+  fun setBatteryLevel(percent: Double, promise: Promise) {
+    val bounded = percent.coerceIn(0.0, 100.0).toInt()
+    setBatteryLevel(bounded.toUByte())
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun clearBatteryLevel(promise: Promise) {
+    clearBatteryLevel()
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun setThermalState(state: String, promise: Promise) {
+    val mapped = when (state.lowercase()) {
+      "normal" -> XybridThermalState.NORMAL
+      "warm" -> XybridThermalState.WARM
+      "hot" -> XybridThermalState.HOT
+      "critical" -> XybridThermalState.CRITICAL
+      else -> {
+        promise.reject("xybrid_thermal", "Unknown thermal state: $state")
+        return
+      }
+    }
+    setThermalState(mapped)
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun clearThermalState(promise: Promise) {
+    clearThermalState()
+    promise.resolve(null)
+  }
+
+  // MARK: - Helpers
+
+  private fun runLoad(promise: Promise, factory: suspend () -> XybridModel) {
+    scope.launch {
+      try {
+        val model = factory()
+        val id = UUID.randomUUID().toString()
+        models[id] = model
+        promise.resolve(id)
+      } catch (e: XybridError) {
+        rejectXybrid(promise, e)
+      } catch (t: Throwable) {
+        promise.reject("xybrid", t.message, t)
+      }
+    }
+  }
+
+  // Build a bolt [XybridEnvelope] via the `Envelope` factories, which fold the
+  // well-known TTS / ASR options (sample_rate, channels, voice_id, speed) into
+  // envelope metadata entries — the bolt `XybridEnvelopeKind` variants
+  // themselves only carry the raw payload.
+  private fun decodeEnvelope(map: ReadableMap): XybridEnvelope {
+    val kind = map.getString("kind") ?: throw IllegalArgumentException("envelope missing 'kind'")
+    return when (kind) {
+      "audio" -> {
+        val b64 = map.getString("bytesBase64")
+          ?: throw IllegalArgumentException("audio envelope: 'bytesBase64' missing")
+        val bytes = Base64.decode(b64, Base64.DEFAULT)
+        val sampleRate = if (map.hasKey("sampleRate")) map.getInt("sampleRate") else 16000
+        val channels = if (map.hasKey("channels")) map.getInt("channels") else 1
+        Envelope.audio(bytes, sampleRate.toUInt(), channels.toUInt())
+      }
+      "text" -> {
+        val text = map.getString("text")
+          ?: throw IllegalArgumentException("text envelope: 'text' missing")
+        val voiceId = if (map.hasKey("voiceId") && !map.isNull("voiceId")) map.getString("voiceId") else null
+        val speed = if (map.hasKey("speed") && !map.isNull("speed")) map.getDouble("speed") else null
+        if (voiceId != null) {
+          Envelope.text(text, voiceId, speed ?: 1.0)
+        } else {
+          Envelope.text(text)
+        }
+      }
+      "embedding" -> {
+        val arr = map.getArray("data")
+          ?: throw IllegalArgumentException("embedding envelope: 'data' missing")
+        Envelope.embedding(arr.toFloatArray())
+      }
+      else -> throw IllegalArgumentException("Unknown envelope kind: $kind")
+    }
+  }
+
+  private fun ReadableArray.toFloatArray(): FloatArray {
+    val out = FloatArray(size())
+    for (i in 0 until size()) out[i] = getDouble(i).toFloat()
+    return out
+  }
+
+  private fun encodeResult(r: XybridResult): WritableMap {
+    val out = Arguments.createMap()
+    out.putBoolean("success", r.success)
+    out.putInt("latencyMs", r.latencyMs.toInt())
+    r.text?.let { out.putString("text", it) }
+    r.audioBytes?.let { out.putString("audioBytesBase64", Base64.encodeToString(it, Base64.NO_WRAP)) }
+    r.embedding?.let {
+      val arr = Arguments.createArray()
+      it.forEach { f -> arr.pushDouble(f.toDouble()) }
+      out.putArray("embedding", arr)
+    }
+    return out
+  }
+
+  private fun encodeVoice(v: XybridVoiceInfo): WritableMap {
+    val out = Arguments.createMap()
+    out.putString("id", v.id)
+    out.putString("name", v.name)
+    v.gender?.let { out.putString("gender", it) }
+    v.language?.let { out.putString("language", it) }
+    v.style?.let { out.putString("style", it) }
+    return out
+  }
+
+  private fun rejectXybrid(promise: Promise, e: XybridError) {
+    val code = when (e) {
+      is XybridError.ModelNotFound -> "xybrid_model_not_found"
+      is XybridError.DirectoryNotFound -> "xybrid_directory_not_found"
+      is XybridError.MetadataNotFound -> "xybrid_metadata_not_found"
+      is XybridError.MetadataInvalid -> "xybrid_metadata_invalid"
+      is XybridError.LoadError -> "xybrid_load_error"
+      is XybridError.InferenceError -> "xybrid_inference_error"
+      is XybridError.AbortedForCloudFallback -> "xybrid_aborted_cloud_fallback"
+      is XybridError.StreamingNotSupported -> "xybrid_streaming_unsupported"
+      is XybridError.NotLoaded -> "xybrid_not_loaded"
+      is XybridError.ConfigError -> "xybrid_config_error"
+      is XybridError.NetworkError -> "xybrid_network_error"
+      is XybridError.Offline -> "xybrid_offline"
+      is XybridError.IoError -> "xybrid_io_error"
+      is XybridError.CacheError -> "xybrid_cache_error"
+      is XybridError.PipelineError -> "xybrid_pipeline_error"
+      is XybridError.CircuitOpen -> "xybrid_circuit_open"
+      is XybridError.RateLimited -> "xybrid_rate_limited"
+      is XybridError.Timeout -> "xybrid_timeout"
+    }
+    promise.reject(code, e.message ?: "Xybrid error", e)
+  }
+
+  companion object {
+    const val NAME = "RNXybrid"
+  }
+}

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridPackage.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridPackage.kt
@@ -1,0 +1,14 @@
+package ai.xybrid.reactnative
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class XybridPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+    listOf(XybridModule(reactContext))
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+    emptyList()
+}

--- a/bindings/react-native/ios/XybridModule.h
+++ b/bindings/react-native/ios/XybridModule.h
@@ -1,0 +1,14 @@
+#import <React/RCTBridgeModule.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNXybridSpec/RNXybridSpec.h>
+
+@interface XybridModule : NSObject <NativeRNXybridSpec>
+@end
+
+#else
+
+@interface XybridModule : NSObject <RCTBridgeModule>
+@end
+
+#endif

--- a/bindings/react-native/ios/XybridModule.mm
+++ b/bindings/react-native/ios/XybridModule.mm
@@ -1,0 +1,143 @@
+#import "XybridModule.h"
+#import "react_native_xybrid-Swift.h"
+
+// ObjC++ shim that forwards every TurboModule call to the Swift
+// `XybridModuleImpl` actor. The split exists because:
+//   1. RCT_EXPORT_MODULE / codegen need an ObjC class on the registration path.
+//   2. The bolt Swift APIs are Swift-native (`throws` functions, handles
+//      surface as Swift class instances) — calling them from ObjC++ is
+//      possible but loses the `throws` ergonomics. Keeping the bridge
+//      thin in ObjC and the work in Swift mirrors how the Apple SDK wrapper
+//      is structured (see bindings/apple/Sources/Xybrid/Xybrid.swift).
+
+@implementation XybridModule {
+  XybridModuleImpl *_impl;
+}
+
+RCT_EXPORT_MODULE(RNXybrid)
+
++ (BOOL)requiresMainQueueSetup { return NO; }
+
+- (instancetype)init {
+  if ((self = [super init])) {
+    _impl = [XybridModuleImpl new];
+  }
+  return self;
+}
+
+#pragma mark - Lifecycle
+
+RCT_REMAP_METHOD(initialize,
+                 initializeWithCacheDir:(NSString * _Nullable)cacheDir
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl initializeWithCacheDir:cacheDir resolve:resolve reject:reject];
+}
+
+#pragma mark - Loaders
+
+RCT_REMAP_METHOD(loadFromRegistry,
+                 loadFromRegistry:(NSString *)modelId
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl loadFromRegistry:modelId resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(loadFromBundle,
+                 loadFromBundle:(NSString *)path
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl loadFromBundle:path resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(loadFromDirectory,
+                 loadFromDirectory:(NSString *)path
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl loadFromDirectory:path resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(loadFromHuggingface,
+                 loadFromHuggingface:(NSString *)repo
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl loadFromHuggingface:repo resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(releaseModel,
+                 releaseModel:(NSString *)handle
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl releaseModel:handle resolve:resolve reject:reject];
+}
+
+#pragma mark - Inference
+
+RCT_REMAP_METHOD(run,
+                 run:(NSString *)handle
+                 envelope:(NSDictionary *)envelope
+                 config:(NSDictionary * _Nullable)config
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl run:handle envelope:envelope config:config resolve:resolve reject:reject];
+}
+
+#pragma mark - TTS introspection
+
+RCT_REMAP_METHOD(voices,
+                 voices:(NSString *)handle
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl voices:handle resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(defaultVoiceId,
+                 defaultVoiceId:(NSString *)handle
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl defaultVoiceId:handle resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(hasVoices,
+                 hasVoices:(NSString *)handle
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl hasVoices:handle resolve:resolve reject:reject];
+}
+
+#pragma mark - Platform-state push
+
+RCT_REMAP_METHOD(setBatteryLevel,
+                 setBatteryLevel:(double)percent
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl setBatteryLevel:percent resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(clearBatteryLevel,
+                 clearBatteryLevelWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl clearBatteryLevel:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(setThermalState,
+                 setThermalState:(NSString *)state
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl setThermalState:state resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(clearThermalState,
+                 clearThermalStateWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl clearThermalState:resolve reject:reject];
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeRNXybridSpecJSI>(params);
+}
+#endif
+
+@end

--- a/bindings/react-native/ios/XybridModuleImpl.swift
+++ b/bindings/react-native/ios/XybridModuleImpl.swift
@@ -1,0 +1,302 @@
+import Foundation
+import React
+
+// `XybridModuleImpl` does the actual work of every TurboModule call. It
+// holds the `id -> XybridModel` map (model handles are opaque strings on
+// the JS side) and translates between RN's NSDictionary payloads and the
+// Swift-native BoltFFI types in the bundled `Xybrid.swift` wrapper.
+//
+// All long-running operations (load, run) hop onto a detached Task so the
+// React Native module thread isn't blocked. Errors map to NSError with the
+// underlying XybridError's `errorDescription` as the message.
+
+@objc(XybridModuleImpl)
+public final class XybridModuleImpl: NSObject {
+  private let modelsLock = NSLock()
+  private var models: [String: XybridModel] = [:]
+
+  // -- Lifecycle --
+
+  @objc public func initializeWithCacheDir(_ cacheDir: String?,
+                                           resolve: @escaping RCTPromiseResolveBlock,
+                                           reject: @escaping RCTPromiseRejectBlock) {
+    // The Swift Xybrid.initialize() registers the binding identifier and
+    // wires up UIDevice battery observers. We override the binding right
+    // before to "react-native" — Xybrid.initialize() registers "swift" by
+    // default, but the registry's first-set-wins OnceLock means we have to
+    // call set_binding *first* if we want a different value.
+    setBinding(binding: "react-native")
+    Xybrid.initialize()
+
+    if let dir = cacheDir, !dir.isEmpty {
+      initSdkCacheDir(cacheDir: dir)
+    } else {
+      // Default cache root: <Library>/Caches/xybrid/models
+      let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+      let xybridCache = caches.appendingPathComponent("xybrid/models", isDirectory: true)
+      try? FileManager.default.createDirectory(at: xybridCache, withIntermediateDirectories: true)
+      initSdkCacheDir(cacheDir: xybridCache.path)
+    }
+    resolve(nil)
+  }
+
+  // -- Loaders --
+  //
+  // Bolt collapsed `XybridModelLoader.fromX(...).load()` into throwing
+  // `XybridModel` convenience initializers; the primary registry path is
+  // `init(fromRegistry:)`. Each initializer loads eagerly (synchronously),
+  // so we run it on a detached Task to keep the RN thread free.
+
+  @objc public func loadFromRegistry(_ modelId: String,
+                                     resolve: @escaping RCTPromiseResolveBlock,
+                                     reject: @escaping RCTPromiseRejectBlock) {
+    runAsyncLoad(resolve: resolve, reject: reject) { try XybridModel(fromRegistry: modelId) }
+  }
+
+  @objc public func loadFromBundle(_ path: String,
+                                   resolve: @escaping RCTPromiseResolveBlock,
+                                   reject: @escaping RCTPromiseRejectBlock) {
+    runAsyncLoad(resolve: resolve, reject: reject) { try XybridModel(fromBundle: path) }
+  }
+
+  @objc public func loadFromDirectory(_ path: String,
+                                      resolve: @escaping RCTPromiseResolveBlock,
+                                      reject: @escaping RCTPromiseRejectBlock) {
+    runAsyncLoad(resolve: resolve, reject: reject) { try XybridModel(fromDirectory: path) }
+  }
+
+  @objc public func loadFromHuggingface(_ repo: String,
+                                        resolve: @escaping RCTPromiseResolveBlock,
+                                        reject: @escaping RCTPromiseRejectBlock) {
+    runAsyncLoad(resolve: resolve, reject: reject) { try XybridModel(fromHuggingface: repo) }
+  }
+
+  @objc public func releaseModel(_ handle: String,
+                                 resolve: @escaping RCTPromiseResolveBlock,
+                                 reject: @escaping RCTPromiseRejectBlock) {
+    modelsLock.lock()
+    models.removeValue(forKey: handle)
+    modelsLock.unlock()
+    resolve(nil)
+  }
+
+  // -- Inference --
+
+  @objc public func run(_ handle: String,
+                        envelope: NSDictionary,
+                        config: NSDictionary?,
+                        resolve: @escaping RCTPromiseResolveBlock,
+                        reject: @escaping RCTPromiseRejectBlock) {
+    guard let model = lookup(handle) else {
+      reject("xybrid_handle", "Unknown model handle: \(handle)", nil)
+      return
+    }
+    let envelopeOrError = decodeEnvelope(envelope)
+    // NOTE: bolt's `XybridModel.run(envelope:)` does not yet accept a
+    // per-call generation config — `config` is ignored until the facade/bolt
+    // surface threads `GenerationConfig` through `run`. Tracked as a
+    // bolt-binding follow-up.
+
+    Task.detached {
+      switch envelopeOrError {
+      case .failure(let err):
+        reject("xybrid_envelope", err, nil)
+      case .success(let env):
+        do {
+          let result = try model.run(envelope: env)
+          resolve(self.encodeResult(result))
+        } catch let error as XybridError {
+          self.rejectXybrid(error, reject)
+        } catch {
+          reject("xybrid", error.localizedDescription, error)
+        }
+      }
+    }
+  }
+
+  // -- TTS introspection --
+
+  @objc public func voices(_ handle: String,
+                           resolve: @escaping RCTPromiseResolveBlock,
+                           reject: @escaping RCTPromiseRejectBlock) {
+    guard let model = lookup(handle) else {
+      reject("xybrid_handle", "Unknown model handle: \(handle)", nil)
+      return
+    }
+    let voices = model.hasVoices() ? model.voices().map { encodeVoice($0) } : nil
+    resolve(voices as Any)
+  }
+
+  @objc public func defaultVoiceId(_ handle: String,
+                                   resolve: @escaping RCTPromiseResolveBlock,
+                                   reject: @escaping RCTPromiseRejectBlock) {
+    guard let model = lookup(handle) else {
+      reject("xybrid_handle", "Unknown model handle: \(handle)", nil)
+      return
+    }
+    resolve(model.defaultVoice()?.id as Any)
+  }
+
+  @objc public func hasVoices(_ handle: String,
+                              resolve: @escaping RCTPromiseResolveBlock,
+                              reject: @escaping RCTPromiseRejectBlock) {
+    guard let model = lookup(handle) else {
+      reject("xybrid_handle", "Unknown model handle: \(handle)", nil)
+      return
+    }
+    resolve(model.hasVoices())
+  }
+
+  // -- Platform-state push --
+
+  @objc public func setBatteryLevel(_ percent: Double,
+                                    resolve: @escaping RCTPromiseResolveBlock,
+                                    reject: @escaping RCTPromiseRejectBlock) {
+    let bounded = max(0, min(100, Int(percent.rounded())))
+    // Free function from xybrid_bolt.swift; overload resolution distinguishes
+    // it from the @objc member above by the `percent:` UInt8 label.
+    setBatteryLevel(percent: UInt8(bounded))
+    resolve(nil)
+  }
+
+  @objc public func clearBatteryLevel(_ resolve: @escaping RCTPromiseResolveBlock,
+                                      reject: @escaping RCTPromiseRejectBlock) {
+    clearBatteryLevel()
+    resolve(nil)
+  }
+
+  @objc public func setThermalState(_ state: String,
+                                    resolve: @escaping RCTPromiseResolveBlock,
+                                    reject: @escaping RCTPromiseRejectBlock) {
+    let mapped: XybridThermalState
+    switch state.lowercased() {
+    case "normal": mapped = .normal
+    case "warm": mapped = .warm
+    case "hot": mapped = .hot
+    case "critical": mapped = .critical
+    default:
+      reject("xybrid_thermal", "Unknown thermal state: \(state)", nil)
+      return
+    }
+    setThermalState(state: mapped)
+    resolve(nil)
+  }
+
+  @objc public func clearThermalState(_ resolve: @escaping RCTPromiseResolveBlock,
+                                      reject: @escaping RCTPromiseRejectBlock) {
+    clearThermalState()
+    resolve(nil)
+  }
+
+  // MARK: - Helpers
+
+  private func lookup(_ handle: String) -> XybridModel? {
+    modelsLock.lock()
+    defer { modelsLock.unlock() }
+    return models[handle]
+  }
+
+  private func store(_ model: XybridModel) -> String {
+    let id = UUID().uuidString
+    modelsLock.lock()
+    models[id] = model
+    modelsLock.unlock()
+    return id
+  }
+
+  private func runAsyncLoad(resolve: @escaping RCTPromiseResolveBlock,
+                            reject: @escaping RCTPromiseRejectBlock,
+                            _ factory: @escaping () throws -> XybridModel) {
+    Task.detached {
+      do {
+        let model = try factory()
+        let id = self.store(model)
+        resolve(id)
+      } catch let error as XybridError {
+        self.rejectXybrid(error, reject)
+      } catch {
+        reject("xybrid", error.localizedDescription, error)
+      }
+    }
+  }
+
+  // Build a bolt [XybridEnvelope] via the `XybridEnvelope` factories in
+  // Xybrid.swift, which fold the well-known TTS / ASR options (sample_rate,
+  // channels, voice_id, speed) into envelope metadata entries — the bolt
+  // `XybridEnvelopeKind` variants themselves only carry the raw payload.
+  private func decodeEnvelope(_ dict: NSDictionary) -> Result<XybridEnvelope, String> {
+    guard let kind = dict["kind"] as? String else {
+      return .failure("Envelope missing 'kind' field")
+    }
+    switch kind {
+    case "audio":
+      guard let b64 = dict["bytesBase64"] as? String,
+            let bytes = Data(base64Encoded: b64) else {
+        return .failure("audio envelope: 'bytesBase64' missing or invalid")
+      }
+      let sampleRate = (dict["sampleRate"] as? NSNumber)?.uint32Value ?? 16000
+      let channels = (dict["channels"] as? NSNumber)?.uint32Value ?? 1
+      return .success(.audio(pcmData: bytes, sampleRate: sampleRate, channels: channels))
+    case "text":
+      guard let text = dict["text"] as? String else {
+        return .failure("text envelope: 'text' missing")
+      }
+      return .success(.text(text: text,
+                            voiceId: dict["voiceId"] as? String,
+                            speed: (dict["speed"] as? NSNumber)?.doubleValue))
+    case "embedding":
+      guard let raw = dict["data"] as? [NSNumber] else {
+        return .failure("embedding envelope: 'data' must be a number array")
+      }
+      return .success(.embedding(data: raw.map { $0.floatValue }))
+    default:
+      return .failure("Unknown envelope kind: \(kind)")
+    }
+  }
+
+  private func encodeResult(_ r: XybridResult) -> [String: Any] {
+    var out: [String: Any] = [
+      "success": r.success,
+      "latencyMs": r.latencyMs,
+    ]
+    if let text = r.text { out["text"] = text }
+    if let bytes = r.audioBytes {
+      out["audioBytesBase64"] = bytes.base64EncodedString()
+    }
+    if let emb = r.embedding { out["embedding"] = emb }
+    return out
+  }
+
+  private func encodeVoice(_ v: XybridVoiceInfo) -> [String: Any] {
+    var out: [String: Any] = ["id": v.id, "name": v.name]
+    if let g = v.gender { out["gender"] = g }
+    if let l = v.language { out["language"] = l }
+    if let s = v.style { out["style"] = s }
+    return out
+  }
+
+  private func rejectXybrid(_ error: XybridError, _ reject: RCTPromiseRejectBlock) {
+    let code: String
+    switch error {
+    case .modelNotFound: code = "xybrid_model_not_found"
+    case .directoryNotFound: code = "xybrid_directory_not_found"
+    case .metadataNotFound: code = "xybrid_metadata_not_found"
+    case .metadataInvalid: code = "xybrid_metadata_invalid"
+    case .loadError: code = "xybrid_load_error"
+    case .inferenceError: code = "xybrid_inference_error"
+    case .abortedForCloudFallback: code = "xybrid_aborted_cloud_fallback"
+    case .streamingNotSupported: code = "xybrid_streaming_unsupported"
+    case .notLoaded: code = "xybrid_not_loaded"
+    case .configError: code = "xybrid_config_error"
+    case .networkError: code = "xybrid_network_error"
+    case .offline: code = "xybrid_offline"
+    case .ioError: code = "xybrid_io_error"
+    case .cacheError: code = "xybrid_cache_error"
+    case .pipelineError: code = "xybrid_pipeline_error"
+    case .circuitOpen: code = "xybrid_circuit_open"
+    case .rateLimited: code = "xybrid_rate_limited"
+    case .timeout: code = "xybrid_timeout"
+    }
+    reject(code, error.errorDescription ?? "Xybrid error", error)
+  }
+}

--- a/bindings/react-native/ios/XybridModuleImpl.swift
+++ b/bindings/react-native/ios/XybridModuleImpl.swift
@@ -32,7 +32,10 @@ public final class XybridModuleImpl: NSObject {
       initSdkCacheDir(cacheDir: dir)
     } else {
       // Default cache root: <Library>/Caches/xybrid/models
-      let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+      guard let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+        reject("xybrid_init", "Failed to resolve caches directory", nil)
+        return
+      }
       let xybridCache = caches.appendingPathComponent("xybrid/models", isDirectory: true)
       try? FileManager.default.createDirectory(at: xybridCache, withIntermediateDirectories: true)
       initSdkCacheDir(cacheDir: xybridCache.path)

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "react-native-xybrid",
+  "version": "0.1.0-beta12",
+  "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "types": "lib/typescript/src/index.d.ts",
+  "react-native": "src/index.ts",
+  "source": "src/index.ts",
+  "files": [
+    "src",
+    "lib",
+    "android/build.gradle",
+    "android/src",
+    "android/libs",
+    "ios",
+    "react-native-xybrid.podspec",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf lib"
+  },
+  "keywords": [
+    "react-native",
+    "ios",
+    "android",
+    "ml",
+    "inference",
+    "asr",
+    "tts",
+    "llm",
+    "xybrid"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xybrid-ai/xybrid.git",
+    "directory": "bindings/react-native"
+  },
+  "author": "Xybrid AI <support@xybrid.dev>",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/xybrid-ai/xybrid/tree/master/bindings/react-native#readme",
+  "peerDependencies": {
+    "react": "*",
+    "react-native": ">=0.74.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "react": "18.3.1",
+    "react-native": "0.76.0",
+    "typescript": "^5.4.0"
+  },
+  "codegenConfig": {
+    "name": "RNXybridSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "ai.xybrid.reactnative"
+    }
+  }
+}

--- a/bindings/react-native/react-native-xybrid.podspec
+++ b/bindings/react-native/react-native-xybrid.podspec
@@ -1,0 +1,57 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-xybrid"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
+
+  s.platforms    = { :ios => "13.0" }
+  s.source       = { :git => "https://github.com/xybrid-ai/xybrid.git", :tag => "v#{s.version}" }
+
+  # Swift wrapper sources (`Xybrid.swift`, `xybrid_bolt.swift`) ride along
+  # with this pod rather than being pulled from SPM. This keeps consumer
+  # setup to a single `npm install` + `pod install` and avoids resolving two
+  # parallel package managers for the same Rust core. The files are copied
+  # in by `cargo xtask stage-react-native`; they live under
+  # `ios/XybridSwift/` so the `.swift` files are discovered alongside the
+  # TurboModule glue.
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.requires_arc = true
+  s.swift_version = "5.0"
+
+  # Pre-built bolt static lib bundled as an XCFramework. Copied in from
+  # `bindings/apple/XCFrameworks/XybridFFI.xcframework` by
+  # `cargo xtask stage-react-native`. (Android pulls its natives from the
+  # Maven AAR instead — see android/build.gradle.)
+  s.vendored_frameworks = "ios/Frameworks/XybridFFI.xcframework"
+
+  # System frameworks the Rust core links against (mirrors Package.swift).
+  s.frameworks = "Metal", "MetalPerformanceShaders", "MetalPerformanceShadersGraph",
+                 "CoreML", "Accelerate", "Security"
+  s.libraries  = "c++"
+
+  s.pod_target_xcconfig = {
+    "DEFINES_MODULE" => "YES",
+    "SWIFT_OBJC_INTEROP_MODE" => "objcxx",
+    # Codegen-emitted headers live under Pods/Headers/Public/RNXybridSpec
+    # once the New Architecture is enabled in the host app.
+    "HEADER_SEARCH_PATHS" => '"$(PODS_TARGET_SRCROOT)/ios" "$(PODS_ROOT)/Headers/Public/RNXybridSpec"',
+    # Apple Silicon required. The staged XCFramework does not contain
+    # `ios-x86_64-simulator` or `macos-x86_64` slices — xtask intentionally
+    # drops those targets because ort-sys (v2.0.0-rc.11) ships no prebuilt
+    # ONNX Runtime for Intel Mac / Intel iOS Simulator. Excluding x86_64
+    # here turns "missing library at link time" into "Xcode picks arm64
+    # automatically" on Apple Silicon hosts. Intel Mac and Rosetta-mode
+    # builds are unsupported by design — see README.md.
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]" => "i386 x86_64"
+  }
+
+  # Wire up React Native's New Architecture (TurboModules + codegen).
+  # Mirrors the boilerplate in react-native-mmkv / react-native-screens.
+  install_modules_dependencies(s) if respond_to?(:install_modules_dependencies)
+end

--- a/bindings/react-native/src/NativeXybrid.ts
+++ b/bindings/react-native/src/NativeXybrid.ts
@@ -1,0 +1,49 @@
+// TurboModule spec consumed by React Native codegen.
+//
+// Codegen constraints (see https://reactnative.dev/docs/the-new-architecture/pure-cxx-modules):
+// only `string`, `number`, `boolean`, `void`, `Promise<T>`, plain object types,
+// and arrays of those are allowed. Discriminated unions cross as plain `Object`
+// and are reconstructed in the TS facade (src/index.ts) — keeping the spec flat
+// avoids per-platform shim differences.
+//
+// Model handles are opaque string IDs. The native modules keep a map of
+// `id -> XybridModel` (Swift) / `id -> XybridModel` (Kotlin) and clean up
+// when `releaseModel` is called.
+
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  // -- Lifecycle --
+  initialize(cacheDir: string | null): Promise<void>;
+
+  // -- Loaders (return opaque handle ID) --
+  loadFromRegistry(modelId: string): Promise<string>;
+  loadFromBundle(path: string): Promise<string>;
+  loadFromDirectory(path: string): Promise<string>;
+  loadFromHuggingface(repo: string): Promise<string>;
+  releaseModel(handle: string): Promise<void>;
+
+  // -- Inference --
+  // `envelope` and `config` cross as Objects; the TS facade narrows to the
+  // discriminated `Envelope` union. Native side validates `kind` and rejects
+  // with an Error if it doesn't match a known variant.
+  run(handle: string, envelope: Object, config: Object | null): Promise<Object>;
+
+  // -- TTS introspection --
+  voices(handle: string): Promise<Object[] | null>;
+  defaultVoiceId(handle: string): Promise<string | null>;
+  hasVoices(handle: string): Promise<boolean>;
+
+  // -- Platform-state push (forwarded to xybrid-sdk) --
+  // The Swift wrapper auto-registers UIDevice battery observers and the
+  // Kotlin wrapper auto-registers BatteryManager + thermal listeners on
+  // `initialize()`, so apps shouldn't need to call these directly. Exposed
+  // for tests and for hosts that want to forward their own readings.
+  setBatteryLevel(percent: number): Promise<void>;
+  clearBatteryLevel(): Promise<void>;
+  setThermalState(state: string): Promise<void>;
+  clearThermalState(): Promise<void>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('RNXybrid');

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -1,0 +1,147 @@
+import NativeXybrid from './NativeXybrid';
+import type {
+  Envelope,
+  GenerationConfig,
+  InferenceResult,
+  ModelHandle,
+  ThermalState,
+  VoiceInfo,
+} from './types';
+
+export type {
+  AudioEnvelope,
+  EmbeddingEnvelope,
+  Envelope,
+  GenerationConfig,
+  InferenceResult,
+  ModelHandle,
+  TextEnvelope,
+  ThermalState,
+  VoiceInfo,
+} from './types';
+
+// Cache the in-flight init promise so concurrent callers all await the same
+// underlying native call. The native side is documented as idempotent, but
+// without this the bare boolean gate lets every caller that arrives before
+// the first await resolves re-enter the bridge — wasting work and risking
+// observable ordering surprises (e.g. multiple `setBinding` writes against
+// the OnceLock, or a load() racing the cache-dir setup).
+let initPromise: Promise<void> | null = null;
+let initialized = false;
+
+export const Xybrid = {
+  /**
+   * Initialize the SDK. Must be called once before any model loading.
+   *
+   * On Android the native module passes the app's files dir as the SDK cache
+   * root; on iOS the cache dir is resolved by the platform layer. Safe to
+   * call concurrently — every caller receives the same underlying promise.
+   */
+  initialize(): Promise<void> {
+    if (initPromise) return initPromise;
+    const p = NativeXybrid.initialize(null).then(
+      () => {
+        initialized = true;
+      },
+      (err: unknown) => {
+        // Reset on failure so the next caller can retry. Without this, a
+        // transient init failure (e.g. cache dir creation) would poison the
+        // module for the rest of the JS context's lifetime.
+        initPromise = null;
+        throw err;
+      },
+    );
+    initPromise = p;
+    return p;
+  },
+
+  /** True after `initialize()` has resolved at least once in this JS context. */
+  get isInitialized(): boolean {
+    return initialized;
+  },
+
+  /** Push a battery percentage (0..=100) to the routing engine. */
+  setBatteryLevel(percent: number): Promise<void> {
+    return NativeXybrid.setBatteryLevel(percent);
+  },
+
+  clearBatteryLevel(): Promise<void> {
+    return NativeXybrid.clearBatteryLevel();
+  },
+
+  setThermalState(state: ThermalState): Promise<void> {
+    return NativeXybrid.setThermalState(state);
+  },
+
+  clearThermalState(): Promise<void> {
+    return NativeXybrid.clearThermalState();
+  },
+};
+
+export class ModelLoader {
+  private constructor(private readonly factory: () => Promise<string>) {}
+
+  static fromRegistry(modelId: string): ModelLoader {
+    return new ModelLoader(() => NativeXybrid.loadFromRegistry(modelId));
+  }
+
+  static fromBundle(path: string): ModelLoader {
+    return new ModelLoader(() => NativeXybrid.loadFromBundle(path));
+  }
+
+  static fromDirectory(path: string): ModelLoader {
+    return new ModelLoader(() => NativeXybrid.loadFromDirectory(path));
+  }
+
+  static fromHuggingface(repo: string): ModelLoader {
+    return new ModelLoader(() => NativeXybrid.loadFromHuggingface(repo));
+  }
+
+  async load(): Promise<Model> {
+    // initialize() now returns the cached promise on subsequent calls, so
+    // unconditionally awaiting it is free after the first resolve and avoids
+    // a second TOCTOU window between the check and the call.
+    await Xybrid.initialize();
+    const handle = await this.factory();
+    return new Model(handle);
+  }
+}
+
+export class Model {
+  constructor(private readonly handle: ModelHandle) {}
+
+  get id(): ModelHandle {
+    return this.handle;
+  }
+
+  async run(envelope: Envelope, config?: GenerationConfig): Promise<InferenceResult> {
+    const result = (await NativeXybrid.run(
+      this.handle,
+      envelope,
+      config ?? null,
+    )) as InferenceResult;
+    return result;
+  }
+
+  async voices(): Promise<VoiceInfo[] | null> {
+    const list = await NativeXybrid.voices(this.handle);
+    return list as VoiceInfo[] | null;
+  }
+
+  defaultVoiceId(): Promise<string | null> {
+    return NativeXybrid.defaultVoiceId(this.handle);
+  }
+
+  hasVoices(): Promise<boolean> {
+    return NativeXybrid.hasVoices(this.handle);
+  }
+
+  /**
+   * Release the underlying native model handle. Subsequent calls on this
+   * instance will reject. Call this when a model is no longer needed —
+   * loaded models hold significant memory (weights live in native heap).
+   */
+  release(): Promise<void> {
+    return NativeXybrid.releaseModel(this.handle);
+  }
+}

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -1,0 +1,58 @@
+// Type definitions mirroring the bolt FFI surface in crates/xybrid-bolt/src/lib.rs.
+// These cross the codegen boundary, so only TurboModule-supported primitives are
+// used here: string, number, boolean, arrays of primitives, and plain object
+// records. Binary payloads (audio bytes) ride as base64-encoded strings until
+// the JSI variant lands — see README.md for the migration path.
+
+export type ModelHandle = string;
+
+export type ThermalState = 'normal' | 'warm' | 'hot' | 'critical';
+
+export interface AudioEnvelope {
+  kind: 'audio';
+  /** PCM/WAV bytes, base64-encoded. */
+  bytesBase64: string;
+  sampleRate: number;
+  channels: number;
+}
+
+export interface TextEnvelope {
+  kind: 'text';
+  text: string;
+  voiceId?: string;
+  speed?: number;
+}
+
+export interface EmbeddingEnvelope {
+  kind: 'embedding';
+  data: number[];
+}
+
+export type Envelope = AudioEnvelope | TextEnvelope | EmbeddingEnvelope;
+
+export interface GenerationConfig {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  minP?: number;
+  topK?: number;
+  repetitionPenalty?: number;
+  stopSequences?: string[];
+}
+
+export interface InferenceResult {
+  success: boolean;
+  text?: string;
+  /** base64-encoded audio bytes when present. */
+  audioBytesBase64?: string;
+  embedding?: number[];
+  latencyMs: number;
+}
+
+export interface VoiceInfo {
+  id: string;
+  name: string;
+  gender?: string;
+  language?: string;
+  style?: string;
+}

--- a/bindings/react-native/tsconfig.build.json
+++ b/bindings/react-native/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "lib/typescript",
+    "rootDir": "."
+  },
+  "exclude": ["lib", "node_modules", "example"]
+}

--- a/bindings/react-native/tsconfig.json
+++ b/bindings/react-native/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -262,6 +262,25 @@ enum Commands {
         version: Option<String>,
     },
 
+    /// Stage the bolt iOS artifacts into bindings/react-native for npm packaging
+    ///
+    /// Builds the XCFramework, then copies it plus the bolt Swift wrapper
+    /// sources into `bindings/react-native/ios/`. Android needs no staging —
+    /// the RN module depends on the `ai.xybrid:xybrid-kotlin` Maven AAR.
+    StageReactNative {
+        /// Build in release mode (default: true)
+        #[arg(long, default_value = "true")]
+        release: bool,
+
+        /// Build in debug mode (overrides --release)
+        #[arg(long)]
+        debug: bool,
+
+        /// Override the version (defaults to Cargo.toml version or git tag)
+        #[arg(long)]
+        version: Option<String>,
+    },
+
     /// Build Android .so files for all ABIs (armeabi-v7a, arm64-v8a, x86_64)
     BuildAndroid {
         /// Build in release mode (default: true)
@@ -505,6 +524,15 @@ fn main() -> Result<()> {
             let is_release = !debug && release;
             let ver = get_version(version.as_deref());
             build_xcframework(is_release, &ver)?;
+        }
+        Commands::StageReactNative {
+            release,
+            debug,
+            version,
+        } => {
+            let is_release = !debug && release;
+            let ver = get_version(version.as_deref());
+            stage_react_native_ios(is_release, &ver)?;
         }
         Commands::BuildAndroid {
             release,
@@ -1137,6 +1165,69 @@ fn build_xcframework(release: bool, version: &str) -> Result<()> {
     println!("  Versioned:  {}", xcframework_versioned.display());
     println!("  Unversioned: {}", xcframework_latest.display());
     println!("  Swift:      {}", swift_dst.display());
+
+    Ok(())
+}
+
+/// Stage the bolt iOS artifacts into the React Native module for npm packaging.
+///
+/// Builds the XCFramework, then copies it plus the bolt Swift wrapper sources
+/// (`Xybrid.swift`, `xybrid_bolt.swift`) into `bindings/react-native/ios/`,
+/// where `react-native-xybrid.podspec` vendors them. Android needs no
+/// equivalent — the RN module depends on the `ai.xybrid:xybrid-kotlin` AAR.
+fn stage_react_native_ios(release: bool, version: &str) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        anyhow::bail!("React Native iOS staging is only supported on macOS");
+    }
+
+    // 1. Build the XCFramework (also refreshes bindings/apple's Swift wrapper).
+    build_xcframework(release, version)?;
+
+    let rn_ios = PathBuf::from("bindings/react-native/ios");
+
+    // 2. Stage the XCFramework (unversioned copy) into ios/Frameworks/.
+    let src_xcfw = PathBuf::from("bindings/apple/XCFrameworks/XybridFFI.xcframework");
+    if !src_xcfw.is_dir() {
+        anyhow::bail!(
+            "Expected XCFramework at {} after build — build_xcframework failed silently?",
+            src_xcfw.display()
+        );
+    }
+    let dst_xcfw = rn_ios.join("Frameworks/XybridFFI.xcframework");
+    if dst_xcfw.exists() {
+        std::fs::remove_dir_all(&dst_xcfw)
+            .with_context(|| format!("Failed to remove existing {}", dst_xcfw.display()))?;
+    }
+    std::fs::create_dir_all(rn_ios.join("Frameworks"))?;
+    copy_dir_recursive(&src_xcfw, &dst_xcfw)
+        .context("Failed to copy XCFramework into RN module")?;
+    println!("  ✓ XCFramework -> {}", dst_xcfw.display());
+
+    // 3. Stage the bolt Swift wrapper sources into ios/XybridSwift/. The RN
+    //    Swift glue (XybridModuleImpl.swift) calls into these directly.
+    let dst_swift = rn_ios.join("XybridSwift");
+    if dst_swift.exists() {
+        std::fs::remove_dir_all(&dst_swift)
+            .with_context(|| format!("Failed to clean {}", dst_swift.display()))?;
+    }
+    std::fs::create_dir_all(&dst_swift)?;
+    for fname in ["Xybrid.swift", "xybrid_bolt.swift"] {
+        let src = PathBuf::from("bindings/apple/Sources/Xybrid").join(fname);
+        if !src.is_file() {
+            anyhow::bail!(
+                "Expected {} — run `cargo xtask build-xcframework` first",
+                src.display()
+            );
+        }
+        let dst = dst_swift.join(fname);
+        std::fs::copy(&src, &dst)
+            .with_context(|| format!("Failed to copy {} to {}", src.display(), dst.display()))?;
+        println!("  ✓ {} -> {}", fname, dst.display());
+    }
+
+    println!();
+    println!("✓ React Native iOS staging complete (version {})", version);
+    println!("  Next: cd bindings/react-native && npm pack");
 
     Ok(())
 }


### PR DESCRIPTION
Re-introduces the React Native binding (dropped from #205 — it was built on the now-deleted `xybrid-uniffi`) on top of the bolt bindings.

## Android — `XybridModule.kt`
- Loaders → bolt `XybridModel` factories: `XybridModel(id)` (registry), `fromBundle`/`fromDirectory`/`fromHuggingface`. No more `XybridModelLoader.fromX().load()`.
- Envelopes via the `Envelope` factories (fold `sample_rate`/`channels`/`voice_id`/`speed` into metadata — bolt `XybridEnvelopeKind` carries only the raw payload).
- `close()` replaces `destroy()`; `defaultVoice()?.id` replaces `defaultVoiceId()`; `XybridError` sealed mapping gains `AbortedForCloudFallback` + `Offline`.
- **`build.gradle` depends on the published `ai.xybrid:xybrid-kotlin` Maven AAR** (bundles `libxybrid-bolt.so` + ORT + the binding classes) and **drops JNA** — bolt uses JNI directly. No per-package Android staging.

## iOS — `XybridModuleImpl.swift`
- Loaders → throwing `XybridModel(fromRegistry:)` convenience inits; `run(envelope:)` sync-throwing; `.audio(pcmData:...)` label; camelCase `XybridError` cases incl. the 2 new ones.
- `podspec` vendors the bolt XCFramework + `xybrid_bolt.swift`, staged by the new **`cargo xtask stage-react-native`** (iOS-only — replaces the deleted uniffi `build-react-native`).

## CI
`build-react-native.yml` drops the Android cross-build/stage job (Maven now) and points the iOS job at `stage-react-native`.

## Verified
`cargo check`/`clippy`/`fmt` clean on `xtask`; Kotlin/Swift ports written against the actual bolt API surface (`Xybrid.kt`/`Xybrid.swift` + generated bindings). The TS layer is unchanged — its `ModelLoader` JS facade maps onto the preserved native `loadFrom*` methods.

> ⚠️ Not device-tested: building the RN module end-to-end needs a host RN app + CocoaPods/Gradle toolchains. The native Kotlin/Swift compile against the bolt AAR/xcframework is validated by CI (`build-react-native.yml`).

## Known gap (tracked in README "Open work")
Bolt's `XybridModel.run(envelope)` takes no per-call `GenerationConfig` yet, so the JS `config` argument is currently ignored — unblocks when the facade/bolt surface threads config through `run`.