### PR TITLE
feat(sdk,cli): speculative cloud fallback serving the model via xycloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,19 @@ jobs:
         working-directory: bindings/web
         run: pnpm build
 
+      # The example pulls a 136 MB LiteRT-LM model from a shared HuggingFace
+      # mirror that rate-limits CI egress by IP. Both assets are pinned by
+      # checksum in prepare-assets.ts, which re-downloads whatever fails to
+      # verify — so keying the cache on that file makes a restore safe and a
+      # pin change self-invalidating.
+      - name: Cache Web example model assets
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            bindings/web/example/public/model.tflite
+            bindings/web/example/public/llm/SmolLM2_135M_Instruct.litertlm
+          key: web-example-assets-${{ hashFiles('bindings/web/example/scripts/prepare-assets.ts') }}
+
       - name: Build Web example
         working-directory: bindings/web
         run: pnpm build:example

--- a/bindings/web/example/scripts/prepare-assets.ts
+++ b/bindings/web/example/scripts/prepare-assets.ts
@@ -84,7 +84,32 @@ const verifyModel = (model: PinnedModel, bytes: Uint8Array): void => {
 
 const downloadModel = async (model: PinnedModel): Promise<Uint8Array> => {
   console.log(`Downloading the ${model.label}...`);
-  return new Uint8Array(await ky.get(model.url, { timeout: 600_000 }).arrayBuffer());
+  return new Uint8Array(
+    await ky
+      .get(model.url, {
+        timeout: 600_000,
+        // The model hosts rate-limit CI egress by IP, and ky's default backoff
+        // (0.3s, then 0.6s) exhausts its two retries inside a second — fast
+        // enough that a routine 429 fails the build. Stretch the window to
+        // roughly a minute, and jitter it so parallel jobs sharing an egress
+        // address stop retrying in lockstep.
+        retry: {
+          limit: 5,
+          delay: (attemptCount) => 2 ** attemptCount * 1_000,
+          backoffLimit: 20_000,
+          maxRetryAfter: 60_000,
+          jitter: (delayMs) => delayMs / 2 + Math.random() * (delayMs / 2),
+        },
+        hooks: {
+          beforeRetry: [
+            ({ error, retryCount }) => {
+              console.log(`  ${model.label}: retry ${retryCount} after ${error.message}`);
+            },
+          ],
+        },
+      })
+      .arrayBuffer(),
+  );
 };
 
 const modelBytes = async (model: PinnedModel): Promise<Uint8Array | undefined> => {

--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -86,8 +86,23 @@ pub(crate) fn handle_repl_command(args: ReplArgs) -> Result<()> {
     // Speculative cloud only applies to a bare registry --model (not config /
     // HuggingFace / GGUF file). When it engages, the model serves from cloud
     // immediately and the weights download in the background.
-    let want_speculative =
-        speculative_cloud && model.is_some() && config.is_none() && huggingface.is_none();
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    let want_speculative = speculative_cloud
+        && model.is_some()
+        && config.is_none()
+        && huggingface.is_none()
+        && model_file.is_none();
+    // Without LLM features the loop has no model-driven path that could consume
+    // the cloud-backed handle — fall through to the normal blocking download.
+    #[cfg(not(any(feature = "llm-mistral", feature = "llm-llamacpp")))]
+    let want_speculative = {
+        if speculative_cloud {
+            ui::warning(
+                "--speculative-cloud requires LLM features (llm-llamacpp) — downloading, then running locally",
+            );
+        }
+        false
+    };
 
     // Holds the cloud-backed (or already-local) model produced by the
     // speculative path, installed into `loaded_model` below.
@@ -473,11 +488,18 @@ pub(crate) fn handle_repl_command(args: ReplArgs) -> Result<()> {
         // Try streaming execution
         #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
         let use_streaming = {
-            let can_stream = stream
-                && !show_reasoning
-                && stages.len() == 1
-                && stage_is_locally_available(&stages[0]);
-            if stream && show_reasoning {
+            let can_stream = stages.len() == 1 && {
+                let locally_available = stage_is_locally_available(&stages[0]);
+                // The speculative cloud-backed model has no local bundle, so the
+                // orchestrator can't run its stage: the model must drive the turn
+                // directly (tokens print as they arrive) even without --stream —
+                // regardless of --show-reasoning. Local models stream only when
+                // asked and when not showing reasoning (which needs the whole
+                // answer up front).
+                let speculative_drives = loaded_model.is_some() && !locally_available;
+                speculative_drives || (stream && !show_reasoning && locally_available)
+            };
+            if stream && show_reasoning && !can_stream {
                 ui::hint("Token streaming disabled so reasoning can be shown before the answer");
             } else if stream && !can_stream {
                 ui::warning("Streaming conditions not met");
@@ -1024,12 +1046,10 @@ fn try_streaming_execution(
     start: std::time::Instant,
     verbose: u8,
 ) -> bool {
-    let bundle_path_str = stages[0].bundle_path.as_ref().unwrap();
-    let bundle_path = PathBuf::from(bundle_path_str);
-
-    let model_for_streaming = loaded_model.as_ref();
-
-    if let Some(model) = model_for_streaming {
+    // A pre-loaded model (including the speculative cloud-backed handle, which
+    // has no on-disk bundle) drives the turn directly. Resolve `bundle_path`
+    // only in the fall-back branch below, so a bundle-less stage never panics.
+    if let Some(model) = loaded_model.as_ref() {
         if model.supports_token_streaming() {
             return execute_streaming(
                 model,
@@ -1044,6 +1064,14 @@ fn try_streaming_execution(
             return false;
         }
     }
+
+    let bundle_path = match stages[0].bundle_path.as_ref() {
+        Some(path) => PathBuf::from(path),
+        None => {
+            ui::warning("No local bundle for stage, falling back to batch mode");
+            return false;
+        }
+    };
 
     // Fall back to loading the model if not pre-loaded
     let model_result = if bundle_path.extension().is_some_and(|ext| ext == "xyb") {

--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -46,8 +46,6 @@ pub(crate) struct ReplArgs {
     pub system_prompt: Option<String>,
     /// Serve from cloud while the registry model downloads, then switch local.
     pub speculative_cloud: bool,
-    pub cloud_provider: Option<String>,
-    pub cloud_model: Option<String>,
     pub no_tools: bool,
     pub tools_file: Option<PathBuf>,
     pub verbose: u8,
@@ -67,8 +65,6 @@ pub(crate) fn handle_repl_command(args: ReplArgs) -> Result<()> {
         max_tokens,
         system_prompt,
         speculative_cloud,
-        cloud_provider,
-        cloud_model,
         no_tools,
         tools_file,
         verbose,
@@ -101,20 +97,14 @@ pub(crate) fn handle_repl_command(args: ReplArgs) -> Result<()> {
     // --huggingface: load from HuggingFace repo
     let stages = if want_speculative {
         let model_id = model.clone().expect("want_speculative implies a model id");
-        let provider = cloud_provider
-            .clone()
-            .unwrap_or_else(|| "openai".to_string());
-        let cloud = cloud_model
-            .clone()
-            .unwrap_or_else(|| "gpt-4o-mini".to_string());
-        let loader = ModelLoader::from_registry(&model_id)
-            .with_speculative_cloud(true)
-            .with_speculative_cloud_model(provider.clone(), cloud.clone());
+        // Serve the registry model itself: the gateway routes its id to xycloud
+        // (the CPU cluster that runs the edge model) while it downloads locally.
+        let loader = ModelLoader::from_registry(&model_id).with_speculative_cloud(true);
 
         if loader.will_speculate() {
             ui::ok(&format!(
-                "Speculative cloud: serving {}/{} while '{}' downloads in the background",
-                provider, cloud, model_id
+                "Speculative cloud: serving '{}' via xycloud while it downloads in the background",
+                model_id
             ));
         } else if xybrid_sdk::cache::CacheManager::new()
             .map(|c| c.is_extracted(&model_id))

--- a/crates/xybrid-cli/src/commands/repl.rs
+++ b/crates/xybrid-cli/src/commands/repl.rs
@@ -32,22 +32,47 @@ use warmup::warmup_models;
 use super::utils::{maybe_warn_thinking_budget, thinking_budget_exhausted, THINKING_BUDGET_HINT};
 use crate::ui;
 
+/// Arguments for the interactive REPL, grouped to keep the entry point legible.
+pub(crate) struct ReplArgs {
+    pub config: Option<PathBuf>,
+    pub model: Option<String>,
+    pub model_file: Option<PathBuf>,
+    pub huggingface: Option<String>,
+    pub voice: Option<String>,
+    pub target: Option<String>,
+    pub stream: bool,
+    pub show_reasoning: bool,
+    pub max_tokens: Option<usize>,
+    pub system_prompt: Option<String>,
+    /// Serve from cloud while the registry model downloads, then switch local.
+    pub speculative_cloud: bool,
+    pub cloud_provider: Option<String>,
+    pub cloud_model: Option<String>,
+    pub no_tools: bool,
+    pub tools_file: Option<PathBuf>,
+    pub verbose: u8,
+}
+
 /// Interactive REPL mode - keeps models loaded for fast repeated inference.
-pub(crate) fn handle_repl_command(
-    config: Option<PathBuf>,
-    model: Option<String>,
-    model_file: Option<PathBuf>,
-    huggingface: Option<String>,
-    voice: Option<String>,
-    target: Option<String>,
-    stream: bool,
-    show_reasoning: bool,
-    max_tokens: Option<usize>,
-    system_prompt: Option<String>,
-    no_tools: bool,
-    tools_file: Option<PathBuf>,
-    verbose: u8,
-) -> Result<()> {
+pub(crate) fn handle_repl_command(args: ReplArgs) -> Result<()> {
+    let ReplArgs {
+        config,
+        model,
+        model_file,
+        huggingface,
+        voice,
+        target,
+        stream,
+        show_reasoning,
+        max_tokens,
+        system_prompt,
+        speculative_cloud,
+        cloud_provider,
+        cloud_model,
+        no_tools,
+        tools_file,
+        verbose,
+    } = args;
     use std::io::{self, Write};
 
     ui::brand_with_version(env!("CARGO_PKG_VERSION"));
@@ -62,8 +87,65 @@ pub(crate) fn handle_repl_command(
     }
     println!();
 
+    // Speculative cloud only applies to a bare registry --model (not config /
+    // HuggingFace / GGUF file). When it engages, the model serves from cloud
+    // immediately and the weights download in the background.
+    let want_speculative =
+        speculative_cloud && model.is_some() && config.is_none() && huggingface.is_none();
+
+    // Holds the cloud-backed (or already-local) model produced by the
+    // speculative path, installed into `loaded_model` below.
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    let mut speculative_model: Option<xybrid_sdk::model::XybridModel> = None;
+
     // --huggingface: load from HuggingFace repo
-    let stages = if let Some(ref repo) = huggingface {
+    let stages = if want_speculative {
+        let model_id = model.clone().expect("want_speculative implies a model id");
+        let provider = cloud_provider
+            .clone()
+            .unwrap_or_else(|| "openai".to_string());
+        let cloud = cloud_model
+            .clone()
+            .unwrap_or_else(|| "gpt-4o-mini".to_string());
+        let loader = ModelLoader::from_registry(&model_id)
+            .with_speculative_cloud(true)
+            .with_speculative_cloud_model(provider.clone(), cloud.clone());
+
+        if loader.will_speculate() {
+            ui::ok(&format!(
+                "Speculative cloud: serving {}/{} while '{}' downloads in the background",
+                provider, cloud, model_id
+            ));
+        } else if xybrid_sdk::cache::CacheManager::new()
+            .map(|c| c.is_extracted(&model_id))
+            .unwrap_or(false)
+        {
+            ui::hint("Model already cached locally — running on device (no speculation needed)");
+        } else {
+            ui::hint(
+                "Speculative cloud unavailable (no API key?) — downloading, then running locally",
+            );
+        }
+
+        let model_obj = loader
+            .load()
+            .context("Failed to load speculative cloud model")?;
+        #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+        {
+            speculative_model = Some(model_obj);
+        }
+        #[cfg(not(any(feature = "llm-mistral", feature = "llm-llamacpp")))]
+        {
+            drop(model_obj);
+        }
+
+        // No bundle_path: the weights aren't on disk yet, so warmup and the
+        // local-load block skip this stage — the speculative model drives the
+        // loop and transparently switches to local once the download lands.
+        let mut stage = StageDescriptor::new(&model_id);
+        stage.target = execution_target.clone();
+        vec![stage]
+    } else if let Some(ref repo) = huggingface {
         let sp = ui::spinner(&format!("Loading from HuggingFace: {}...", repo));
         let loader = ModelLoader::from_huggingface_parsed(repo);
         let _model = loader.load().context(format!(
@@ -184,6 +266,26 @@ pub(crate) fn handle_repl_command(
                     ui::hint("Use 'history' to view conversation, 'clear' to reset");
                 }
             }
+            loaded_model = Some(model);
+        }
+    }
+
+    // Install the speculative model. Its placeholder handle isn't locally
+    // available, so the block above skipped it. Speculation targets LLM/chat,
+    // so enable conversation context up front (the placeholder can't report
+    // `is_llm()` until the local weights land).
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    if loaded_model.is_none() {
+        if let Some(model) = speculative_model.take() {
+            let mut ctx = ConversationContext::new();
+            if let Some(ref prompt) = system_prompt {
+                ui::kv("System", prompt);
+                ctx = ctx.with_system(
+                    Envelope::new(EnvelopeKind::Text(prompt.clone()))
+                        .with_role(MessageRole::System),
+                );
+            }
+            conversation_context = Some(ctx);
             loaded_model = Some(model);
         }
     }

--- a/crates/xybrid-cli/src/commands/run.rs
+++ b/crates/xybrid-cli/src/commands/run.rs
@@ -821,6 +821,75 @@ pub(crate) fn run_model(
     Ok(())
 }
 
+/// Run a one-shot registry-model inference with speculative cloud fallback:
+/// serve the answer from the cloud gateway instead of blocking on the model
+/// download. Streams tokens to stdout and optionally writes the text output.
+///
+/// One-shot, so the background download (started by `load()`) doesn't outlive
+/// the process — the point here is the immediate cloud answer; the REPL is
+/// where the local switchover matters.
+pub(crate) fn run_model_speculative(
+    model_id: &str,
+    input_audio: Option<&PathBuf>,
+    input_text: Option<&str>,
+    input_images: &[PathBuf],
+    voice: Option<&str>,
+    output_path: Option<&PathBuf>,
+    max_tokens: Option<usize>,
+) -> Result<()> {
+    use std::io::Write;
+
+    ui::header(&format!("Run · {} (speculative cloud)", model_id));
+
+    // Serve the registry model itself: the gateway routes its id to xycloud
+    // (the CPU cluster that runs the edge model) while it downloads locally.
+    let loader = xybrid_sdk::ModelLoader::from_registry(model_id).with_speculative_cloud(true);
+
+    if loader.will_speculate() {
+        ui::ok(&format!(
+            "Serving '{}' via xycloud while it downloads in the background",
+            model_id
+        ));
+    } else if xybrid_sdk::cache::CacheManager::new()
+        .map(|c| c.is_extracted(model_id))
+        .unwrap_or(false)
+    {
+        ui::hint("Model already cached locally — running on device (no speculation needed)");
+    } else {
+        ui::hint("Speculative cloud unavailable (no API key?) — downloading, then running locally");
+    }
+
+    let model = loader
+        .load()
+        .context("Failed to load speculative cloud model")?;
+
+    let envelope = build_input_envelope(input_audio, input_text, input_images, voice, max_tokens)?;
+
+    ui::section("Output");
+    let accumulated = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let acc = std::sync::Arc::clone(&accumulated);
+    let result = model.run_streaming(&envelope, None, move |token| {
+        print!("{}", token.token);
+        std::io::stdout().flush().ok();
+        if let Ok(mut text) = acc.lock() {
+            text.push_str(&token.token);
+        }
+        Ok(())
+    });
+    println!();
+
+    result.context("Speculative inference failed")?;
+
+    if let Some(path) = output_path {
+        let text = accumulated.lock().map(|t| t.clone()).unwrap_or_default();
+        fs::write(path, text)
+            .with_context(|| format!("Failed to write output to {}", path.display()))?;
+        ui::ok(&format!("Saved output to {}", path.display()));
+    }
+
+    Ok(())
+}
+
 /// Run inference from a local model directory.
 pub(crate) fn run_directory(
     dir: &Path,

--- a/crates/xybrid-cli/src/main.rs
+++ b/crates/xybrid-cli/src/main.rs
@@ -269,6 +269,20 @@ enum Commands {
         #[arg(long, value_name = "PROMPT")]
         system: Option<String>,
 
+        /// Serve from the cloud while the registry model downloads in the
+        /// background, then switch to local once ready. Requires --api-key
+        /// (or XYBRID_API_KEY) and a registry --model. LLM/chat only.
+        #[arg(long)]
+        speculative_cloud: bool,
+
+        /// Cloud provider to serve speculatively (default: openai)
+        #[arg(long, value_name = "PROVIDER", requires = "speculative_cloud")]
+        cloud_provider: Option<String>,
+
+        /// Cloud model to serve speculatively (default: gpt-4o-mini)
+        #[arg(long, value_name = "MODEL", requires = "speculative_cloud")]
+        cloud_model: Option<String>,
+
         /// Disable built-in tool calling (web_search, fetch_url, current_time),
         /// which is otherwise on for models whose metadata declares support
         #[arg(long)]
@@ -457,6 +471,12 @@ fn configure_log_level(cli: &Cli) {
 /// Initialize platform telemetry from CLI args.
 fn init_telemetry(cli: &Cli) -> bool {
     if let Some(ref api_key) = cli.api_key {
+        // Make the key resolvable by the cloud gateway too (speculative cloud,
+        // reactive fallback), not just the telemetry exporter. `--api-key` may
+        // arrive by flag rather than the XYBRID_API_KEY env var, so set the
+        // in-memory cell that CloudConfig::resolve_api_key reads.
+        xybrid_sdk::set_api_key(api_key);
+
         let platform = Platform::detect().to_string();
 
         let device_id = cli.device_id.clone().unwrap_or_else(|| {
@@ -654,9 +674,12 @@ fn run_command(cli: Cli) -> Result<()> {
             show_reasoning,
             max_tokens,
             system,
+            speculative_cloud,
+            cloud_provider,
+            cloud_model,
             no_tools,
             tools_file,
-        } => commands::repl::handle_repl_command(
+        } => commands::repl::handle_repl_command(commands::repl::ReplArgs {
             config,
             model,
             model_file,
@@ -666,11 +689,14 @@ fn run_command(cli: Cli) -> Result<()> {
             stream,
             show_reasoning,
             max_tokens,
-            system,
+            system_prompt: system,
+            speculative_cloud,
+            cloud_provider,
+            cloud_model,
             no_tools,
             tools_file,
             verbose,
-        ),
+        }),
         Commands::Trace {
             session,
             latest,

--- a/crates/xybrid-cli/src/main.rs
+++ b/crates/xybrid-cli/src/main.rs
@@ -223,6 +223,12 @@ enum Commands {
         /// Export trace to JSON file (Chrome trace format)
         #[arg(long, value_name = "FILE")]
         trace_export: Option<PathBuf>,
+
+        /// Serve from the cloud while the registry model downloads, instead of
+        /// blocking on the download. Requires --api-key (or XYBRID_API_KEY) and
+        /// a registry --model. LLM/chat only.
+        #[arg(long)]
+        speculative_cloud: bool,
     },
     /// Interactive REPL mode - keeps models loaded for fast repeated inference
     Repl {
@@ -274,14 +280,6 @@ enum Commands {
         /// (or XYBRID_API_KEY) and a registry --model. LLM/chat only.
         #[arg(long)]
         speculative_cloud: bool,
-
-        /// Cloud provider to serve speculatively (default: openai)
-        #[arg(long, value_name = "PROVIDER", requires = "speculative_cloud")]
-        cloud_provider: Option<String>,
-
-        /// Cloud model to serve speculatively (default: gpt-4o-mini)
-        #[arg(long, value_name = "MODEL", requires = "speculative_cloud")]
-        cloud_model: Option<String>,
 
         /// Disable built-in tool calling (web_search, fetch_url, current_time),
         /// which is otherwise on for models whose metadata declares support
@@ -500,6 +498,15 @@ fn init_telemetry(cli: &Cli) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn run_command(cli: Cli) -> Result<()> {
     let verbose = cli.verbose;
+    // Propagate --platform-url into the env var the SDK's CloudConfig reads, so
+    // cloud gateway calls (speculative cloud, reactive fallback) target the same
+    // endpoint as telemetry. clap's `env =` only *reads* this var as a fallback;
+    // passing the flag does not write it, so without this the gateway falls back
+    // to the production default (`api.xybrid.dev`) and a staging key 401s.
+    // XYBRID_GATEWAY_URL (explicit, /v1-suffixed) still takes precedence if set.
+    if std::env::var_os("XYBRID_PLATFORM_URL").is_none() {
+        std::env::set_var("XYBRID_PLATFORM_URL", &cli.platform_url);
+    }
     match cli.command {
         Commands::Init {
             directory,
@@ -560,6 +567,7 @@ fn run_command(cli: Cli) -> Result<()> {
             show_reasoning,
             max_tokens,
             trace_export,
+            speculative_cloud,
         } => {
             if trace {
                 tracing_viz::reset_collector();
@@ -579,6 +587,23 @@ fn run_command(cli: Cli) -> Result<()> {
                     max_tokens,
                     trace_export.as_ref(),
                 );
+            }
+
+            if speculative_cloud {
+                if let Some(model_id) = model.as_deref() {
+                    return commands::run::run_model_speculative(
+                        model_id,
+                        input_audio.as_ref(),
+                        input_text.as_deref(),
+                        &input_images,
+                        voice.as_deref(),
+                        output.as_ref(),
+                        max_tokens,
+                    );
+                }
+                return Err(anyhow::anyhow!(
+                    "--speculative-cloud requires a registry --model"
+                ));
             }
 
             if let Some(model_id) = model {
@@ -675,8 +700,6 @@ fn run_command(cli: Cli) -> Result<()> {
             max_tokens,
             system,
             speculative_cloud,
-            cloud_provider,
-            cloud_model,
             no_tools,
             tools_file,
         } => commands::repl::handle_repl_command(commands::repl::ReplArgs {
@@ -691,8 +714,6 @@ fn run_command(cli: Cli) -> Result<()> {
             max_tokens,
             system_prompt: system,
             speculative_cloud,
-            cloud_provider,
-            cloud_model,
             no_tools,
             tools_file,
             verbose,

--- a/crates/xybrid-cli/src/main.rs
+++ b/crates/xybrid-cli/src/main.rs
@@ -498,15 +498,14 @@ fn init_telemetry(cli: &Cli) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn run_command(cli: Cli) -> Result<()> {
     let verbose = cli.verbose;
-    // Propagate --platform-url into the env var the SDK's CloudConfig reads, so
-    // cloud gateway calls (speculative cloud, reactive fallback) target the same
-    // endpoint as telemetry. clap's `env =` only *reads* this var as a fallback;
-    // passing the flag does not write it, so without this the gateway falls back
-    // to the production default (`api.xybrid.dev`) and a staging key 401s.
-    // XYBRID_GATEWAY_URL (explicit, /v1-suffixed) still takes precedence if set.
-    if std::env::var_os("XYBRID_PLATFORM_URL").is_none() {
-        std::env::set_var("XYBRID_PLATFORM_URL", &cli.platform_url);
-    }
+    // Point the SDK's cloud gateway at the same endpoint as telemetry, so cloud
+    // calls (speculative cloud, reactive fallback) don't silently fall back to
+    // the production default (`api.xybrid.dev`) and 401 with a staging key.
+    // `cli.platform_url` already encodes clap's flag > env > default precedence,
+    // so set it unconditionally. Use the in-memory setter rather than
+    // `std::env::set_var`: telemetry threads are already running by now, and a
+    // concurrent `setenv`/`getenv` is UB. XYBRID_GATEWAY_URL still wins if set.
+    xybrid_sdk::set_platform_url(&cli.platform_url);
     match cli.command {
         Commands::Init {
             directory,
@@ -589,7 +588,10 @@ fn run_command(cli: Cli) -> Result<()> {
                 );
             }
 
-            if speculative_cloud {
+            // A dry run must not hit the network, so let `--dry-run` fall
+            // through to `run_model` (plan-only), which also honours
+            // --trace/--trace-export that the speculative path doesn't emit.
+            if speculative_cloud && !dry_run {
                 if let Some(model_id) = model.as_deref() {
                     return commands::run::run_model_speculative(
                         model_id,

--- a/crates/xybrid-core/src/cloud/config.rs
+++ b/crates/xybrid-core/src/cloud/config.rs
@@ -34,6 +34,35 @@ pub fn xybrid_api_key() -> Option<String> {
         .clone()
 }
 
+/// Programmatically-set Xybrid platform base URL, held in process memory.
+///
+/// Set via [`set_xybrid_platform_url`] — mirrors [`XYBRID_API_KEY`]. Consulted
+/// by [`default_gateway_url`] ahead of the `XYBRID_PLATFORM_URL` environment
+/// variable so a host (e.g. the CLI `--platform-url` flag) can point the
+/// gateway at a staging endpoint without mutating the process environment after
+/// telemetry threads have spawned (a concurrent `setenv`/`getenv` is UB).
+static XYBRID_PLATFORM_URL: RwLock<Option<String>> = RwLock::new(None);
+
+/// Store (or clear, with `None`) the in-memory Xybrid platform base URL.
+///
+/// Consulted by [`default_gateway_url`] ahead of the `XYBRID_PLATFORM_URL`
+/// environment variable. The stored value is a bare base URL (no `/v1`); the
+/// gateway suffix is applied at read time.
+pub fn set_xybrid_platform_url(url: Option<String>) {
+    let mut guard = XYBRID_PLATFORM_URL
+        .write()
+        .unwrap_or_else(|e| e.into_inner());
+    *guard = url;
+}
+
+/// Read the in-memory Xybrid platform base URL, if one has been set.
+pub fn xybrid_platform_url() -> Option<String> {
+    XYBRID_PLATFORM_URL
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
 /// Report whether an in-memory Xybrid gateway API key has been set.
 ///
 /// Cheaper than [`xybrid_api_key`] for presence checks — it never clones the
@@ -100,13 +129,21 @@ pub struct CloudConfig {
 fn default_gateway_url() -> String {
     // Priority:
     // 1. XYBRID_GATEWAY_URL env var (explicit override, should include /v1)
-    // 2. XYBRID_PLATFORM_URL env var + /v1 suffix (shared with telemetry)
-    // 3. Default production URL (api.xybrid.dev/v1)
+    // 2. In-memory platform URL (set via set_xybrid_platform_url) + /v1 suffix
+    // 3. XYBRID_PLATFORM_URL env var + /v1 suffix (shared with telemetry)
+    // 4. Default production URL (api.xybrid.dev/v1)
     //
     // Note: The /v1 prefix is required for OpenAI-compatible API endpoints.
     // The client appends /chat/completions, so the full path becomes /v1/chat/completions.
     if let Ok(url) = std::env::var("XYBRID_GATEWAY_URL") {
         return url;
+    }
+    // Programmatic platform URL (set via the SDK/CLI, held in memory) takes
+    // precedence over the ambient XYBRID_PLATFORM_URL env var — same ordering as
+    // the API key resolution above.
+    if let Some(url) = xybrid_platform_url() {
+        // Platform URL needs /v1 suffix for gateway endpoints
+        return format!("{}/v1", url.trim_end_matches('/'));
     }
     if let Ok(url) = std::env::var("XYBRID_PLATFORM_URL") {
         // Platform URL needs /v1 suffix for gateway endpoints
@@ -204,6 +241,9 @@ mod tests {
 
     #[test]
     fn test_default_config() {
+        // Shares the process-global gateway-URL env/cell with the precedence
+        // tests below, so serialize against them.
+        let _guard = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let config = CloudConfig::default();
         assert_eq!(config.backend, CloudBackend::Gateway);
         // Default URL should be api.xybrid.dev/v1 or from env vars (with /v1)
@@ -272,5 +312,39 @@ mod tests {
         assert_eq!(explicit.resolve_api_key(), Some("field-key".to_string()));
 
         std::env::remove_var("XYBRID_API_KEY");
+    }
+
+    #[test]
+    fn test_gateway_url_in_memory_precedence() {
+        let _guard = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+        // RAII reset: clear the process-global cell + env vars on drop, so a
+        // failing assertion below can't leak state into `test_default_config`
+        // (which reads the same shared cell) and cascade into a false failure.
+        struct ResetOnDrop;
+        impl Drop for ResetOnDrop {
+            fn drop(&mut self) {
+                set_xybrid_platform_url(None);
+                std::env::remove_var("XYBRID_GATEWAY_URL");
+                std::env::remove_var("XYBRID_PLATFORM_URL");
+            }
+        }
+        let _reset = ResetOnDrop;
+
+        // The in-memory platform URL is consulted before the env var, and the
+        // bare base URL gains the /v1 gateway suffix.
+        std::env::remove_var("XYBRID_GATEWAY_URL");
+        std::env::set_var("XYBRID_PLATFORM_URL", "https://env.example.com");
+        set_xybrid_platform_url(Some("https://staging.example.com".to_string()));
+        assert_eq!(default_gateway_url(), "https://staging.example.com/v1");
+
+        // Clearing the cell falls back to the env var (also /v1-suffixed).
+        set_xybrid_platform_url(None);
+        assert_eq!(default_gateway_url(), "https://env.example.com/v1");
+
+        // XYBRID_GATEWAY_URL (already /v1) wins over the in-memory override.
+        set_xybrid_platform_url(Some("https://staging.example.com".to_string()));
+        std::env::set_var("XYBRID_GATEWAY_URL", "https://explicit.example.com/v1");
+        assert_eq!(default_gateway_url(), "https://explicit.example.com/v1");
     }
 }

--- a/crates/xybrid-core/src/cloud/mod.rs
+++ b/crates/xybrid-core/src/cloud/mod.rs
@@ -64,6 +64,7 @@ pub(crate) use client::parse_gateway_usage;
 pub use client::Cloud;
 pub use completion::{CompletionRequest, CompletionResponse, Message, Role, Usage};
 pub use config::{
-    has_xybrid_api_key, set_xybrid_api_key, xybrid_api_key, CloudBackend, CloudConfig,
+    has_xybrid_api_key, set_xybrid_api_key, set_xybrid_platform_url, xybrid_api_key,
+    xybrid_platform_url, CloudBackend, CloudConfig,
 };
 pub use error::CloudError;

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -486,6 +486,18 @@ pub fn set_api_key(api_key: &str) {
     xybrid_core::cloud::set_xybrid_api_key(Some(api_key.to_string()));
 }
 
+/// Point the cloud gateway at a specific platform base URL, held in memory.
+///
+/// Mirrors [`set_api_key`]: the value is stored in a process-memory cell rather
+/// than the environment, so it is safe to call after telemetry threads have
+/// started (a concurrent `setenv`/`getenv` is UB). Consulted by the gateway
+/// ahead of the `XYBRID_PLATFORM_URL` env var; `XYBRID_GATEWAY_URL` (explicit,
+/// `/v1`-suffixed) still takes precedence. Pass a bare base URL — the `/v1`
+/// suffix is applied internally.
+pub fn set_platform_url(url: &str) {
+    xybrid_core::cloud::set_xybrid_platform_url(Some(url.to_string()));
+}
+
 /// Set a provider-specific API key for direct API calls.
 ///
 /// Use this when running LLM stages with `backend: "direct"` in the pipeline.

--- a/crates/xybrid-sdk/src/llm.rs
+++ b/crates/xybrid-sdk/src/llm.rs
@@ -203,6 +203,14 @@ pub fn default_gateway_url() -> String {
     if let Ok(url) = std::env::var("XYBRID_GATEWAY_URL") {
         return url;
     }
+    // Programmatic platform URL (set via `set_platform_url`, held in the core
+    // in-memory cell) takes precedence over the ambient XYBRID_PLATFORM_URL env
+    // var — same ordering as `xybrid_core::cloud::default_gateway_url`, so this
+    // resolver and the core `Cloud`/`CloudConfig` one stay in agreement.
+    if let Some(url) = xybrid_core::cloud::xybrid_platform_url() {
+        // Platform URL needs /v1 suffix for gateway endpoints
+        return format!("{}/v1", url.trim_end_matches('/'));
+    }
     if let Ok(url) = std::env::var("XYBRID_PLATFORM_URL") {
         // Platform URL needs /v1 suffix for gateway endpoints
         return format!("{}/v1", url.trim_end_matches('/'));
@@ -574,6 +582,29 @@ mod tests {
         set_gateway_url("https://local.gateway.test/v1");
         assert_eq!(default_gateway_url(), "https://local.gateway.test/v1");
         clear_gateway_url_override();
+    }
+
+    /// The core in-memory platform URL (set via `xybrid_sdk::set_platform_url`)
+    /// must reach this resolver too, not just `xybrid_core::cloud`'s — otherwise
+    /// an SDK `llm` consumer would ignore `--platform-url` and hit production.
+    #[test]
+    fn test_core_platform_url_reaches_llm_resolver() {
+        // RAII reset so a failing assertion can't leak the process-global cell.
+        struct ResetOnDrop;
+        impl Drop for ResetOnDrop {
+            fn drop(&mut self) {
+                clear_gateway_url_override();
+                xybrid_core::cloud::set_xybrid_platform_url(None);
+            }
+        }
+        let _reset = ResetOnDrop;
+
+        // The llm-local override must be clear so the core cell is what wins.
+        clear_gateway_url_override();
+        xybrid_core::cloud::set_xybrid_platform_url(Some(
+            "https://staging.example.com".to_string(),
+        ));
+        assert_eq!(default_gateway_url(), "https://staging.example.com/v1");
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -31,6 +31,7 @@ use xybrid_core::orchestrator::authority::{
 };
 use xybrid_core::orchestrator::routing_engine::LocalReliabilityHint;
 use xybrid_core::runtime_adapter::types::GenerationConfig;
+use xybrid_core::runtime_adapter::{CloudRuntimeAdapter, CloudStreaming, RuntimeAdapter};
 use xybrid_core::streaming::{StreamConfig as CoreStreamConfig, VadStreamConfig as CoreVadConfig};
 
 /// A token generated during streaming inference.
@@ -1004,6 +1005,167 @@ pub struct ModelLoader {
     /// Per-load speculative-cloud override. `None` inherits the process-global
     /// default set via [`crate::set_speculative_cloud`].
     speculative_cloud: Option<bool>,
+    /// Cloud model identity to serve from while the local weights download.
+    /// `None` uses [`SpeculativeCloud::default`] (`openai`/`gpt-4o-mini`).
+    speculative_cloud_model: Option<SpeculativeCloud>,
+}
+
+/// Cloud model identity used to serve inference *while a local model is still
+/// downloading* (speculative cloud fallback).
+///
+/// The Xybrid gateway dispatches OpenAI-style `provider` + `model` (it cannot
+/// serve an arbitrary registry id), so a speculating load answers with this
+/// configured cloud model until the local weights are extracted and ready —
+/// at which point subsequent runs transparently switch to local. Mirrors the
+/// envelope metadata the reactive fallback path (`dispatch_after_local`) and
+/// the Flutter binding's `apply_cloud_fallback_metadata` already use.
+#[derive(Debug, Clone)]
+pub(crate) struct SpeculativeCloud {
+    provider: String,
+    model: String,
+}
+
+impl Default for SpeculativeCloud {
+    fn default() -> Self {
+        Self {
+            provider: "openai".to_string(),
+            model: "gpt-4o-mini".to_string(),
+        }
+    }
+}
+
+impl SpeculativeCloud {
+    /// Build the cloud-bound envelope by overlaying the cloud routing metadata
+    /// the gateway dispatches on. `provider`/`model` are forced to this config;
+    /// `backend`/`max_tokens`/`temperature` defer to caller-supplied values.
+    fn build_envelope(&self, envelope: &Envelope, config: Option<&GenerationConfig>) -> Envelope {
+        let mut cloud = envelope.clone();
+        cloud
+            .metadata
+            .insert("provider".to_string(), self.provider.clone());
+        cloud
+            .metadata
+            .insert("model".to_string(), self.model.clone());
+        cloud
+            .metadata
+            .entry("backend".to_string())
+            .or_insert_with(|| "gateway".to_string());
+        if let Some(cfg) = config {
+            cloud
+                .metadata
+                .entry("max_tokens".to_string())
+                .or_insert_with(|| cfg.max_tokens.to_string());
+            cloud
+                .metadata
+                .entry("temperature".to_string())
+                .or_insert_with(|| cfg.temperature.to_string());
+        }
+        cloud
+    }
+}
+
+/// Privacy gate for the speculative cloud leg: run the orchestrator policy over
+/// the cloud-bound envelope and fail closed unless it is explicitly allowed.
+///
+/// Mirrors the `Deny`/`Transform` handling in [`dispatch_after_local`] — the
+/// SDK has no redact seam yet, so `Transform` (which the orchestrator would
+/// satisfy by redacting) hard-fails rather than dispatching an un-redacted
+/// prompt to cloud.
+fn speculative_cloud_policy_gate(cloud_envelope: &Envelope) -> SdkResult<()> {
+    let model = cloud_envelope
+        .metadata
+        .get("model")
+        .cloned()
+        .unwrap_or_default();
+    let metrics = xybrid_core::context::DeviceMetrics::default().with_live_snapshot(
+        xybrid_core::device::ResourceMonitor::global()
+            .current_snapshot(FALLBACK_POLICY_RESOURCE_MAX_AGE),
+    );
+    let decision = fallback_authority().apply_policy(&PolicyRequest {
+        stage_id: model,
+        envelope: cloud_envelope.clone(),
+        metrics,
+    });
+    match decision.result {
+        PolicyOutcome::Allow => Ok(()),
+        PolicyOutcome::Deny { reason } => Err(SdkError::inference(format!(
+            "cloud_denied_by_policy: {reason}"
+        ))),
+        PolicyOutcome::Transform { transforms } => Err(SdkError::inference(format!(
+            "cloud_denied_by_policy: transforms_unsupported_in_speculation: {transforms:?}"
+        ))),
+    }
+}
+
+/// Emit a `ModelComplete` telemetry event for a speculative cloud serve.
+fn publish_speculative_cloud_event(model_id: &str, latency_ms: u32, streaming: bool) {
+    let event = crate::telemetry::TelemetryEvent {
+        event_type: "ModelComplete".to_string(),
+        stage_name: Some(model_id.to_string()),
+        target: Some("cloud".to_string()),
+        latency_ms: Some(latency_ms),
+        error: None,
+        data: Some(
+            serde_json::json!({
+                "model_id": model_id,
+                "target": "cloud",
+                "speculative": true,
+                "streaming": streaming,
+            })
+            .to_string(),
+        ),
+        timestamp_ms: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+    };
+    crate::telemetry::publish_telemetry_event(event);
+}
+
+/// Serve a batch inference from the cloud gateway because the local model is
+/// not ready yet. Shared by `run` and `run_async`.
+fn cloud_serve_batch(
+    spec: &SpeculativeCloud,
+    model_id: &str,
+    envelope: &Envelope,
+    config: Option<&GenerationConfig>,
+) -> SdkResult<InferenceResult> {
+    let start = Instant::now();
+    let cloud_envelope = spec.build_envelope(envelope, config);
+    speculative_cloud_policy_gate(&cloud_envelope)?;
+    let output = CloudRuntimeAdapter::new()
+        .execute(&cloud_envelope)
+        .map_err(|e| sdk_execution_error("Speculative cloud execution failed", e))?;
+    let latency_ms = start.elapsed().as_millis() as u32;
+    publish_speculative_cloud_event(model_id, latency_ms, false);
+    Ok(InferenceResult::new(output, model_id, latency_ms))
+}
+
+/// Serve a streaming inference from the cloud gateway because the local model
+/// is not ready yet. Shared by the streaming entry points.
+fn cloud_serve_streaming<F>(
+    spec: &SpeculativeCloud,
+    model_id: &str,
+    envelope: &Envelope,
+    config: Option<&GenerationConfig>,
+    on_token: &mut F,
+) -> SdkResult<InferenceResult>
+where
+    F: FnMut(
+            xybrid_core::runtime_adapter::types::PartialToken,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+        + Send,
+{
+    let start = Instant::now();
+    let cloud_envelope = spec.build_envelope(envelope, config);
+    speculative_cloud_policy_gate(&cloud_envelope)?;
+    let callback: xybrid_core::runtime_adapter::types::StreamingCallback<'_> = Box::new(on_token);
+    let output = CloudRuntimeAdapter::new()
+        .execute_streaming(&cloud_envelope, callback)
+        .map_err(streaming_execution_error)?;
+    let latency_ms = start.elapsed().as_millis() as u32;
+    publish_speculative_cloud_event(model_id, latency_ms, true);
+    Ok(InferenceResult::new(output, model_id, latency_ms))
 }
 
 /// Whether a cloud gateway API key can be resolved right now.
@@ -1038,6 +1200,7 @@ impl ModelLoader {
             model_id: Some(id.to_string()),
             version: None, // Version is resolved by registry API
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1058,6 +1221,7 @@ impl ModelLoader {
             model_id: Some(id.to_string()),
             version: None,
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1073,6 +1237,7 @@ impl ModelLoader {
             model_id: Some(model_id.to_string()),
             version: Some(version.to_string()),
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1096,6 +1261,7 @@ impl ModelLoader {
             model_id: Some(model_id.to_string()),
             version: Some(version.to_string()),
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1113,6 +1279,7 @@ impl ModelLoader {
             model_id: None,
             version: None,
             speculative_cloud: None,
+            speculative_cloud_model: None,
         })
     }
 
@@ -1147,6 +1314,7 @@ impl ModelLoader {
             model_id: None,
             version: None,
             speculative_cloud: None,
+            speculative_cloud_model: None,
         })
     }
 
@@ -1178,6 +1346,7 @@ impl ModelLoader {
             model_id: Some(repo.to_string()),
             version: None,
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1198,6 +1367,7 @@ impl ModelLoader {
             model_id: Some(repo.to_string()),
             version: Some(revision.to_string()),
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1223,6 +1393,7 @@ impl ModelLoader {
             model_id: Some(repo),
             version: None,
             speculative_cloud: None,
+            speculative_cloud_model: None,
         }
     }
 
@@ -1259,6 +1430,33 @@ impl ModelLoader {
     /// ```
     pub fn with_speculative_cloud(mut self, enabled: bool) -> Self {
         self.speculative_cloud = Some(enabled);
+        self
+    }
+
+    /// Choose the cloud model that serves inference while the local weights
+    /// download, for this load only.
+    ///
+    /// The Xybrid gateway dispatches OpenAI-style `provider` + `model`, so this
+    /// is the model that answers speculatively (e.g. `"openai"` / `"gpt-4o-mini"`)
+    /// until the local model is ready. Defaults to `openai`/`gpt-4o-mini` when
+    /// not set. Only takes effect when [`Self::will_speculate`] holds.
+    ///
+    /// # Examples
+    /// ```
+    /// use xybrid_sdk::ModelLoader;
+    /// let loader = ModelLoader::from_registry("qwen2.5-0.5b-instruct")
+    ///     .with_speculative_cloud(true)
+    ///     .with_speculative_cloud_model("anthropic", "claude-haiku-4-5");
+    /// ```
+    pub fn with_speculative_cloud_model(
+        mut self,
+        provider: impl Into<String>,
+        model: impl Into<String>,
+    ) -> Self {
+        self.speculative_cloud_model = Some(SpeculativeCloud {
+            provider: provider.into(),
+            model: model.into(),
+        });
         self
     }
 
@@ -1402,6 +1600,13 @@ impl ModelLoader {
     where
         F: Fn(f32),
     {
+        // Speculative cloud: when enabled, a key is set, and the model isn't
+        // cached yet, serve from cloud while the weights download in the
+        // background instead of blocking the caller on the download.
+        if self.will_speculate() {
+            return Ok(self.load_speculative(id, platform));
+        }
+
         // Create registry client (uses default API or environment variable)
         let client = RegistryClient::from_env()?;
 
@@ -1410,6 +1615,79 @@ impl ModelLoader {
 
         // Load from extracted directory
         self.load_from_directory(&model_dir)
+    }
+
+    /// Build a cloud-backed [`XybridModel`] that serves from the gateway while
+    /// the registry weights download in a background thread, then transparently
+    /// switches to local once the real handle is swapped in.
+    ///
+    /// The returned model holds a placeholder handle (`loaded == false`); every
+    /// run routes to cloud via [`XybridModel::speculative`] until the download
+    /// thread installs the extracted local handle. Never blocks the caller.
+    fn load_speculative(&self, id: &str, platform: Option<&str>) -> XybridModel {
+        let spec = self.speculative_cloud_model.clone().unwrap_or_default();
+
+        // The future extraction directory for the placeholder executor. The
+        // executor is lazy (no weights touched until `execute`), so pointing it
+        // at a not-yet-populated path is fine — it is never executed while the
+        // handle stays `loaded == false`.
+        let model_dir = crate::cache::CacheManager::new()
+            .map(|cache| cache.extraction_dir(id))
+            .unwrap_or_else(|_| PathBuf::from(id));
+
+        let placeholder = ModelHandle {
+            executor: TemplateExecutor::with_base_path(model_dir.to_str().unwrap_or(".")),
+            // Placeholder metadata, never read: runs route to cloud while
+            // `loaded == false`, and the background thread overwrites the whole
+            // handle (with real metadata) once the download completes.
+            metadata: ModelMetadata::onnx(id, "", ""),
+            model_dir,
+            loaded: false,
+        };
+        let handle = Arc::new(RwLock::new(placeholder));
+
+        // Background download + extract, then swap in the real local handle.
+        // On failure the placeholder stays put and cloud keeps serving.
+        let bg_handle = Arc::clone(&handle);
+        let id_owned = id.to_string();
+        let platform_owned = platform.map(String::from);
+        std::thread::spawn(move || {
+            let built = RegistryClient::from_env().and_then(|client| {
+                let dir = client.fetch_extracted(&id_owned, platform_owned.as_deref(), |_| {})?;
+                Self::create_model_handle(&dir)
+            });
+            match built {
+                Ok(real) => {
+                    *bg_handle.write().unwrap_or_else(|e| e.into_inner()) = real;
+                }
+                Err(e) => {
+                    crate::telemetry::publish_telemetry_event(crate::telemetry::TelemetryEvent {
+                        event_type: "SpeculativeDownloadFailed".to_string(),
+                        stage_name: Some(id_owned.clone()),
+                        target: Some("local".to_string()),
+                        latency_ms: None,
+                        error: Some(e.to_string()),
+                        data: None,
+                        timestamp_ms: std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0),
+                    });
+                }
+            }
+        });
+
+        XybridModel {
+            handle,
+            model_id: id.to_string(),
+            version: String::new(),
+            // Speculation only serves the gateway's text/chat surface; the real
+            // output type is refreshed implicitly once the local handle lands.
+            output_type: OutputType::Text,
+            supports_streaming: true,
+            current_run: Arc::new(Mutex::new(None)),
+            speculative: Some(Arc::new(spec)),
+        }
     }
 
     /// Load from legacy registry (deprecated - use load_from_registry_api instead).
@@ -1478,6 +1756,7 @@ impl ModelLoader {
             output_type,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
+            speculative: None,
         })
     }
 
@@ -1739,6 +2018,7 @@ impl ModelLoader {
             output_type,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
+            speculative: None,
         })
     }
 
@@ -1899,6 +2179,12 @@ pub struct XybridModel {
     /// must see the previous concurrent run's token even though it ran on a
     /// different clone.
     current_run: Arc<Mutex<Option<CancellationToken>>>,
+    /// Speculative cloud backing. `Some` while this model was loaded under
+    /// speculative cloud fallback: until the background download installs a
+    /// `loaded` local handle, every run is routed to the gateway via this
+    /// config (see [`Self::cloud_serve`]). `None` for ordinary local models.
+    /// `Arc`-shared so clones observe the same routing config.
+    speculative: Option<Arc<SpeculativeCloud>>,
 }
 
 struct WarmupEventFields {
@@ -1969,6 +2255,20 @@ impl XybridModel {
             .read()
             .ok()
             .and_then(|h| h.metadata.supports_tool_calling())
+    }
+
+    /// Whether this run should be served speculatively from the cloud.
+    ///
+    /// Returns the cloud routing config when this model was loaded under
+    /// speculative cloud fallback *and* the local handle isn't ready yet. Once
+    /// the background download swaps in a `loaded` handle this returns `None`
+    /// and runs go local. Checked without holding the handle write lock so the
+    /// cloud round-trip never blocks a concurrent local promotion.
+    fn cloud_serve(&self) -> Option<Arc<SpeculativeCloud>> {
+        match &self.speculative {
+            Some(spec) if !self.is_loaded() => Some(Arc::clone(spec)),
+            _ => None,
+        }
     }
 
     /// Check if this model supports streaming.
@@ -2354,6 +2654,11 @@ impl XybridModel {
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
         crate::telemetry::maybe_emit_dev_nudge();
+        // Speculative cloud: serve from the gateway until the local handle is
+        // ready (see `cloud_serve`).
+        if let Some(spec) = self.cloud_serve() {
+            return cloud_serve_batch(&spec, &self.model_id, envelope, config);
+        }
         let start = Instant::now();
         // Begin a resource-telemetry scope for this run. When
         // `resource_telemetry_mode()` is `Off` the guard is a no-op; otherwise
@@ -2553,6 +2858,13 @@ impl XybridModel {
         context: &ConversationContext,
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
+        // Speculative cloud: serve from the gateway until the local handle is
+        // ready. The gateway leg is stateless — `context` is not replayed (the
+        // reactive fallback behaves the same) — full history resumes once the
+        // local model takes over.
+        if let Some(spec) = self.cloud_serve() {
+            return cloud_serve_batch(&spec, &self.model_id, envelope, config);
+        }
         let start = Instant::now();
         let resource_guard = crate::telemetry::begin_resource_run();
 
@@ -2701,6 +3013,13 @@ impl XybridModel {
             + Send,
     {
         use xybrid_core::runtime_adapter::types::PartialToken;
+
+        // Speculative cloud: stream from the gateway until the local handle is
+        // ready. The gateway leg is stateless (`context` not replayed, matching
+        // the reactive fallback); full history resumes once local takes over.
+        if let Some(spec) = self.cloud_serve() {
+            return cloud_serve_streaming(&spec, &self.model_id, envelope, config, &mut on_token);
+        }
 
         let start = Instant::now();
 
@@ -2902,6 +3221,12 @@ impl XybridModel {
             + Send,
     {
         use xybrid_core::runtime_adapter::types::PartialToken;
+
+        // Speculative cloud: stream from the gateway until the local handle is
+        // ready (see `cloud_serve`).
+        if let Some(spec) = self.cloud_serve() {
+            return cloud_serve_streaming(&spec, &self.model_id, envelope, config, &mut on_token);
+        }
 
         let start = Instant::now();
 
@@ -3304,6 +3629,8 @@ impl XybridModel {
         let model_id = self.model_id.clone();
         let version = self.version.clone();
         let output_type = self.output_type;
+        // Speculative cloud routing decision, captured before the worker spawns.
+        let speculative = self.cloud_serve();
 
         // Clone tx for the completion event (before moving into spawn_blocking)
         let tx_completion = tx.clone();
@@ -3319,6 +3646,28 @@ impl XybridModel {
                 let trace_id = uuid::Uuid::new_v4();
                 let _telemetry_ctx =
                     crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
+
+                // Speculative cloud: stream from the gateway until the local
+                // handle is ready, forwarding each token as a StreamEvent.
+                if let Some(spec) = speculative {
+                    let tx_token = tx.clone();
+                    return cloud_serve_streaming(
+                        &spec,
+                        &model_id,
+                        &envelope,
+                        config.as_ref(),
+                        &mut |token: PartialToken| {
+                            let _ = tx_token.blocking_send(StreamEvent::Token(StreamToken {
+                                token: token.token.clone(),
+                                token_id: token.token_id,
+                                index: token.index,
+                                cumulative_text: token.cumulative_text.clone(),
+                                finish_reason: token.finish_reason.clone(),
+                            }));
+                            Ok(())
+                        },
+                    );
+                }
 
                 // Get write lock on handle
                 let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
@@ -3455,6 +3804,18 @@ impl XybridModel {
         config: Option<&GenerationConfig>,
     ) -> SdkResult<InferenceResult> {
         crate::telemetry::maybe_emit_dev_nudge();
+        // Speculative cloud: serve from the gateway (off the runtime via
+        // spawn_blocking, like the local path) until the local handle is ready.
+        if let Some(spec) = self.cloud_serve() {
+            let model_id = self.model_id.clone();
+            let envelope = envelope.clone();
+            let config = config.cloned();
+            return tokio::task::spawn_blocking(move || {
+                cloud_serve_batch(&spec, &model_id, &envelope, config.as_ref())
+            })
+            .await
+            .map_err(|e| SdkError::inference_src("Task join error", e))?;
+        }
         let handle = self.handle.clone();
         let model_id = self.model_id.clone();
         let version = self.version.clone();
@@ -3601,6 +3962,7 @@ impl Clone for XybridModel {
             // Share the in-flight slot so all clones coordinate preemption
             // through one mutex (see field docs).
             current_run: self.current_run.clone(),
+            speculative: self.speculative.clone(),
         }
     }
 }
@@ -3859,6 +4221,108 @@ mod tests {
         assert!(!ModelLoader::from_registry("m").speculative_enabled());
 
         crate::set_speculative_cloud(prev);
+    }
+
+    #[test]
+    fn speculative_cloud_default_is_openai_gpt4o_mini() {
+        let spec = SpeculativeCloud::default();
+        assert_eq!(spec.provider, "openai");
+        assert_eq!(spec.model, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn with_speculative_cloud_model_overrides_identity() {
+        let loader = ModelLoader::from_registry("m")
+            .with_speculative_cloud_model("anthropic", "claude-haiku-4-5");
+        let spec = loader.speculative_cloud_model.expect("model set");
+        assert_eq!(spec.provider, "anthropic");
+        assert_eq!(spec.model, "claude-haiku-4-5");
+    }
+
+    #[test]
+    fn build_envelope_overlays_cloud_routing_metadata() {
+        let spec = SpeculativeCloud::default();
+        let input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
+        let config = GenerationConfig {
+            max_tokens: 64,
+            temperature: 0.3,
+            ..Default::default()
+        };
+        let cloud = spec.build_envelope(&input, Some(&config));
+        assert_eq!(
+            cloud.metadata.get("provider").map(String::as_str),
+            Some("openai")
+        );
+        assert_eq!(
+            cloud.metadata.get("model").map(String::as_str),
+            Some("gpt-4o-mini")
+        );
+        assert_eq!(
+            cloud.metadata.get("backend").map(String::as_str),
+            Some("gateway")
+        );
+        assert_eq!(
+            cloud.metadata.get("max_tokens").map(String::as_str),
+            Some("64")
+        );
+        assert_eq!(
+            cloud.metadata.get("temperature").map(String::as_str),
+            Some("0.3")
+        );
+    }
+
+    #[test]
+    fn build_envelope_does_not_clobber_caller_backend() {
+        let spec = SpeculativeCloud::default();
+        let mut input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
+        input
+            .metadata
+            .insert("backend".to_string(), "direct".to_string());
+        let cloud = spec.build_envelope(&input, None);
+        // provider/model are forced; backend defers to the caller's value.
+        assert_eq!(
+            cloud.metadata.get("provider").map(String::as_str),
+            Some("openai")
+        );
+        assert_eq!(
+            cloud.metadata.get("backend").map(String::as_str),
+            Some("direct")
+        );
+    }
+
+    /// A not-yet-downloaded speculative model routes to cloud; a loaded local
+    /// model never does.
+    #[test]
+    fn cloud_serve_engages_only_while_not_loaded() {
+        let speculating = XybridModel {
+            handle: Arc::new(RwLock::new(ModelHandle {
+                executor: TemplateExecutor::default(),
+                metadata: ModelMetadata::onnx("spec-model", "", ""),
+                model_dir: PathBuf::from("."),
+                loaded: false,
+            })),
+            model_id: "spec-model".to_string(),
+            version: String::new(),
+            output_type: OutputType::Text,
+            supports_streaming: true,
+            current_run: Arc::new(Mutex::new(None)),
+            speculative: Some(Arc::new(SpeculativeCloud::default())),
+        };
+        assert!(speculating.cloud_serve().is_some(), "not loaded -> cloud");
+
+        // Flip the placeholder to loaded: the local handle is now ready.
+        speculating
+            .handle
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .loaded = true;
+        assert!(
+            speculating.cloud_serve().is_none(),
+            "loaded local handle -> no speculation"
+        );
+
+        // A plain local model with no speculative config never routes to cloud.
+        assert!(test_loaded_model(true).cloud_serve().is_none());
     }
 
     /// The inherent `SdkError::is_retryable` / `retry_after` accessors and
@@ -4262,6 +4726,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
+            speculative: None,
         }
     }
 
@@ -5071,6 +5536,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
+            speculative: None,
         }
     }
 

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -559,19 +559,28 @@ where
             on_seam(seam);
 
             // FR-6: reuse the original prompt; no partial-token reuse.
-            let cloud_envelope = envelope.clone();
+            let mut cloud_envelope = envelope.clone();
+            // Default the cloud-leg routing to the registry model when the caller
+            // didn't pick an explicit hosted override: the platform gateway routes
+            // an id it doesn't recognise as a hosted provider's model through to
+            // xycloud (the CPU cluster that runs the same edge LLM), so the
+            // fallback serves the *same* model rather than erroring or silently
+            // defaulting to `gpt-4o-mini`. `provider` is a benign validation label
+            // — the gateway dispatches on `model` alone.
+            cloud_envelope
+                .metadata
+                .entry("model".to_string())
+                .or_insert_with(|| model_id.to_string());
+            cloud_envelope
+                .metadata
+                .entry("provider".to_string())
+                .or_insert_with(|| "openai".to_string());
             let cloud_provider = cloud_envelope.metadata.get("provider").cloned();
-            // The cloud leg almost always runs a different model than the
-            // local leg (e.g. local `qwen2.5-0.5b-instruct` falling back to
-            // cloud `deepseek-chat`). The dashboard reads `model_id` off
-            // the published event, so passing the local `model_id` through
-            // to the cloud event makes the trace lie about which model
-            // actually produced the cloud tokens. Pull the cloud model from
-            // the envelope's `model` metadata (the same field the gateway
-            // dispatches on) and fall back to the local id only when the
-            // caller didn't set one — in that case the dispatch would have
-            // failed at the gateway anyway, so the local id is a fine
-            // last-resort label.
+            // The cloud leg runs a different model than the local leg only when the
+            // caller set an explicit override (e.g. local `qwen2.5-0.5b-instruct` →
+            // cloud `deepseek-chat`); otherwise it is the registry id defaulted
+            // above, routed to xycloud. Read it back off the envelope so the
+            // published event names the model that actually produced the tokens.
             let cloud_model_id = cloud_envelope
                 .metadata
                 .get("model")
@@ -1005,63 +1014,41 @@ pub struct ModelLoader {
     /// Per-load speculative-cloud override. `None` inherits the process-global
     /// default set via [`crate::set_speculative_cloud`].
     speculative_cloud: Option<bool>,
-    /// Cloud model identity to serve from while the local weights download.
-    /// `None` uses [`SpeculativeCloud::default`] (`openai`/`gpt-4o-mini`).
-    speculative_cloud_model: Option<SpeculativeCloud>,
 }
 
-/// Cloud model identity used to serve inference *while a local model is still
-/// downloading* (speculative cloud fallback).
-///
-/// The Xybrid gateway dispatches OpenAI-style `provider` + `model` (it cannot
-/// serve an arbitrary registry id), so a speculating load answers with this
-/// configured cloud model until the local weights are extracted and ready —
-/// at which point subsequent runs transparently switch to local. Mirrors the
-/// envelope metadata the reactive fallback path (`dispatch_after_local`) and
-/// the Flutter binding's `apply_cloud_fallback_metadata` already use.
-#[derive(Debug, Clone)]
-pub(crate) struct SpeculativeCloud {
-    provider: String,
-    model: String,
-}
-
-impl Default for SpeculativeCloud {
-    fn default() -> Self {
-        Self {
-            provider: "openai".to_string(),
-            model: "gpt-4o-mini".to_string(),
-        }
+/// Build the cloud-bound envelope for serving a not-yet-local model from the
+/// gateway. Sets `model` to the registry id so the gateway routes it to xycloud
+/// (the CPU cluster that runs the edge model) — an id it doesn't recognise as a
+/// hosted provider's model falls through there. `provider` is a benign
+/// validation/trace label, never sent on the wire (the gateway routes on
+/// `model` alone). `backend`/`max_tokens`/`temperature` defer to caller values.
+fn build_speculative_cloud_envelope(
+    model_id: &str,
+    envelope: &Envelope,
+    config: Option<&GenerationConfig>,
+) -> Envelope {
+    let mut cloud = envelope.clone();
+    cloud
+        .metadata
+        .insert("provider".to_string(), "openai".to_string());
+    cloud
+        .metadata
+        .insert("model".to_string(), model_id.to_string());
+    cloud
+        .metadata
+        .entry("backend".to_string())
+        .or_insert_with(|| "gateway".to_string());
+    if let Some(cfg) = config {
+        cloud
+            .metadata
+            .entry("max_tokens".to_string())
+            .or_insert_with(|| cfg.max_tokens.to_string());
+        cloud
+            .metadata
+            .entry("temperature".to_string())
+            .or_insert_with(|| cfg.temperature.to_string());
     }
-}
-
-impl SpeculativeCloud {
-    /// Build the cloud-bound envelope by overlaying the cloud routing metadata
-    /// the gateway dispatches on. `provider`/`model` are forced to this config;
-    /// `backend`/`max_tokens`/`temperature` defer to caller-supplied values.
-    fn build_envelope(&self, envelope: &Envelope, config: Option<&GenerationConfig>) -> Envelope {
-        let mut cloud = envelope.clone();
-        cloud
-            .metadata
-            .insert("provider".to_string(), self.provider.clone());
-        cloud
-            .metadata
-            .insert("model".to_string(), self.model.clone());
-        cloud
-            .metadata
-            .entry("backend".to_string())
-            .or_insert_with(|| "gateway".to_string());
-        if let Some(cfg) = config {
-            cloud
-                .metadata
-                .entry("max_tokens".to_string())
-                .or_insert_with(|| cfg.max_tokens.to_string());
-            cloud
-                .metadata
-                .entry("temperature".to_string())
-                .or_insert_with(|| cfg.temperature.to_string());
-        }
-        cloud
-    }
+    cloud
 }
 
 /// Privacy gate for the speculative cloud leg: run the orchestrator policy over
@@ -1125,13 +1112,12 @@ fn publish_speculative_cloud_event(model_id: &str, latency_ms: u32, streaming: b
 /// Serve a batch inference from the cloud gateway because the local model is
 /// not ready yet. Shared by `run` and `run_async`.
 fn cloud_serve_batch(
-    spec: &SpeculativeCloud,
     model_id: &str,
     envelope: &Envelope,
     config: Option<&GenerationConfig>,
 ) -> SdkResult<InferenceResult> {
     let start = Instant::now();
-    let cloud_envelope = spec.build_envelope(envelope, config);
+    let cloud_envelope = build_speculative_cloud_envelope(model_id, envelope, config);
     speculative_cloud_policy_gate(&cloud_envelope)?;
     let output = CloudRuntimeAdapter::new()
         .execute(&cloud_envelope)
@@ -1144,7 +1130,6 @@ fn cloud_serve_batch(
 /// Serve a streaming inference from the cloud gateway because the local model
 /// is not ready yet. Shared by the streaming entry points.
 fn cloud_serve_streaming<F>(
-    spec: &SpeculativeCloud,
     model_id: &str,
     envelope: &Envelope,
     config: Option<&GenerationConfig>,
@@ -1157,7 +1142,7 @@ where
         + Send,
 {
     let start = Instant::now();
-    let cloud_envelope = spec.build_envelope(envelope, config);
+    let cloud_envelope = build_speculative_cloud_envelope(model_id, envelope, config);
     speculative_cloud_policy_gate(&cloud_envelope)?;
     let callback: xybrid_core::runtime_adapter::types::StreamingCallback<'_> = Box::new(on_token);
     let output = CloudRuntimeAdapter::new()
@@ -1200,7 +1185,6 @@ impl ModelLoader {
             model_id: Some(id.to_string()),
             version: None, // Version is resolved by registry API
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1221,7 +1205,6 @@ impl ModelLoader {
             model_id: Some(id.to_string()),
             version: None,
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1237,7 +1220,6 @@ impl ModelLoader {
             model_id: Some(model_id.to_string()),
             version: Some(version.to_string()),
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1261,7 +1243,6 @@ impl ModelLoader {
             model_id: Some(model_id.to_string()),
             version: Some(version.to_string()),
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1279,7 +1260,6 @@ impl ModelLoader {
             model_id: None,
             version: None,
             speculative_cloud: None,
-            speculative_cloud_model: None,
         })
     }
 
@@ -1314,7 +1294,6 @@ impl ModelLoader {
             model_id: None,
             version: None,
             speculative_cloud: None,
-            speculative_cloud_model: None,
         })
     }
 
@@ -1346,7 +1325,6 @@ impl ModelLoader {
             model_id: Some(repo.to_string()),
             version: None,
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1367,7 +1345,6 @@ impl ModelLoader {
             model_id: Some(repo.to_string()),
             version: Some(revision.to_string()),
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1393,7 +1370,6 @@ impl ModelLoader {
             model_id: Some(repo),
             version: None,
             speculative_cloud: None,
-            speculative_cloud_model: None,
         }
     }
 
@@ -1430,33 +1406,6 @@ impl ModelLoader {
     /// ```
     pub fn with_speculative_cloud(mut self, enabled: bool) -> Self {
         self.speculative_cloud = Some(enabled);
-        self
-    }
-
-    /// Choose the cloud model that serves inference while the local weights
-    /// download, for this load only.
-    ///
-    /// The Xybrid gateway dispatches OpenAI-style `provider` + `model`, so this
-    /// is the model that answers speculatively (e.g. `"openai"` / `"gpt-4o-mini"`)
-    /// until the local model is ready. Defaults to `openai`/`gpt-4o-mini` when
-    /// not set. Only takes effect when [`Self::will_speculate`] holds.
-    ///
-    /// # Examples
-    /// ```
-    /// use xybrid_sdk::ModelLoader;
-    /// let loader = ModelLoader::from_registry("qwen2.5-0.5b-instruct")
-    ///     .with_speculative_cloud(true)
-    ///     .with_speculative_cloud_model("anthropic", "claude-haiku-4-5");
-    /// ```
-    pub fn with_speculative_cloud_model(
-        mut self,
-        provider: impl Into<String>,
-        model: impl Into<String>,
-    ) -> Self {
-        self.speculative_cloud_model = Some(SpeculativeCloud {
-            provider: provider.into(),
-            model: model.into(),
-        });
         self
     }
 
@@ -1625,8 +1574,6 @@ impl ModelLoader {
     /// run routes to cloud via [`XybridModel::speculative`] until the download
     /// thread installs the extracted local handle. Never blocks the caller.
     fn load_speculative(&self, id: &str, platform: Option<&str>) -> XybridModel {
-        let spec = self.speculative_cloud_model.clone().unwrap_or_default();
-
         // The future extraction directory for the placeholder executor. The
         // executor is lazy (no weights touched until `execute`), so pointing it
         // at a not-yet-populated path is fine — it is never executed while the
@@ -1686,7 +1633,7 @@ impl ModelLoader {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: Some(Arc::new(spec)),
+            speculative: true,
         }
     }
 
@@ -1756,7 +1703,7 @@ impl ModelLoader {
             output_type,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: None,
+            speculative: false,
         })
     }
 
@@ -2018,7 +1965,7 @@ impl ModelLoader {
             output_type,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: None,
+            speculative: false,
         })
     }
 
@@ -2179,12 +2126,12 @@ pub struct XybridModel {
     /// must see the previous concurrent run's token even though it ran on a
     /// different clone.
     current_run: Arc<Mutex<Option<CancellationToken>>>,
-    /// Speculative cloud backing. `Some` while this model was loaded under
+    /// Speculative cloud backing. `true` while this model was loaded under
     /// speculative cloud fallback: until the background download installs a
-    /// `loaded` local handle, every run is routed to the gateway via this
-    /// config (see [`Self::cloud_serve`]). `None` for ordinary local models.
-    /// `Arc`-shared so clones observe the same routing config.
-    speculative: Option<Arc<SpeculativeCloud>>,
+    /// `loaded` local handle, every run is routed to the gateway (which serves
+    /// the registry model via xycloud — see [`Self::cloud_serve`]). `false` for
+    /// ordinary local models.
+    speculative: bool,
 }
 
 struct WarmupEventFields {
@@ -2259,16 +2206,13 @@ impl XybridModel {
 
     /// Whether this run should be served speculatively from the cloud.
     ///
-    /// Returns the cloud routing config when this model was loaded under
-    /// speculative cloud fallback *and* the local handle isn't ready yet. Once
-    /// the background download swaps in a `loaded` handle this returns `None`
-    /// and runs go local. Checked without holding the handle write lock so the
-    /// cloud round-trip never blocks a concurrent local promotion.
-    fn cloud_serve(&self) -> Option<Arc<SpeculativeCloud>> {
-        match &self.speculative {
-            Some(spec) if !self.is_loaded() => Some(Arc::clone(spec)),
-            _ => None,
-        }
+    /// `true` when this model was loaded under speculative cloud fallback *and*
+    /// the local handle isn't ready yet. Once the background download swaps in a
+    /// `loaded` handle this returns `false` and runs go local. Checked without
+    /// holding the handle write lock so the cloud round-trip never blocks a
+    /// concurrent local promotion.
+    fn cloud_serve(&self) -> bool {
+        self.speculative && !self.is_loaded()
     }
 
     /// Check if this model supports streaming.
@@ -2656,8 +2600,8 @@ impl XybridModel {
         crate::telemetry::maybe_emit_dev_nudge();
         // Speculative cloud: serve from the gateway until the local handle is
         // ready (see `cloud_serve`).
-        if let Some(spec) = self.cloud_serve() {
-            return cloud_serve_batch(&spec, &self.model_id, envelope, config);
+        if self.cloud_serve() {
+            return cloud_serve_batch(&self.model_id, envelope, config);
         }
         let start = Instant::now();
         // Begin a resource-telemetry scope for this run. When
@@ -2862,8 +2806,8 @@ impl XybridModel {
         // ready. The gateway leg is stateless — `context` is not replayed (the
         // reactive fallback behaves the same) — full history resumes once the
         // local model takes over.
-        if let Some(spec) = self.cloud_serve() {
-            return cloud_serve_batch(&spec, &self.model_id, envelope, config);
+        if self.cloud_serve() {
+            return cloud_serve_batch(&self.model_id, envelope, config);
         }
         let start = Instant::now();
         let resource_guard = crate::telemetry::begin_resource_run();
@@ -3017,8 +2961,8 @@ impl XybridModel {
         // Speculative cloud: stream from the gateway until the local handle is
         // ready. The gateway leg is stateless (`context` not replayed, matching
         // the reactive fallback); full history resumes once local takes over.
-        if let Some(spec) = self.cloud_serve() {
-            return cloud_serve_streaming(&spec, &self.model_id, envelope, config, &mut on_token);
+        if self.cloud_serve() {
+            return cloud_serve_streaming(&self.model_id, envelope, config, &mut on_token);
         }
 
         let start = Instant::now();
@@ -3224,8 +3168,8 @@ impl XybridModel {
 
         // Speculative cloud: stream from the gateway until the local handle is
         // ready (see `cloud_serve`).
-        if let Some(spec) = self.cloud_serve() {
-            return cloud_serve_streaming(&spec, &self.model_id, envelope, config, &mut on_token);
+        if self.cloud_serve() {
+            return cloud_serve_streaming(&self.model_id, envelope, config, &mut on_token);
         }
 
         let start = Instant::now();
@@ -3649,10 +3593,9 @@ impl XybridModel {
 
                 // Speculative cloud: stream from the gateway until the local
                 // handle is ready, forwarding each token as a StreamEvent.
-                if let Some(spec) = speculative {
+                if speculative {
                     let tx_token = tx.clone();
                     return cloud_serve_streaming(
-                        &spec,
                         &model_id,
                         &envelope,
                         config.as_ref(),
@@ -3806,12 +3749,12 @@ impl XybridModel {
         crate::telemetry::maybe_emit_dev_nudge();
         // Speculative cloud: serve from the gateway (off the runtime via
         // spawn_blocking, like the local path) until the local handle is ready.
-        if let Some(spec) = self.cloud_serve() {
+        if self.cloud_serve() {
             let model_id = self.model_id.clone();
             let envelope = envelope.clone();
             let config = config.cloned();
             return tokio::task::spawn_blocking(move || {
-                cloud_serve_batch(&spec, &model_id, &envelope, config.as_ref())
+                cloud_serve_batch(&model_id, &envelope, config.as_ref())
             })
             .await
             .map_err(|e| SdkError::inference_src("Task join error", e))?;
@@ -3962,7 +3905,7 @@ impl Clone for XybridModel {
             // Share the in-flight slot so all clones coordinate preemption
             // through one mutex (see field docs).
             current_run: self.current_run.clone(),
-            speculative: self.speculative.clone(),
+            speculative: self.speculative,
         }
     }
 }
@@ -4224,38 +4167,33 @@ mod tests {
     }
 
     #[test]
-    fn speculative_cloud_default_is_openai_gpt4o_mini() {
-        let spec = SpeculativeCloud::default();
-        assert_eq!(spec.provider, "openai");
-        assert_eq!(spec.model, "gpt-4o-mini");
-    }
-
-    #[test]
-    fn with_speculative_cloud_model_overrides_identity() {
-        let loader = ModelLoader::from_registry("m")
-            .with_speculative_cloud_model("anthropic", "claude-haiku-4-5");
-        let spec = loader.speculative_cloud_model.expect("model set");
-        assert_eq!(spec.provider, "anthropic");
-        assert_eq!(spec.model, "claude-haiku-4-5");
+    fn speculative_envelope_sends_registry_id_to_gateway() {
+        // The registry id goes out as the gateway `model`, so the gateway routes
+        // it to xycloud (runs the real edge model) instead of a hosted provider.
+        let input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
+        let cloud = build_speculative_cloud_envelope("lfm2.5-350m", &input, None);
+        assert_eq!(
+            cloud.metadata.get("model").map(String::as_str),
+            Some("lfm2.5-350m")
+        );
     }
 
     #[test]
     fn build_envelope_overlays_cloud_routing_metadata() {
-        let spec = SpeculativeCloud::default();
         let input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
         let config = GenerationConfig {
             max_tokens: 64,
             temperature: 0.3,
             ..Default::default()
         };
-        let cloud = spec.build_envelope(&input, Some(&config));
+        let cloud = build_speculative_cloud_envelope("lfm2.5-350m", &input, Some(&config));
         assert_eq!(
             cloud.metadata.get("provider").map(String::as_str),
             Some("openai")
         );
         assert_eq!(
             cloud.metadata.get("model").map(String::as_str),
-            Some("gpt-4o-mini")
+            Some("lfm2.5-350m")
         );
         assert_eq!(
             cloud.metadata.get("backend").map(String::as_str),
@@ -4273,12 +4211,11 @@ mod tests {
 
     #[test]
     fn build_envelope_does_not_clobber_caller_backend() {
-        let spec = SpeculativeCloud::default();
         let mut input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
         input
             .metadata
             .insert("backend".to_string(), "direct".to_string());
-        let cloud = spec.build_envelope(&input, None);
+        let cloud = build_speculative_cloud_envelope("lfm2.5-350m", &input, None);
         // provider/model are forced; backend defers to the caller's value.
         assert_eq!(
             cloud.metadata.get("provider").map(String::as_str),
@@ -4306,9 +4243,9 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: Some(Arc::new(SpeculativeCloud::default())),
+            speculative: true,
         };
-        assert!(speculating.cloud_serve().is_some(), "not loaded -> cloud");
+        assert!(speculating.cloud_serve(), "not loaded -> cloud");
 
         // Flip the placeholder to loaded: the local handle is now ready.
         speculating
@@ -4317,12 +4254,12 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner())
             .loaded = true;
         assert!(
-            speculating.cloud_serve().is_none(),
+            !speculating.cloud_serve(),
             "loaded local handle -> no speculation"
         );
 
         // A plain local model with no speculative config never routes to cloud.
-        assert!(test_loaded_model(true).cloud_serve().is_none());
+        assert!(!test_loaded_model(true).cloud_serve());
     }
 
     /// The inherent `SdkError::is_retryable` / `retry_after` accessors and
@@ -4726,7 +4663,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: None,
+            speculative: false,
         }
     }
 
@@ -5536,7 +5473,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: None,
+            speculative: false,
         }
     }
 

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1582,12 +1582,23 @@ impl ModelLoader {
             .map(|cache| cache.extraction_dir(id))
             .unwrap_or_else(|_| PathBuf::from(id));
 
+        // Speculation is LLM/chat-only and the gateway streams tokens, so mark
+        // the placeholder as GGUF. Otherwise `is_llm()` / `supports_token_streaming()`
+        // read this metadata and report `false`, dropping the REPL to batch mode
+        // until the real handle swaps in. The background download replaces the
+        // whole handle (with real metadata) once it completes.
+        let mut metadata = ModelMetadata::onnx(id, "", "");
+        metadata.execution_template = ExecutionTemplate::Gguf {
+            model_file: String::new(),
+            chat_template: None,
+            context_length: 2048,
+            generation_params: None,
+        };
         let placeholder = ModelHandle {
-            executor: TemplateExecutor::with_base_path(model_dir.to_str().unwrap_or(".")),
-            // Placeholder metadata, never read: runs route to cloud while
-            // `loaded == false`, and the background thread overwrites the whole
-            // handle (with real metadata) once the download completes.
-            metadata: ModelMetadata::onnx(id, "", ""),
+            // Lazy executor over the not-yet-populated extraction dir; never run
+            // while `loaded == false` (runs route to cloud).
+            executor: TemplateExecutor::with_base_path(&model_dir.to_string_lossy()),
+            metadata,
             model_dir,
             loaded: false,
         };
@@ -1598,31 +1609,41 @@ impl ModelLoader {
         let bg_handle = Arc::clone(&handle);
         let id_owned = id.to_string();
         let platform_owned = platform.map(String::from);
-        std::thread::spawn(move || {
-            let built = RegistryClient::from_env().and_then(|client| {
-                let dir = client.fetch_extracted(&id_owned, platform_owned.as_deref(), |_| {})?;
-                Self::create_model_handle(&dir)
-            });
-            match built {
-                Ok(real) => {
-                    *bg_handle.write().unwrap_or_else(|e| e.into_inner()) = real;
+        let thread_name = format!("speculative-download-{id_owned}");
+        if let Err(err) = std::thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                let built = RegistryClient::from_env().and_then(|client| {
+                    let dir =
+                        client.fetch_extracted(&id_owned, platform_owned.as_deref(), |_| {})?;
+                    Self::create_model_handle(&dir)
+                });
+                match built {
+                    Ok(real) => {
+                        *bg_handle.write().unwrap_or_else(|e| e.into_inner()) = real;
+                    }
+                    Err(e) => {
+                        log::error!("speculative background download failed for '{id_owned}': {e}");
+                        crate::telemetry::publish_telemetry_event(
+                            crate::telemetry::TelemetryEvent {
+                                event_type: "SpeculativeDownloadFailed".to_string(),
+                                stage_name: Some(id_owned.clone()),
+                                target: Some("local".to_string()),
+                                latency_ms: None,
+                                error: Some(e.to_string()),
+                                data: None,
+                                timestamp_ms: std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_millis() as u64)
+                                    .unwrap_or(0),
+                            },
+                        );
+                    }
                 }
-                Err(e) => {
-                    crate::telemetry::publish_telemetry_event(crate::telemetry::TelemetryEvent {
-                        event_type: "SpeculativeDownloadFailed".to_string(),
-                        stage_name: Some(id_owned.clone()),
-                        target: Some("local".to_string()),
-                        latency_ms: None,
-                        error: Some(e.to_string()),
-                        data: None,
-                        timestamp_ms: std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_millis() as u64)
-                            .unwrap_or(0),
-                    });
-                }
-            }
-        });
+            })
+        {
+            log::error!("failed to spawn speculative download thread for '{id}': {err}");
+        }
 
         XybridModel {
             handle,

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1111,6 +1111,44 @@ fn publish_speculative_cloud_event(model_id: &str, latency_ms: u32, streaming: b
 
 /// Serve a batch inference from the cloud gateway because the local model is
 /// not ready yet. Shared by `run` and `run_async`.
+/// Completion signal for the background download started by
+/// [`ModelLoader::load_speculative`].
+///
+/// Lets a *failed* cloud leg degrade to the pre-speculation behaviour — block
+/// until the weights land, then run locally — instead of surfacing a gateway
+/// error for a model the caller only ever asked to run. `outcome` is `None`
+/// while the download is in flight, `Some(true)` once the real local handle is
+/// installed, and `Some(false)` if the download failed (cloud keeps serving).
+#[derive(Debug, Default)]
+pub(crate) struct SpeculativeDownload {
+    outcome: Mutex<Option<bool>>,
+    finished: std::sync::Condvar,
+}
+
+impl SpeculativeDownload {
+    /// Record the download outcome and wake every waiter.
+    fn finish(&self, installed_local: bool) {
+        let mut guard = self.outcome.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(installed_local);
+        drop(guard);
+        self.finished.notify_all();
+    }
+
+    /// Block until the background download finishes; `true` if it installed a
+    /// local handle.
+    ///
+    /// Deliberately unbounded: waiting exactly as long as the download takes is
+    /// what a non-speculative `load()` would have done anyway, so degrading
+    /// never blocks longer than not speculating in the first place.
+    fn wait_for_local(&self) -> bool {
+        let mut guard = self.outcome.lock().unwrap_or_else(|e| e.into_inner());
+        while guard.is_none() {
+            guard = self.finished.wait(guard).unwrap_or_else(|e| e.into_inner());
+        }
+        guard.unwrap_or(false)
+    }
+}
+
 fn cloud_serve_batch(
     model_id: &str,
     envelope: &Envelope,
@@ -1129,11 +1167,15 @@ fn cloud_serve_batch(
 
 /// Serve a streaming inference from the cloud gateway because the local model
 /// is not ready yet. Shared by the streaming entry points.
+/// `emitted` counts tokens actually forwarded to `on_token`. A caller degrading
+/// a failed cloud leg to local must not restart a stream the user has already
+/// seen output from, so it checks this before retrying.
 fn cloud_serve_streaming<F>(
     model_id: &str,
     envelope: &Envelope,
     config: Option<&GenerationConfig>,
     on_token: &mut F,
+    emitted: &std::sync::atomic::AtomicU32,
 ) -> SdkResult<InferenceResult>
 where
     F: FnMut(
@@ -1144,7 +1186,10 @@ where
     let start = Instant::now();
     let cloud_envelope = build_speculative_cloud_envelope(model_id, envelope, config);
     speculative_cloud_policy_gate(&cloud_envelope)?;
-    let callback: xybrid_core::runtime_adapter::types::StreamingCallback<'_> = Box::new(on_token);
+    let callback: xybrid_core::runtime_adapter::types::StreamingCallback<'_> = Box::new(|token| {
+        emitted.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        on_token(token)
+    });
     let output = CloudRuntimeAdapter::new()
         .execute_streaming(&cloud_envelope, callback)
         .map_err(streaming_execution_error)?;
@@ -1607,6 +1652,8 @@ impl ModelLoader {
         // Background download + extract, then swap in the real local handle.
         // On failure the placeholder stays put and cloud keeps serving.
         let bg_handle = Arc::clone(&handle);
+        let download = Arc::new(SpeculativeDownload::default());
+        let bg_download = Arc::clone(&download);
         let id_owned = id.to_string();
         let platform_owned = platform.map(String::from);
         let thread_name = format!("speculative-download-{id_owned}");
@@ -1621,8 +1668,12 @@ impl ModelLoader {
                 match built {
                     Ok(real) => {
                         *bg_handle.write().unwrap_or_else(|e| e.into_inner()) = real;
+                        // Signal only after the handle is installed, so a waiter
+                        // woken by `true` always observes `loaded == true`.
+                        bg_download.finish(true);
                     }
                     Err(e) => {
+                        bg_download.finish(false);
                         log::error!("speculative background download failed for '{id_owned}': {e}");
                         crate::telemetry::publish_telemetry_event(
                             crate::telemetry::TelemetryEvent {
@@ -1642,6 +1693,9 @@ impl ModelLoader {
                 }
             })
         {
+            // No thread means no download will ever land: unblock any waiter
+            // rather than leaving a degrading run parked forever.
+            download.finish(false);
             log::error!("failed to spawn speculative download thread for '{id}': {err}");
         }
 
@@ -1654,7 +1708,7 @@ impl ModelLoader {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: true,
+            speculative: Some(download),
         }
     }
 
@@ -1724,7 +1778,7 @@ impl ModelLoader {
             output_type,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: false,
+            speculative: None,
         })
     }
 
@@ -1986,7 +2040,7 @@ impl ModelLoader {
             output_type,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: false,
+            speculative: None,
         })
     }
 
@@ -2147,12 +2201,15 @@ pub struct XybridModel {
     /// must see the previous concurrent run's token even though it ran on a
     /// different clone.
     current_run: Arc<Mutex<Option<CancellationToken>>>,
-    /// Speculative cloud backing. `true` while this model was loaded under
+    /// Speculative cloud backing. `Some` while this model was loaded under
     /// speculative cloud fallback: until the background download installs a
     /// `loaded` local handle, every run is routed to the gateway (which serves
-    /// the registry model via xycloud — see [`Self::cloud_serve`]). `false` for
-    /// ordinary local models.
-    speculative: bool,
+    /// the registry model via xycloud — see [`Self::cloud_serve`]). `None` for
+    /// ordinary local models. Carries the download's completion signal so a
+    /// failed cloud leg can degrade to waiting for local (see
+    /// [`Self::degrade_to_local`]); `Arc`-shared so every clone observes the
+    /// same download.
+    speculative: Option<Arc<SpeculativeDownload>>,
 }
 
 struct WarmupEventFields {
@@ -2211,6 +2268,93 @@ impl XybridModel {
         self.handle.read().map(|h| h.loaded).unwrap_or(false)
     }
 
+    /// Whether this run should be served speculatively from the cloud.
+    ///
+    /// `true` when this model was loaded under speculative cloud fallback *and*
+    /// the local handle isn't ready yet. Once the background download swaps in a
+    /// `loaded` handle this returns `false` and runs go local. Checked without
+    /// holding the handle write lock so the cloud round-trip never blocks a
+    /// concurrent local promotion.
+    fn cloud_serve(&self) -> bool {
+        self.speculative.is_some() && !self.is_loaded()
+    }
+
+    /// Block until the speculative download finishes, reporting whether a local
+    /// handle is now installed.
+    ///
+    /// Used to degrade a *failed* cloud leg to the pre-speculation behaviour
+    /// rather than surfacing a gateway error: speculation is an optimisation,
+    /// so it must never leave the caller worse off than not speculating.
+    /// Returns `false` for non-speculative models and for failed downloads.
+    fn degrade_to_local(&self) -> bool {
+        self.speculative
+            .as_ref()
+            .is_some_and(|download| download.wait_for_local())
+    }
+
+    /// Run the speculative cloud batch leg. `None` means the cloud leg failed
+    /// but the local handle has since landed — the caller should fall through
+    /// to its normal local path.
+    fn cloud_leg_batch(
+        &self,
+        envelope: &Envelope,
+        config: Option<&GenerationConfig>,
+    ) -> Option<SdkResult<InferenceResult>> {
+        match cloud_serve_batch(&self.model_id, envelope, config) {
+            Ok(result) => Some(Ok(result)),
+            Err(err) => self.after_failed_cloud_leg(err, 0),
+        }
+    }
+
+    /// Streaming counterpart of [`Self::cloud_leg_batch`].
+    fn cloud_leg_streaming<F>(
+        &self,
+        envelope: &Envelope,
+        config: Option<&GenerationConfig>,
+        on_token: &mut F,
+    ) -> Option<SdkResult<InferenceResult>>
+    where
+        F: FnMut(
+                xybrid_core::runtime_adapter::types::PartialToken,
+            ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+            + Send,
+    {
+        let emitted = std::sync::atomic::AtomicU32::new(0);
+        match cloud_serve_streaming(&self.model_id, envelope, config, on_token, &emitted) {
+            Ok(result) => Some(Ok(result)),
+            Err(err) => {
+                self.after_failed_cloud_leg(err, emitted.load(std::sync::atomic::Ordering::SeqCst))
+            }
+        }
+    }
+
+    /// Decide what a failed speculative cloud leg turns into: `None` to retry
+    /// locally, `Some(Err)` to surface the gateway failure.
+    ///
+    /// Speculation is an optimisation, so a gateway failure should not be worse
+    /// than never having speculated — wait for the download and run locally.
+    /// The exception is a stream that already emitted tokens: re-running would
+    /// duplicate output the caller has seen, so that failure stays terminal
+    /// (same "no partial-token reuse" rule the reactive fallback follows).
+    fn after_failed_cloud_leg(
+        &self,
+        err: SdkError,
+        emitted: u32,
+    ) -> Option<SdkResult<InferenceResult>> {
+        if emitted > 0 {
+            return Some(Err(err));
+        }
+        if self.degrade_to_local() {
+            log::warn!(
+                target: "xybrid_sdk",
+                "speculative cloud leg failed for '{}' ({err}); falling back to the local model",
+                self.model_id
+            );
+            return None;
+        }
+        Some(Err(err))
+    }
+
     /// Whether the model bundle declares local tool-calling support.
     ///
     /// Advisory tri-state from the bundle's optional `tool_calling` metadata
@@ -2225,25 +2369,34 @@ impl XybridModel {
             .and_then(|h| h.metadata.supports_tool_calling())
     }
 
-    /// Whether this run should be served speculatively from the cloud.
-    ///
-    /// `true` when this model was loaded under speculative cloud fallback *and*
-    /// the local handle isn't ready yet. Once the background download swaps in a
-    /// `loaded` handle this returns `false` and runs go local. Checked without
-    /// holding the handle write lock so the cloud round-trip never blocks a
-    /// concurrent local promotion.
-    fn cloud_serve(&self) -> bool {
-        self.speculative && !self.is_loaded()
-    }
-
     /// Check if this model supports streaming.
+    ///
+    /// A speculative load caches an optimistic value (the placeholder handle
+    /// predates the real metadata), so once the background download installs
+    /// the local handle this reads the truth back off that metadata rather than
+    /// the stale cached field.
     pub fn supports_streaming(&self) -> bool {
-        self.supports_streaming
+        self.metadata_derived(ModelLoader::check_streaming_support)
+            .unwrap_or(self.supports_streaming)
     }
 
     /// Get the expected output type for this model.
+    ///
+    /// Like [`Self::supports_streaming`], this re-derives from the installed
+    /// local metadata once a speculative download lands.
     pub fn output_type(&self) -> OutputType {
-        self.output_type
+        self.metadata_derived(ModelLoader::infer_output_type)
+            .unwrap_or(self.output_type)
+    }
+
+    /// Re-derive a property from the *installed* handle metadata, but only for
+    /// a speculative model whose local handle has landed — every other model's
+    /// cached fields were computed from this same metadata at load, so paying
+    /// for a read lock would buy nothing.
+    fn metadata_derived<T>(&self, derive: impl Fn(&ModelMetadata) -> T) -> Option<T> {
+        self.speculative.as_ref()?;
+        let handle = self.handle.read().ok()?;
+        handle.loaded.then(|| derive(&handle.metadata))
     }
 
     /// Check if this is an LLM model (uses GGUF execution template).
@@ -2622,7 +2775,10 @@ impl XybridModel {
         // Speculative cloud: serve from the gateway until the local handle is
         // ready (see `cloud_serve`).
         if self.cloud_serve() {
-            return cloud_serve_batch(&self.model_id, envelope, config);
+            if let Some(result) = self.cloud_leg_batch(envelope, config) {
+                return result;
+            }
+            // Cloud failed but the download landed — run locally below.
         }
         let start = Instant::now();
         // Begin a resource-telemetry scope for this run. When
@@ -2828,7 +2984,10 @@ impl XybridModel {
         // reactive fallback behaves the same) — full history resumes once the
         // local model takes over.
         if self.cloud_serve() {
-            return cloud_serve_batch(&self.model_id, envelope, config);
+            if let Some(result) = self.cloud_leg_batch(envelope, config) {
+                return result;
+            }
+            // Cloud failed but the download landed — run locally below.
         }
         let start = Instant::now();
         let resource_guard = crate::telemetry::begin_resource_run();
@@ -2983,7 +3142,11 @@ impl XybridModel {
         // ready. The gateway leg is stateless (`context` not replayed, matching
         // the reactive fallback); full history resumes once local takes over.
         if self.cloud_serve() {
-            return cloud_serve_streaming(&self.model_id, envelope, config, &mut on_token);
+            if let Some(result) = self.cloud_leg_streaming(envelope, config, &mut on_token) {
+                return result;
+            }
+            // Cloud failed before emitting a token but the download landed —
+            // stream locally below.
         }
 
         let start = Instant::now();
@@ -3190,7 +3353,11 @@ impl XybridModel {
         // Speculative cloud: stream from the gateway until the local handle is
         // ready (see `cloud_serve`).
         if self.cloud_serve() {
-            return cloud_serve_streaming(&self.model_id, envelope, config, &mut on_token);
+            if let Some(result) = self.cloud_leg_streaming(envelope, config, &mut on_token) {
+                return result;
+            }
+            // Cloud failed before emitting a token but the download landed —
+            // stream locally below.
         }
 
         let start = Instant::now();
@@ -3595,7 +3762,7 @@ impl XybridModel {
         let version = self.version.clone();
         let output_type = self.output_type;
         // Speculative cloud routing decision, captured before the worker spawns.
-        let speculative = self.cloud_serve();
+        let speculative = self.cloud_serve().then(|| self.clone());
 
         // Clone tx for the completion event (before moving into spawn_blocking)
         let tx_completion = tx.clone();
@@ -3614,10 +3781,9 @@ impl XybridModel {
 
                 // Speculative cloud: stream from the gateway until the local
                 // handle is ready, forwarding each token as a StreamEvent.
-                if speculative {
+                if let Some(model) = speculative {
                     let tx_token = tx.clone();
-                    return cloud_serve_streaming(
-                        &model_id,
+                    let cloud = model.cloud_leg_streaming(
                         &envelope,
                         config.as_ref(),
                         &mut |token: PartialToken| {
@@ -3631,6 +3797,11 @@ impl XybridModel {
                             Ok(())
                         },
                     );
+                    if let Some(result) = cloud {
+                        return result;
+                    }
+                    // Cloud failed before emitting a token but the download
+                    // landed — stream locally below.
                 }
 
                 // Get write lock on handle
@@ -3771,14 +3942,19 @@ impl XybridModel {
         // Speculative cloud: serve from the gateway (off the runtime via
         // spawn_blocking, like the local path) until the local handle is ready.
         if self.cloud_serve() {
-            let model_id = self.model_id.clone();
-            let envelope = envelope.clone();
-            let config = config.cloned();
-            return tokio::task::spawn_blocking(move || {
-                cloud_serve_batch(&model_id, &envelope, config.as_ref())
+            let model = self.clone();
+            let cloud_envelope = envelope.clone();
+            let cloud_config = config.cloned();
+            // `None` = the cloud leg failed and the download landed; fall
+            // through to the local path below (also off the runtime).
+            let cloud_result = tokio::task::spawn_blocking(move || {
+                model.cloud_leg_batch(&cloud_envelope, cloud_config.as_ref())
             })
             .await
             .map_err(|e| SdkError::inference_src("Task join error", e))?;
+            if let Some(result) = cloud_result {
+                return result;
+            }
         }
         let handle = self.handle.clone();
         let model_id = self.model_id.clone();
@@ -3926,7 +4102,7 @@ impl Clone for XybridModel {
             // Share the in-flight slot so all clones coordinate preemption
             // through one mutex (see field docs).
             current_run: self.current_run.clone(),
-            speculative: self.speculative,
+            speculative: self.speculative.clone(),
         }
     }
 }
@@ -4264,7 +4440,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: true,
+            speculative: Some(Arc::new(SpeculativeDownload::default())),
         };
         assert!(speculating.cloud_serve(), "not loaded -> cloud");
 
@@ -4281,6 +4457,111 @@ mod tests {
 
         // A plain local model with no speculative config never routes to cloud.
         assert!(!test_loaded_model(true).cloud_serve());
+    }
+
+    /// A speculative model caches optimistic `output_type` / `supports_streaming`
+    /// values from its placeholder handle. Once the background download installs
+    /// the real handle, the accessors must report the *installed* metadata — not
+    /// the stale placeholder guess.
+    #[test]
+    fn speculative_accessors_refresh_after_handle_swap() {
+        let mut real = ModelMetadata::onnx("spec-model", "model.onnx", "1.2.3");
+        real.execution_template = ExecutionTemplate::Onnx {
+            model_file: "model.onnx".to_string(),
+        };
+        let speculating = XybridModel {
+            handle: Arc::new(RwLock::new(ModelHandle {
+                executor: TemplateExecutor::default(),
+                metadata: ModelMetadata::onnx("spec-model", "", ""),
+                model_dir: PathBuf::from("."),
+                loaded: false,
+            })),
+            model_id: "spec-model".to_string(),
+            version: String::new(),
+            // Placeholder guesses, matching `load_speculative`.
+            output_type: OutputType::Text,
+            supports_streaming: true,
+            current_run: Arc::new(Mutex::new(None)),
+            speculative: Some(Arc::new(SpeculativeDownload::default())),
+        };
+
+        // Pre-swap: the optimistic cached values stand (the cloud leg streams
+        // text), because the placeholder metadata is not authoritative yet.
+        assert!(speculating.supports_streaming());
+
+        // Swap in a non-streaming ONNX handle, as the download thread would.
+        {
+            let mut guard = speculating
+                .handle
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            guard.metadata = real;
+            guard.loaded = true;
+        }
+
+        assert!(
+            !speculating.supports_streaming(),
+            "installed ONNX metadata must override the optimistic placeholder value"
+        );
+        assert_eq!(
+            speculating.output_type(),
+            ModelLoader::infer_output_type(
+                &speculating
+                    .handle
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .metadata
+            ),
+        );
+    }
+
+    /// A failed cloud leg must degrade to the local model rather than surface a
+    /// gateway error — speculation is an optimisation, never a regression. But
+    /// once tokens have reached the caller, restarting would duplicate output,
+    /// so that failure stays terminal.
+    #[test]
+    fn failed_cloud_leg_degrades_only_before_any_token() {
+        let download = Arc::new(SpeculativeDownload::default());
+        let model = XybridModel {
+            handle: Arc::new(RwLock::new(ModelHandle {
+                executor: TemplateExecutor::default(),
+                metadata: ModelMetadata::onnx("spec-model", "", ""),
+                model_dir: PathBuf::from("."),
+                loaded: false,
+            })),
+            model_id: "spec-model".to_string(),
+            version: String::new(),
+            output_type: OutputType::Text,
+            supports_streaming: true,
+            current_run: Arc::new(Mutex::new(None)),
+            speculative: Some(Arc::clone(&download)),
+        };
+
+        // Download already landed, so a token-less failure can retry locally.
+        download.finish(true);
+        assert!(
+            model
+                .after_failed_cloud_leg(SdkError::network("gateway 502"), 0)
+                .is_none(),
+            "no tokens emitted + local ready -> fall through to local"
+        );
+
+        // Tokens already streamed to the caller: the failure is terminal.
+        assert!(
+            model
+                .after_failed_cloud_leg(SdkError::network("gateway 502"), 3)
+                .is_some_and(|r| r.is_err()),
+            "partial stream must not be restarted"
+        );
+    }
+
+    /// A failed *download* must not park a degrading run forever, and must not
+    /// claim a local handle exists.
+    #[test]
+    fn failed_download_reports_no_local_handle() {
+        let download = SpeculativeDownload::default();
+        download.finish(false);
+        assert!(!download.wait_for_local());
     }
 
     /// The inherent `SdkError::is_retryable` / `retry_after` accessors and
@@ -4684,7 +4965,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: false,
+            speculative: None,
         }
     }
 
@@ -4704,6 +4985,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
+            speculative: None,
         }
     }
 
@@ -5494,7 +5776,7 @@ mod tests {
             output_type: OutputType::Text,
             supports_streaming: true,
             current_run: Arc::new(Mutex::new(None)),
-            speculative: false,
+            speculative: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Implements speculative cloud fallback: when a registry model isn't downloaded yet (and an API key is present), the SDK serves inference from the platform gateway while the weights download in the background, then transparently switches to local — exposed via `run`/`repl --speculative-cloud`. Crucially, both this path and the existing reactive cloud-fallback leg now send the **registry model id** to the gateway, which routes it to xycloud (the CPU cluster running the same model), instead of defaulting to a hosted OpenAI model (`gpt-4o-mini`). The cloud-model override (`with_speculative_cloud_model` / `--cloud-provider` / `--cloud-model`) was dropped so both paths consistently serve the 1:1 same model. Verified live on staging; no public API break (the reactive leg's default cloud model changes from `gpt-4o-mini` to the registry model only when the caller sets no explicit override).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, gateway routing, policy-gated cloud inference, and large SDK/CLI inference paths; reactive fallback’s default cloud model behavior changes when callers omit an explicit override.
> 
> **Overview**
> Adds **speculative cloud fallback**: uncached registry models can answer from the platform gateway immediately while weights download in the background, then switch to local inference once the handle is ready.
> 
> The SDK introduces placeholder models, background registry fetch, policy-gated cloud batch/stream paths, and degradation when the cloud leg fails before any tokens are emitted. Cloud requests use the **registry model id** (routed to xycloud) rather than silently defaulting to a hosted model like `gpt-4o-mini`; the same default applies to the existing reactive cloud-fallback leg when no override is set.
> 
> The CLI exposes **`--speculative-cloud`** on `run` and `repl` (registry `--model` + API key). `run` adds a streaming one-shot path; `repl` loads speculatively, streams without a local bundle, and refactors args into `ReplArgs`. **`set_platform_url`** and **`set_api_key`** from `--platform-url` / `--api-key` align gateway calls with staging without unsafe `setenv` after telemetry starts.
> 
> CI caches large Web example model assets; **`prepare-assets.ts`** uses longer, jittered retries for HuggingFace rate limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9556554b22bf27af56154c92d95d09ce184b2b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->