### PR TITLE
ci(natives): finish Android — publish + consume all 3 ABIs

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -150,13 +150,14 @@ jobs:
         # the CLI's own bundled Cargo.lock for reproducibility.
         run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
-      # Prebuilt-natives fast path (pilot: arm64 only). Best-effort: pull the
-      # prebuilt llama.cpp slice for aarch64-linux-android from ghcr and point
-      # build.rs at it so the arm64 ABI skips the ~25-min cmake compile. On ANY
-      # miss/error this is a silent no-op (continue-on-error) and every ABI
-      # compiles from source exactly as before — it can never break the build.
-      # build.rs keys on XYBRID_NATIVES_PREBUILT_DIR/<target>, so the other
-      # ABIs (no slice for them yet) fall through to source automatically.
+      # Prebuilt-natives fast path. Best-effort: pull the prebuilt llama.cpp
+      # slice for each shipped ABI from ghcr and point build.rs at it so that
+      # ABI skips the ~25-min cmake compile. On ANY miss/error this is a silent
+      # no-op (continue-on-error) and the affected ABI compiles from source
+      # exactly as before — it can never break the build. build.rs keys on
+      # XYBRID_NATIVES_PREBUILT_DIR/<target>, so each ABI in the single
+      # `cargo xtask build-android` invocation resolves its own slice (or falls
+      # through to source on a miss).
       - name: Setup oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
       # Best-effort ghcr login for SAME-REPO runs (not forks — they have no
@@ -172,17 +173,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull prebuilt natives (arm64, best-effort)
+      - name: Pull prebuilt natives (all shipped ABIs, best-effort)
         continue-on-error: true
         env:
           XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
         run: |
+          # One base dir holds a per-triple subdir for each ABI that has a
+          # published slice. The i686/x86 ABI is built but not packaged, so it
+          # is not pulled.
           DEST="$RUNNER_TEMP/natives"
-          if tools/scripts/natives-pull.sh aarch64-linux-android base "$DEST"; then
+          got_any=0
+          for triple in aarch64-linux-android armv7-linux-androideabi x86_64-linux-android; do
+            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+              echo "prebuilt natives staged for $triple (will skip cmake)"
+              got_any=1
+            else
+              echo "no prebuilt natives for $triple — compiles from source"
+            fi
+          done
+          if [ "$got_any" = 1 ]; then
             echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
-            echo "prebuilt natives staged at $DEST (arm64 will skip cmake)"
           else
-            echo "no prebuilt natives — all ABIs compile from source (unchanged)"
+            echo "no prebuilt natives for any ABI — all compile from source (unchanged)"
           fi
 
       - name: Build Android .so files (all ABIs)

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -7,8 +7,10 @@ name: Build Natives (prebuilt llama.cpp)
 # the slice instead of recompiling it (~25 min on Android). See
 # .context/natives-prebuilt-plan.md.
 #
-# PILOT SCOPE: aarch64-linux-android, baseline (non-vision) only. Other
-# targets/feature columns are added incrementally once this leg is proven.
+# SCOPE: the three shipped Android ABIs (aarch64/armv7/x86_64-linux-android),
+# baseline (non-vision). Apple/Linux/Windows rows land in later stages once the
+# fingerprint gains the Apple-SDK + Windows-CRT dimensions and natives-push.sh
+# learns MSVC `.lib` naming.
 
 on:
   # Primary trigger: anything that feeds the fingerprint changed, so the cache
@@ -38,13 +40,23 @@ env:
   CARGO_TERM_COLOR: always
   XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
   # Match build-android.yml so the publisher's NDK revision (folded into the
-  # fingerprint) equals the consumer's.
+  # fingerprint) equals the consumer's. PARITY-CRITICAL: a one-sided bump here
+  # or in build-android.yml silently invalidates every Android slice.
   NDK_VERSION: "27.0.12077973"
 
 jobs:
-  android-arm64:
-    name: Publish native (aarch64-linux-android, base)
+  publish-native:
+    name: Publish native (${{ matrix.target }}, base)
     runs-on: ubuntu-latest
