### PR TITLE
ci(natives): fingerprint Apple-SDK + Windows-CRT dims; MSVC .lib push guard

### DIFF
--- a/tools/scripts/natives-fingerprint.sh
+++ b/tools/scripts/natives-fingerprint.sh
@@ -52,6 +52,8 @@ BUILD_RS="$(sha256 "$SYS/build.rs")"
 CMAKE_VER="$(cmake --version 2>/dev/null | head -1 || true)"
 CC_VER=""
 NDK_REV=""
+SDK_VER=""   # Apple: xcrun SDK version + active clang banner (codegen ABI)
+CRT=""       # Windows: CRT flavor the -sys slice links (MD = dynamic)
 case "$TARGET" in
   *android*)
     NDK="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}"
@@ -59,17 +61,42 @@ case "$TARGET" in
       NDK_REV="$(grep -E '^Pkg.Revision' "$NDK/source.properties" | cut -d= -f2 | tr -d ' ')"
     fi
     ;;
+  *apple-ios-sim*)
+    # Mirror build.rs generate_bindings: iOS simulator -> iphonesimulator SDK.
+    # This arm MUST precede the bare *apple-ios* arm (build.rs checks
+    # contains("sim") first); reversing them tags a sim slice with the device SDK.
+    SDK_VER="$(xcrun --sdk iphonesimulator --show-sdk-version 2>/dev/null || true)/$(xcrun clang --version 2>/dev/null | head -1 || true)"
+    ;;
+  *apple-ios*)
+    SDK_VER="$(xcrun --sdk iphoneos --show-sdk-version 2>/dev/null || true)/$(xcrun clang --version 2>/dev/null | head -1 || true)"
+    ;;
+  *apple-darwin*)
+    SDK_VER="$(xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)/$(xcrun clang --version 2>/dev/null | head -1 || true)"
+    ;;
+  *windows-msvc*)
+    # The publisher builds xybrid-llama-sys WITHOUT crt-static, so cc-rs + CMake
+    # (forced Release on Windows) both emit /MD; the cdylib consumers (Flutter,
+    # Unity) are also /MD. Fold the CRT flavor as a literal — cl.exe has no
+    # portable --version, and MSVC toolset drift is ABI-tolerant within one CRT.
+    # A future /MT consumer would need its own crt=MT dimension + slice.
+    CRT="MD"
+    ;;
   *)
-    # Split CC so a wrapper/args form (e.g. "ccache clang") isn't treated as a
-    # single executable name.
+    # Generic host (linux gnu, etc). Split CC so a wrapper/args form
+    # (e.g. "ccache clang") isn't treated as a single executable name.
     read -r -a cc_cmd <<< "${CC:-cc}"
     CC_VER="$({ "${cc_cmd[0]}" --version 2>/dev/null || true; } | head -1)"
     ;;
 esac
 
 # 4. Combine with a record separator (0x1f) so no two values can collide by
-#    concatenation. Bump the leading schema version when this formula changes
-#    so old caches invalidate cleanly.
+#    concatenation. The android/linux payload is INTENTIONALLY byte-identical to
+#    the original formula so their already-published slices stay valid; apple
+#    and windows append a target-specific dimension (sdk/crt). Those targets
+#    have no published slices yet, so adding the dim costs no cache churn.
 US=$'\x1f'
-PAYLOAD="v1${US}llama=${LLAMA_SHA}${US}wrapper_cpp=${WRAPPER_CPP}${US}wrapper_h=${WRAPPER_H}${US}build_rs=${BUILD_RS}${US}target=${TARGET}${US}features=${FEATURES}${US}profile=release${US}cmake=${CMAKE_VER}${US}cc=${CC_VER}${US}ndk=${NDK_REV}"
+SUFFIX=""
+[ -n "$SDK_VER" ] && SUFFIX="${US}sdk=${SDK_VER}"
+[ -n "$CRT" ] && SUFFIX="${US}crt=${CRT}"
+PAYLOAD="v1${US}llama=${LLAMA_SHA}${US}wrapper_cpp=${WRAPPER_CPP}${US}wrapper_h=${WRAPPER_H}${US}build_rs=${BUILD_RS}${US}target=${TARGET}${US}features=${FEATURES}${US}profile=release${US}cmake=${CMAKE_VER}${US}cc=${CC_VER}${US}ndk=${NDK_REV}${SUFFIX}"
 printf '%s' "$PAYLOAD" | sha256

--- a/tools/scripts/natives-fingerprint.sh
+++ b/tools/scripts/natives-fingerprint.sh
@@ -61,17 +61,24 @@ case "$TARGET" in
       NDK_REV="$(grep -E '^Pkg.Revision' "$NDK/source.properties" | cut -d= -f2 | tr -d ' ')"
     fi
     ;;
