### PR TITLE
fix(bolt): align boltffi_cli to runtime 0.25.3 (fix warmup/unload drop + leak)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -137,17 +137,18 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/boltffi
-          key: boltffi-cli-${{ runner.os }}-0.25
+          key: boltffi-cli-${{ runner.os }}-0.25.3
 
       - name: Install boltffi CLI
         # `which || install` is idempotent whether or not the cache
         # populated the binary (actions/cache only sets cache-hit on an
         # exact key match).
-        # `--locked` is required: boltffi_cli 0.25.0 fails to compile against
-        # the newer 0.25.1 of its own lib crates (boltffi_bindgen added
-        # required `KotlinOptions` fields in a non-additive minor bump). The
-        # bundled Cargo.lock pins those libs to 0.25.0.
-        run: which boltffi || cargo install boltffi_cli --version 0.25.0 --locked
+        # Pinned to 0.25.3 to MATCH the runtime `boltffi` crate (Cargo.lock):
+        # a CLI/runtime version skew mis-generates unit-ok `Result<(), E>`
+        # exports (model warmup/unload) as a `void` foreign function that drops
+        # the error and leaks the result buffer. `--locked` installs against
+        # the CLI's own bundled Cargo.lock for reproducibility.
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
       - name: Build Android .so files (all ABIs)
         run: cargo xtask build-android --release

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -91,16 +91,16 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/boltffi
-          key: boltffi-cli-${{ runner.os }}-0.25
+          key: boltffi-cli-${{ runner.os }}-0.25.3
 
       - name: Install boltffi CLI
         # `which || install` is idempotent whether or not the cache populated
-        # the binary. `--locked` is required: boltffi_cli 0.25.0 fails to
-        # compile against the newer 0.25.1 of its own lib crates
-        # (boltffi_bindgen added required `KotlinOptions` fields in a
-        # non-additive minor bump). The bundled Cargo.lock pins those libs to
-        # 0.25.0.
-        run: which boltffi || cargo install boltffi_cli --version 0.25.0 --locked
+        # the binary. Pinned to 0.25.3 to MATCH the runtime `boltffi` crate
+        # (Cargo.lock): a CLI/runtime version skew mis-generates unit-ok
+        # `Result<(), E>` exports (model warmup/unload) as a `void` foreign
+        # function that drops the error and leaks the result buffer. `--locked`
+        # installs against the CLI's own bundled Cargo.lock for reproducibility.
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
       - name: Build XCFramework
         run: cargo xtask build-xcframework --release

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -88,17 +88,18 @@ jobs:
           save-if: "true"
 
       # boltffi CLI provides the `boltffi pack apple` that build-xcframework
-      # (invoked by stage-react-native) shells out to. `--locked` pins the
-      # 0.25.0 lib crates (see build-apple.yml for the rationale).
+      # (invoked by stage-react-native) shells out to. Pinned to 0.25.3 to
+      # match the runtime `boltffi` crate (see build-apple.yml for why the
+      # CLI/runtime versions must match).
       - name: Cache boltffi CLI
         id: cache-boltffi
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/boltffi
-          key: boltffi-cli-${{ runner.os }}-0.25
+          key: boltffi-cli-${{ runner.os }}-0.25.3
 
       - name: Install boltffi CLI
-        run: which boltffi || cargo install boltffi_cli --version 0.25.0 --locked
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
       - name: Stage iOS artifacts
         run: cargo xtask stage-react-native --release

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -383,11 +383,12 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
 
       - name: Install boltffi CLI
