### PR TITLE
ci(natives): Apple stage — publish + consume iOS device + simulator slices

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -102,6 +102,47 @@ jobs:
         # installs against the CLI's own bundled Cargo.lock for reproducibility.
         run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
+      # Prebuilt-natives fast path (iOS device + arm64 simulator — the two
+      # slices boltffi's xcframework builds). Best-effort: pull the prebuilt
+      # llama.cpp slices and point build.rs at them so the xcframework build
+      # skips the llama.cpp cmake compile per slice. On ANY miss/error this is a
+      # silent no-op (continue-on-error) and the slice compiles from source — it
+      # can never break the build. build.rs keys on
+      # XYBRID_NATIVES_PREBUILT_DIR/<target>, so each slice in the single
+      # `boltffi pack apple` invocation resolves its own (or falls through).
+      - name: Setup oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      - name: Log in to ghcr (best-effort, same-repo)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull prebuilt natives (iOS device + sim, best-effort)
+        continue-on-error: true
+        env:
+          XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+        run: |
+          # Use the Rust TARGET spelling aarch64-apple-ios-sim (with -sim);
+          # build.rs keys the slice dir on it.
+          DEST="$RUNNER_TEMP/natives"
+          got_any=0
+          for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
+            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+              echo "prebuilt natives staged for $triple (will skip cmake)"
+              got_any=1
+            else
+              echo "no prebuilt natives for $triple — compiles from source"
+            fi
+          done
+          if [ "$got_any" = 1 ]; then
+            echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
+          else
+            echo "no prebuilt natives — compiles from source (unchanged)"
+          fi
+
       - name: Build XCFramework
         run: cargo xtask build-xcframework --release
 

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -7,10 +7,11 @@ name: Build Natives (prebuilt llama.cpp)
 # the slice instead of recompiling it (~25 min on Android). See
 # .context/natives-prebuilt-plan.md.
 #
-# SCOPE: the three shipped Android ABIs (aarch64/armv7/x86_64-linux-android),
-# baseline (non-vision). Apple/Linux/Windows rows land in later stages once the
-# fingerprint gains the Apple-SDK + Windows-CRT dimensions and natives-push.sh
-# learns MSVC `.lib` naming.
+# SCOPE: the three shipped Android ABIs + the two iOS slices the xcframework
+# ships (device + arm64 simulator), baseline (non-vision). macOS/Linux/Windows
+# rows land once a consumer pulls them. NOTE: apple/host slices fold the runner
+# image's toolchain (Xcode SDK, gcc) into their fingerprint, so the weekly cron
+# re-warms them across GitHub image rotations.
 
 on:
   # Primary trigger: anything that feeds the fingerprint changed, so the cache
@@ -24,6 +25,13 @@ on:
       - 'crates/llama-cpp-sys/**'
       - 'tools/scripts/natives-*.sh'
       - '.github/workflows/build-natives.yml'
+  # Weekly re-publish: GitHub rotates the macOS/Linux runner images, changing
+  # the host toolchain (Xcode SDK, gcc) folded into apple/host fingerprints.
+  # Re-running weekly re-warms those slices under the current image so the cache
+  # doesn't sit cold after a rotation. Write-once keeps it cheap — unchanged
+  # slices short-circuit on the oras exists-check.
+  schedule:
+    - cron: "17 6 * * 1"
   workflow_dispatch:
 
 # Do NOT cancel in-progress publishes: a half-finished push leaves the cache
@@ -47,16 +55,32 @@ env:
 jobs:
   publish-native:
     name: Publish native (${{ matrix.target }}, base)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       # One slice miss must not abort the others — write-once makes every row
       # idempotent, so let them attempt independently.
       fail-fast: false
       matrix:
-        target:
-          - aarch64-linux-android
-          - armv7-linux-androideabi
-          - x86_64-linux-android
+        include:
+          # --- Android (cross-compiled on Linux via cargo-ndk + NDK) ---
+          - target: aarch64-linux-android
+            runner: ubuntu-latest
+            needs-ndk: true
+          - target: armv7-linux-androideabi
+            runner: ubuntu-latest
+            needs-ndk: true
+          - target: x86_64-linux-android
+            runner: ubuntu-latest
+            needs-ndk: true
+          # --- Apple iOS (native build on macOS; device + arm64 simulator only.
+          #     boltffi's xcframework sets include_macos=false, so aarch64-apple-
+          #     darwin / x86_64 are not consumed and are not published here). ---
+          - target: aarch64-apple-ios
+            runner: macos-14
+            needs-ndk: false
+          - target: aarch64-apple-ios-sim
+            runner: macos-14
+            needs-ndk: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -86,7 +110,9 @@ jobs:
           cache-all-crates: "true"
           save-if: "true"
 
+      # --- Android toolchain (NDK + cargo-ndk), only on the android rows ---
       - name: Cache Android NDK
+        if: matrix.needs-ndk
         id: cache-ndk
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -94,16 +120,19 @@ jobs:
           key: android-ndk-${{ env.NDK_VERSION }}
 
       - name: Setup Android SDK
+        if: matrix.needs-ndk
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Install NDK
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
+        if: matrix.needs-ndk && steps.cache-ndk.outputs.cache-hit != 'true'
         run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
 
       - name: Set NDK environment