+    strategy:
+      # One slice miss must not abort the others — write-once makes every row
+      # idempotent, so let them attempt independently.
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-linux-android
+          - armv7-linux-androideabi
+          - x86_64-linux-android
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -52,7 +64,7 @@ jobs:
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
-          targets: aarch64-linux-android
+          targets: ${{ matrix.target }}
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -69,7 +81,8 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: "v1-rust"
-          shared-key: "natives-android-arm64"
+          # Per-target shared-key: the rows must not stomp each other's cache.
+          shared-key: "natives-${{ matrix.target }}"
           cache-all-crates: "true"
           save-if: "true"
 
@@ -103,24 +116,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build the llama-cpp-sys static slice for arm64 ONLY (the -sys crate's
+      # Build the llama-cpp-sys static slice for this ABI (the -sys crate's
       # `bindings` feature triggers the cmake compile in build.rs). The export
       # env makes build.rs copy the produced lib/ + include/ to a known dir;
       # natives-push.sh then tars + uploads it tagged by fingerprint. We build
-      # the -sys crate directly (not the full SDK) because the android cmake
+      # the -sys crate directly (not the full SDK) because the Android cmake
       # defines are a deterministic function of target+vision, so this slice is
-      # byte-equivalent to what the shipped build's arm64 ABI produces.
+      # byte-equivalent to what the shipped bolt build's ABI produces.
       - name: Build + publish native slice (best-effort skip if already present)
         env:
           XYBRID_NATIVES_EXPORT_DIR: ${{ runner.temp }}/natives-export
         run: |
           set -euo pipefail
-          FP="$(tools/scripts/natives-fingerprint.sh aarch64-linux-android base)"
+          FP="$(tools/scripts/natives-fingerprint.sh ${{ matrix.target }} base)"
           echo "fingerprint=$FP"
           if oras manifest fetch --descriptor "$XYBRID_NATIVES_PKG:$FP" >/dev/null 2>&1; then
             echo "already published — nothing to build"
             exit 0
           fi
-          cargo ndk --target aarch64-linux-android --platform 28 \
+          cargo ndk --target ${{ matrix.target }} --platform 28 \
             build --release -p xybrid-llama-sys --features bindings
-          tools/scripts/natives-push.sh aarch64-linux-android base "$XYBRID_NATIVES_EXPORT_DIR"
+          tools/scripts/natives-push.sh ${{ matrix.target }} base "$XYBRID_NATIVES_EXPORT_DIR"


### PR DESCRIPTION
## Summary

Extends the prebuilt-natives cache from the arm64 pilot to the **full shipped Android ABI set** so a complete `build-android` run collapses, not just arm64: the publisher (`build-natives.yml`) becomes a 3-row `fail-fast: false` matrix (aarch64/armv7/x86_64-linux-android) with a per-target sccache key, and the `build-android` consumer pull step loops all three ABIs into one base dir (build.rs resolves each ABI's slice by target triple, missing → source compile). This stays on **fingerprint v1** (no script change), so the live arm64 slice stays warm while armv7/x86_64 publish fresh under the matched NDK r27. Every consumer pull remains `continue-on-error`, so a miss only costs a source compile — it can never break the build. This is Stage 1 of the propagation; Apple/Linux/Windows need the fingerprint v2 dimensions (Apple-SDK + Windows-CRT) and the MSVC `.lib` push-guard fix, which land in later PRs (Unity deferred — its NDK r26 pin would permanently miss the r27 cache).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below) — CI / build-time performance (cache expansion)

## Checklist

- [ ] Tests pass (`cargo test`) — no Rust changed; both workflows valid YAML, consumer loop shellcheck-clean.
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## After merge

The merge re-triggers `build-natives.yml`; expect 3 publisher jobs — arm64 short-circuits (already published, write-once), armv7 + x86_64 compile + publish fresh. Once all three slices exist, the next Android PR's pull step stages all three and `cargo xtask build-android` skips cmake for every ABI (not just arm64), collapsing the bulk of the ~25-min native compile.
