### PR TITLE
ci: restore per-platform vision compile-check (iOS + Android)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -122,6 +122,14 @@ jobs:
       - name: Set NDK environment
         run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
 
+      # cargo-ndk drives a single-target Android cross-compile that accepts a
+      # `--features` arg (the bolt pack script the shipped build uses can't).
+      # Same idempotent `which || install` pattern as test-ci.yml /
+      # release.yml / build-unity.yml. Used only by the vision compile-check
+      # below — it does not touch the shipped AAR build path.
+      - name: Install cargo-ndk
+        run: which cargo-ndk || cargo install cargo-ndk
+
       # boltffi CLI provides the `boltffi pack android` the build script
       # calls. Cache the installed binary across runs.
       - name: Cache boltffi CLI
@@ -180,6 +188,22 @@ jobs:
               echo "OK: $LIB"
             done
           done
+
+      - name: Check Android vision build (compile-only, not shipped)
+        # Compile-only gate for the OPT-IN native llama.cpp vision backend
+        # (mtmd) — in NO platform preset and NOT packaged in the AAR above.
+        # Proves the `llm-llamacpp-vision` (mtmd) chain still cross-compiles
+        # for Android, the gate the UniFFI->bolt migration dropped (it pointed
+        # at the deleted `xybrid-uniffi`; retargeted here at `xybrid-sdk`:
+        # platform-android + llm-llamacpp-vision -> xybrid-core/llm-llamacpp-vision
+        # -> xybrid-llama-sys/vision; -sys crate at crates/llama-cpp-sys/).
+        # One ABI (arm64-v8a) exercises the C++/mtmd cmake build, matching the
+        # baseline. `check` is sufficient: crates/llama-cpp-sys/build.rs
+        # compiles llama.cpp + mtmd via cmake on `check` (gated on
+        # CARGO_FEATURE_VISION). cargo-ndk uses ANDROID_NDK_HOME (set above)
+        # for the NDK toolchain; llama.cpp source comes from build.rs's
+        # OUT_DIR clone, same as the shipped llm-llamacpp build.
+        run: cargo ndk --target aarch64-linux-android --platform 28 check -p xybrid-sdk --features platform-android,llm-llamacpp-vision
 
       - name: Upload Android .so artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -127,6 +127,26 @@ jobs:
           fi
           echo "$found" | while read -r lib; do file "$lib"; done
 
+      - name: Check iOS vision build (compile-only, not shipped)
+        # Compile-only gate for the OPT-IN native llama.cpp vision backend
+        # (mtmd). This backend is in NO platform preset and is NOT shipped in
+        # the XCFramework above — this step only proves the
+        # `llm-llamacpp-vision` (mtmd) chain still cross-compiles for iOS, the
+        # gate the UniFFI->bolt migration dropped (it pointed at the deleted
+        # `xybrid-uniffi`; retargeted here at `xybrid-sdk`, which now carries
+        # both `platform-ios` and `llm-llamacpp-vision`: xybrid-sdk ->
+        # xybrid-core/llm-llamacpp-vision -> xybrid-llama-sys/vision; the -sys
+        # crate lives at crates/llama-cpp-sys/, package `xybrid-llama-sys`).
+        #
+        # `check` (not `build`) is sufficient and matches the old gate: the
+        # crates/llama-cpp-sys/build.rs runs on `check` and is what compiles
+        # llama.cpp + the mtmd C++ via cmake and bindgens the mtmd FFI (gated
+        # on CARGO_FEATURE_VISION). Like the shipped llm-llamacpp build above,
+        # it sources llama.cpp through build.rs's pinned-commit OUT_DIR clone
+        # (vendor/llama-cpp is an un-checked-out submodule), so no extra
+        # checkout is needed.
+        run: cargo check -p xybrid-sdk --features platform-ios,llm-llamacpp-vision --target aarch64-apple-ios
+
       - name: Upload XCFramework artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
Restores the two compile-only CI gates the UniFFI→BoltFFI migration dropped (#61 from the parity audit). They ensured the **opt-in** native llama.cpp vision backend (`llm-llamacpp-vision` / mtmd) still cross-compiles for iOS and Android. Both pointed at the deleted `xybrid-uniffi`.

## What

Retargeted at `xybrid-sdk`, which now carries both the `platform-*` presets and `llm-llamacpp-vision` (`xybrid-sdk` → `xybrid-core/llm-llamacpp-vision` → the mtmd native chain in `crates/llama-cpp-sys`, package `xybrid-llama-sys`):

- **build-apple.yml**: `cargo check -p xybrid-sdk --features platform-ios,llm-llamacpp-vision --target aarch64-apple-ios` (after Verify XCFramework; `aarch64-apple-ios` is already installed by the toolchain step).
- **build-android.yml**: `cargo ndk --target aarch64-linux-android --platform 28 check -p xybrid-sdk --features platform-android,llm-llamacpp-vision`, plus the idempotent `which cargo-ndk || cargo install cargo-ndk` step the migration dropped (same pattern as test-ci/release/build-unity workflows).

## Scope (compile-only — nothing shipped changes)

Vision is in **no** platform preset and is **not** packaged in the XCFramework/AAR — exactly as before the migration. This PR does not change product behaviour; it only re-adds the gate that proves the mtmd chain compiles.

- **`check` (not `build`) is sufficient and matches the old gate**: `crates/llama-cpp-sys/build.rs` compiles llama.cpp + the mtmd C++ via cmake on `check` (gated on `CARGO_FEATURE_VISION`); only the final Rust static-lib link is skipped (the shipped non-vision build already covers linking).
- **No submodule checkout added**: `vendor/llama-cpp` is an un-checked-out submodule; vision sources llama.cpp through build.rs's pinned-commit `OUT_DIR` clone — the same path the existing shipped `llm-llamacpp` build already uses. Known cost: the first cold run after merge pays a cmake build of the mtmd target (matches the deleted baseline's cost; cached thereafter).

## Verification

YAML lints clean; `cargo metadata` confirms `xybrid-sdk` exposes `platform-ios`/`platform-android`/`llm-llamacpp-vision` and the feature set resolves. (Designed + adversarially verified via a multi-agent pass against the actual feature graph, workflow anchors, and the `-sys` build.rs gating lines.)