### PR TITLE
ci: warm native build cache on master pushes

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -17,6 +17,27 @@ on:
       # Docs-only changes under the paths above (READMEs, examples) never
       # affect the native build — exclude markdown so they don't trigger it.
       - '!**.md'
+  # Run on master merges too, so each merge saves a default-branch-scoped
+  # cache (sccache + rust-cache). GitHub Actions caches are branch-scoped:
+  # a PR run can only restore caches from its own branch or the default
+  # branch. Without this trigger master never builds, so master has no
+  # cache, so every new PR branch's first run is cold (~35 min). Warming
+  # master here lets new branches start warm (~5 min). Keep these paths in
+  # sync with the pull_request trigger above.
+  push:
+    branches: [master]
+    paths:
+      - 'bindings/kotlin/**'
+      - 'crates/xybrid-bolt/**'
+      - 'crates/xybrid-ffi-facade/**'
+      - 'crates/xybrid-core/**'
+      - 'crates/xybrid-sdk/**'
+      - 'tools/scripts/build-android-bolt.sh'
+      - 'xtask/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - '.github/workflows/build-android.yml'
+      - '!**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -16,6 +16,26 @@ on:
       # Docs-only changes under the paths above (READMEs, examples) never
       # affect the native build — exclude markdown so they don't trigger it.
       - '!**.md'
+  # Run on master merges too, so each merge saves a default-branch-scoped
+  # cache (sccache + rust-cache). GitHub Actions caches are branch-scoped:
+  # a PR run can only restore caches from its own branch or the default
+  # branch. Without this trigger master never builds, so master has no
+  # cache, so every new PR branch's first run is cold (~30 min). Warming
+  # master here lets new branches start warm (~5 min). Keep these paths in
+  # sync with the pull_request trigger above.
+  push:
+    branches: [master]
+    paths:
+      - 'bindings/apple/**'
+      - 'crates/xybrid-bolt/**'
+      - 'crates/xybrid-ffi-facade/**'
+      - 'crates/xybrid-core/**'
+      - 'crates/xybrid-sdk/**'
+      - 'xtask/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - '.github/workflows/build-apple.yml'
+      - '!**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -11,6 +11,21 @@ on:
       # Docs-only changes under the paths above (READMEs, examples) never
       # affect the native build — exclude markdown so they don't trigger it.
       - '!**.md'
+  # Run on master merges too, so each merge saves a default-branch-scoped
+  # cache (sccache + rust-cache). GitHub Actions caches are branch-scoped:
+  # a PR run can only restore caches from its own branch or the default
+  # branch. Without this trigger master never builds, so master has no
+  # cache, so every new PR branch's first run is cold. Warming master here
+  # lets new branches start warm. Keep these paths in sync with the
+  # pull_request trigger above.
+  push:
+    branches: [master]
+    paths:
+      - 'bindings/flutter/**'
+      - 'crates/xybrid-ffi-facade/**'
+      - 'xtask/**'
+      - '.github/workflows/build-flutter.yml'
+      - '!**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -11,6 +11,23 @@ on:
       - 'crates/xybrid-ffi-facade/**'
       - 'xtask/**'
       - '.github/workflows/build-react-native.yml'
+  # Run on master merges too, so each merge saves a default-branch-scoped
+  # cache (sccache + rust-cache). GitHub Actions caches are branch-scoped:
+  # a PR run can only restore caches from its own branch or the default
+  # branch. Without this trigger master never builds, so master has no
+  # cache, so every new PR branch's first run is cold. Warming master here
+  # lets new branches start warm. Keep these paths in sync with the
+  # pull_request trigger above.
+  push:
+    branches: [master]
+    paths:
+      - 'bindings/react-native/**'
+      - 'bindings/apple/**'
+      - 'bindings/kotlin/**'
+      - 'crates/xybrid-bolt/**'
+      - 'crates/xybrid-ffi-facade/**'
+      - 'xtask/**'
+      - '.github/workflows/build-react-native.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The native build workflows (Android, Apple, Flutter, React Native) only ran on `pull_request`, so master never built and never saved a build cache. Because GitHub Actions caches are branch-scoped — a PR run can only restore caches from its own branch or the default branch — every new PR branch's first push started cold and recompiled the full multi-ABI llama.cpp/CMake stack (~30–35 min), with only subsequent pushes on the same branch hitting a warm cache (~5 min). This PR adds a path-filtered `push: [master]` trigger to each of the four native build workflows, mirroring each one's existing `pull_request` paths, so every relevant master merge saves a default-branch-scoped sccache + rust-cache entry that new PR branches restore from. The result: first-push native builds on new branches start warm instead of cold. `concurrency` is keyed on `github.ref`, so master runs don't cancel in-flight PR runs, and the path filters keep unrelated/docs-only merges from triggering the build.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below)

CI/build-infrastructure change — no production code or behavior affected.

## Checklist

- [x] Tests pass (`cargo test`) — n/a, CI workflow config only
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable) — inline comments added to each trigger explaining the cache scoping
- [x] No breaking changes (or breaking changes documented)