### PR TITLE
feat(vision): wire Image/MultiPart envelopes + typed capability errors through bolt

### DIFF
--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -52,6 +52,15 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          # The GHA-backed sccache server occasionally needs more than the
+          # default 10s to complete its first handshake with the cache
+          # service, which surfaces as "Timed out waiting for server startup"
+          # and aborts the build. There is no env var for this, so write a
+          # minimal config file (it coexists with the env-based GHA settings
+          # above) bumping the startup timeout. https://github.com/mozilla/sccache
+          SCCACHE_CONF="$RUNNER_TEMP/sccache-config.toml"
+          echo "server_startup_timeout_ms = 60000" > "$SCCACHE_CONF"
+          echo "SCCACHE_CONF=$SCCACHE_CONF" >> $GITHUB_ENV
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -274,26 +274,37 @@ public extension XybridEnvelope {
         return XybridEnvelope(kind: .embedding(values: data), metadata: [])
     }
 
-    /// Creates an encoded image envelope for vision-language models.
+    /// Creates an encoded image envelope for vision-language models. The bytes
+    /// are decode-validated on the Rust side at run time (surfacing as a
+    /// `XybridError.invalidImage` for bad/oversized/unsupported input).
     /// - Parameters:
     ///   - bytes: Encoded PNG, JPEG, or WebP data
-    ///   - format: Image format (`png`, `jpeg`, `jpg`, or `webp`)
+    ///   - format: Image format hint (`png`, `jpeg`, `jpg`, or `webp`)
     static func image(_ bytes: Data, format: String) throws -> XybridEnvelope {
-        return .image(bytes: bytes, format: try normalizeImageFormat(format))
+        return XybridEnvelope(
+            kind: .image(bytes: bytes, format: try normalizeImageFormat(format)),
+            metadata: []
+        )
     }
 
-    /// Creates a multi-part user message with text and image attachments.
+    /// Creates a multi-part user message with text and image attachments,
+    /// tagged with the `User` role.
     /// - Parameters:
     ///   - text: User prompt text
     ///   - images: Image envelopes created by `image(_:format:)`
     static func userMessage(_ text: String, images: [XybridEnvelope] = []) throws -> XybridEnvelope {
         guard images.allSatisfy({ envelope in
-            if case .image = envelope { return true }
+            if case .image = envelope.kind { return true }
             return false
         }) else {
-            throw XybridError.ConfigError(message: "Envelope.userMessage accepts only image envelopes")
+            throw XybridError.configError(message: "Envelope.userMessage accepts only image envelopes")
         }
-        return .userMessage(text: text, images: images)
+        var parts = [XybridEnvelope(kind: .text(text: text), metadata: [])]
+        parts.append(contentsOf: images)
+        return XybridEnvelope(
+            kind: .multiPart(parts: parts),
+            metadata: [XybridMetadataEntry(key: "xybrid.role", value: "user")]
+        )
     }
 
     private static func normalizeImageFormat(_ format: String) throws -> String {
@@ -304,7 +315,7 @@ public extension XybridEnvelope {
         case "jpeg", "png", "webp":
             return normalized
         default:
-            throw XybridError.ConfigError(
+            throw XybridError.configError(
                 message: "Unsupported image format '\(format)'. Supported formats: png, jpeg, jpg, webp"
             )
         }

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -375,12 +375,14 @@ extension XybridError: LocalizedError {
             return "Rate limited, retry after \(retryAfterSecs) seconds"
         case .timeout(let timeoutMs):
             return "Request timeout after \(timeoutMs)ms"
-        case .MissingArtifact(let artifact, let path):
-            return "Missing artifact \(artifact) at \(path)"
-        case .UnsupportedModelCapability(let modelId, let capability, let hint):
-            return "Model \(modelId) does not support \(capability)\(hint.isEmpty ? "" : ". Hint: \(hint)")"
-        case .UnsupportedBackendCapability(let modelId, let backend, let capability, let hint):
-            return "Backend \(backend) cannot satisfy \(capability) required by \(modelId)\(hint.isEmpty ? "" : ". Hint: \(hint)")"
+        case .missingArtifact(let message):
+            return "Missing artifact: \(message)"
+        case .unsupportedModelCapability(let message):
+            return "Unsupported model capability: \(message)"
+        case .unsupportedBackendCapability(let message):
+            return "Unsupported backend capability: \(message)"
+        case .invalidImage(let message):
+            return "Invalid image: \(message)"
         }
     }
 }

--- a/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
@@ -280,6 +280,10 @@ public enum XybridError: Hashable, Equatable, Sendable, Error {
     case circuitOpen(message: String)
     case rateLimited(retryAfterSecs: UInt64)
     case timeout(timeoutMs: UInt64)
+    case missingArtifact(message: String)
+    case unsupportedModelCapability(message: String)
+    case unsupportedBackendCapability(message: String)
+    case invalidImage(message: String)
 
 }
 
