### PR TITLE
feat(swift,kotlin): restore async/suspend load + run conveniences

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -213,8 +213,8 @@ public extension XybridModel {
     }
 
     /// Warm up the model without blocking the calling thread or actor.
-    func warmupAsync() async throws {
-        try await Task.detached { try self.warmup() }.value
+    func warmupAsync() async {
+        await Task.detached { self.warmup() }.value
     }
 }
 

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -172,6 +172,52 @@ public extension XybridModel {
     }
 }
 
+// MARK: - Async conveniences
+//
+// bolt's `load` and `run` are synchronous + blocking. These wrappers restore the
+// pre-migration `async` API shape: each runs the blocking call on a detached
+// background executor (`Task.detached`), so callers `await` without blocking the
+// calling thread or actor — exactly what UI code wants for model load / inference.
+//
+// (boltffi *can* export `async fn` natively, but the SDK's async path uses tokio
+// `spawn_blocking`, which panics without an ambient tokio runtime context that
+// boltffi's own future driver does not establish. Wrapping the synchronous call
+// off-thread is therefore the correct, low-risk way to surface async today.)
+public extension XybridModel {
+    /// Load a model from the xybrid registry without blocking the caller.
+    static func fromRegistryAsync(_ id: String) async throws -> XybridModel {
+        try await Task.detached { try XybridModel(fromRegistry: id) }.value
+    }
+
+    /// Load a model from a local directory without blocking the caller.
+    static func fromDirectoryAsync(_ path: String) async throws -> XybridModel {
+        try await Task.detached { try XybridModel(fromDirectory: path) }.value
+    }
+
+    /// Load a model from a local `.xyb` bundle without blocking the caller.
+    static func fromBundleAsync(_ path: String) async throws -> XybridModel {
+        try await Task.detached { try XybridModel(fromBundle: path) }.value
+    }
+
+    /// Resolve and load a model from a HuggingFace repo without blocking the caller.
+    static func fromHuggingfaceAsync(_ repo: String) async throws -> XybridModel {
+        try await Task.detached { try XybridModel(fromHuggingface: repo) }.value
+    }
+
+    /// Run inference without blocking the calling thread or actor.
+    func runAsync(
+        envelope: XybridEnvelope,
+        options: XybridRunOptions? = nil
+    ) async throws -> XybridResult {
+        try await Task.detached { try self.run(envelope: envelope, options: options) }.value
+    }
+
+    /// Warm up the model without blocking the calling thread or actor.
+    func warmupAsync() async throws {
+        try await Task.detached { try self.warmup() }.value
+    }
+}
+
 /// Input data for model inference.
 /// Use `.audio(pcmData:sampleRate:channels:)` or `.text(_:voice:speed:)`.
 public typealias Envelope = XybridEnvelope

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -19,6 +19,8 @@ import android.os.BatteryManager
 import android.os.Build
 import android.os.PowerManager
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 // -- SDK Initialization --
 
@@ -164,6 +166,43 @@ typealias Model = XybridModel
  * generation config, abort signals, or cloud-fallback behaviour.
  */
 fun XybridModel.run(envelope: XybridEnvelope): XybridResult = this.run(envelope, null)
