### PR TITLE
fix(llama-sys): pass clang the canonical iOS-simulator triple for bindgen

### DIFF
--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -130,18 +130,19 @@ fn generate_bindings(llama_cpp_dir: &Path, out_dir: &Path, ndk_root: Option<&str
     // which resolves headers (`<stdio.h>` etc.) relative to its own
     // sysroot — wrong on cross-builds without explicit overrides.
     // Mirrors the pattern `mlx-c-sys/build.rs` uses for the macOS slice.
-    // clang 21+ rejects Rust's iOS *simulator* triple `aarch64-apple-ios-sim`
-    // verbatim ("error: version 'sim' in target triple ... is invalid") and
-    // wants the canonical `arm64-apple-ios-simulator` form. Older clang (e.g.
-    // the Xcode on the CI runners) accepted `-sim`, which is why this only bites
-    // on newer Xcode locally. Translate just the simulator triple for libclang;
-    // device/other triples pass through unchanged. The deployment-version and
-    // codegen target are set elsewhere (rustflags / cc), so the version is
-    // intentionally omitted here — bindgen only needs a triple clang will parse.
-    let clang_target = if target == "aarch64-apple-ios-sim" {
-        "arm64-apple-ios-simulator"
-    } else {
-        target.as_str()
+    // clang 21+ rejects Rust's `-sim` simulator triples (e.g.
+    // `aarch64-apple-ios-sim`) verbatim ("error: version 'sim' in target triple
+    // ... is invalid") and wants the canonical `<arch>-apple-<os>-simulator`
+    // form. Older clang (the Xcode on the CI runners) accepted `-sim`, which is
+    // why this only bites on newer Xcode locally. Translate any `-sim` triple
+    // for the bindgen clang arg (`arm64` is clang's spelling of `aarch64`);
+    // device and other triples (incl. the x86_64 iOS simulator, which Rust
+    // spells `x86_64-apple-ios` with no `-sim` and clang parses fine) pass
+    // through unchanged. The deployment version + codegen target are set
+    // elsewhere (rustflags / cc), so the bindgen triple only needs to parse.
+    let clang_target = match target.strip_suffix("-sim") {
+        Some(base) => format!("{}-simulator", base.replace("aarch64", "arm64")),
+        None => target.clone(),
     };
     builder = builder.clang_arg(format!("--target={clang_target}"));
     if target_os == "macos" || target_os == "ios" {

--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -130,7 +130,20 @@ fn generate_bindings(llama_cpp_dir: &Path, out_dir: &Path, ndk_root: Option<&str
     // which resolves headers (`<stdio.h>` etc.) relative to its own
     // sysroot — wrong on cross-builds without explicit overrides.
     // Mirrors the pattern `mlx-c-sys/build.rs` uses for the macOS slice.
-    builder = builder.clang_arg(format!("--target={target}"));
+    // clang 21+ rejects Rust's iOS *simulator* triple `aarch64-apple-ios-sim`
+    // verbatim ("error: version 'sim' in target triple ... is invalid") and
+    // wants the canonical `arm64-apple-ios-simulator` form. Older clang (e.g.
+    // the Xcode on the CI runners) accepted `-sim`, which is why this only bites
+    // on newer Xcode locally. Translate just the simulator triple for libclang;
+    // device/other triples pass through unchanged. The deployment-version and
+    // codegen target are set elsewhere (rustflags / cc), so the version is
+    // intentionally omitted here — bindgen only needs a triple clang will parse.
+    let clang_target = if target == "aarch64-apple-ios-sim" {
+        "arm64-apple-ios-simulator"
+    } else {
+        target.as_str()
+    };
+    builder = builder.clang_arg(format!("--target={clang_target}"));
     if target_os == "macos" || target_os == "ios" {
         let sdk = if target_os == "ios" {
             if target.contains("sim") {


### PR DESCRIPTION
## Symptom

`cargo xtask build-xcframework --release` fails packing the iOS **simulator** slice on current Xcode:

```
error: build failed for targets: ["aarch64-apple-ios-sim"]
…
llama-cpp-sys: bindgen failed to generate bindings: ClangDiagnostic(
  "error: version 'sim' in target triple 'aarch64-apple-ios-sim' is invalid")
```

## Cause

`crates/llama-cpp-sys/build.rs` drives bindgen with `--target=<cargo TARGET>`. **clang 21** (current Xcode) rejects Rust's `aarch64-apple-ios-sim` triple — it wants the canonical `arm64-apple-ios-simulator`. **Older clang** (the Xcode on the macOS CI runners) accepted `-sim`, which is why `build-apple` stays green and this only reproduces on a newer local Xcode. The iOS **device** slice (`aarch64-apple-ios`) is a valid triple and was never affected.

## Fix

Translate **only** the simulator triple for the bindgen clang arg; device and all other triples pass through unchanged:

```rust
let clang_target = if target == "aarch64-apple-ios-sim" {
    "arm64-apple-ios-simulator"
} else {
    target.as_str()
};
builder = builder.clang_arg(format!("--target={clang_target}"));
```

The deployment version + codegen target are set elsewhere (rustflags / cc), so the bindgen triple only needs to *parse*.

## Verification

`cargo build -p xybrid-bolt --features platform-ios --target aarch64-apple-ios-sim --release` now succeeds on clang 21 (was: bindgen panic). Device slice unchanged.

## Scope

**Toolchain-compat fix** (new Xcode/clang 21), not a bolt-migration regression — it would fail identically pre-migration. Filed separately for that reason. Unblocks local iOS device testing (the full xcframework now builds without env-var workarounds) and protects any teammate on a current Xcode; CI's older clang keeps working either way. Worth noting the CI runners will hit this when they bump Xcode.