@@ -323,6 +327,14 @@ extension XybridError: WireCodable {
             return .rateLimited(retryAfterSecs: reader.readU64())
         case 17:
             return .timeout(timeoutMs: reader.readU64())
+        case 18:
+            return .missingArtifact(message: reader.readString())
+        case 19:
+            return .unsupportedModelCapability(message: reader.readString())
+        case 20:
+            return .unsupportedBackendCapability(message: reader.readString())
+        case 21:
+            return .invalidImage(message: reader.readString())
         default:
             fatalError("Invalid XybridError tag: \(tag)")
         }
@@ -382,6 +394,18 @@ extension XybridError: WireCodable {
         case let .timeout(timeoutMs):
             writer.writeI32(17)
             writer.writeU64(timeoutMs)
+        case let .missingArtifact(message):
+            writer.writeI32(18)
+            writer.writeString(message)
+        case let .unsupportedModelCapability(message):
+            writer.writeI32(19)
+            writer.writeString(message)
+        case let .unsupportedBackendCapability(message):
+            writer.writeI32(20)
+            writer.writeString(message)
+        case let .invalidImage(message):
+            writer.writeI32(21)
+            writer.writeString(message)
         }
     }
 }
@@ -390,6 +414,8 @@ public enum XybridEnvelopeKind: Hashable, Equatable, Sendable {
     case text(text: String)
     case audio(bytes: Data)
     case embedding(values: [Float])
+    case image(bytes: Data, format: String)
+    case multiPart(parts: [XybridEnvelope])
 
 }
 
@@ -403,6 +429,10 @@ extension XybridEnvelopeKind: WireCodable {
             return .audio(bytes: reader.readBytes())
         case 2:
             return .embedding(values: reader.readBlittableArray() as [Float])
+        case 3:
+            return .image(bytes: reader.readBytes(), format: reader.readString())
+        case 4:
+            return .multiPart(parts: reader.readArray { reader in XybridEnvelope.decode(from: &reader) })
         default:
             fatalError("Invalid XybridEnvelopeKind tag: \(tag)")
         }
