### PR TITLE
fix(ios-example): migrate LiveVision demo to the bolt run() shape

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -152,6 +152,15 @@ public enum Xybrid {
 /// Call `run(envelope:)` to execute inference on input data.
 public typealias Model = XybridModel
 
+// The bolt handle wraps a thread-safe, `Arc`-backed Rust model (the facade's
+// types are `Send + Sync`), so the handle is safe to move across threads and
+// actors — e.g. loading or running on a `Task.detached` background executor,
+// which is the recommended pattern since bolt's `load`/`run` are blocking.
+// boltffi does not emit `Sendable` on generated handle types yet, so declare it
+// here in the hand-written wrapper (regen-safe — never overwritten by
+// `boltffi generate`, unlike `xybrid_bolt.swift`).
+extension XybridModel: @unchecked Sendable {}
+
 public extension XybridModel {
     /// Run inference with the model's default options.
     ///

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -139,18 +139,19 @@ Xybrid.initialize(
 ### Load Model
 
 ```swift
-let loader = XybridModelLoader.fromRegistry(modelId: "kokoro-82m")
-let model = try await loader.load()
-let voices = model.voices()  // [XybridVoiceInfo]?
+// Loading is synchronous + blocking — call it off the main thread
+// (e.g. inside `Task.detached`) so the UI stays responsive.
+let model = try Model(fromRegistry: "kokoro-82m")
+let voices = model.voices()  // [XybridVoiceInfo]
 ```
 
 ### Run Inference
 
 ```swift
 let envelope = XybridEnvelope.text(text: "Hello!", voiceId: "af", speed: 1.0)
-let result = try await model.run(envelope: envelope, config: nil)
+let result = try model.run(envelope: envelope)
 
-if result.success, let audio = result.audioBytes {
+if let audio = result.audioBytes {
     // Play audio (wrap in WAV header for AVAudioPlayer)
 }
 ```
@@ -164,9 +165,17 @@ let config = XybridGenerationConfig(
     topP: 0.9,
     minP: nil, topK: nil,
     repetitionPenalty: nil,
-    stopSequences: nil
+    stopSequences: []
 )
-let result = try await model.run(envelope: envelope, config: config)
+let result = try model.run(
+    envelope: envelope,
+    options: XybridRunOptions(
+        generationConfig: config,
+        abortOn: [],
+        fallbackToCloud: false,
+        maxGraceTokens: 0
+    )
+)
 ```
 
 ### Vision (image → VLM, batch)
@@ -174,9 +183,17 @@ let result = try await model.run(envelope: envelope, config: config)
 ```swift
 // Encode a camera frame (or any image) to JPEG, then send it as a multimodal
 // user turn. Batch only on Swift today — see "responsiveness model" above.
-let image = XybridEnvelope.image(bytes: jpegData, format: "jpeg")
-let envelope = XybridEnvelope.userMessage(text: "What do you see?", images: [image])
-let result = try await model.run(envelope: envelope, config: config)
+let image = try XybridEnvelope.image(jpegData, format: "jpeg")
+let envelope = try XybridEnvelope.userMessage("What do you see?", images: [image])
+let result = try model.run(
+    envelope: envelope,
+    options: XybridRunOptions(
+        generationConfig: config,
+        abortOn: [],
+        fallbackToCloud: false,
+        maxGraceTokens: 0
+    )
+)
 let caption = result.text
 ```
 

--- a/examples/ios/XybridExample/LiveVision.swift
+++ b/examples/ios/XybridExample/LiveVision.swift
@@ -6,16 +6,16 @@
 //  change-gate wakes the VLM only when the scene changes; each gated frame is
 //  sent as a single *batch* multimodal turn:
 //
-//      XybridEnvelope.userMessage(text: prompt, images: [.image(jpeg, "jpeg")])
-//          → model.run(envelope:config:)  →  caption
+//      try XybridEnvelope.userMessage(prompt, images: [.image(jpeg, format: "jpeg")])
+//          → model.run(envelope:options:)  →  caption
 //
 //  Responsiveness model — drop-if-busy (not cancel-and-replace):
-//  The Swift / UniFFI bindings currently expose only the batch `run`. Streaming
-//  tokens, cancel-and-replace, and raw-frame (`imageRaw`) envelopes — the
-//  realtime-vision primitives already in the Flutter SDK — are not yet bound for
-//  Swift. So while one frame is being answered, newly gated frames are *dropped*
-//  rather than preempting the in-flight run. When the streaming/cancellation
-//  surface lands for Swift this loop can move to latest-frame-wins.
+//  The Swift bindings currently expose only the batch, synchronous `run`.
+//  Streaming tokens, cancel-and-replace, and raw-frame (`imageRaw`) envelopes —
+//  the realtime-vision primitives already in the Flutter SDK — are not yet bound
+//  for Swift. So while one frame is being answered, newly gated frames are
+//  *dropped* rather than preempting the in-flight run. When the streaming/
+//  cancellation surface lands for Swift this loop can move to latest-frame-wins.
 //
 
 import AVFoundation
@@ -344,24 +344,35 @@ final class LiveVisionViewModel: ObservableObject {
     private func infer(frame: LiveVisionFrame, prompt: String) async -> LiveVisionHistoryItem {
         do {
             let model = try await ensureModel()
-            let image = XybridEnvelope.image(bytes: frame.jpegData, format: "jpeg")
-            let envelope = XybridEnvelope.userMessage(text: prompt, images: [image])
-            let config = XybridGenerationConfig(
-                maxTokens: 96,
-                temperature: 0.0,
-                topP: 0.9,
-                minP: 0.05,
-                topK: 40,
-                repetitionPenalty: 1.05,
-                stopSequences: []
+            let image = try XybridEnvelope.image(frame.jpegData, format: "jpeg")
+            let envelope = try XybridEnvelope.userMessage(prompt, images: [image])
+            let options = XybridRunOptions(
+                generationConfig: XybridGenerationConfig(
+                    maxTokens: 96,
+                    temperature: 0.0,
+                    topP: 0.9,
+                    minP: 0.05,
+                    topK: 40,
+                    repetitionPenalty: 1.05,
+                    stopSequences: []
+                ),
+                abortOn: [],
+                fallbackToCloud: false,
+                maxGraceTokens: 0
             )
-            let result = try await model.run(envelope: envelope, config: config)
+            // bolt's `run` is synchronous + blocking; execute it OFF the main
+            // actor so the camera feed and UI stay responsive (the realtime gate
+            // already drops frames while a run is in flight).
+            let result = try await Task.detached {
+                try model.run(envelope: envelope, options: options)
+            }.value
+            // Errors throw (caught below), so a returned result is a success.
             let text = result.text?.trimmingCharacters(in: .whitespacesAndNewlines)
             return LiveVisionHistoryItem(
                 question: prompt,
-                answer: (text?.isEmpty == false) ? text! : (result.success ? "(no text returned)" : "Inference failed"),
+                answer: (text?.isEmpty == false) ? text! : "(no text returned)",
                 latencyMs: result.latencyMs,
-                isError: !result.success
+                isError: false
             )
         } catch {
             return LiveVisionHistoryItem(
@@ -375,10 +386,15 @@ final class LiveVisionViewModel: ObservableObject {
 
     private func ensureModel() async throws -> XybridModel {
         if let model, loadedModelId == modelId { return model }
-        status = "Loading \(modelId)…"
-        let loaded = try await XybridModelLoader.fromRegistry(modelId: modelId).load()
+        let targetId = modelId
+        status = "Loading \(targetId)…"
+        // bolt collapsed the loader into a synchronous, blocking
+        // `XybridModel(fromRegistry:)`; load OFF the main actor (see `infer`).
+        let loaded = try await Task.detached {
+            try XybridModel(fromRegistry: targetId)
+        }.value
         model = loaded
-        loadedModelId = modelId
+        loadedModelId = targetId
         return loaded
     }
 


### PR DESCRIPTION
Restores the iOS Live Vision camera demo (#59 from the migration-parity audit). `LiveVision.swift` was never migrated off UniFFI — it's byte-identical to the pre-migration version and still calls deleted symbols. Because `ContentView` wires in `LiveVisionView()`, this broke the **entire iOS example target**, not just the vision tab.

## Fixes

| Old (uniffi) | New (bolt) |
|---|---|
| `XybridModelLoader.fromRegistry(modelId:).load()` (async) | `try XybridModel(fromRegistry:)` (sync) |
| `XybridEnvelope.image(bytes:format:)` (enum case) | `try XybridEnvelope.image(_:format:)` (throwing factory) |
| `XybridEnvelope.userMessage(text:images:)` | `try XybridEnvelope.userMessage(_:images:)` |
| `try await model.run(envelope:config:)` | `try model.run(envelope:options:)` (config nested in `XybridRunOptions`) |

## Concurrency

bolt's `load` and `run` are **synchronous and blocking** (no async FFI variant is exported yet — that's the separate #60 capability gap). Both now run on `Task.detached`, off the main actor, exactly like the already-migrated `ContentView` — so the camera feed and UI stay responsive. The realtime **drop-if-busy** gate is unchanged. The success path follows the throw-based error model (no longer reads the always-true `result.success` shim).

## Docs

Also refreshed `examples/ios/README.md`, whose Load/Run/Generation-Config/Vision snippets documented the same removed API (sync loader, `config:` param, `stopSequences: nil` which no longer compiles).

## Verification

No iOS toolchain in CI compiles the example (that's #58 — `swift build` CI gate), so this is statically verified: every call site uses confirmed generated symbols (`XybridRunOptions`/`XybridGenerationConfig` inits, `XybridResult.latencyMs: UInt32`, the throwing `image`/`userMessage` wrapper factories) and mirrors the proven `ContentView` `Task.detached` pattern. A repo-wide sweep confirms zero remaining uniffi shapes in `examples/ios/`.