### PR TITLE
Release v0.2.0-alpha

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -133,7 +133,11 @@ jobs:
         # (non-exhaustive errorDescription switch, a missing import, an
         # enum-shape mismatch vs the regenerated bindings) fails CI here instead
         # of only when a human builds the example app. Uses the xcframework
-        # just built above (root Package.swift has useLocalNatives = true).
+        # just built above: the committed state is useLocalNatives = false (so
+        # SPM consumers resolve the published release asset), so this step flips
+        # to local mode at CI runtime before resolving — otherwise it would try
+        # to download the remote asset, which 404s on a release PR while the
+        # v<version> release is still a draft. The flip is CI-only, never committed.
         #
         # Targets the iOS Simulator for two reasons: (1) the xcframework ships
         # only ios-arm64 + ios-arm64-simulator (boltffi.toml include_macos=false),
@@ -145,6 +149,8 @@ jobs:
         # destination = compile + link, no run, no signing).
         run: |
           set -euo pipefail
+          # CI-runtime flip to the locally-built xcframework. Do NOT commit this.
+          ./bindings/apple/scripts/set-natives-mode.sh --set-local
           xcodebuild -resolvePackageDependencies
           xcodebuild build \
             -scheme Xybrid \

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -275,6 +275,25 @@ jobs:
 
       - run: brew install llvm
 
+      # boltffi CLI provides the `boltffi pack apple` that
+      # `cargo xtask build-xcframework` shells out to. Cache the installed
+      # binary across runs.
+      - name: Cache boltffi CLI
+        id: cache-boltffi
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/boltffi
+          key: boltffi-cli-${{ runner.os }}-0.25.3
+
+      - name: Install boltffi CLI
+        # `which || install` is idempotent whether or not the cache populated
+        # the binary. Pinned to 0.25.3 to MATCH the runtime `boltffi` crate
+        # (Cargo.lock): a CLI/runtime version skew mis-generates unit-ok
+        # `Result<(), E>` exports (model warmup/unload) as a `void` foreign
+        # function that drops the error and leaks the result buffer. `--locked`
+        # installs against the CLI's own bundled Cargo.lock for reproducibility.
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
+
       - name: Build XCFramework (release)
         run: cargo xtask build-xcframework --release
 
@@ -388,6 +407,26 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
 
       - run: which cargo-ndk || cargo install cargo-ndk
+
+      # boltffi CLI provides the `boltffi pack android` the build script
+      # calls. Cache the installed binary across runs.
+      - name: Cache boltffi CLI
+        id: cache-boltffi
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/boltffi
+          key: boltffi-cli-${{ runner.os }}-0.25.3
+
+      - name: Install boltffi CLI
+        # `which || install` is idempotent whether or not the cache
+        # populated the binary (actions/cache only sets cache-hit on an
+        # exact key match).
+        # Pinned to 0.25.3 to MATCH the runtime `boltffi` crate (Cargo.lock):
+        # a CLI/runtime version skew mis-generates unit-ok `Result<(), E>`
+        # exports (model warmup/unload) as a `void` foreign function that drops
+        # the error and leaks the result buffer. `--locked` installs against
+        # the CLI's own bundled Cargo.lock for reproducibility.
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
       - name: Build Android .so
         run: cargo xtask build-android --release

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -178,6 +178,22 @@ jobs:
           cache-all-crates: "true"
           save-if: "true"
 
+      # `cargo xtask build-xcframework` shells out to `boltffi pack apple`, so
+      # the CLI must be present here just as it is in the Android job. Without
+      # it the build fails with "Failed to run `boltffi pack apple`. Install
+      # with `cargo install boltffi_cli`." Cache + pin to 0.25.3 to match the
+      # runtime `boltffi` crate (Cargo.lock) — a CLI/runtime skew mis-generates
+      # the bindings (see the Android job's note).
+      - name: Cache boltffi CLI
+        id: cache-boltffi
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/boltffi
+          key: boltffi-cli-${{ runner.os }}-0.25.3
+
+      - name: Install boltffi CLI
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
+
       - name: Build XCFramework
         run: cargo xtask build-xcframework --release
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -399,6 +399,26 @@ jobs:
       - name: Install cargo-ndk
         run: which cargo-ndk || cargo install cargo-ndk
 