@@ -419,6 +449,13 @@ extension XybridEnvelopeKind: WireCodable {
         case let .embedding(values):
             writer.writeI32(2)
             writer.writeBlittableArray(values)
+        case let .image(bytes, format):
+            writer.writeI32(3)
+            writer.writeBytes(bytes)
+            writer.writeString(format)
+        case let .multiPart(parts):
+            writer.writeI32(4)
+            writer.writeArray(parts) { writer, item in item.encode(to: &writer) }
         }
     }
 }

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -298,10 +298,36 @@ object Envelope {
     @JvmStatic
     fun embedding(data: FloatArray): XybridEnvelope =
         XybridEnvelope(kind = XybridEnvelopeKind.Embedding(data), metadata = emptyList())
-    // NOTE: the vision envelope helpers (image / multimodal userMessage) added
-    // in #245 are not ported here — the bolt `XybridEnvelopeKind` has no Image
-    // variant yet. They land with the "wire vision through the facade/bolt"
-    // follow-up, alongside the deferred vision CI build-checks.
+
+    /**
+     * Creates an encoded image envelope for vision-language models. The bytes
+     * are decode-validated on the Rust side at run time (surfacing as a
+     * [XybridError.InvalidImage] for bad/oversized/unsupported input).
+     * @param bytes Encoded PNG, JPEG, or WebP bytes.
+     * @param format Image format hint (`png`, `jpeg`, `jpg`, or `webp`).
+     */
+    @JvmStatic
+    fun image(bytes: ByteArray, format: String): XybridEnvelope =
+        XybridEnvelope(kind = XybridEnvelopeKind.Image(bytes, format), metadata = emptyList())
+
+    /**
+     * Creates a multimodal user message: prompt text plus image attachments,
+     * tagged with the `User` role.
+     * @param text User prompt text.
+     * @param images Image envelopes created by [image].
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun userMessage(text: String, images: List<XybridEnvelope> = emptyList()): XybridEnvelope {
+        val parts = mutableListOf(
+            XybridEnvelope(kind = XybridEnvelopeKind.Text(text), metadata = emptyList()),
+        )
+        parts.addAll(images)
+        return XybridEnvelope(
+            kind = XybridEnvelopeKind.MultiPart(parts),
+            metadata = listOf(XybridMetadataEntry("xybrid.role", "user")),
+        )
+    }
 }
 
 // -- XybridVoiceInfo Extensions --

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -319,6 +319,9 @@ object Envelope {
     @JvmStatic
     @JvmOverloads
     fun userMessage(text: String, images: List<XybridEnvelope> = emptyList()): XybridEnvelope {
+        if (!images.all { it.kind is XybridEnvelopeKind.Image }) {
+            throw XybridError.ConfigError("Envelope.userMessage accepts only image envelopes")
+        }
         val parts = mutableListOf(
             XybridEnvelope(kind = XybridEnvelopeKind.Text(text), metadata = emptyList()),
         )

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
@@ -623,6 +623,14 @@ sealed class XybridError : Exception() {
 
     data class Timeout(val timeoutMs: ULong) : XybridError()
 
+    data class MissingArtifact(override val message: String) : XybridError()
+
+    data class UnsupportedModelCapability(override val message: String) : XybridError()
+
+    data class UnsupportedBackendCapability(override val message: String) : XybridError()
+
+    data class InvalidImage(override val message: String) : XybridError()
+
     companion object {
         fun decode(reader: WireReader): XybridError {
             val tag = reader.readI32()
@@ -713,6 +721,26 @@ sealed class XybridError : Exception() {
                         reader.readU64()
                     )
                 }
+                18 -> {
+                    MissingArtifact(
+                        reader.readString()
+                    )
+                }
+                19 -> {
+                    UnsupportedModelCapability(
+                        reader.readString()
+                    )
+                }
+                20 -> {
+                    UnsupportedBackendCapability(
+                        reader.readString()
+                    )
+                }
+                21 -> {
+                    InvalidImage(
+                        reader.readString()
+                    )
+                }
                 else -> throw FfiException(-1, "Unknown XybridError tag: $tag")
             }
         }
@@ -737,6 +765,10 @@ sealed class XybridError : Exception() {
         is CircuitOpen -> (4 + Utf8Codec.maxBytes(message))
         is RateLimited -> 8
         is Timeout -> 8
+        is MissingArtifact -> (4 + Utf8Codec.maxBytes(message))
+        is UnsupportedModelCapability -> (4 + Utf8Codec.maxBytes(message))
+        is UnsupportedBackendCapability -> (4 + Utf8Codec.maxBytes(message))
+        is InvalidImage -> (4 + Utf8Codec.maxBytes(message))
     }
 
     fun wireEncodeTo(wire: WireWriter) {
@@ -807,6 +839,22 @@ sealed class XybridError : Exception() {
                 wire.writeI32(17)
                 wire.writeU64(timeoutMs)
             }
+            is MissingArtifact -> {
+                wire.writeI32(18)
+                wire.writeString(message)
+            }
+            is UnsupportedModelCapability -> {
+                wire.writeI32(19)
+                wire.writeString(message)
+            }
+            is UnsupportedBackendCapability -> {
+                wire.writeI32(20)
+                wire.writeString(message)
+            }
+            is InvalidImage -> {
+                wire.writeI32(21)
+                wire.writeString(message)
+            }
         }
     }
 }
@@ -818,6 +866,10 @@ sealed class XybridEnvelopeKind {
     data class Audio(val bytes: ByteArray) : XybridEnvelopeKind()
 
     data class Embedding(val values: FloatArray) : XybridEnvelopeKind()
+
+    data class Image(val bytes: ByteArray, val format: String) : XybridEnvelopeKind()
+
+    data class MultiPart(val parts: List<XybridEnvelope>) : XybridEnvelopeKind()
 
     companion object {
         fun decode(reader: WireReader): XybridEnvelopeKind {
@@ -838,6 +890,17 @@ sealed class XybridEnvelopeKind {
                         reader.readFloatArray()
                     )
                 }
+                3 -> {
+                    Image(
+                        reader.readBytes(),
+                        reader.readString()
+                    )
+                }
+                4 -> {
+                    MultiPart(
+                        reader.readList { XybridEnvelope.decode(reader) }
+                    )
+                }
                 else -> throw FfiException(-1, "Unknown XybridEnvelopeKind tag: $tag")
             }
         }
@@ -847,6 +910,8 @@ sealed class XybridEnvelopeKind {
         is Text -> (4 + Utf8Codec.maxBytes(text))
         is Audio -> (4 + bytes.size)
         is Embedding -> (4 + values.size * 4)
+        is Image -> (4 + bytes.size) + (4 + Utf8Codec.maxBytes(format))
+        is MultiPart -> (4 + parts.sumOf { item -> item.wireEncodedSize() })
     }
 
     fun wireEncodeTo(wire: WireWriter) {
@@ -862,6 +927,15 @@ sealed class XybridEnvelopeKind {
             is Embedding -> {
                 wire.writeI32(2)
                 wire.writePrimitiveList(values)
+            }
+            is Image -> {
+                wire.writeI32(3)
+                wire.writePrimitiveList(bytes)
+                wire.writeString(format)
+            }
+            is MultiPart -> {
+                wire.writeI32(4)
+                wire.writeU32(parts.size.toUInt()); parts.forEach { item -> item.wireEncodeTo(wire) }
             }
         }
     }

--- a/crates/xybrid-bolt/src/lib.rs
+++ b/crates/xybrid-bolt/src/lib.rs
@@ -91,6 +91,10 @@ pub enum XybridError {
     CircuitOpen { message: String },
     RateLimited { retry_after_secs: u64 },
     Timeout { timeout_ms: u64 },
+    MissingArtifact { message: String },
+    UnsupportedModelCapability { message: String },
+    UnsupportedBackendCapability { message: String },
+    InvalidImage { message: String },
 }
 
 impl XybridError {
@@ -129,6 +133,14 @@ impl From<XybridError> for facade::Error {
                 facade::Error::RateLimited { retry_after_secs }
             }
             XybridError::Timeout { timeout_ms } => facade::Error::Timeout { timeout_ms },
+            XybridError::MissingArtifact { message } => facade::Error::MissingArtifact { message },
+            XybridError::UnsupportedModelCapability { message } => {
+                facade::Error::UnsupportedModelCapability { message }
+            }
+            XybridError::UnsupportedBackendCapability { message } => {
+                facade::Error::UnsupportedBackendCapability { message }
+            }
+            XybridError::InvalidImage { message } => facade::Error::InvalidImage { message },
         }
     }
 }
@@ -158,6 +170,14 @@ impl From<facade::Error> for XybridError {
                 XybridError::RateLimited { retry_after_secs }
             }
             facade::Error::Timeout { timeout_ms } => XybridError::Timeout { timeout_ms },
+            facade::Error::MissingArtifact { message } => XybridError::MissingArtifact { message },
+            facade::Error::UnsupportedModelCapability { message } => {
+                XybridError::UnsupportedModelCapability { message }
+            }
+            facade::Error::UnsupportedBackendCapability { message } => {
+                XybridError::UnsupportedBackendCapability { message }
+            }
+            facade::Error::InvalidImage { message } => XybridError::InvalidImage { message },
         }
     }
 }
@@ -172,6 +192,8 @@ pub enum XybridEnvelopeKind {
     Text { text: String },
     Audio { bytes: Vec<u8> },
     Embedding { values: Vec<f32> },
+    Image { bytes: Vec<u8>, format: String },
+    MultiPart { parts: Vec<XybridEnvelope> },
 }
 
 impl From<XybridEnvelopeKind> for facade::EnvelopeKind {
@@ -180,6 +202,12 @@ impl From<XybridEnvelopeKind> for facade::EnvelopeKind {
             XybridEnvelopeKind::Text { text } => facade::EnvelopeKind::Text { text },
             XybridEnvelopeKind::Audio { bytes } => facade::EnvelopeKind::Audio { bytes },
             XybridEnvelopeKind::Embedding { values } => facade::EnvelopeKind::Embedding { values },
+            XybridEnvelopeKind::Image { bytes, format } => {
+                facade::EnvelopeKind::Image { bytes, format }
+            }
+            XybridEnvelopeKind::MultiPart { parts } => facade::EnvelopeKind::MultiPart {
+                parts: parts.into_iter().map(Into::into).collect(),
+            },
         }
     }
 }
@@ -190,6 +218,12 @@ impl From<facade::EnvelopeKind> for XybridEnvelopeKind {
             facade::EnvelopeKind::Text { text } => XybridEnvelopeKind::Text { text },
             facade::EnvelopeKind::Audio { bytes } => XybridEnvelopeKind::Audio { bytes },
             facade::EnvelopeKind::Embedding { values } => XybridEnvelopeKind::Embedding { values },
+            facade::EnvelopeKind::Image { bytes, format } => {
+                XybridEnvelopeKind::Image { bytes, format }
+            }
+            facade::EnvelopeKind::MultiPart { parts } => XybridEnvelopeKind::MultiPart {
+                parts: parts.into_iter().map(Into::into).collect(),
+            },
         }
     }
 }

--- a/crates/xybrid-ffi-facade/src/lib.rs
+++ b/crates/xybrid-ffi-facade/src/lib.rs
@@ -56,24 +56,75 @@ use xybrid_sdk as sdk;
 /// `message` string plus a stable [`Error::code`].
 #[derive(Debug, Clone)]
 pub enum Error {
-    ModelNotFound { id: String },
-    DirectoryNotFound { path: String },
-    MetadataNotFound { path: String },
-    MetadataInvalid { message: String },
-    LoadError { message: String },
-    InferenceError { message: String },
-    AbortedForCloudFallback { reason: String },
+    ModelNotFound {
+        id: String,
+    },
+    DirectoryNotFound {
+        path: String,
+    },
+    MetadataNotFound {
+        path: String,
+    },
+    MetadataInvalid {
+        message: String,
+    },
+    LoadError {
+        message: String,
+    },
+    InferenceError {
+        message: String,
+    },
+    AbortedForCloudFallback {
+        reason: String,
+    },
     StreamingNotSupported,
     NotLoaded,
-    ConfigError { message: String },
-    NetworkError { message: String },
-    Offline { message: String },
-    IoError { message: String },
-    CacheError { message: String },
-    PipelineError { message: String },
-    CircuitOpen { message: String },
-    RateLimited { retry_after_secs: u64 },
-    Timeout { timeout_ms: u64 },
+    ConfigError {
+        message: String,
+    },
+    NetworkError {
+        message: String,
+    },
+    Offline {
+        message: String,
+    },
+    IoError {
+        message: String,
+    },
+    CacheError {
+        message: String,
+    },
+    PipelineError {
+        message: String,
+    },
+    CircuitOpen {
+        message: String,
+    },
+    RateLimited {
+        retry_after_secs: u64,
+    },
+    Timeout {
+        timeout_ms: u64,
+    },
+    /// A required model artifact (weights, tokenizer, …) was missing.
+    MissingArtifact {
+        message: String,
+    },
+    /// The model can't satisfy the request (e.g. image input to a text-only
+    /// model).
+    UnsupportedModelCapability {
+        message: String,
+    },
+    /// The active backend/build can't satisfy the request (e.g. vision input
+    /// without a vision-capable backend).
+    UnsupportedBackendCapability {
+        message: String,
+    },
+    /// An image envelope failed decode/validation (bad bytes, unsupported
+    /// format, oversized payload).
+    InvalidImage {
+        message: String,
+    },
 }
 
 impl Error {
@@ -101,6 +152,10 @@ impl Error {
             Error::CircuitOpen { .. } => 16,
             Error::RateLimited { .. } => 17,
             Error::Timeout { .. } => 18,
+            Error::MissingArtifact { .. } => 19,
+            Error::UnsupportedModelCapability { .. } => 20,
+            Error::UnsupportedBackendCapability { .. } => 21,
+            Error::InvalidImage { .. } => 22,
         }
     }
 
@@ -146,6 +201,14 @@ impl std::fmt::Display for Error {
                 write!(f, "Rate limited, retry after {retry_after_secs} seconds")
             }
             Error::Timeout { timeout_ms } => write!(f, "Request timeout after {timeout_ms}ms"),
+            Error::MissingArtifact { message } => write!(f, "Missing artifact: {message}"),
+            Error::UnsupportedModelCapability { message } => {
+                write!(f, "Unsupported model capability: {message}")
+            }
+            Error::UnsupportedBackendCapability { message } => {
+                write!(f, "Unsupported backend capability: {message}")
+            }
+            Error::InvalidImage { message } => write!(f, "Invalid image input: {message}"),
         }
     }
 }
@@ -205,32 +268,37 @@ impl From<sdk::SdkError> for Error {
                 Error::RateLimited { retry_after_secs }
             }
             sdk::SdkError::Timeout { timeout_ms } => Error::Timeout { timeout_ms },
-            // Capability / artifact errors were added alongside the vision
-            // work. The bolt error surface doesn't carry dedicated variants for
-            // them yet, so flatten onto the closest existing kind, preserving
-            // the full diagnostic message. Revisit when vision lands on bolt.
-            sdk::SdkError::MissingArtifact { artifact, path } => Error::LoadError {
+            // Capability / artifact errors (vision-era). First-class typed
+            // variants so foreign consumers can branch on them; the structured
+            // SDK fields are flattened into the diagnostic message.
+            sdk::SdkError::MissingArtifact { artifact, path } => Error::MissingArtifact {
                 message: format!("missing artifact '{artifact}' at {path}"),
             },
             sdk::SdkError::UnsupportedModelCapability {
                 model_id,
                 capability,
                 hint,
-            } => Error::ConfigError {
-                message: format!(
-                    "model '{model_id}' does not support {capability}; {hint}"
-                ),
+            } => Error::UnsupportedModelCapability {
+                message: format!("model '{model_id}' does not support {capability}; {hint}"),
             },
             sdk::SdkError::UnsupportedBackendCapability {
                 model_id,
                 backend,
                 capability,
                 hint,
-            } => Error::ConfigError {
+            } => Error::UnsupportedBackendCapability {
                 message: format!(
                     "model '{model_id}' requires {capability}, but backend/build '{backend}' does not support it; {hint}"
                 ),
             },
+        }
+    }
+}
+
+impl From<xybrid_core::ir::envelope::EnvelopeError> for Error {
+    fn from(e: xybrid_core::ir::envelope::EnvelopeError) -> Self {
+        Error::InvalidImage {
+            message: e.to_string(),
         }
     }
 }
@@ -246,9 +314,27 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// [`xybrid_core::ir::EnvelopeKind`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum EnvelopeKind {
-    Text { text: String },
-    Audio { bytes: Vec<u8> },
-    Embedding { values: Vec<f32> },
+    Text {
+        text: String,
+    },
+    Audio {
+        bytes: Vec<u8>,
+    },
+    Embedding {
+        values: Vec<f32>,
+    },
+    /// Encoded image input (PNG/JPEG/WebP) for vision-capable models. The
+    /// bytes are decode-validated and the dimensions derived when this is
+    /// lowered to the SDK in [`Envelope::into_sdk`] — so construction is
+    /// cheap and validation surfaces as an [`Error::InvalidImage`] at run.
+    Image {
+        bytes: Vec<u8>,
+        format: String,
+    },
+    /// Ordered parts of one logical multimodal message (e.g. text + images).
+    MultiPart {
+        parts: Vec<Envelope>,
+    },
 }
 
 /// Owned envelope carrying a typed payload plus string metadata.
@@ -256,7 +342,7 @@ pub enum EnvelopeKind {
 /// Construct via [`Envelope::text`] / [`Envelope::audio`] /
 /// [`Envelope::embedding`]; the SDK form is reconstructed at the FFI
 /// boundary inside the facade.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Envelope {
     pub kind: EnvelopeKind,
     pub metadata: HashMap<String, String>,
@@ -284,6 +370,28 @@ impl Envelope {
         }
     }
 
+    /// Encoded image envelope (PNG/JPEG/WebP). Construction is infallible;
+    /// the bytes are decode-validated when lowered in [`into_sdk`], surfacing
+    /// as [`Error::InvalidImage`].
+    ///
+    /// [`into_sdk`]: Self::into_sdk
+    pub fn image(bytes: Vec<u8>, format: String) -> Self {
+        Self {
+            kind: EnvelopeKind::Image { bytes, format },
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Multi-part message (e.g. text + image attachments) tagged with the
+    /// `User` role, mirroring `xybrid_sdk::ir::Envelope::user_message`.
+    pub fn multipart(parts: Vec<Envelope>) -> Self {
+        Self {
+            kind: EnvelopeKind::MultiPart { parts },
+            metadata: HashMap::new(),
+        }
+        .with_role(MessageRole::User)
+    }
+
     /// Set the LLM message role on this envelope. Stored under
     /// `xybrid.role` metadata — matches the SDK's own convention so the
     /// envelope is interchangeable with `xybrid_sdk::ir::Envelope::with_role`.
@@ -307,16 +415,37 @@ impl Envelope {
             .and_then(|raw| MessageRole::parse(raw))
     }
 
-    /// Consuming conversion to the SDK type — moves owned payload fields
-    /// into [`sdk::ir::Envelope`] without cloning. `pub` so binding crates
-    /// with their own Ffi envelope POD can convert through the facade.
-    pub fn into_sdk(self) -> sdk::ir::Envelope {
-        let kind = match self.kind {
+    /// Consuming conversion to the SDK type. `pub` so binding crates with
+    /// their own Ffi envelope POD can convert through the facade.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidImage`] if an image envelope (here or nested in
+    /// a [`MultiPart`]) fails decode/validation. Text/audio/embedding never
+    /// fail.
+    ///
+    /// [`MultiPart`]: EnvelopeKind::MultiPart
+    pub fn into_sdk(self) -> Result<sdk::ir::Envelope> {
+        let Envelope { kind, metadata } = self;
+        let sdk_kind = match kind {
             EnvelopeKind::Text { text } => sdk::ir::EnvelopeKind::Text(text),
             EnvelopeKind::Audio { bytes } => sdk::ir::EnvelopeKind::Audio(bytes),
             EnvelopeKind::Embedding { values } => sdk::ir::EnvelopeKind::Embedding(values),
+            EnvelopeKind::Image { bytes, format } => {
+                // Decode-validates the bytes and derives dimensions; carry
+                // over this envelope's metadata onto the validated result.
+                let mut env = sdk::ir::Envelope::image(bytes, format)?;
+                env.metadata = metadata;
+                return Ok(env);
+            }
+            EnvelopeKind::MultiPart { parts } => {
+                let sdk_parts = parts
+                    .into_iter()
+                    .map(Envelope::into_sdk)
+                    .collect::<Result<Vec<_>>>()?;
+                sdk::ir::EnvelopeKind::MultiPart(sdk_parts)
+            }
         };
-        sdk::ir::Envelope::with_metadata(kind, self.metadata)
+        Ok(sdk::ir::Envelope::with_metadata(sdk_kind, metadata))
     }
 
     pub fn from_sdk(env: sdk::ir::Envelope) -> Self {
@@ -324,13 +453,20 @@ impl Envelope {
             sdk::ir::EnvelopeKind::Text(text) => EnvelopeKind::Text { text },
             sdk::ir::EnvelopeKind::Audio(bytes) => EnvelopeKind::Audio { bytes },
             sdk::ir::EnvelopeKind::Embedding(values) => EnvelopeKind::Embedding { values },
-            // The SDK's vision envelope kinds (`Image`, `MultiPart`) have no
-            // representation on the bolt surface yet. They're input kinds —
-            // model outputs (what `from_sdk` sees) are never images — so
-            // collapse to a text marker until vision is wired through the
-            // facade (follow-up PR).
-            other => EnvelopeKind::Text {
-                text: format!("[unsupported envelope kind: {other:?}]"),
+            sdk::ir::EnvelopeKind::Image { source } => match source.as_encoded() {
+                Some((bytes, format)) => EnvelopeKind::Image {
+                    bytes: bytes.to_vec(),
+                    format: format.as_str().to_string(),
+                },
+                // Raw (camera) images aren't representable on the facade
+                // surface yet; outputs are never raw images, so this is a
+                // defensive marker rather than a real path.
+                None => EnvelopeKind::Text {
+                    text: "[raw image]".to_string(),
+                },
+            },
+            sdk::ir::EnvelopeKind::MultiPart(parts) => EnvelopeKind::MultiPart {
+                parts: parts.into_iter().map(Envelope::from_sdk).collect(),
             },
         };
         Self {
@@ -411,16 +547,27 @@ impl ConversationContextHandle {
     }
 
     /// Append an envelope (typically `MessageRole::User` or `Assistant`).
-    pub fn push(&self, envelope: Envelope) {
-        let mut guard = self.lock();
-        guard.push(envelope.into_sdk());
+    ///
+    /// # Errors
+    /// [`Error::InvalidImage`] if the envelope carries an image that fails
+    /// decode/validation (so multimodal history can't store a bad image).
+    pub fn push(&self, envelope: Envelope) -> Result<()> {
+        let sdk_env = envelope.into_sdk()?;
+        self.lock().push(sdk_env);
+        Ok(())
     }
 
     /// Set the persistent system prompt envelope. Survives [`clear`].
-    pub fn set_system(&self, envelope: Envelope) {
+    ///
+    /// # Errors
+    /// [`Error::InvalidImage`] if the envelope carries an image that fails
+    /// decode/validation.
+    pub fn set_system(&self, envelope: Envelope) -> Result<()> {
+        let sdk_env = envelope.into_sdk()?;
         let mut guard = self.lock();
-        let new_ctx = std::mem::take(&mut *guard).with_system(envelope.into_sdk());
+        let new_ctx = std::mem::take(&mut *guard).with_system(sdk_env);
         *guard = new_ctx;
+        Ok(())
     }
 
     /// Drop history; the system envelope (if any) is preserved.
@@ -957,7 +1104,7 @@ impl XybridModel {
 
     /// Run inference with no overrides.
     pub fn run(&self, envelope: Envelope) -> Result<InferenceResult> {
-        let env = envelope.into_sdk();
+        let env = envelope.into_sdk()?;
         let result = self.inner.run(&env, None).map_err(Error::from)?;
         Ok(InferenceResult::from_sdk(result))
     }
@@ -970,7 +1117,7 @@ impl XybridModel {
         options: RunOptions,
         cancel: Option<Arc<CancellationToken>>,
     ) -> Result<InferenceResult> {
-        let env = envelope.into_sdk();
+        let env = envelope.into_sdk()?;
         let opts = options.to_sdk(cancel.as_deref());
         let result = self
             .inner
@@ -990,7 +1137,7 @@ impl XybridModel {
         context: Arc<ConversationContextHandle>,
         generation_config: Option<GenerationConfig>,
     ) -> Result<InferenceResult> {
-        let env = envelope.into_sdk();
+        let env = envelope.into_sdk()?;
         let ctx = context.snapshot();
         let gc = generation_config.as_ref().map(GenerationConfig::to_sdk);
         let result = self
@@ -1002,7 +1149,7 @@ impl XybridModel {
 
     /// Async inference. The SDK offloads to `spawn_blocking` internally.
     pub async fn run_async(&self, envelope: Envelope) -> Result<InferenceResult> {
-        let env = envelope.into_sdk();
+        let env = envelope.into_sdk()?;
         let result = self
             .inner
             .run_async(&env, None)
@@ -1169,7 +1316,7 @@ mod tests {
     #[test]
     fn envelope_roundtrip_preserves_text_and_metadata() {
         let env = Envelope::text("hello".into()).with_role(MessageRole::User);
-        let sdk_env = env.clone().into_sdk();
+        let sdk_env = env.clone().into_sdk().unwrap();
         let back = Envelope::from_sdk(sdk_env);
 
         assert_eq!(
@@ -1188,9 +1335,30 @@ mod tests {
     }
 
     #[test]
+    fn image_envelope_invalid_bytes_surfaces_typed_invalid_image() {
+        // Garbage bytes can't be decoded → fallible `into_sdk` yields the
+        // typed `InvalidImage` (code 22), never a panic across the boundary.
+        let err = Envelope::image(vec![0xde, 0xad, 0xbe, 0xef], "png".into())
+            .into_sdk()
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidImage { .. }));
+        assert_eq!(err.code(), 22);
+    }
+
+    #[test]
+    fn multipart_envelope_propagates_nested_image_error() {
+        // A bad image nested in a multipart message must surface, not panic.
+        let msg = Envelope::multipart(vec![
+            Envelope::text("describe".into()),
+            Envelope::image(vec![0x00, 0x01], "jpeg".into()),
+        ]);
+        assert!(matches!(msg.into_sdk(), Err(Error::InvalidImage { .. })));
+    }
+
+    #[test]
     fn envelope_roundtrip_audio() {
         let env = Envelope::audio(vec![1, 2, 3, 4]);
-        let back = Envelope::from_sdk(env.into_sdk());
+        let back = Envelope::from_sdk(env.into_sdk().unwrap());
         assert_eq!(
             back.kind,
             EnvelopeKind::Audio {
@@ -1202,7 +1370,7 @@ mod tests {
     #[test]
     fn envelope_roundtrip_embedding() {
         let env = Envelope::embedding(vec![0.1, 0.2, 0.3]);
-        let back = Envelope::from_sdk(env.into_sdk());
+        let back = Envelope::from_sdk(env.into_sdk().unwrap());
         assert_eq!(
             back.kind,
             EnvelopeKind::Embedding {
@@ -1301,8 +1469,10 @@ mod tests {
     #[test]
     fn conversation_context_push_history_clear() {
         let ctx = ConversationContextHandle::new();
-        ctx.push(Envelope::text("hi".into()).with_role(MessageRole::User));
-        ctx.push(Envelope::text("hello".into()).with_role(MessageRole::Assistant));
+        ctx.push(Envelope::text("hi".into()).with_role(MessageRole::User))
+            .unwrap();
+        ctx.push(Envelope::text("hello".into()).with_role(MessageRole::Assistant))
+            .unwrap();
 
         let hist = ctx.history();
         assert_eq!(hist.len(), 2);

--- a/crates/xybrid-ffi-facade/src/lib.rs
+++ b/crates/xybrid-ffi-facade/src/lib.rs
@@ -431,11 +431,12 @@ impl Envelope {
             EnvelopeKind::Audio { bytes } => sdk::ir::EnvelopeKind::Audio(bytes),
             EnvelopeKind::Embedding { values } => sdk::ir::EnvelopeKind::Embedding(values),
             EnvelopeKind::Image { bytes, format } => {
-                // Decode-validates the bytes and derives dimensions; carry
-                // over this envelope's metadata onto the validated result.
-                let mut env = sdk::ir::Envelope::image(bytes, format)?;
-                env.metadata = metadata;
-                return Ok(env);
+                // Decode-validates the bytes and derives dimensions, then carry
+                // this envelope's metadata onto the validated kind via
+                // `with_metadata` so a `local_id` is always preserved/minted —
+                // matching the non-image branches below.
+                let env = sdk::ir::Envelope::image(bytes, format)?;
+                return Ok(sdk::ir::Envelope::with_metadata(env.kind, metadata));
             }
             EnvelopeKind::MultiPart { parts } => {
                 let sdk_parts = parts


### PR DESCRIPTION
## What

Now that vision is unconditional in core (#263), surface it on the **bolt** bindings. Restores the multimodal envelope kinds and the distinct capability errors that were flattened during the UniFFI→BoltFFI migration.

## Facade (`xybrid-ffi-facade`)

- `EnvelopeKind` gains `Image { bytes, format }` and `MultiPart { parts }`; new `Envelope::image` / `Envelope::multipart` constructors.
- **`into_sdk` is now fallible** (`Result`). An image envelope is decode-validated and its dimensions derived via `sdk::ir::Envelope::image`; failures surface as the typed `Error::InvalidImage` (code 22) rather than panicking across the FFI boundary. This is the microsoft-rust mandate (M-PANIC-IS-STOP: recoverable input → `Result`, never unwind across FFI). `MultiPart` recurses; nested image errors propagate.
- `run*` thread `?`; `ConversationContextHandle::push` / `set_system` now return `Result` (multimodal history can carry images).
- The **3 capability errors** — `MissingArtifact`, `UnsupportedModelCapability`, `UnsupportedBackendCapability` (codes 19–21) — are restored as first-class typed variants, replacing the generic-flatten stub from the migration.
- `from_sdk` maps `Image`/`MultiPart` for real (encoded path; a raw-image source becomes a defensive `[raw image]` marker — outputs are never raw images).

## Bolt (`xybrid-bolt`)

- `XybridEnvelopeKind` gains `Image` / `MultiPart` (recursive `Vec<XybridEnvelope>` — verified boltffi `#[data]` codegen handles the self-reference). `XybridError` gains the 4 new variants, **appended** to preserve the wire contract (variant order = ordinal tag).
- Regenerated Kotlin/Swift bindings via `boltffi generate`; re-applied the Kotlin 1.9 `override val message` patch.

## Wrappers

- Kotlin `Envelope.image` / `Envelope.userMessage(text, images)` helpers (re-added on the bolt shape).
- Swift `image` / `userMessage` helpers **fixed** — they were left written against the old uniffi enum shape (`.image` case, `XybridError.ConfigError`), which no CI job compiles, so the breakage had gone unnoticed.

## Tests

facade unit tests (17): added `image_envelope_invalid_bytes_surfaces_typed_invalid_image` (locks code 22 + no-panic) and `multipart_envelope_propagates_nested_image_error`. fmt + clippy clean; bolt tests pass.

## Follow-ups (separate PRs)

- Flutter (FRB) + React Native `image` envelope helpers.
- A `swift build` CI check for the SPM wrapper (the gap that hid the Swift breakage).
- Restore the vision example apps (LiveVision / ContentView use the old `run(envelope:config:)` shape).