-  *apple-ios-sim*)
-    # Mirror build.rs generate_bindings: iOS simulator -> iphonesimulator SDK.
-    # This arm MUST precede the bare *apple-ios* arm (build.rs checks
-    # contains("sim") first); reversing them tags a sim slice with the device SDK.
-    SDK_VER="$(xcrun --sdk iphonesimulator --show-sdk-version 2>/dev/null || true)/$(xcrun clang --version 2>/dev/null | head -1 || true)"
-    ;;
-  *apple-ios*)
-    SDK_VER="$(xcrun --sdk iphoneos --show-sdk-version 2>/dev/null || true)/$(xcrun clang --version 2>/dev/null | head -1 || true)"
-    ;;
-  *apple-darwin*)
-    SDK_VER="$(xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)/$(xcrun clang --version 2>/dev/null | head -1 || true)"
+  *apple-ios-sim*|*apple-ios*|*apple-darwin*)
+    # Mirror build.rs generate_bindings SDK selection: iOS sim -> iphonesimulator,
+    # iOS device -> iphoneos, macOS -> macosx. The -sim case MUST be checked
+    # before the bare ios case (build.rs checks contains("sim") first); reversing
+    # them tags a sim slice with the device SDK.
+    case "$TARGET" in
+      *apple-ios-sim*) sdk="iphonesimulator" ;;
+      *apple-ios*)     sdk="iphoneos" ;;
+      *)               sdk="macosx" ;;
+    esac
+    sdk_v="$(xcrun --sdk "$sdk" --show-sdk-version 2>/dev/null || true)"
+    clang_v="$(xcrun clang --version 2>/dev/null | head -1 || true)"
+    # Leave SDK_VER empty (no sdk= dim) when xcrun is unavailable, rather than a
+    # meaningless literal "/". On the real Apple parity path both publisher and
+    # consumer run macOS, so this is populated identically on both sides.
+    if [ -n "$sdk_v" ] || [ -n "$clang_v" ]; then
+      SDK_VER="${sdk_v}/${clang_v}"
+    fi
     ;;
   *windows-msvc*)
     # The publisher builds xybrid-llama-sys WITHOUT crt-static, so cc-rs + CMake

--- a/tools/scripts/natives-push.sh
+++ b/tools/scripts/natives-push.sh
@@ -40,12 +40,17 @@ SLICE="$EXPORT/$TARGET"
 # Never poison the write-once tag with an incomplete slice: verify the
 # archives build.rs's resolve_prebuilt requires are present and non-empty in
 # lib/ OR lib64/ before publishing. Mirror required_archives() in build.rs:
-# the base set, plus ggml-metal on Apple targets and mtmd under vision.
-archives=(libllama.a libggml.a libggml-base.a libggml-cpu.a)
+# MSVC names static libs `<name>.lib` (no prefix); every other target is
+# Unix-style `lib<name>.a`. Base set, plus ggml-metal on Apple and mtmd on vision.
 case "$TARGET" in
-  *apple*) archives+=(libggml-metal.a) ;;
+  *windows-msvc*) pfx=''; sfx='.lib' ;;
+  *) pfx='lib'; sfx='.a' ;;
 esac
-[ "$FEATURES" = "vision" ] && archives+=(libmtmd.a)
+archives=("${pfx}llama${sfx}" "${pfx}ggml${sfx}" "${pfx}ggml-base${sfx}" "${pfx}ggml-cpu${sfx}")
+case "$TARGET" in
+  *apple*) archives+=("${pfx}ggml-metal${sfx}") ;;
+esac
+[ "$FEATURES" = "vision" ] && archives+=("${pfx}mtmd${sfx}")
 for a in "${archives[@]}"; do
   [ -s "$SLICE/lib/$a" ] || [ -s "$SLICE/lib64/$a" ] || {
     echo "natives-push: required archive $a missing — refusing to publish incomplete slice" >&2


### PR DESCRIPTION
## Summary

Foundation for the Apple and Windows publisher rows (later stages) — pure script changes, **no publisher/consumer wiring**, additive and safe. `natives-fingerprint.sh` gains an Apple SDK-version + clang-banner dimension (per triple, `-sim` matched before device, mirroring build.rs's SDK selection) and a literal Windows `crt=MD` dimension, so an Apple/Windows slice can never silently collide across an Xcode/CRT change. These are added as a **conditional suffix** so the Android/Linux payload stays **byte-identical** — the just-published Android slices stay warm, and Apple/Windows have no slices yet so the new dims cost zero cache churn (verified: `aarch64-linux-android` base fingerprint is unchanged). `natives-push.sh`'s archive-presence guard now derives the lib prefix/suffix from the target (`<name>.lib` on MSVC vs `lib<name>.a` elsewhere, mirroring build.rs `required_archives`), fixing the blocker where a Windows slice would `exit 1` on the hard-coded `.a` names and publish nothing.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below) — CI / cache-correctness foundation

## Checklist

- [ ] Tests pass (`cargo test`) — no Rust changed; `shellcheck` clean; fingerprint verified stable, Android byte-preserved, sim≠device.
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## After merge

Re-triggers `build-natives.yml` (touches `natives-*.sh`); the 3 Android jobs recompute their fingerprints, find them **unchanged**, and short-circuit on the write-once check — no rebuild, no churn. This unblocks the Apple publisher + consumers (next stage, with a shared Xcode pin) and the Windows row.
