### PR TITLE
ci(natives): use oras login for ghcr on macOS (no docker on macos-14)

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -112,14 +112,14 @@ jobs:
       # `boltffi pack apple` invocation resolves its own (or falls through).
       - name: Setup oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      # `oras login`, not docker/login-action: macOS runners have no docker.
+      # Best-effort + same-repo only (forks have no token → anonymous pull).
       - name: Log in to ghcr (best-effort, same-repo)
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Pull prebuilt natives (iOS device + sim, best-effort)
         continue-on-error: true
         env:

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -138,12 +138,14 @@ jobs:
       - name: Setup oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
 
+      # Log in via `oras login`, not docker/login-action: the macOS runners have
+      # no docker binary (the action errors there). oras (set up above) needs no
+      # docker and works on every runner OS. Token passed via env (not the
+      # command line) and --password-stdin so it never lands in argv/logs.
       - name: Log in to ghcr
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       # Build the llama-cpp-sys static slice for this target (the -sys crate's
       # `bindings` feature triggers the cmake compile in build.rs). The export

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -108,14 +108,14 @@ jobs:
       # never break the build.
       - name: Setup oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      # `oras login`, not docker/login-action: macOS runners have no docker.
+      # Best-effort + same-repo only (forks have no token → anonymous pull).
       - name: Log in to ghcr (best-effort, same-repo)
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Pull prebuilt natives (iOS device + sim, best-effort)
         continue-on-error: true
         env:


### PR DESCRIPTION
## Summary

Hotfix for #288: the Apple publisher rows fail at the `Log in to ghcr` step with `Unable to locate executable file: docker` — `docker/login-action` needs the docker binary, which `macos-14` runners don't ship. This switches the publisher (`build-natives.yml`) and the two Apple consumers (`build-apple.yml`, `build-react-native.yml`) to `oras login` (already installed via setup-oras, cross-platform, no docker), passing the token via env + `--password-stdin` so it never lands in argv/logs. `build-android.yml` keeps `docker/login-action` — it only runs on ubuntu where docker is present and the cache is already validated.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist
- [ ] Tests pass (`cargo test`) — no Rust changed; three workflows valid YAML.
- [x] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] No breaking changes

## After merge
The merge re-triggers `build-natives.yml`; the two iOS jobs should now authenticate and **publish** (Android jobs short-circuit). Then a warm iOS run on `build-apple`/`build-react-native` becomes possible.