### PR TITLE
chore(release): bump workspace to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — real-time vision primitives (`feat/realtime-vision`, code-complete, not yet merged or device-validated)
-
-The following SDK/runtime additions land on the `feat/realtime-vision` branch in
-support of Studio's live camera vision (the app-side live loop lives in the meta
-workstation). They are code-complete and reviewed but **not yet validated on a
-real device**, so they are recorded here as unreleased rather than under a cut
-version. The version bump + `/sync-api` + tag are a merge/release-time action via
-the existing `version-sync.sh` tooling — **not** done in this entry.
-
-- **Reachable streaming cancellation**: cancelling a streaming generation now
-  drives a real runtime abort end-to-end (FFI `FfiCancellationToken` +
-  options-aware streaming routing + sink-closed-as-cancel), so the generation
-  halts at the next token and releases the model lock. Previously the Dart-side
-  "stop" only unsubscribed and the runtime kept generating. `UserCancelled` is the
-  default abort outcome.
-- **Preemptive cancel-and-replace slot** on the model handle: a new run can
-  preempt the in-flight run (latest-frame-wins), so a live loop no longer
-  head-of-line-blocks behind a stale frame.
-- **Raw-frame `mtmd` path + `imageRaw` binding**: a packed-RGB
-  `mtmd_bitmap_init` shim routes `ImageSource::Raw` through `mtmd` without
-  per-frame JPEG re-encoding; the `imageRaw` envelope binding is exposed to Dart/FRB
-  and consumed by Studio behind a default-off flag. The encoded `image` path is
-  unchanged and remains the fallback.
-- **Live-mode telemetry tagging + per-session sampler**: live inferences are
-  tagged (`live_mode` + `frame_session_id`) and rate-limited by a per-session
-  sampler (≈1 row/sec/session, TTL-bounded), so live sessions don't emit a
-  telemetry row per frame.
-
-Multimodal KV-prefix reuse (the per-frame prefill cost lever) is **deferred** —
-not implemented this cycle.
-
-### Planned (0.1.x)
+### Planned
 
 - **OpenUPM registry**: Publish Unity SDK to [openupm.com](https://openupm.com) for scoped registry install
+- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.2.0] - 2026-06-17
+
+The vision release. xybrid gains an on-device multimodal stack — VLM inference,
+real-time camera vision primitives, and streaming TTS — and the FFI surface is
+re-platformed from UniFFI onto BoltFFI through a single shared facade. This is a
+**breaking release** for binding consumers: the Swift / Kotlin / Java / C# / RN
+bindings are now generated through `xybrid-bolt` + `xybrid-ffi-facade` rather
+than UniFFI, and the run/envelope call shapes changed accordingly.
+
+### Added
+
+- **On-device vision foundation** (#245): VLM inference, real-time camera vision
+  primitives, and streaming TTS land in the runtime. The vision pipeline is now
+  unconditional rather than feature-gated (#263).
+- **Vision envelopes through bolt** (#265): `Image` / `MultiPart` envelopes and
+  typed capability errors are threaded through the BoltFFI bindings; generation
+  config is now plumbed through `XybridModel.run` (#262).
+- **Reachable streaming cancellation**: cancelling a streaming generation drives a
+  real runtime abort end-to-end (`FfiCancellationToken` + options-aware streaming
+  routing + sink-closed-as-cancel), so generation halts at the next token and
+  releases the model lock. `UserCancelled` is the default abort outcome.
+- **Preemptive cancel-and-replace slot** on the model handle: a new run can preempt
+  the in-flight run (latest-frame-wins), so a live loop no longer head-of-line-blocks
+  behind a stale frame.
+- **Raw-frame `mtmd` path + `imageRaw` binding**: a packed-RGB `mtmd_bitmap_init`
+  shim routes `ImageSource::Raw` through `mtmd` without per-frame JPEG re-encoding;
+  the `imageRaw` envelope binding is exposed to Dart/FRB. The encoded `image` path
+  is unchanged and remains the fallback.
+- **Live-mode telemetry tagging + per-session sampler**: live inferences are tagged
+  (`live_mode` + `frame_session_id`) and rate-limited by a per-session sampler
+  (≈1 row/sec/session, TTL-bounded), so live sessions don't emit a telemetry row
+  per frame.
+- **Speculative cloud loader decision layer** (#250): `set_speculative_cloud` +
+  `ModelLoader::with_speculative_cloud` / `will_speculate` let the loader begin a
+  cloud execution while the local model is still downloading.
+- **React Native binding** (#93, #260): a React Native binding, now ported onto
+  BoltFFI alongside the other foreign-language bindings.
+- **Async/suspend conveniences restored** (#269) for Swift and Kotlin load + run.
+
+### Changed
+
+- **FFI bindings migrated from UniFFI to BoltFFI** (#205) via a shared
+  `xybrid-ffi-facade` — one canonical SDK→foreign-language translation feeding the
+  Swift / Kotlin / Java / C# / WASM bindings. **Breaking** for binding consumers.
+- **Executor decomposition**: LLM envelope and gen-config helpers deduped (#261),
+  LLM telemetry extracted into `execution::llm_telemetry` (#251), and TTS chunking
+  + audio crossfade extracted from the executor (#239).
+- **iOS LiveVision example** migrated to the bolt `run()` shape (#267).
+- **Docs**: docs site refreshed — restored deploys, surfaced hidden nav, added
+  missing pages (#254); local-first foundation vs additive platform layer
+  clarified (#248).
+- **Release/CI**: `llama-cpp-sys` renamed to `xybrid-llama-sys` (#247) and both
+  `xybrid-llama-sys` + `xybrid-llama` now publish to crates.io (#246); native
+  build cache is warmed on master pushes (#268).
+
+### Fixed
+
+- **Kotlin image format validation** restored and `EnvelopeTest` fixed for the bolt
+  envelope shape (#266).
+- **`tokens_out` emitted** on local LLM telemetry paths (#253).
+- **`.npz` voice files detected** by magic header rather than extension (#252).
+- **TTS text chunking is UTF-8-safe** (#249) — no longer splits multi-byte
+  codepoints mid-character.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -6759,14 +6759,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6803,7 +6803,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "tokio",
  "xybrid-core",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = true
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.1.2"
+let sdkVersion = "0.2.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ import PackageDescription
 //                            external SPM consumers resolve.
 //
 // =============================================================================
-let useLocalNatives = true
+let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.0
+
+The vision release. The binding gains on-device multimodal input and the
+real-time camera vision primitives behind Studio's live loop.
+
+* On-device vision (VLM): new `XybridEnvelope.image` (encoded PNG/JPEG/WebP), `XybridEnvelope.imageRaw` (raw camera/canvas pixel frames), and `XybridEnvelope.multiPart` (user-role message with image attachments) for running vision-language models from Dart (xybrid-ai/xybrid#245, #265)
+* Reachable streaming cancellation: new `CancellationToken` whose `cancel()` drives a real runtime abort end-to-end — the generation halts at the next token and releases the model lock, instead of the old behavior where "stop" only unsubscribed while the runtime kept generating (xybrid-ai/xybrid#245)
+* Live-loop run options on the model handle: `preempt` (latest-frame-wins — a new run preempts the in-flight one so a live loop no longer head-of-line-blocks behind a stale frame) and `frameSessionId` for tagging live inferences (xybrid-ai/xybrid#245)
+* Raw-frame path avoids per-frame JPEG re-encoding: `imageRaw` packs RGB pixel buffers straight through to the multimodal runtime; the encoded `image` path remains the fallback (xybrid-ai/xybrid#245)
+* Streaming TTS support on top of the new audio generation path (xybrid-ai/xybrid#245)
+* Live-mode telemetry is rate-limited by a per-session sampler (≈1 row/sec/session), so live camera sessions no longer emit a telemetry row per frame (xybrid-ai/xybrid#245)
+* Fixed: TTS text chunking is now UTF-8-safe — multi-byte codepoints are no longer split mid-character (xybrid-ai/xybrid#249)
+* Fixed: `.npz` voice files are detected by magic header rather than file extension (xybrid-ai/xybrid#252)
+* Fixed: `tokens_out` is now emitted on local LLM telemetry paths (xybrid-ai/xybrid#253)
+
 ## 0.1.2
 
 * Audio inputs now detect MP3, OGG, and FLAC in addition to WAV, and mono audio is upmixed to stereo when a model expects two channels (xybrid-ai/xybrid#132, #141)

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.1.2"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.2.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.1.2"
+version = "0.2.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.1.2", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.1.2", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.2.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.1.2" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.1.0-rc3", path = "../../macros" }
+xybrid-macros = { version = "0.2.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.1.0-rc3", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.1.0-rc3", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.1.0-rc3", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.2.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

Cuts the **0.2.0** release: bumps all 13 crates and every binding manifest (Flutter, Unity, Kotlin, Swift, flutter-rust) from 0.1.2, regenerates `Cargo.lock`, and writes the 0.2.0 entry into both the root and Flutter CHANGELOGs (on-device vision/VLM + real-time camera primitives, streaming TTS, speculative cloud loader, and the breaking UniFFI→BoltFFI binding migration). It also repairs stale internal path-dep version pins (`xybrid-sdk`/`xybrid-core`/`xybrid-macros` at `0.1.0-rc3`, llama crates at `0.1.2`) that `version-sync.sh` does not touch and which otherwise break lockfile regen under `^0.1.x`. `cargo check --workspace` is green and `version-sync.sh --check` passes; tagging and publishing are intentionally left as follow-up steps.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (release: version bump + changelog)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)