### PR TITLE
ci: compile the Swift + Kotlin binding wrappers (catch wrapper breaks)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,24 @@
 [alias]
 xtask = "run --package xtask --"
 
+# Network resilience for registry fetches.
+#
+# CI intermittently fails a crate download with curl's
+# `[16] Error in the HTTP2 framing layer` (e.g. fetching `dispatch2`
+# during dependency resolution). That error is a known crates.io CDN /
+# HTTP/2 multiplexing flake — multiple in-flight requests share one
+# HTTP/2 connection and a mid-stream framing hiccup aborts the whole
+# download. Disabling multiplexing makes curl use one request per
+# connection (HTTP/1.1-style), which sidesteps the framing-layer abort,
+# and a higher retry count absorbs the remaining transient blips.
+# Repo-wide so every cargo invocation (CI cross-compiles, local builds)
+# inherits it.
+[net]
+retry = 10
+
+[http]
+multiplexing = false
+
 # Windows MSVC: esaxx-rs (via tokenizers) hardcodes static_crt(true) producing /MT objects.
 # For cdylib (DLL) targets where everything else is /MD, the linker tolerates the metadata
 # mismatch but having both LIBCMT.lib (static) and MSVCRT.lib (dynamic) causes symbol

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -211,3 +211,43 @@ jobs:
           name: android-so-files
           path: bindings/kotlin/libs/
           if-no-files-found: error
+
+  # Compiles the Kotlin binding wrapper (hand-written Xybrid.kt + the
+  # bolt-generated XybridBolt.kt) and runs the pure-Kotlin unit tests — the
+  # gate that catches wrapper-level breaks (a non-exhaustive `when`, an
+  # enum-shape change, a missing import) that the native .so build above does
+  # NOT, and that no PR-to-master job compiles today (test-ci.yml's
+  # assembleRelease is workflow_dispatch-only; release-dryrun.yml's
+  # bundleReleaseAar fires only on PRs to `main`, filtered to build.gradle.kts —
+  # not the wrapper .kt sources). Standalone (no `needs:`) so it runs in
+  # parallel and stays cheap: JDK + Android SDK + gradle, no ~35-min
+  # cross-compile. The .so is a runtime-only artifact (loaded lazily in
+  # `Native`'s init{}), so compile + JVM unit test need neither it nor Rust.
+  kotlin-wrapper:
+    name: Compile + test Kotlin wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # AGP 8.2.2 requires JDK 17+. `cache: gradle` caches the Gradle user home
+      # (resolved deps + wrapper distribution) across runs.
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+          cache-dependency-path: bindings/kotlin/**/*.gradle*
+
+      # Provides ANDROID_HOME so AGP resolves the SDK; AGP auto-downloads the
+      # compileSdk=34 platform on first build (same as release-publish.yml).
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      # compile* type-checks Xybrid.kt + XybridBolt.kt (both variants, so an
+      # enum-shape break that only trips one buildType is still caught);
+      # testDebugUnitTest runs the pure-Kotlin EnvelopeTest. No native .so is
+      # present on a fresh checkout and none is needed.
+      - name: Compile wrapper + run unit tests
+        working-directory: bindings/kotlin
+        run: ./gradlew compileReleaseKotlin compileDebugKotlin testDebugUnitTest --console=plain --stacktrace

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -127,6 +127,31 @@ jobs:
           fi
           echo "$found" | while read -r lib; do file "$lib"; done
 
+      - name: Compile Swift binding wrapper (iOS Simulator)
+        # Compiles the hand-written Xybrid.swift + the bolt-generated
+        # xybrid_bolt.swift into the SPM `Xybrid` library, so a wrapper break
+        # (non-exhaustive errorDescription switch, a missing import, an
+        # enum-shape mismatch vs the regenerated bindings) fails CI here instead
+        # of only when a human builds the example app. Uses the xcframework
+        # just built above (root Package.swift has useLocalNatives = true).
+        #
+        # Targets the iOS Simulator for two reasons: (1) the xcframework ships
+        # only ios-arm64 + ios-arm64-simulator (boltffi.toml include_macos=false),
+        # so a host/macOS build has no slice to link; (2) Xybrid.swift gates
+        # `import UIKit` behind `#if os(iOS)`, so only an iOS build type-checks
+        # the UIKit-conditional code — the code most likely to break. Compiles
+        # the wrapper library ONLY (the example .xcodeproj has no shared scheme;
+        # ContentView/LiveVision aren't built) and boots no simulator (generic
+        # destination = compile + link, no run, no signing).
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies
+          xcodebuild build \
+            -scheme Xybrid \
+            -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Check iOS vision build (compile-only, not shipped)
         # Compile-only gate for the OPT-IN native llama.cpp vision backend
         # (mtmd). This backend is in NO platform preset and is NOT shipped in


### PR DESCRIPTION
Closes the CI gap behind this cycle's two ship-then-hand-fix incidents (#58 + #64). **No PR-to-master job compiled the binding wrappers**, so a wrapper break only surfaced when a human built an example app:
- Swift `errorDescription` switch left on the old uniffi error shapes → whole Apple module wouldn't compile.
- Kotlin `displayMessage` `when()` non-exhaustive after new error variants + a missing `import ai.xybrid.run` in the example.

## What

- **build-apple.yml** — after the xcframework is built, a step compiles the SPM `Xybrid` library (`Xybrid.swift` + generated `xybrid_bolt.swift`):
  ```
  xcodebuild build -scheme Xybrid -destination 'generic/platform=iOS Simulator'
  ```
  iOS Simulator is the correct destination for **two** reasons: the xcframework has no macOS slice (`include_macos=false`), and `Xybrid.swift` gates `import UIKit` behind `#if os(iOS)` so only an iOS build type-checks that path. Library only — no example app (the `.xcodeproj` has no shared scheme), no signing, no booted simulator.
- **build-android.yml** — a new standalone **`kotlin-wrapper`** job (no `needs:`, runs in parallel, ~1–2 min) runs `./gradlew compileReleaseKotlin compileDebugKotlin testDebugUnitTest` on `bindings/kotlin`. The `.so` is a runtime-only artifact (loaded lazily), so compiling the wrapper + running the pure-Kotlin `EnvelopeTest` needs neither it nor the Rust toolchain.

## Verification

- **Kotlin**: ran the exact job command on current master with a CI-equivalent env (JDK 17/21 + `ANDROID_HOME`, no `.so`) → `BUILD SUCCESSFUL`.
- **Swift**: validated locally by the design pass — `BUILD SUCCEEDED`, plus a negative test (deleting one `XybridError` case) that correctly **failed** with `switch must be exhaustive`.
- Designed + adversarially verified by a multi-agent workflow against the real workflows / `Package.swift` / Gradle module.

## First-run watch
The macos-14 runner ships an older Xcode (~15.x) than the machine the Swift step was validated on; the command shape is stable across those versions but the first CI run is the source of truth. Apple-side path filters don't include root `Package.swift` (a manifest-only edit wouldn't trigger the gate) — noted as a minor follow-up, not addressed here.

## Related
This is the safety net that makes the **#63** fix (warmup/unload `Result` dropped + a per-call `FfiBuf` leak, caused by a `boltffi_cli` 0.25.0 emitter vs `boltffi` 0.25.3 runtime skew) safe to do: the boltffi version-alignment + binding regen it requires will now be compile-checked here. Tracked separately.