### PR TITLE
ci(natives): Linux stage — publish + consume the x86_64 linux slice

### DIFF
--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -153,6 +153,37 @@ jobs:
           fi
           echo "FRB bindings are up-to-date."
 
+      # Prebuilt-natives fast path (Linux x86_64). Best-effort: pull the prebuilt
+      # llama.cpp slice and point build.rs at it so the Linux Flutter build skips
+      # the llama.cpp cmake compile. On ANY miss/error this is a silent no-op
+      # (continue-on-error) and it compiles from source — it can never break the
+      # build. Only the linux leg pulls (the only published non-android slice a
+      # Flutter build consumes today; macOS/Windows legs build at release time).
+      - name: Setup oras
+        if: matrix.platform == 'linux'
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      # `oras login` (not docker/login-action) for cross-platform consistency.
+      # Best-effort + same-repo only (forks have no token → anonymous pull).
+      - name: Log in to ghcr (best-effort, same-repo)
+        if: matrix.platform == 'linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        continue-on-error: true
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Pull prebuilt natives (linux x86_64, best-effort)
+        if: matrix.platform == 'linux'
+        continue-on-error: true
+        env:
+          XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+        run: |
+          DEST="$RUNNER_TEMP/natives"
+          if tools/scripts/natives-pull.sh x86_64-unknown-linux-gnu base "$DEST"; then
+            echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
+            echo "prebuilt natives staged at $DEST (linux will skip cmake)"
+          else
+            echo "no prebuilt natives — compiles from source (unchanged)"
+          fi
+
       - name: Build Flutter native library
         run: cargo xtask build-flutter --platform ${{ matrix.platform }} --release --skip-frb-codegen
 

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -81,6 +81,10 @@ jobs:
           - target: aarch64-apple-ios-sim
             runner: macos-14
             needs-ndk: false
+          # --- Linux (host build; consumed by the Flutter linux leg) ---
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            needs-ndk: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Summary

Stage 4 of the prebuilt-natives propagation: **Linux**. Adds `x86_64-unknown-linux-gnu` to the publisher matrix (ubuntu, plain `cargo build --target`, no NDK) and a best-effort pull to `build-flutter`'s linux leg so the Linux Flutter build skips the llama.cpp cmake compile. The pull is gated on `matrix.platform == 'linux'` (the only published non-android slice a Flutter build consumes today; macOS/Windows legs build at release time) and uses `oras login` for cross-platform consistency. As with every consumer, it's `continue-on-error` → a miss just source-compiles and can never break the build.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below) — CI / build-time performance (cache expansion to Linux)

## Checklist
- [ ] Tests pass (`cargo test`) — no Rust changed; both workflows valid YAML, pull loop shellcheck-clean.
- [x] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] No breaking changes

## After merge
The publisher re-runs: Android + iOS short-circuit (fingerprints unchanged), the new Linux job builds + publishes `x86_64-unknown-linux-gnu`. Then the next Flutter PR's linux leg pulls it and skips the native cmake compile. Remaining: **Stage 5 (Windows)** — its MSVC `.lib` push-guard already landed in #286; Unity stays deferred (NDK r26 vs r27).