+        if: matrix.needs-ndk
         run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
 
       - name: Install cargo-ndk
+        if: matrix.needs-ndk
         run: which cargo-ndk || cargo install cargo-ndk
 
       - name: Setup oras
@@ -116,13 +145,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build the llama-cpp-sys static slice for this ABI (the -sys crate's
+      # Build the llama-cpp-sys static slice for this target (the -sys crate's
       # `bindings` feature triggers the cmake compile in build.rs). The export
       # env makes build.rs copy the produced lib/ + include/ to a known dir;
       # natives-push.sh then tars + uploads it tagged by fingerprint. We build
-      # the -sys crate directly (not the full SDK) because the Android cmake
-      # defines are a deterministic function of target+vision, so this slice is
-      # byte-equivalent to what the shipped bolt build's ABI produces.
+      # the -sys crate directly (not the full SDK) because the cmake defines are
+      # a deterministic function of target+vision, so this slice is
+      # byte-equivalent to what the shipped binding build produces.
       - name: Build + publish native slice (best-effort skip if already present)
         env:
           XYBRID_NATIVES_EXPORT_DIR: ${{ runner.temp }}/natives-export
@@ -134,6 +163,11 @@ jobs:
             echo "already published — nothing to build"
             exit 0
           fi
-          cargo ndk --target ${{ matrix.target }} --platform 28 \
-            build --release -p xybrid-llama-sys --features bindings
+          if [ "${{ matrix.needs-ndk }}" = "true" ]; then
+            cargo ndk --target ${{ matrix.target }} --platform 28 \
+              build --release -p xybrid-llama-sys --features bindings
+          else
+            cargo build --release -p xybrid-llama-sys --features bindings \
+              --target ${{ matrix.target }}
+          fi
           tools/scripts/natives-push.sh ${{ matrix.target }} base "$XYBRID_NATIVES_EXPORT_DIR"

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -101,6 +101,42 @@ jobs:
       - name: Install boltffi CLI
         run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
 
+      # Prebuilt-natives fast path (iOS device + arm64 simulator). stage-ios
+      # routes through the same `boltffi pack apple` as build-apple, so it
+      # consumes the identical two slices. Best-effort: a miss/error is a silent
+      # no-op (continue-on-error) and the slice compiles from source — it can
+      # never break the build.
+      - name: Setup oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      - name: Log in to ghcr (best-effort, same-repo)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull prebuilt natives (iOS device + sim, best-effort)
+        continue-on-error: true
+        env:
+          XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+        run: |
+          DEST="$RUNNER_TEMP/natives"
+          got_any=0
+          for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
+            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+              echo "prebuilt natives staged for $triple (will skip cmake)"
+              got_any=1
+            else
+              echo "no prebuilt natives for $triple — compiles from source"
+            fi
+          done
+          if [ "$got_any" = 1 ]; then
+            echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
+          else
+            echo "no prebuilt natives — compiles from source (unchanged)"
+          fi
+
       - name: Stage iOS artifacts
         run: cargo xtask stage-react-native --release
 


### PR DESCRIPTION
## Summary

Stage 3 of the prebuilt-natives propagation: extends the cache to **iOS**. The publisher gains the two iOS slices boltffi's xcframework ships — `aarch64-apple-ios` (device) and `aarch64-apple-ios-sim` (arm64 simulator); macOS/x86_64 are excluded because `include_macos = false`. The publisher matrix moves to `include`-form with a per-row `runner` + `needs-ndk`, so Android rows keep cargo-ndk + NDK on ubuntu while the iOS rows build on `macos-14` via plain `cargo build --target` (the `-sys` crate's cmake compile needs only the rust target + Xcode/cmake, not ORT). `build-apple.yml` and `build-react-native.yml` (stage-ios) get a best-effort pull of the two iOS slices into one base dir — build.rs resolves each by triple and falls through to a source compile on any miss, so it can never break a build. A **weekly cron** is added to the publisher to re-warm the Apple/host slices across GitHub runner-image rotations (their SDK version is folded into the fingerprint by #286).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below) — CI / build-time performance (cache expansion to iOS)

## Checklist

- [ ] Tests pass (`cargo test`) — no Rust changed; all three workflows valid YAML, Apple pull loop shellcheck-clean.
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## Notes / follow-ups

- **No hard Xcode pin yet.** Publisher iOS rows and both consumers all run `macos-14`, so within an image generation they share the same default Xcode → same SDK version → fingerprint parity. After a GitHub image rotation a consumer may miss until the next publish; the weekly cron bounds that cold window. Pinning Xcode identically across all four jobs (`maxim-lobanov/setup-xcode`) is the long-term warmth fix and a clean follow-up once a target version is chosen.
- macOS (`aarch64-apple-darwin`) is intentionally **not** published — no consumer pulls it yet (Flutter-macOS / Unity). It lands when those consumers are wired.

## After merge

The merge re-triggers `build-natives.yml`: Android jobs short-circuit (fingerprints unchanged), the two iOS jobs build on `macos-14` and publish fresh. Then the next iOS PR's `build-apple` / `build-react-native` run pulls both slices and the xcframework build skips the llama.cpp cmake compile for device + simulator.
