### PR TITLE
ci(natives): prebuilt llama.cpp slices on ghcr (Android arm64 pilot)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -150,6 +150,28 @@ jobs:
         # the CLI's own bundled Cargo.lock for reproducibility.
         run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
+      # Prebuilt-natives fast path (pilot: arm64 only). Best-effort: pull the
+      # prebuilt llama.cpp slice for aarch64-linux-android from ghcr and point
+      # build.rs at it so the arm64 ABI skips the ~25-min cmake compile. On ANY
+      # miss/error this is a silent no-op (continue-on-error) and every ABI
+      # compiles from source exactly as before — it can never break the build.
+      # build.rs keys on XYBRID_NATIVES_PREBUILT_DIR/<target>, so the other
+      # ABIs (no slice for them yet) fall through to source automatically.
+      - name: Setup oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      - name: Pull prebuilt natives (arm64, best-effort)
+        continue-on-error: true
+        env:
+          XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+        run: |
+          DEST="$RUNNER_TEMP/natives"
+          if tools/scripts/natives-pull.sh aarch64-linux-android base "$DEST"; then
+            echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
+            echo "prebuilt natives staged at $DEST (arm64 will skip cmake)"
+          else
+            echo "no prebuilt natives — all ABIs compile from source (unchanged)"
+          fi
+
       - name: Build Android .so files (all ABIs)
         run: cargo xtask build-android --release
 

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -1,0 +1,126 @@
+name: Build Natives (prebuilt llama.cpp)
+
+# Publisher for the prebuilt-natives cache: compiles the llama.cpp static
+# slice ONCE per (target, feature-set) and pushes it to ghcr, tagged by the
+# fingerprint that crates/llama-cpp-sys/build.rs + the consumer pre-step
+# compute. Every binding build (build-android, build-apple, ...) then DOWNLOADS
+# the slice instead of recompiling it (~25 min on Android). See
+# .context/natives-prebuilt-plan.md.
+#
+# PILOT SCOPE: aarch64-linux-android, baseline (non-vision) only. Other
+# targets/feature columns are added incrementally once this leg is proven.
+
+on:
+  # Primary trigger: anything that feeds the fingerprint changed, so the cache
+  # is now stale and must be (re)built. Keep in sync with the inputs hashed by
+  # tools/scripts/natives-fingerprint.sh.
+  push:
+    branches: [master]
+    paths:
+      - 'vendor/llama-cpp'
+      - '.gitmodules'
+      - 'crates/llama-cpp-sys/**'
+      - 'tools/scripts/natives-*.sh'
+      - '.github/workflows/build-natives.yml'
+  workflow_dispatch:
+
+# Do NOT cancel in-progress publishes: a half-finished push leaves the cache
+# cold (correct, just slow), and write-once means a re-run is idempotent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  CARGO_TERM_COLOR: always
+  XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+  # Match build-android.yml so the publisher's NDK revision (folded into the
+  # fingerprint) equals the consumer's.
+  NDK_VERSION: "27.0.12077973"
+
+jobs:
+  android-arm64:
+    name: Publish native (aarch64-linux-android, base)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          targets: aarch64-linux-android
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Configure sccache environment
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: "v1-rust"
+          shared-key: "natives-android-arm64"
+          cache-all-crates: "true"
+          save-if: "true"
+
+      - name: Cache Android NDK
+        id: cache-ndk
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
+          key: android-ndk-${{ env.NDK_VERSION }}
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install NDK
+        if: steps.cache-ndk.outputs.cache-hit != 'true'
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+
+      - name: Set NDK environment
+        run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
+
+      - name: Install cargo-ndk
+        run: which cargo-ndk || cargo install cargo-ndk
+
+      - name: Setup oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Log in to ghcr
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build the llama-cpp-sys static slice for arm64 ONLY (the -sys crate's
+      # `bindings` feature triggers the cmake compile in build.rs). The export
+      # env makes build.rs copy the produced lib/ + include/ to a known dir;
+      # natives-push.sh then tars + uploads it tagged by fingerprint. We build
+      # the -sys crate directly (not the full SDK) because the android cmake
+      # defines are a deterministic function of target+vision, so this slice is
+      # byte-equivalent to what the shipped build's arm64 ABI produces.
+      - name: Build + publish native slice (best-effort skip if already present)
+        env:
+          XYBRID_NATIVES_EXPORT_DIR: ${{ runner.temp }}/natives-export
+        run: |
+          set -euo pipefail
+          FP="$(tools/scripts/natives-fingerprint.sh aarch64-linux-android base)"
+          echo "fingerprint=$FP"
+          if oras manifest fetch --descriptor "$XYBRID_NATIVES_PKG:$FP" >/dev/null 2>&1; then
+            echo "already published — nothing to build"
+            exit 0
+          fi
+          cargo ndk --target aarch64-linux-android --platform 28 \
+            build --release -p xybrid-llama-sys --features bindings
+          tools/scripts/natives-push.sh aarch64-linux-android base "$XYBRID_NATIVES_EXPORT_DIR"

--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -668,14 +668,26 @@ fn emit_link_and_wrapper(
 /// must stay in sync with the `rustc-link-lib=static=` directives in
 /// [`emit_link_and_wrapper`]. Used to validate a prebuilt slice before
 /// trusting it.
-fn required_archives(target_os: &str, vision_enabled: bool) -> Vec<&'static str> {
-    let mut libs = vec!["libllama.a", "libggml.a", "libggml-base.a", "libggml-cpu.a"];
+fn required_archives(target_os: &str, vision_enabled: bool) -> Vec<String> {
+    // MSVC names static libs `<name>.lib` (no `lib` prefix); every other target
+    // we build for is Unix-style `lib<name>.a`.
+    let (prefix, suffix) = if target_os == "windows" {
+        ("", ".lib")
+    } else {
+        ("lib", ".a")
+    };
+    let mut libs = vec![
+        format!("{prefix}llama{suffix}"),
+        format!("{prefix}ggml{suffix}"),
+        format!("{prefix}ggml-base{suffix}"),
+        format!("{prefix}ggml-cpu{suffix}"),
+    ];
     if target_os == "macos" || target_os == "ios" {
         // Apple links ggml-metal unconditionally (see emit_link_and_wrapper).
-        libs.push("libggml-metal.a");
+        libs.push(format!("{prefix}ggml-metal{suffix}"));
     }
     if vision_enabled {
-        libs.push("libmtmd.a");
+        libs.push(format!("{prefix}mtmd{suffix}"));
     }
     libs
 }
@@ -709,7 +721,7 @@ fn resolve_prebuilt(ctx: &BuildContext, vision_enabled: bool) -> Option<PathBuf>
     let dir = base.join(&ctx.target);
 
     for archive in required_archives(&ctx.target_os, vision_enabled) {
-        if !archive_present(&dir, archive) {
+        if !archive_present(&dir, &archive) {
             println!(
                 "cargo:warning=llama.cpp: prebuilt slice for {} incomplete (missing {archive}); compiling from source",
                 ctx.target
@@ -743,6 +755,8 @@ fn export_prebuilt(ctx: &BuildContext, dst: &Path) {
         return;
     }
     let out = base.join(&ctx.target);
+    let mut exported_any = false;
+    let mut had_error = false;
     for sub in ["lib", "lib64", "include"] {
         let src = dst.join(sub);
         if src.is_dir() {
@@ -751,14 +765,19 @@ fn export_prebuilt(ctx: &BuildContext, dst: &Path) {
                     "cargo:warning=llama.cpp: failed to export {sub} for {}: {e}",
                     ctx.target
                 );
+                had_error = true;
+            } else {
+                exported_any = true;
             }
         }
     }
-    println!(
-        "cargo:warning=llama.cpp: exported prebuilt slice for {} to {}",
-        ctx.target,
-        out.display()
-    );
+    if exported_any && !had_error {
+        println!(
+            "cargo:warning=llama.cpp: exported prebuilt slice for {} to {}",
+            ctx.target,
+            out.display()
+        );
+    }
 }
 
 /// Recursively copy a directory tree (portable; no extra deps). Used only by

--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -487,6 +487,52 @@ fn compile_llama_cpp() {
     // resolve `<stdio.h>` through the NDK sysroot.
     generate_bindings(&llama_cpp_dir, &ctx.out_dir, ctx.android_ndk_path());
 
+    // rerun signals (apply to both the prebuilt fast path and the source
+    // build, so they live before the branch below).
+    println!("cargo:rerun-if-changed={}", llama_cpp_dir.display());
+    println!("cargo:rerun-if-changed={}", wrapper_path.display());
+    if vision_enabled {
+        println!(
+            "cargo:rerun-if-changed={}",
+            llama_cpp_dir.join("tools/mtmd/mtmd.h").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            llama_cpp_dir.join("tools/mtmd/mtmd-helper.h").display()
+        );
+    }
+    // The prebuilt fast path and the publisher export hook are selected by
+    // these env vars; declare them so toggling either re-runs the script.
+    println!("cargo:rerun-if-env-changed=XYBRID_NATIVES_PREBUILT_DIR");
+    println!("cargo:rerun-if-env-changed=XYBRID_NATIVES_EXPORT_DIR");
+
+    // Resolve the install prefix (`dst`) one of two ways:
+    //   - Fast path: a complete prebuilt slice staged for this target+feature
+    //     in `XYBRID_NATIVES_PREBUILT_DIR/<target>` — link it, skip the cmake
+    //     compile (the dominant cold-build cost on Android/Apple).
+    //   - Source path: today's cmake build, also the fallback when the fast
+    //     path misses for any reason (absent dir, incomplete slice).
+    let dst = match resolve_prebuilt(&ctx, vision_enabled) {
+        Some(prebuilt) => {
+            println!(
+                "cargo:warning=llama.cpp: using prebuilt natives for {} ({})",
+                ctx.target,
+                prebuilt.display()
+            );
+            prebuilt
+        }
+        None => build_from_source(&ctx, &llama_cpp_dir, vision_enabled),
+    };
+
+    emit_link_and_wrapper(&ctx, &llama_cpp_dir, &wrapper_path, &dst, vision_enabled);
+}
+
+/// Compile llama.cpp (+ the mtmd vision libs when enabled) from source via
+/// cmake and return the install prefix. This is the original build path; it is
+/// taken whenever the prebuilt fast path misses. When
+/// `XYBRID_NATIVES_EXPORT_DIR` is set, the produced archives + headers are also
+/// copied out so a publisher job can upload them as a reusable slice.
+fn build_from_source(ctx: &BuildContext, llama_cpp_dir: &Path, vision_enabled: bool) -> PathBuf {
     if !check_cmake_available() {
         fatal(
             "CMake not found!",
@@ -504,20 +550,7 @@ fn compile_llama_cpp() {
     let mut metal_enabled = false;
     let mut ndk_path_used: Option<String> = None;
 
-    println!("cargo:rerun-if-changed={}", llama_cpp_dir.display());
-    println!("cargo:rerun-if-changed={}", wrapper_path.display());
-    if vision_enabled {
-        println!(
-            "cargo:rerun-if-changed={}",
-            llama_cpp_dir.join("tools/mtmd/mtmd.h").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            llama_cpp_dir.join("tools/mtmd/mtmd-helper.h").display()
-        );
-    }
-
-    let mut cmake_config = cmake::Config::new(&llama_cpp_dir);
+    let mut cmake_config = cmake::Config::new(llama_cpp_dir);
     cmake_config
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("LLAMA_BUILD_EXAMPLES", "OFF")
@@ -531,7 +564,7 @@ fn compile_llama_cpp() {
         .define("GGML_OPENMP", "OFF");
 
     if ctx.target_os == "android" {
-        ndk_path_used = configure_android(&mut cmake_config, &ctx);
+        ndk_path_used = configure_android(&mut cmake_config, ctx);
     } else if ctx.target_os == "macos" || ctx.target_os == "ios" {
         cmake_config
             .define("GGML_METAL", "ON")
@@ -562,7 +595,20 @@ fn compile_llama_cpp() {
     );
 
     let dst = cmake_config.build();
+    export_prebuilt(ctx, &dst);
+    dst
+}
 
+/// Emit the link directives and compile the first-party `wrapper.cpp` shim
+/// against `dst`. Shared by both the prebuilt and source paths so the linked
+/// surface is identical regardless of how `dst` was produced.
+fn emit_link_and_wrapper(
+    ctx: &BuildContext,
+    llama_cpp_dir: &Path,
+    wrapper_path: &Path,
+    dst: &Path,
+    vision_enabled: bool,
+) {
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());
     println!("cargo:rustc-link-search=native={}", dst.display());
@@ -582,7 +628,7 @@ fn compile_llama_cpp() {
     wrapper_build
         .cpp(true)
         .std("c++17")
-        .file(&wrapper_path)
+        .file(wrapper_path)
         .include(llama_cpp_dir.join("include"))
         .include(llama_cpp_dir.join("ggml/include"));
     if vision_enabled {
@@ -616,6 +662,120 @@ fn compile_llama_cpp() {
     } else if ctx.target_os == "windows" {
         // Windows linking handled by CMake
     }
+}
+
+/// The static archives the link step requires for a target + feature set —
+/// must stay in sync with the `rustc-link-lib=static=` directives in
+/// [`emit_link_and_wrapper`]. Used to validate a prebuilt slice before
+/// trusting it.
+fn required_archives(target_os: &str, vision_enabled: bool) -> Vec<&'static str> {
+    let mut libs = vec!["libllama.a", "libggml.a", "libggml-base.a", "libggml-cpu.a"];
+    if target_os == "macos" || target_os == "ios" {
+        // Apple links ggml-metal unconditionally (see emit_link_and_wrapper).
+        libs.push("libggml-metal.a");
+    }
+    if vision_enabled {
+        libs.push("libmtmd.a");
+    }
+    libs
+}
+
+/// True if static archive `name` exists and is non-empty under any of the
+/// link-search roots [`emit_link_and_wrapper`] emits (`<dir>/lib`,
+/// `<dir>/lib64`, `<dir>`).
+fn archive_present(dir: &Path, name: &str) -> bool {
+    ["lib", "lib64", ""].iter().any(|sub| {
+        std::fs::metadata(dir.join(sub).join(name)).is_ok_and(|m| m.is_file() && m.len() > 0)
+    })
+}
+
+/// Fast path: if `XYBRID_NATIVES_PREBUILT_DIR` is set and holds a *complete*
+/// install prefix for this exact target under `<dir>/<target-triple>`, return
+/// it to be linked in place of a cmake build.
+///
+/// Returns `None` — falling through to a source build — on any miss: env unset,
+/// the per-target slice absent, a required archive missing/empty, or no
+/// `include/` dir. The fast path therefore never fails the build; a cold or
+/// partial cache degrades silently to compiling from source. Keying by the
+/// full target triple lets one base dir serve a multi-ABI build (the Android
+/// build compiles every ABI from one cargo invocation, each running this
+/// script for its own `TARGET`).
+fn resolve_prebuilt(ctx: &BuildContext, vision_enabled: bool) -> Option<PathBuf> {
+    let base = env::var_os("XYBRID_NATIVES_PREBUILT_DIR")?;
+    let base = PathBuf::from(base);
+    if base.as_os_str().is_empty() {
+        return None;
+    }
+    let dir = base.join(&ctx.target);
+
+    for archive in required_archives(&ctx.target_os, vision_enabled) {
+        if !archive_present(&dir, archive) {
+            println!(
+                "cargo:warning=llama.cpp: prebuilt slice for {} incomplete (missing {archive}); compiling from source",
+                ctx.target
+            );
+            return None;
+        }
+    }
+    // wrapper.cpp includes `dst/include` for cmake-generated headers.
+    if !dir.join("include").is_dir() {
+        println!(
+            "cargo:warning=llama.cpp: prebuilt slice for {} has no include/; compiling from source",
+            ctx.target
+        );
+        return None;
+    }
+    Some(dir)
+}
+
+/// Publisher hook: when `XYBRID_NATIVES_EXPORT_DIR` is set, copy the freshly
+/// built install prefix (`lib/`, `lib64/`, `include/`) into
+/// `<export>/<target-triple>/` so a CI job can tar + upload it as a reusable
+/// slice that [`resolve_prebuilt`] later consumes. No-op when the env var is
+/// unset (the normal build). Best-effort: a copy failure warns but does not
+/// fail the build, which already succeeded.
+fn export_prebuilt(ctx: &BuildContext, dst: &Path) {
+    let Some(base) = env::var_os("XYBRID_NATIVES_EXPORT_DIR") else {
+        return;
+    };
+    let base = PathBuf::from(base);
+    if base.as_os_str().is_empty() {
+        return;
+    }
+    let out = base.join(&ctx.target);
+    for sub in ["lib", "lib64", "include"] {
+        let src = dst.join(sub);
+        if src.is_dir() {
+            if let Err(e) = copy_dir(&src, &out.join(sub)) {
+                println!(
+                    "cargo:warning=llama.cpp: failed to export {sub} for {}: {e}",
+                    ctx.target
+                );
+            }
+        }
+    }
+    println!(
+        "cargo:warning=llama.cpp: exported prebuilt slice for {} to {}",
+        ctx.target,
+        out.display()
+    );
+}
+
+/// Recursively copy a directory tree (portable; no extra deps). Used only by
+/// the export hook in CI.
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }
 
 fn configure_android(cmake_config: &mut cmake::Config, ctx: &BuildContext) -> Option<String> {

--- a/tools/scripts/natives-fingerprint.sh
+++ b/tools/scripts/natives-fingerprint.sh
@@ -25,7 +25,18 @@ FEATURES="${2:-base}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SYS="$ROOT/crates/llama-cpp-sys"
 
-sha256() { sha256sum "$1" | cut -d' ' -f1; }
+# Portable SHA-256: Linux has `sha256sum`, macOS has `shasum`. Hashes a file
+# argument, or stdin when called with none.
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$@" | cut -d' ' -f1
+  else
+    echo "natives-fingerprint: no sha256sum/shasum found" >&2
+    exit 1
+  fi
+}
 
 # 1. llama.cpp source identity. CI does not init the submodule, so build.rs's
 #    clone-at-const is the source of record; key on that pinned commit.
@@ -58,4 +69,4 @@ esac
 #    so old caches invalidate cleanly.
 US=$'\x1f'
 PAYLOAD="v1${US}llama=${LLAMA_SHA}${US}wrapper_cpp=${WRAPPER_CPP}${US}wrapper_h=${WRAPPER_H}${US}build_rs=${BUILD_RS}${US}target=${TARGET}${US}features=${FEATURES}${US}profile=release${US}cmake=${CMAKE_VER}${US}cc=${CC_VER}${US}ndk=${NDK_REV}"
-printf '%s' "$PAYLOAD" | sha256sum | cut -d' ' -f1
+printf '%s' "$PAYLOAD" | sha256

--- a/tools/scripts/natives-fingerprint.sh
+++ b/tools/scripts/natives-fingerprint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# natives-fingerprint.sh
+#
+# Computes the content fingerprint that identifies one prebuilt llama.cpp
+# native slice (a per-target set of static archives + headers). The SAME
+# script is run by the publisher (to TAG the upload) and by the consumer
+# pre-step (to PULL by tag) so the two can never drift — a single source of
+# truth. See .context/natives-prebuilt-plan.md.
+#
+# The fingerprint MUST change whenever the compiled bytes would change, or a
+# consumer could link a stale/ABI-mismatched archive under a matching tag.
+# So it folds in, besides the source identity and our own files, the
+# toolchain versions that drive codegen (NDK revision on Android, cc/cmake
+# elsewhere). Pilot scope: Android + a generic host path; Apple SDK / Windows
+# CRT dimensions are deferred (see the plan doc).
+#
+# Usage: natives-fingerprint.sh <target-triple> <feature-set>
+#   <feature-set>: "base" (shipped llm-llamacpp) | "vision" (+ mtmd)
+# Prints the hex fingerprint to stdout.
+set -euo pipefail
+
+TARGET="${1:?usage: natives-fingerprint.sh <target-triple> <feature-set>}"
+FEATURES="${2:-base}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SYS="$ROOT/crates/llama-cpp-sys"
+
+sha256() { sha256sum "$1" | cut -d' ' -f1; }
+
+# 1. llama.cpp source identity. CI does not init the submodule, so build.rs's
+#    clone-at-const is the source of record; key on that pinned commit.
+LLAMA_SHA="$(grep -E 'const LLAMA_CPP_COMMIT' "$SYS/build.rs" | grep -oE '[0-9a-f]{40}')"
+
+# 2. First-party inputs that change the compiled objects / link surface.
+WRAPPER_CPP="$(sha256 "$SYS/wrapper.cpp")"
+WRAPPER_H="$(sha256 "$SYS/wrapper.h")"
+BUILD_RS="$(sha256 "$SYS/build.rs")"
+
+# 3. Toolchain identity — codegen depends on it, so a slice built by a
+#    different toolchain must NOT collide on the same fingerprint.
+CMAKE_VER="$(cmake --version 2>/dev/null | head -1 || true)"
+CC_VER=""
+NDK_REV=""
+case "$TARGET" in
+  *android*)
+    NDK="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}"
+    if [ -n "$NDK" ] && [ -f "$NDK/source.properties" ]; then
+      NDK_REV="$(grep -E '^Pkg.Revision' "$NDK/source.properties" | cut -d= -f2 | tr -d ' ')"
+    fi
+    ;;
+  *)
+    CC_VER="$({ "${CC:-cc}" --version 2>/dev/null || true; } | head -1)"
+    ;;
+esac
+
+# 4. Combine with a record separator (0x1f) so no two values can collide by
+#    concatenation. Bump the leading schema version when this formula changes
+#    so old caches invalidate cleanly.
+US=$'\x1f'
+PAYLOAD="v1${US}llama=${LLAMA_SHA}${US}wrapper_cpp=${WRAPPER_CPP}${US}wrapper_h=${WRAPPER_H}${US}build_rs=${BUILD_RS}${US}target=${TARGET}${US}features=${FEATURES}${US}profile=release${US}cmake=${CMAKE_VER}${US}cc=${CC_VER}${US}ndk=${NDK_REV}"
+printf '%s' "$PAYLOAD" | sha256sum | cut -d' ' -f1

--- a/tools/scripts/natives-pull.sh
+++ b/tools/scripts/natives-pull.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# natives-pull.sh
+#
+# Best-effort pull of one prebuilt llama.cpp native slice from ghcr into a
+# target-keyed dir, for the consumer fast path. Prints the BASE dir to stdout
+# on success (point XYBRID_NATIVES_PREBUILT_DIR at it). Exits non-zero on ANY
+# miss/error so the caller falls back to a source compile — this is never the
+# critical path; a miss is normal and must not fail the build.
+#
+# Layout produced:  <dest>/<target-triple>/{lib,include}   (build.rs reads
+# XYBRID_NATIVES_PREBUILT_DIR/<target>; see resolve_prebuilt in build.rs).
+#
+# Usage: natives-pull.sh <target-triple> <feature-set> <dest-base-dir>
+# Requires: oras on PATH (public package pulls anonymously).
+set -uo pipefail
+
+TARGET="${1:?usage: natives-pull.sh <target-triple> <feature-set> <dest-base-dir>}"
+FEATURES="${2:?}"
+DEST="${3:?}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PKG="${XYBRID_NATIVES_PKG:-ghcr.io/xybrid-ai/llama-natives}"
+
+command -v oras >/dev/null 2>&1 || { echo "natives-pull: oras not found" >&2; exit 1; }
+
+FP="$("$ROOT/tools/scripts/natives-fingerprint.sh" "$TARGET" "$FEATURES")" || exit 1
+
+SLICE="$DEST/$TARGET"
+mkdir -p "$SLICE"
+
+# Pull is best-effort: anonymous works for a public package; any failure
+# (absent tag, network, auth) drops us to the source build.
+if ! oras pull "$PKG:$FP" -o "$SLICE" >/dev/null 2>&1; then
+  echo "natives-pull: no prebuilt for $PKG:$FP" >&2
+  exit 1
+fi
+
+# The artifact is a single native.tar.gz of {lib,include}; unpack in place.
+if [ ! -f "$SLICE/native.tar.gz" ]; then
+  echo "natives-pull: pulled artifact missing native.tar.gz" >&2
+  exit 1
+fi
+tar -C "$SLICE" -xzf "$SLICE/native.tar.gz" && rm -f "$SLICE/native.tar.gz" || exit 1
+
+# build.rs re-validates completeness (required archives + include/) before
+# trusting the slice, so a partial unpack here just degrades to source.
+echo "$DEST"

--- a/tools/scripts/natives-pull.sh
+++ b/tools/scripts/natives-pull.sh
@@ -12,7 +12,7 @@
 #
 # Usage: natives-pull.sh <target-triple> <feature-set> <dest-base-dir>
 # Requires: oras on PATH (public package pulls anonymously).
-set -uo pipefail
+set -euo pipefail
 
 TARGET="${1:?usage: natives-pull.sh <target-triple> <feature-set> <dest-base-dir>}"
 FEATURES="${2:?}"

--- a/tools/scripts/natives-push.sh
+++ b/tools/scripts/natives-push.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# natives-push.sh
+#
+# Publish one freshly-built llama.cpp native slice to ghcr, tagged by its
+# fingerprint. Write-once: if the fingerprint tag already exists it is left
+# untouched (never overwrite a published slice — mutable tags are a
+# cache-poisoning vector). Run by the publisher workflow only.
+#
+# Expects the slice already exported by build.rs (XYBRID_NATIVES_EXPORT_DIR),
+# i.e. <export>/<target-triple>/{lib,include}.
+#
+# Usage: natives-push.sh <target-triple> <feature-set> <export-base-dir>
+# Requires: oras on PATH, logged in to ghcr with packages:write.
+set -euo pipefail
+
+TARGET="${1:?usage: natives-push.sh <target-triple> <feature-set> <export-base-dir>}"
+FEATURES="${2:?}"
+EXPORT="${3:?}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PKG="${XYBRID_NATIVES_PKG:-ghcr.io/xybrid-ai/llama-natives}"
+
+FP="$("$ROOT/tools/scripts/natives-fingerprint.sh" "$TARGET" "$FEATURES")"
+LLAMA_SHA="$(grep -E 'const LLAMA_CPP_COMMIT' "$ROOT/crates/llama-cpp-sys/build.rs" | grep -oE '[0-9a-f]{40}')"
+echo "natives-push: target=$TARGET features=$FEATURES fingerprint=$FP"
+
+# Write-once: skip if this fingerprint is already published.
+if oras manifest fetch --descriptor "$PKG:$FP" >/dev/null 2>&1; then
+  echo "natives-push: $PKG:$FP already published — skip"
+  exit 0
+fi
+
+SLICE="$EXPORT/$TARGET"
+[ -d "$SLICE/lib" ] || { echo "natives-push: no built slice at $SLICE/lib" >&2; exit 1; }
+[ -d "$SLICE/include" ] || { echo "natives-push: no headers at $SLICE/include" >&2; exit 1; }
+
+slice_dirs=(lib include)
+[ -d "$SLICE/lib64" ] && slice_dirs+=(lib64)
+tar -C "$SLICE" -czf "$SLICE/native.tar.gz" "${slice_dirs[@]}"
+
+oras push "$PKG:$FP" \
+  --artifact-type application/vnd.xybrid.natives.layer.v1+gzip \
+  --annotation "org.opencontainers.image.source=https://github.com/xybrid-ai/xybrid" \
+  --annotation "dev.xybrid.triple=$TARGET" \
+  --annotation "dev.xybrid.features=$FEATURES" \
+  --annotation "dev.xybrid.llama-sha=$LLAMA_SHA" \
+  "$SLICE/native.tar.gz:application/vnd.xybrid.natives.layer.v1.tar+gzip"
+
+echo "natives-push: pushed $PKG:$FP"


### PR DESCRIPTION
## Summary

Stop recompiling llama.cpp (the C++) from source on every build: compile each `(target × features)` static slice once, publish it to GitHub Packages (ghcr) keyed by a content fingerprint, and have builds download + link it instead — the same pattern already used for ONNX Runtime (`ort-download`). `build.rs` gains an env-gated prebuilt fast path (`resolve_prebuilt`, skips cmake) plus a publisher export hook, with the link/wrapper tail shared so prebuilt and source builds link identically and default builds stay byte-unchanged (both env vars unset). This pilot wires the publisher (`build-natives.yml`) and the consumer pre-step (`build-android.yml`) for `aarch64-linux-android` only; a cache miss falls through to a source compile, so it can never break a build. On a hit the arm64 ABI skips the ~25-min cmake step, cutting cold Android build time, while release builds still source-compile pending cosign + digest-pin hardening (this is a PR/CI accelerator only).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below) — CI / build-time performance

## Checklist

- [ ] Tests pass (`cargo test`) — full suite not run locally; change is additive and env-gated (default build path byte-unchanged). `cargo check` / `clippy -D warnings` / `fmt --check` green on the crate; `shellcheck` clean on the scripts.
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## Bootstrap (required before consumers hit the cache)

1. Merge this PR → the publisher auto-runs on the master push (its trigger paths) and publishes the first arm64 slice (package created **private**).
2. Make the package **public** + link it to the repo: `gh api -X PATCH /orgs/xybrid-ai/packages/container/llama-natives/visibility -f visibility=public`.
3. The next Android PR's pre-step pulls the slice — watch for `using prebuilt natives for aarch64-linux-android` and the arm64 cmake step being skipped.