+      # boltffi CLI provides the `boltffi pack android` the build script
+      # (tools/scripts/build-android-bolt.sh) calls. The standalone
+      # build-android.yml / test-ci.yml jobs install it; release-prep must too,
+      # or `cargo xtask build-android` fails with `boltffi: command not found`.
+      # Cache the installed binary across runs.
+      - name: Cache boltffi CLI
+        id: cache-boltffi
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/boltffi
+          key: boltffi-cli-${{ runner.os }}-0.25.3
+
+      - name: Install boltffi CLI
+        # `which || install` is idempotent whether or not the cache populated
+        # the binary. Pinned to 0.25.3 to MATCH the runtime `boltffi` crate
+        # (Cargo.lock): a CLI/runtime skew mis-generates unit-ok `Result<(), E>`
+        # exports as a `void` foreign function that drops the error and leaks
+        # the result buffer. `--locked` installs against the CLI's bundled lock.
+        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
+
       - name: Build Android .so files
         run: cargo xtask build-android --release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0-alpha] - 2026-06-19
+
+Prerelease of `0.2.0` cut to validate the release pipeline and exercise the
+new BoltFFI binding surface across every distribution channel (crates.io,
+pub.dev, Maven Central, SPM) ahead of the stable tag. No functional changes
+from the `0.2.0` candidate — see the [0.2.0] entry below for the full change
+set.
+
+---
+
 ## [0.2.0] - 2026-06-17
 
 The vision release. xybrid gains an on-device multimodal stack — VLM inference,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — real-time vision primitives (`feat/realtime-vision`, code-complete, not yet merged or device-validated)