+
+// -- Async (suspend) conveniences --
+//
+// bolt's load/run are synchronous + blocking. These suspend wrappers restore the
+// pre-migration suspend API shape: each runs the blocking call on
+// `Dispatchers.IO`, so coroutine callers `suspend` without blocking the calling
+// thread (e.g. the main/UI thread).
+//
+// (boltffi *can* export `async fn` natively, but the SDK's async path uses tokio
+// `spawn_blocking`, which needs an ambient tokio runtime context that boltffi's
+// future driver does not establish. Wrapping the synchronous call on a worker
+// dispatcher is therefore the correct, low-risk way to surface suspend today.)
+
+/** Load a model from the xybrid registry off the caller's thread. */
+suspend fun XybridModel.Companion.fromRegistryAsync(id: String): XybridModel =
+    withContext(Dispatchers.IO) { XybridModel(id) }
+
+/** Load a model from a local directory off the caller's thread. */
+suspend fun XybridModel.Companion.fromDirectoryAsync(path: String): XybridModel =
+    withContext(Dispatchers.IO) { fromDirectory(path) }
+
+/** Load a model from a local `.xyb` bundle off the caller's thread. */
+suspend fun XybridModel.Companion.fromBundleAsync(path: String): XybridModel =
+    withContext(Dispatchers.IO) { fromBundle(path) }
+
+/** Resolve and load a model from a HuggingFace repo off the caller's thread. */
+suspend fun XybridModel.Companion.fromHuggingfaceAsync(repo: String): XybridModel =
+    withContext(Dispatchers.IO) { fromHuggingface(repo) }
+
+/** Run inference off the caller's thread (on [Dispatchers.IO]). */
+suspend fun XybridModel.runAsync(
+    envelope: XybridEnvelope,
+    options: XybridRunOptions? = null,
+): XybridResult = withContext(Dispatchers.IO) { this@runAsync.run(envelope, options) }
+
+/** Warm up the model off the caller's thread (on [Dispatchers.IO]). */
+suspend fun XybridModel.warmupAsync() = withContext(Dispatchers.IO) { this@warmupAsync.warmup() }
 
 /** The result of a model inference operation. */
 typealias Result = XybridResult


### PR DESCRIPTION
Restores the pre-migration **async (Swift) / suspend (Kotlin)** API shape for model load and inference (#60 from the parity audit). Option 2 — wrapper-level, not native FFI async.

## Background

Baseline uniffi exposed `load`/`run` as `async`/`suspend` across the FFI. bolt exports them **synchronously + blocking**, so hosts had to hand-roll `Task.detached` / `Dispatchers.IO` (the iOS examples already do).

I investigated native async: **boltffi 0.25.3 *can* export `async fn`** on the stable `#[export]` path (it lowers to a poll-handle protocol → Swift `async` / Kotlin `suspend`). But the facade's async methods delegate to the SDK, which uses tokio `spawn_blocking` — and that **panics without an ambient tokio runtime context**, which boltffi's own future driver (plain `thread::spawn`) does not establish. Native async would therefore require threading a tokio `Handle` into every bolt async method + a full 5-language regen + runtime validation. Not worth it right now.

## This PR

Adds the async API shape in the **hand-written wrappers** (regen-safe — untouched by `boltffi generate`), each running the existing synchronous call off the caller's thread:

**Swift** (`Xybrid.swift`)
- `static func fromRegistryAsync/fromDirectoryAsync/fromBundleAsync/fromHuggingfaceAsync(_:) async throws -> XybridModel`
- `func runAsync(envelope:options:) async throws -> XybridResult`
- `func warmupAsync() async throws`
- → `try await Task.detached { try <sync call> }.value`

**Kotlin** (`Xybrid.kt`)
- `suspend fun XybridModel.Companion.fromRegistryAsync/fromDirectoryAsync/fromBundleAsync/fromHuggingfaceAsync(...): XybridModel`
- `suspend fun XybridModel.runAsync(envelope, options?)`, `suspend fun XybridModel.warmupAsync()`
- → `withContext(Dispatchers.IO) { <sync call> }` (kotlinx-coroutines is already a dependency)

Relies on `XybridModel: @unchecked Sendable` (added in #267) for the Swift cross-actor capture.

## Microsoft-rust alignment

This is consistent with **M-YIELD-POINTS** ("your future might be executed in a runtime that cannot work around blocking or long-running tasks") — the exact reason a blocking SDK future can't be driven by boltffi's foreign executor — and **M-TYPES-SEND** (the handle is `Send`, so moving it onto a background executor is sound).

## Verification

No CI compiles the Swift/Kotlin wrappers (tracked as #58). Statically verified: signatures mirror the proven `Task.detached` pattern from the shipped ContentView/LiveVision, use only confirmed symbols, and the Kotlin companion-extension factories resolve against the existing `companion object`.

## Not included
Native FFI-level async (true cross-boundary futures + cancellation propagation) — a larger future effort gated on the tokio-runtime-context work described above.