### PR TITLE
feat(bolt): thread generation config through XybridModel.run

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -152,6 +152,17 @@ public enum Xybrid {
 /// Call `run(envelope:)` to execute inference on input data.
 public typealias Model = XybridModel
 
+public extension XybridModel {
+    /// Run inference with the model's default options.
+    ///
+    /// Convenience over `run(envelope:options:)` so simple call sites stay
+    /// one-argument; forwards `nil` options. Use the two-arg form to override
+    /// generation config, abort signals, or cloud-fallback behaviour.
+    func run(envelope: XybridEnvelope) throws -> XybridResult {
+        try run(envelope: envelope, options: nil)
+    }
+}
+
 /// Input data for model inference.
 /// Use `.audio(pcmData:sampleRate:channels:)` or `.text(_:voice:speed:)`.
 public typealias Envelope = XybridEnvelope

--- a/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
@@ -255,6 +255,12 @@ extension XybridVoiceInfo: WireCodable {
 /// shadow / collide with Swift's stdlib `Error` protocol, and so the
 /// Kotlin sealed-hierarchy name matches the existing uniffi consumer
 /// expectations.
+///
+/// **Variant order is part of the wire contract.** BoltFFI encodes `#[error]`
+/// (and `#[data]`) enums by ordinal tag, so reordering or inserting a variant
+/// renumbers every variant after it and breaks already-built foreign clients.
+/// Only ever append at the tail, and keep this order in lockstep with
+/// [`facade::Error`] and its `code()` table.
 public enum XybridError: Hashable, Equatable, Sendable, Error {
     case modelNotFound(id: String)
     case directoryNotFound(path: String)
@@ -719,12 +725,20 @@ public final class XybridModel {
         }
     }
 
-    public func run(envelope: XybridEnvelope) throws -> XybridResult {
+    /// Run inference, optionally with [`XybridRunOptions`] (generation config,
+    /// abort signals, cloud-fallback). Pass `None` for the model's defaults.
+    ///
+    /// The hand-written wrappers add a one-arg `run(envelope)` convenience that
+    /// forwards `None`, so simple call sites stay ergonomic.
+    public func run(envelope: XybridEnvelope, options: XybridRunOptions?) throws -> XybridResult {
         let envelopeBytes = boltffiEncode { writer in envelope.encode(to: &writer) }
+        let optionsBytes = boltffiEncode { writer in writer.writeOptional(options) { writer, v in v.encode(to: &writer) } }
         return try envelopeBytes.withUnsafeBufferPointer { envelopeBuf in
-            let buf = boltffi_xybrid_model_run(handle, envelopeBuf.baseAddress, UInt(envelopeBuf.count))
-            defer { boltffi_free_buf(buf) }
-            return try boltffiDecodeOwnedBuf(buf.ptr, Int(buf.len)) { reader in try { let tag = reader.readU8(); if tag == 0 { return XybridResult.decode(from: &reader) } else { throw XybridError.decode(from: &reader) } }() }
+            return try optionsBytes.withUnsafeBufferPointer { optionsBuf in
+                let buf = boltffi_xybrid_model_run(handle, envelopeBuf.baseAddress, UInt(envelopeBuf.count), optionsBuf.baseAddress, UInt(optionsBuf.count))
+                defer { boltffi_free_buf(buf) }
+                return try boltffiDecodeOwnedBuf(buf.ptr, Int(buf.len)) { reader in try { let tag = reader.readU8(); if tag == 0 { return XybridResult.decode(from: &reader) } else { throw XybridError.decode(from: &reader) } }() }
+            }
         }
     }
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -155,6 +155,16 @@ object Xybrid {
 /** A loaded model ready for inference. */
 typealias Model = XybridModel
 
+/**
+ * Run inference with the model's default options.
+ *
+ * Convenience over the generated [XybridModel.run] (which takes an
+ * `XybridRunOptions?`) so simple call sites stay one-argument. Forwards
+ * `null` options. Use the two-arg `run(envelope, options)` to override
+ * generation config, abort signals, or cloud-fallback behaviour.
+ */
+fun XybridModel.run(envelope: XybridEnvelope): XybridResult = this.run(envelope, null)
+
 /** The result of a model inference operation. */
 typealias Result = XybridResult
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
@@ -578,6 +578,12 @@ internal object WireWriterPool {
  * shadow / collide with Swift's stdlib `Error` protocol, and so the
  * Kotlin sealed-hierarchy name matches the existing uniffi consumer
  * expectations.
+ *
+ * **Variant order is part of the wire contract.** BoltFFI encodes `#[error]`
+ * (and `#[data]`) enums by ordinal tag, so reordering or inserting a variant
+ * renumbers every variant after it and breaks already-built foreign clients.
+ * Only ever append at the tail, and keep this order in lockstep with
+ * [`facade::Error`] and its `code()` table.
  */
 sealed class XybridError : Exception() {
 
@@ -1369,21 +1375,34 @@ class XybridModel private constructor(internal val handle: Long) : AutoCloseable
         return reader.readOptional { XybridVoiceInfo.decode(reader) }
     }
 
+    /**
+     * Run inference, optionally with [`XybridRunOptions`] (generation config,
+     * abort signals, cloud-fallback). Pass `None` for the model's defaults.
+     *
+     * The hand-written wrappers add a one-arg `run(envelope)` convenience that
+     * forwards `None`, so simple call sites stay ergonomic.
+     */
 
     @Throws(XybridError::class)
-    fun run(envelope: XybridEnvelope): XybridResult {
+    fun run(envelope: XybridEnvelope, options: XybridRunOptions?): XybridResult {
         val wire_writer_envelope = WireWriterPool.acquire(envelope.wireEncodedSize())
             kotlin.run {
                 val wire = wire_writer_envelope.writer
                 envelope.wireEncodeTo(wire)
             }
+        val wire_writer_options = WireWriterPool.acquire((options?.let { v -> 1 + v.wireEncodedSize() } ?: 1.toInt()))
+            kotlin.run {
+                val wire = wire_writer_options.writer
+                options?.let { v -> wire.writeU8(1u); v.wireEncodeTo(wire) } ?: wire.writeU8(0u)
+            }
         try {
-            val buf = Native.boltffi_xybrid_model_run(handle, wire_writer_envelope.buffer)
+            val buf = Native.boltffi_xybrid_model_run(handle, wire_writer_envelope.buffer, wire_writer_options.buffer)
                 ?: throw FfiException(-1, "Null buffer returned")
             val reader = WireReader(buf)
             return reader.readResult({ XybridResult.decode(reader) }, { XybridError.decode(reader) }).getOrThrow()
         } finally {
             wire_writer_envelope.close()
+            wire_writer_options.close()
         }
     }
 
@@ -1557,7 +1576,7 @@ private object Native {
     @JvmStatic external fun boltffi_xybrid_model_voices(handle: Long): ByteArray?
     @JvmStatic external fun boltffi_xybrid_model_default_voice(handle: Long): ByteArray?
     @JvmStatic external fun boltffi_xybrid_model_voice(handle: Long, voice_id: ByteArray): ByteArray?
-    @JvmStatic external fun boltffi_xybrid_model_run(handle: Long, envelope: ByteBuffer): ByteArray?
+    @JvmStatic external fun boltffi_xybrid_model_run(handle: Long, envelope: ByteBuffer, options: ByteBuffer): ByteArray?
     @JvmStatic external fun boltffi_xybrid_model_warmup(handle: Long): Unit
     @JvmStatic external fun boltffi_xybrid_model_unload(handle: Long): Unit
 }

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
@@ -13,8 +13,10 @@ import ai.xybrid.Envelope
 import ai.xybrid.Xybrid
 import ai.xybrid.XybridEnvelope
 import ai.xybrid.XybridError
+import ai.xybrid.XybridGenerationConfig
 import ai.xybrid.XybridModel
 import ai.xybrid.XybridResult
+import ai.xybrid.XybridRunOptions
 import ai.xybrid.XybridThermalState
 import ai.xybrid.XybridVoiceInfo
 import ai.xybrid.audioBytes
@@ -137,14 +139,11 @@ class XybridModule(reactContext: ReactApplicationContext) :
       promise.reject("xybrid_envelope", e.message, e)
       return
     }
-    // NOTE: bolt's `XybridModel.run(envelope)` does not yet accept a
-    // per-call generation config — config is ignored until the facade/bolt
-    // surface threads `GenerationConfig` through `run`. Tracked as a
-    // bolt-binding follow-up.
+    val opts = config?.let(::decodeRunOptions)
 
     scope.launch {
       try {
-        val result = model.run(env)
+        val result = model.run(env, opts)
         promise.resolve(encodeResult(result))
       } catch (e: XybridError) {
         rejectXybrid(promise, e)
@@ -291,6 +290,39 @@ class XybridModule(reactContext: ReactApplicationContext) :
     val out = FloatArray(size())
     for (i in 0 until size()) out[i] = getDouble(i).toFloat()
     return out
+  }
+
+  // Map the JS generation-config payload onto bolt's XybridRunOptions. The JS
+  // surface only exposes sampling params today, so the abort / cloud-fallback
+  // fields are left at their defaults.
+  private fun decodeRunOptions(map: ReadableMap): XybridRunOptions {
+    fun uintOrNull(key: String) =
+      if (map.hasKey(key) && !map.isNull(key)) map.getInt(key).toUInt() else null
+    fun floatOrNull(key: String) =
+      if (map.hasKey(key) && !map.isNull(key)) map.getDouble(key).toFloat() else null
+    val stops = if (map.hasKey("stopSequences") && !map.isNull("stopSequences")) {
+      val arr = map.getArray("stopSequences")!!
+      val out = ArrayList<String>(arr.size())
+      for (i in 0 until arr.size()) out.add(arr.getString(i) ?: "")
+      out
+    } else {
+      emptyList()
+    }
+    return XybridRunOptions(
+      generationConfig = XybridGenerationConfig(
+        maxTokens = uintOrNull("maxTokens"),
+        temperature = floatOrNull("temperature"),
+        topP = floatOrNull("topP"),
+        minP = floatOrNull("minP"),
+        topK = uintOrNull("topK"),
+        repetitionPenalty = floatOrNull("repetitionPenalty"),
+        stopSequences = stops,
+      ),
+      abortOn = emptyList(),
+      fallbackToCloud = false,
+      maxGraceTokens = 0u,
+      correlationId = null,
+    )
   }
 
   private fun encodeResult(r: XybridResult): WritableMap {

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
@@ -296,8 +296,12 @@ class XybridModule(reactContext: ReactApplicationContext) :
   // surface only exposes sampling params today, so the abort / cloud-fallback
   // fields are left at their defaults.
   private fun decodeRunOptions(map: ReadableMap): XybridRunOptions {
-    fun uintOrNull(key: String) =
-      if (map.hasKey(key) && !map.isNull(key)) map.getInt(key).toUInt() else null
+    fun uintOrNull(key: String): UInt? {
+      if (!map.hasKey(key) || map.isNull(key)) return null
+      // Guard against negative JS values wrapping around to a huge UInt.
+      val value = map.getInt(key)
+      return if (value >= 0) value.toUInt() else null
+    }
     fun floatOrNull(key: String) =
       if (map.hasKey(key) && !map.isNull(key)) map.getDouble(key).toFloat() else null
     val stops = if (map.hasKey("stopSequences") && !map.isNull("stopSequences")) {

--- a/bindings/react-native/ios/XybridModuleImpl.swift
+++ b/bindings/react-native/ios/XybridModuleImpl.swift
@@ -258,12 +258,17 @@ public final class XybridModuleImpl: NSObject {
   // surface only exposes sampling params today, so the abort / cloud-fallback
   // fields are left at their defaults.
   private func decodeRunOptions(_ dict: NSDictionary) -> XybridRunOptions {
+    // Guard against negative JS values wrapping around to a huge UInt32.
+    func uint32OrNil(_ key: String) -> UInt32? {
+      guard let n = dict[key] as? NSNumber, n.intValue >= 0 else { return nil }
+      return n.uint32Value
+    }
     let gc = XybridGenerationConfig(
-      maxTokens: (dict["maxTokens"] as? NSNumber)?.uint32Value,
+      maxTokens: uint32OrNil("maxTokens"),
       temperature: (dict["temperature"] as? NSNumber)?.floatValue,
       topP: (dict["topP"] as? NSNumber)?.floatValue,
       minP: (dict["minP"] as? NSNumber)?.floatValue,
-      topK: (dict["topK"] as? NSNumber)?.uint32Value,
+      topK: uint32OrNil("topK"),
       repetitionPenalty: (dict["repetitionPenalty"] as? NSNumber)?.floatValue,
       stopSequences: dict["stopSequences"] as? [String] ?? []
     )

--- a/bindings/react-native/ios/XybridModuleImpl.swift
+++ b/bindings/react-native/ios/XybridModuleImpl.swift
@@ -95,10 +95,7 @@ public final class XybridModuleImpl: NSObject {
       return
     }
     let envelopeOrError = decodeEnvelope(envelope)
-    // NOTE: bolt's `XybridModel.run(envelope:)` does not yet accept a
-    // per-call generation config — `config` is ignored until the facade/bolt
-    // surface threads `GenerationConfig` through `run`. Tracked as a
-    // bolt-binding follow-up.
+    let options = config.map(decodeRunOptions)
 
     Task.detached {
       switch envelopeOrError {
@@ -106,7 +103,7 @@ public final class XybridModuleImpl: NSObject {
         reject("xybrid_envelope", err, nil)
       case .success(let env):
         do {
-          let result = try model.run(envelope: env)
+          let result = try model.run(envelope: env, options: options)
           resolve(self.encodeResult(result))
         } catch let error as XybridError {
           self.rejectXybrid(error, reject)
@@ -255,6 +252,28 @@ public final class XybridModuleImpl: NSObject {
     default:
       return .failure("Unknown envelope kind: \(kind)")
     }
+  }
+
+  // Map the JS generation-config payload onto bolt's XybridRunOptions. The JS
+  // surface only exposes sampling params today, so the abort / cloud-fallback
+  // fields are left at their defaults.
+  private func decodeRunOptions(_ dict: NSDictionary) -> XybridRunOptions {
+    let gc = XybridGenerationConfig(
+      maxTokens: (dict["maxTokens"] as? NSNumber)?.uint32Value,
+      temperature: (dict["temperature"] as? NSNumber)?.floatValue,
+      topP: (dict["topP"] as? NSNumber)?.floatValue,
+      minP: (dict["minP"] as? NSNumber)?.floatValue,
+      topK: (dict["topK"] as? NSNumber)?.uint32Value,
+      repetitionPenalty: (dict["repetitionPenalty"] as? NSNumber)?.floatValue,
+      stopSequences: dict["stopSequences"] as? [String] ?? []
+    )
+    return XybridRunOptions(
+      generationConfig: gc,
+      abortOn: [],
+      fallbackToCloud: false,
+      maxGraceTokens: 0,
+      correlationId: nil
+    )
   }
 
   private func encodeResult(_ r: XybridResult) -> [String: Any] {

--- a/crates/xybrid-bolt/src/lib.rs
+++ b/crates/xybrid-bolt/src/lib.rs
@@ -633,8 +633,23 @@ impl XybridModel {
         self.inner.voice(voice_id).map(XybridVoiceInfo::from)
     }
 
-    pub fn run(&self, envelope: XybridEnvelope) -> Result<XybridResult, XybridError> {
-        let result = self.inner.run(envelope.into()).map_err(XybridError::from)?;
+    /// Run inference, optionally with [`XybridRunOptions`] (generation config,
+    /// abort signals, cloud-fallback). Pass `None` for the model's defaults.
+    ///
+    /// The hand-written wrappers add a one-arg `run(envelope)` convenience that
+    /// forwards `None`, so simple call sites stay ergonomic.
+    pub fn run(
+        &self,
+        envelope: XybridEnvelope,
+        options: Option<XybridRunOptions>,
+    ) -> Result<XybridResult, XybridError> {
+        let result = match options {
+            Some(opts) => self
+                .inner
+                .run_with_options(envelope.into(), opts.into(), None),
+            None => self.inner.run(envelope.into()),
+        }
+        .map_err(XybridError::from)?;
         Ok(result.into())
     }
 


### PR DESCRIPTION
## What

Restores **per-call generation config** on the bolt bindings (Swift / Kotlin / React Native). The uniffi→bolt migration dropped it: `XybridModel.run` was scaffolded envelope-only, and `XybridRunOptions` was *defined* (with `generation_config`) + given a `From`-into-facade impl, but **never wired to a callable method** — so LLM callers on iOS/Android/RN could only get default sampling.

## How

- **`xybrid-bolt`**: `run(&self, envelope, options: Option<XybridRunOptions>)` → delegates to the facade's `run_with_options` when options are present, else plain `run`. `XybridRunOptions` carries `generation_config` + abort signals + cloud-fallback, so it's a **superset** of uniffi's old bare `config`.
- **One function, not two** (per review): kept it a single `run` with optional options, and added a one-arg `run(envelope)` **convenience overload** in the `Xybrid.kt` / `Xybrid.swift` wrappers that forwards `null`/`nil`. Existing call sites (both example apps) are unchanged.
- **Regenerated** the Kotlin / Swift bindings (re-applied the Kotlin 1.9 `override val message` patch on `XybridError`).
- **React Native**: wired the JS `config` payload → `XybridRunOptions` on Android *and* iOS — it was previously decoded then ignored.

## Verification

- `cargo check`/`test`/`clippy` on `xybrid-bolt` + `xybrid-ffi-facade` — green (3 bolt tests pass).
- Confirmed the generated `XybridGenerationConfig`/`XybridRunOptions` constructors in both languages match the wiring.
- Native `.so`/xcframework are gitignored and rebuilt by CI from the updated Rust, so the 3-arg native symbol stays in sync with the regenerated bindings.

## Scope notes

- This is the first of the two "feature-loss recovery" follow-ups. The second (vision/image envelopes + restoring the 3 typed capability errors as first-class variants) is a separate PR.
- `LiveVision.swift` / some READMEs still reference `run(envelope:config:)` — those are #245 vision-era artifacts the vision PR will reconcile; not touched here.