-
-The following SDK/runtime additions land on the `feat/realtime-vision` branch in
-support of Studio's live camera vision (the app-side live loop lives in the meta
-workstation). They are code-complete and reviewed but **not yet validated on a
-real device**, so they are recorded here as unreleased rather than under a cut
-version. The version bump + `/sync-api` + tag are a merge/release-time action via
-the existing `version-sync.sh` tooling — **not** done in this entry.
-
-- **Reachable streaming cancellation**: cancelling a streaming generation now
-  drives a real runtime abort end-to-end (FFI `FfiCancellationToken` +
-  options-aware streaming routing + sink-closed-as-cancel), so the generation
-  halts at the next token and releases the model lock. Previously the Dart-side
-  "stop" only unsubscribed and the runtime kept generating. `UserCancelled` is the
-  default abort outcome.
-- **Preemptive cancel-and-replace slot** on the model handle: a new run can
-  preempt the in-flight run (latest-frame-wins), so a live loop no longer
-  head-of-line-blocks behind a stale frame.
-- **Raw-frame `mtmd` path + `imageRaw` binding**: a packed-RGB
-  `mtmd_bitmap_init` shim routes `ImageSource::Raw` through `mtmd` without
-  per-frame JPEG re-encoding; the `imageRaw` envelope binding is exposed to Dart/FRB
-  and consumed by Studio behind a default-off flag. The encoded `image` path is
-  unchanged and remains the fallback.
-- **Live-mode telemetry tagging + per-session sampler**: live inferences are
-  tagged (`live_mode` + `frame_session_id`) and rate-limited by a per-session
-  sampler (≈1 row/sec/session, TTL-bounded), so live sessions don't emit a
-  telemetry row per frame.
-
-Multimodal KV-prefix reuse (the per-frame prefill cost lever) is **deferred** —
-not implemented this cycle.
-
-### Planned (0.1.x)
+### Planned
 
 - **OpenUPM registry**: Publish Unity SDK to [openupm.com](https://openupm.com) for scoped registry install
+- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.2.0] - 2026-06-17
+
+The vision release. xybrid gains an on-device multimodal stack — VLM inference,
+real-time camera vision primitives, and streaming TTS — and the FFI surface is
+re-platformed from UniFFI onto BoltFFI through a single shared facade. This is a
+**breaking release** for binding consumers: the Swift / Kotlin / Java / C# / RN
+bindings are now generated through `xybrid-bolt` + `xybrid-ffi-facade` rather
+than UniFFI, and the run/envelope call shapes changed accordingly.
+
+### Added
+
+- **On-device vision foundation** (#245): VLM inference, real-time camera vision
+  primitives, and streaming TTS land in the runtime. The vision pipeline is now
+  unconditional rather than feature-gated (#263).
+- **Vision envelopes through bolt** (#265): `Image` / `MultiPart` envelopes and
+  typed capability errors are threaded through the BoltFFI bindings; generation
+  config is now plumbed through `XybridModel.run` (#262).
+- **Reachable streaming cancellation**: cancelling a streaming generation drives a
+  real runtime abort end-to-end (`FfiCancellationToken` + options-aware streaming
+  routing + sink-closed-as-cancel), so generation halts at the next token and
+  releases the model lock. `UserCancelled` is the default abort outcome.
+- **Preemptive cancel-and-replace slot** on the model handle: a new run can preempt
+  the in-flight run (latest-frame-wins), so a live loop no longer head-of-line-blocks
+  behind a stale frame.
+- **Raw-frame `mtmd` path + `imageRaw` binding**: a packed-RGB `mtmd_bitmap_init`
+  shim routes `ImageSource::Raw` through `mtmd` without per-frame JPEG re-encoding;
+  the `imageRaw` envelope binding is exposed to Dart/FRB. The encoded `image` path
+  is unchanged and remains the fallback.
+- **Live-mode telemetry tagging + per-session sampler**: live inferences are tagged
+  (`live_mode` + `frame_session_id`) and rate-limited by a per-session sampler
+  (≈1 row/sec/session, TTL-bounded), so live sessions don't emit a telemetry row
+  per frame.
+- **Speculative cloud loader decision layer** (#250): `set_speculative_cloud` +
+  `ModelLoader::with_speculative_cloud` / `will_speculate` let the loader begin a
+  cloud execution while the local model is still downloading.
+- **React Native binding** (#93, #260): a React Native binding, now ported onto
+  BoltFFI alongside the other foreign-language bindings.
+- **Async/suspend conveniences restored** (#269) for Swift and Kotlin load + run.
+
+### Changed
+
+- **FFI bindings migrated from UniFFI to BoltFFI** (#205) via a shared
+  `xybrid-ffi-facade` — one canonical SDK→foreign-language translation feeding the
+  Swift / Kotlin / Java / C# / WASM bindings. **Breaking** for binding consumers.
+- **Executor decomposition**: LLM envelope and gen-config helpers deduped (#261),
+  LLM telemetry extracted into `execution::llm_telemetry` (#251), and TTS chunking
+  + audio crossfade extracted from the executor (#239).
+- **iOS LiveVision example** migrated to the bolt `run()` shape (#267).
+- **Docs**: docs site refreshed — restored deploys, surfaced hidden nav, added
+  missing pages (#254); local-first foundation vs additive platform layer
+  clarified (#248).
+- **Release/CI**: `llama-cpp-sys` renamed to `xybrid-llama-sys` (#247) and both
+  `xybrid-llama-sys` + `xybrid-llama` now publish to crates.io (#246); native
+  build cache is warmed on master pushes (#268).
+
+### Fixed
+
+- **Kotlin image format validation** restored and `EnvelopeTest` fixed for the bolt
+  envelope shape (#266).
+- **`tokens_out` emitted** on local LLM telemetry paths (#253).
+- **`.npz` voice files detected** by magic header rather than extension (#252).
+- **TTS text chunking is UTF-8-safe** (#249) — no longer splits multi-byte
+  codepoints mid-character.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -6759,14 +6759,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6803,7 +6803,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "tokio",
  "xybrid-core",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "bindgen",
  "cc",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -6759,14 +6759,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6803,7 +6803,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "tokio",
  "xybrid-core",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.0-alpha"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.2.0"
+let sdkVersion = "0.2.0-alpha"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.0-alpha"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "e775ec6b5fd8d17e3d99dc16b9ceecf5086d17beb71a63f642ab84588395a42a"
+let xybridFFIChecksum = "4c713818adc4b7cccc2c04748d2bd672ec676fea5356548bfcc32f62d2804234"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = true
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.1.2"
+let sdkVersion = "0.2.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ import PackageDescription
 //                            external SPM consumers resolve.
 //
 // =============================================================================
-let useLocalNatives = true
+let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "f06d7395ab811ecc06e4872a142d82888d2163ed3f1d3d035a9c9e0d1f3dad89"
+let xybridFFIChecksum = "e775ec6b5fd8d17e3d99dc16b9ceecf5086d17beb71a63f642ab84588395a42a"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "e9d8b652eb4be17add14502012b0ae9f306361b92ac130d6974e6d3770f655af"
+let xybridFFIChecksum = "f06d7395ab811ecc06e4872a142d82888d2163ed3f1d3d035a9c9e0d1f3dad89"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.0-alpha"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "4c713818adc4b7cccc2c04748d2bd672ec676fea5356548bfcc32f62d2804234"
+let xybridFFIChecksum = "ebf2fcf5bb7c3f424892bfa597498135b69c409ad9b98fac1e330d513f34ba66"
 
 let package = Package(
     name: "Xybrid",

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.0
+
+The vision release. The binding gains on-device multimodal input and the
+real-time camera vision primitives behind Studio's live loop.
+
+* On-device vision (VLM): new `XybridEnvelope.image` (encoded PNG/JPEG/WebP), `XybridEnvelope.imageRaw` (raw camera/canvas pixel frames), and `XybridEnvelope.multiPart` (user-role message with image attachments) for running vision-language models from Dart (xybrid-ai/xybrid#245, #265)
+* Reachable streaming cancellation: new `CancellationToken` whose `cancel()` drives a real runtime abort end-to-end — the generation halts at the next token and releases the model lock, instead of the old behavior where "stop" only unsubscribed while the runtime kept generating (xybrid-ai/xybrid#245)
+* Live-loop run options on the model handle: `preempt` (latest-frame-wins — a new run preempts the in-flight one so a live loop no longer head-of-line-blocks behind a stale frame) and `frameSessionId` for tagging live inferences (xybrid-ai/xybrid#245)
+* Raw-frame path avoids per-frame JPEG re-encoding: `imageRaw` packs RGB pixel buffers straight through to the multimodal runtime; the encoded `image` path remains the fallback (xybrid-ai/xybrid#245)
+* Streaming TTS support on top of the new audio generation path (xybrid-ai/xybrid#245)
+* Live-mode telemetry is rate-limited by a per-session sampler (≈1 row/sec/session), so live camera sessions no longer emit a telemetry row per frame (xybrid-ai/xybrid#245)
+* Fixed: TTS text chunking is now UTF-8-safe — multi-byte codepoints are no longer split mid-character (xybrid-ai/xybrid#249)
+* Fixed: `.npz` voice files are detected by magic header rather than file extension (xybrid-ai/xybrid#252)
+* Fixed: `tokens_out` is now emitted on local LLM telemetry paths (xybrid-ai/xybrid#253)
+
 ## 0.1.2
 
 * Audio inputs now detect MP3, OGG, and FLAC in addition to WAV, and mono audio is upmixed to stereo when a model expects two channels (xybrid-ai/xybrid#132, #141)

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0-alpha
+
+Prerelease of `0.2.0`, published to validate the release pipeline ahead of the
+stable tag. No functional changes from `0.2.0` — see the `0.2.0` entry below
+for the full change set.
+
 ## 0.2.0
 
 The vision release. The binding gains on-device multimodal input and the

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.2.0
+version: 0.2.0-alpha
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -17,11 +17,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # Pinned exactly: must equal the Rust `flutter_rust_bridge = "=2.11.1"`
-  # crate and the codegen version, or the generated bindings throw a
-  # codegen/runtime version-mismatch at startup. `^2.11.1` floats up to
-  # 2.12.x and breaks consumers.
-  flutter_rust_bridge: 2.11.1
+  # Effectively pinned to 2.11.1: must equal the Rust
+  # `flutter_rust_bridge = "=2.11.1"` crate and the codegen version, or the
+  # generated bindings throw a codegen/runtime version-mismatch at startup.
+  # `^2.11.1` floats up to 2.12.x and breaks consumers. The two-sided range
+  # below resolves to only 2.11.1 (same as a bare `2.11.1`) but, unlike an
+  # exact-version constraint, does not trip pub.dev's "allow more than one
+  # version" publish warning — which `pub publish --dry-run` now treats as a
+  # hard failure (exit 65).
+  flutter_rust_bridge: '>=2.11.1 <2.11.2'
   plugin_platform_interface: ^2.0.2
   freezed_annotation: ^2.0.0
   path_provider: ^2.1.5

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.1.2"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.2.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.2.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.2.0-alpha"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.2.0"
+version = "0.2.0-alpha"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.1.2"
+version = "0.2.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.2.0",
+  "version": "0.2.0-alpha",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/crates/xybrid-bolt/boltffi.toml
+++ b/crates/xybrid-bolt/boltffi.toml
@@ -49,6 +49,11 @@ bundle = "unstripped"
 enabled = true
 output = "dist/android"
 min_sdk = 24
+# 32-bit x86 (i686) is intentionally omitted. It is emulator-only (no real
+# devices ship it), was already a non-first-class target with no vendored ORT
+# slice, and the native vision (mtmd/ggml) backend added in 0.2.0 does not
+# compile for 32-bit x86. Ship arm64-v8a + armeabi-v7a + x86_64.
+architectures = ["arm64", "armv7", "x86_64"]
 
 [targets.android.kotlin]
 # Matches the existing `import ai.xybrid.…` lines in

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.1.2", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.1.2", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.2.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.2.0", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0-alpha", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.2.0-alpha", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0-alpha" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.1.2" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.2.0", path = "../../macros" }
+xybrid-macros = { version = "0.2.0-alpha", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.2.0-alpha", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.2.0-alpha", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.1.0-rc3", path = "../../macros" }
+xybrid-macros = { version = "0.2.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.1.0-rc3", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.1.0-rc3", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.2.0", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.2.0-alpha", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.1.0-rc3", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.2.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []

--- a/tools/scripts/build-android-bolt.sh
+++ b/tools/scripts/build-android-bolt.sh
@@ -104,10 +104,9 @@ export CXX_x86_64_linux_android="$BIN/x86_64-linux-android${ANDROID_API}-clang++
 export AR_x86_64_linux_android="$BIN/llvm-ar"
 export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$CC_x86_64_linux_android"
 
-export CC_i686_linux_android="$BIN/i686-linux-android${ANDROID_API}-clang"
-export CXX_i686_linux_android="$BIN/i686-linux-android${ANDROID_API}-clang++"
-export AR_i686_linux_android="$BIN/llvm-ar"
-export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$CC_i686_linux_android"
+# NOTE: 32-bit x86 (i686-linux-android) is intentionally not built — see the
+# `architectures` note in crates/xybrid-bolt/boltffi.toml. Emulator-only,
+# ORT-less, and the 0.2.0 native vision backend doesn't compile for it.
 
 echo "==> Packing Android bolt artifact"
 echo "    NDK:      $ANDROID_NDK_HOME"
@@ -128,7 +127,7 @@ boltffi pack android $PROFILE_FLAG \
     --cargo-arg=--features --cargo-arg=platform-android
 
 echo "==> Copying libxybrid-bolt.so into bindings/kotlin/libs/"
-for abi in arm64-v8a armeabi-v7a x86 x86_64; do
+for abi in arm64-v8a armeabi-v7a x86_64; do
     src="$BOLT_CRATE/dist/android/jniLibs/$abi/libxybrid-bolt.so"
     dst_dir="$KOTLIN_LIBS/$abi"
     if [ -f "$src" ]; then
@@ -150,7 +149,7 @@ echo "==> Patching DT_NEEDED to include libc++_shared.so"
 # Fix: add DT_NEEDED post-link via patchelf. Works regardless of which
 # linker boltffi invoked; treats the .so as an opaque ELF artifact.
 if command -v patchelf > /dev/null 2>&1; then
-    for abi in arm64-v8a armeabi-v7a x86 x86_64; do
+    for abi in arm64-v8a armeabi-v7a x86_64; do
         so="$KOTLIN_LIBS/$abi/libxybrid-bolt.so"
         if [ -f "$so" ]; then
             patchelf --add-needed libc++_shared.so "$so"
@@ -188,11 +187,10 @@ echo "==> Bundling libc++_shared.so from NDK for every ABI"
 # A `case` map (not an associative array) keeps this working on the stock
 # macOS /bin/bash 3.2 that local dev may pick up, where `declare -A` errors.
 NDK_SYSROOT_LIB="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$HOST/sysroot/usr/lib"
-for abi in arm64-v8a armeabi-v7a x86 x86_64; do
+for abi in arm64-v8a armeabi-v7a x86_64; do
     case "$abi" in
         arm64-v8a)   triple=aarch64-linux-android ;;
         armeabi-v7a) triple=arm-linux-androideabi ;;
-        x86)         triple=i686-linux-android ;;
         x86_64)      triple=x86_64-linux-android ;;
     esac
     src="$NDK_SYSROOT_LIB/$triple/libc++_shared.so"


### PR DESCRIPTION
Release **v0.2.0-alpha**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.2.0-alpha).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.2.0-alpha`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.