### PR TITLE
fix(kotlin): restore image format validation + fix EnvelopeTest for bolt shape

### DIFF
--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -300,15 +300,20 @@ object Envelope {
         XybridEnvelope(kind = XybridEnvelopeKind.Embedding(data), metadata = emptyList())
 
     /**
-     * Creates an encoded image envelope for vision-language models. The bytes
-     * are decode-validated on the Rust side at run time (surfacing as a
-     * [XybridError.InvalidImage] for bad/oversized/unsupported input).
+     * Creates an encoded image envelope for vision-language models. The format
+     * hint is normalized and validated up front (`jpg` -> `jpeg`; unsupported
+     * formats throw [XybridError.ConfigError], mirroring the Swift binding);
+     * the bytes themselves are decode-validated on the Rust side at run time
+     * (surfacing as a [XybridError.InvalidImage] for bad or oversized input).
      * @param bytes Encoded PNG, JPEG, or WebP bytes.
      * @param format Image format hint (`png`, `jpeg`, `jpg`, or `webp`).
      */
     @JvmStatic
     fun image(bytes: ByteArray, format: String): XybridEnvelope =
-        XybridEnvelope(kind = XybridEnvelopeKind.Image(bytes, format), metadata = emptyList())
+        XybridEnvelope(
+            kind = XybridEnvelopeKind.Image(bytes, normalizeImageFormat(format)),
+            metadata = emptyList(),
+        )
 
     /**
      * Creates a multimodal user message: prompt text plus image attachments,
@@ -331,6 +336,22 @@ object Envelope {
             metadata = listOf(XybridMetadataEntry("xybrid.role", "user")),
         )
     }
+
+    /**
+     * Normalizes an image format hint to the canonical lowercase form the
+     * Rust core expects (`jpg` -> `jpeg`), rejecting unsupported formats early
+     * with [XybridError.ConfigError] rather than deferring to a run-time
+     * [XybridError.InvalidImage]. Mirrors the Swift binding's
+     * `normalizeImageFormat`.
+     */
+    private fun normalizeImageFormat(format: String): String =
+        when (val normalized = format.trim().lowercase()) {
+            "jpg" -> "jpeg"
+            "jpeg", "png", "webp" -> normalized
+            else -> throw XybridError.ConfigError(
+                "Unsupported image format '$format'. Supported formats: png, jpeg, jpg, webp",
+            )
+        }
 }
 
 // -- XybridVoiceInfo Extensions --

--- a/bindings/kotlin/src/test/kotlin/ai/xybrid/EnvelopeTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/xybrid/EnvelopeTest.kt
@@ -34,8 +34,9 @@ class EnvelopeTest {
         val envelope = Envelope.userMessage("describe this", listOf(image))
 
         val multipart = envelope.kind as XybridEnvelopeKind.MultiPart
-        assertEquals("describe this", (multipart.parts.first().kind as XybridEnvelopeKind.Text).text)
-        assertEquals(listOf(image), multipart.parts.drop(1))
+        assertEquals(2, multipart.parts.size)
+        assertEquals("describe this", (multipart.parts[0].kind as XybridEnvelopeKind.Text).text)
+        assertEquals(image, multipart.parts[1])
         assertTrue(envelope.metadata.any { it.key == "xybrid.role" && it.value == "user" })
     }
 

--- a/bindings/kotlin/src/test/kotlin/ai/xybrid/EnvelopeTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/xybrid/EnvelopeTest.kt
@@ -13,19 +13,18 @@ class EnvelopeTest {
 
         val envelope = Envelope.image(bytes, "JPG")
 
-        assertTrue(envelope is XybridEnvelope.Image)
-        val image = envelope as XybridEnvelope.Image
+        val image = envelope.kind as XybridEnvelopeKind.Image
         assertArrayEquals(bytes, image.bytes)
         assertEquals("jpeg", image.format)
     }
 
     @Test
     fun imageRejectsUnsupportedFormat() {
-        val error = assertThrows(IllegalArgumentException::class.java) {
+        val error = assertThrows(XybridError.ConfigError::class.java) {
             Envelope.image(byteArrayOf(1), "gif")
         }
 
-        assertTrue(error.message!!.contains("Unsupported image format"))
+        assertTrue(error.message.contains("Unsupported image format"))
     }
 
     @Test
@@ -34,18 +33,18 @@ class EnvelopeTest {
 
         val envelope = Envelope.userMessage("describe this", listOf(image))
 
-        assertTrue(envelope is XybridEnvelope.UserMessage)
-        val message = envelope as XybridEnvelope.UserMessage
-        assertEquals("describe this", message.text)
-        assertEquals(listOf(image), message.images)
+        val multipart = envelope.kind as XybridEnvelopeKind.MultiPart
+        assertEquals("describe this", (multipart.parts.first().kind as XybridEnvelopeKind.Text).text)
+        assertEquals(listOf(image), multipart.parts.drop(1))
+        assertTrue(envelope.metadata.any { it.key == "xybrid.role" && it.value == "user" })
     }
 
     @Test
     fun userMessageRejectsNonImageAttachments() {
-        val error = assertThrows(IllegalArgumentException::class.java) {
+        val error = assertThrows(XybridError.ConfigError::class.java) {
             Envelope.userMessage("describe this", listOf(Envelope.text("not an image")))
         }
 
-        assertTrue(error.message!!.contains("only image envelopes"))
+        assertTrue(error.message.contains("only image envelopes"))
     }
 }


### PR DESCRIPTION
Follow-up to the vision-through-bolt work (#265). A migration-parity audit of every binding (BASE = last pre-UniFFI→BoltFFI commit vs current master) surfaced two Kotlin gaps that #265 left behind, neither caught by CI because no job runs the Kotlin test suite or compiles the Kotlin binding against the generated bolt symbols.

## 1. `Envelope.image()` lost client-side format validation

BASE normalized the format hint (`jpg` → `jpeg`) and rejected unsupported formats up front. The Swift binding still does this (`normalizeImageFormat`, throwing `configError`); the Kotlin helper was re-added without it, so the two SDKs diverged and every format error was deferred to a run-time `XybridError.InvalidImage`. Restored `normalizeImageFormat()`, throwing `XybridError.ConfigError` to match **both** the Swift binding and the already-merged `userMessage()` non-image guard (which #265 implemented with `ConfigError`).

## 2. `EnvelopeTest.kt` no longer compiles

The test still referenced the deleted nested types `XybridEnvelope.Image` / `XybridEnvelope.UserMessage` and expected `IllegalArgumentException`. At HEAD `XybridEnvelope` is a flat data class whose variants live under `XybridEnvelopeKind` (`.Image`, `.MultiPart`). Rewrote the assertions against the bolt shape (`envelope.kind as XybridEnvelopeKind.Image` / `.MultiPart` + the `xybrid.role` metadata) and the `XybridError.ConfigError` the helpers actually throw.

Note: the parallel Swift compile-break (the `errorDescription` switch still matched the old uniffi error shapes) was already fixed independently on #265 before it merged, so no Swift change is needed here.

The broader audit also flagged several genuine baseline regressions to triage separately (broken iOS `LiveVision` example, async `run`/`load` no longer exported through bolt, removed per-platform vision CI checks, stale READMEs). Those are tracked as follow-ups, not in this PR.