-        # `--locked` is required: boltffi_cli 0.25.0 fails to compile against
-        # the newer 0.25.1 of its own lib crates (boltffi_bindgen added
-        # required `KotlinOptions` fields in a non-additive minor bump). The
-        # bundled Cargo.lock pins those libs to 0.25.0.
-        run: which boltffi || cargo install boltffi_cli --version 0.25.0 --locked
+        # Pinned to 0.25.3 to MATCH the runtime `boltffi` crate (Cargo.lock):
+        # a CLI/runtime version skew mis-generates unit-ok `Result<(), E>`
+        # exports (model warmup/unload) as a `void` foreign function that drops
+        # the error and leaks the result buffer. `--locked` installs against
+        # the CLI's own bundled Cargo.lock for reproducibility.
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
       - name: Build Android .so files
         run: cargo xtask build-android --release

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -213,8 +213,8 @@ public extension XybridModel {
     }
 
     /// Warm up the model without blocking the calling thread or actor.
-    func warmupAsync() async {
-        await Task.detached { self.warmup() }.value
+    func warmupAsync() async throws {
+        try await Task.detached { try self.warmup() }.value
     }
 }
 

--- a/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
@@ -779,12 +779,16 @@ public final class XybridModel {
         }
     }
 
-    public func warmup() {
-        boltffi_xybrid_model_warmup(handle)
+    public func warmup() throws {
+        let buf = boltffi_xybrid_model_warmup(handle)
+        defer { boltffi_free_buf(buf) }
+        return try boltffiDecodeOwnedBuf(buf.ptr, Int(buf.len)) { reader in try { let tag = reader.readU8(); if tag == 0 { return () } else { throw XybridError.decode(from: &reader) } }() }
     }
 
-    public func unload() {
-        boltffi_xybrid_model_unload(handle)
+    public func unload() throws {
+        let buf = boltffi_xybrid_model_unload(handle)
+        defer { boltffi_free_buf(buf) }
+        return try boltffiDecodeOwnedBuf(buf.ptr, Int(buf.len)) { reader in try { let tag = reader.readU8(); if tag == 0 { return () } else { throw XybridError.decode(from: &reader) } }() }
     }
 
 }

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
@@ -14,9 +14,9 @@ import java.time.Instant
 import java.util.UUID
 import java.net.URI
 
-class FfiException(val code: Int, message: String) : Exception(message)
+class FfiException(val code: kotlin.Int, message: kotlin.String) : kotlin.Exception(message)
 
-private fun takeLastErrorMessage(): String =
+private fun takeLastErrorMessage(): kotlin.String =
     Native.boltffi_last_error_message().toString(Charsets.UTF_8)
 
 private inline fun <T> useWireBytes(bytes: ByteArray, block: (java.nio.ByteBuffer) -> T): T {
@@ -267,16 +267,16 @@ class WireReader {
 }
 
 sealed class BoltFFIResult<out T, out E> {
-    data class Ok<T>(val value: T) : BoltFFIResult<T, Nothing>()
-    data class Err<E>(val error: E) : BoltFFIResult<Nothing, E>()
+    data class Ok<T>(val value: T) : BoltFFIResult<T, kotlin.Nothing>()
+    data class Err<E>(val error: E) : BoltFFIResult<kotlin.Nothing, E>()
 
-    val isSuccess: Boolean get() = this is Ok
-    val isFailure: Boolean get() = this is Err
+    val isSuccess: kotlin.Boolean get() = this is Ok
+    val isFailure: kotlin.Boolean get() = this is Err
 
     fun getOrThrow(): T = when (this) {
         is Ok -> value
         is Err -> throw when (error) {
-            is Throwable -> error
+            is kotlin.Throwable -> error
             else -> FfiException(-1, error.toString())
         }
     }
@@ -286,10 +286,10 @@ sealed class BoltFFIResult<out T, out E> {
         is Err -> null
     }
 
-    fun exceptionOrNull(): Throwable? = when (this) {
+    fun exceptionOrNull(): kotlin.Throwable? = when (this) {
         is Ok -> null
         is Err -> when (error) {
-            is Throwable -> error
+            is kotlin.Throwable -> error
             else -> FfiException(-1, error.toString())
         }
     }
@@ -585,7 +585,7 @@ internal object WireWriterPool {
  * Only ever append at the tail, and keep this order in lockstep with
  * [`facade::Error`] and its `code()` table.
  */
-sealed class XybridError : Exception() {
+sealed class XybridError : kotlin.Exception() {
 
     data class ModelNotFound(val id: String) : XybridError()
 
@@ -1481,13 +1481,21 @@ class XybridModel private constructor(internal val handle: Long) : AutoCloseable
     }
 
 
-    fun warmup() {
-        Native.boltffi_xybrid_model_warmup(handle)
+    @Throws(XybridError::class)
+    fun warmup(): Unit {
+        val buf = Native.boltffi_xybrid_model_warmup(handle)
+            ?: throw FfiException(-1, "Null buffer returned")
+        val reader = WireReader(buf)
+        return reader.readResult({ Unit }, { XybridError.decode(reader) }).getOrThrow()
     }
 
 
-    fun unload() {
-        Native.boltffi_xybrid_model_unload(handle)
+    @Throws(XybridError::class)
+    fun unload(): Unit {
+        val buf = Native.boltffi_xybrid_model_unload(handle)
+            ?: throw FfiException(-1, "Null buffer returned")
+        val reader = WireReader(buf)
+        return reader.readResult({ Unit }, { XybridError.decode(reader) }).getOrThrow()
     }
 }
 
@@ -1651,6 +1659,6 @@ private object Native {
     @JvmStatic external fun boltffi_xybrid_model_default_voice(handle: Long): ByteArray?
     @JvmStatic external fun boltffi_xybrid_model_voice(handle: Long, voice_id: ByteArray): ByteArray?
     @JvmStatic external fun boltffi_xybrid_model_run(handle: Long, envelope: ByteBuffer, options: ByteBuffer): ByteArray?
-    @JvmStatic external fun boltffi_xybrid_model_warmup(handle: Long): Unit
-    @JvmStatic external fun boltffi_xybrid_model_unload(handle: Long): Unit
+    @JvmStatic external fun boltffi_xybrid_model_warmup(handle: Long): ByteArray?
+    @JvmStatic external fun boltffi_xybrid_model_unload(handle: Long): ByteArray?
 }


### PR DESCRIPTION
## Summary

The boltffi codegen CLI was pinned to **0.25.0** in CI while the runtime `boltffi` crate is **0.25.3** (Cargo.lock), and that skew mis-generated the unit-ok `Result<(), E>` exports — model `warmup()`/`unload()` — as non-throwing `void` Swift/Kotlin functions that **dropped the error and leaked the returned 32-byte result buffer on every call** (the Rust extern wire-encodes the full `Result` into an `FfiBuf` the caller ignored). This PR bumps `boltffi_cli` 0.25.0 → 0.25.3 (and busts the cache key) across `build-apple`/`build-android`/`build-react-native`/`test-ci` so CI codegen matches the runtime, and regenerates `xybrid_bolt.swift` + `XybridBolt.kt` with 0.25.3 — `warmup`/`unload` are now throwing, free the buffer (`defer boltffi_free_buf` / `readResult().getOrThrow()`), and surface the error; `Xybrid.swift`'s `warmupAsync` returns to `async throws` (reverting the earlier workaround for the buggy codegen). I verified the 0.25.0 CLI reproduces the prior committed bindings byte-for-byte, so the only behavioral delta is `warmup`/`unload` (0.25.3 also cosmetically fully-qualifies `kotlin.*` stdlib types), and the Kotlin module compiles + `EnvelopeTest` passes while #275's new wrapper-compile CI validates the Swift side.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test` unaffected; Kotlin `EnvelopeTest` passes against the regenerated binding)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable) — n/a
- [x] No breaking changes (or breaking changes documented) — `warmup()`/`unload()` go from non-throwing to **throwing** in Swift/Kotlin; documented above. The only in-repo caller (`warmupAsync`) is updated; the prior `void` form was non-functional (leaked + swallowed errors), so no working consumer relied on it.