### PR TITLE
feat(bindings): expose model warmup/unload on Flutter; fill async symmetry

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -216,6 +216,12 @@ public extension XybridModel {
     func warmupAsync() async throws {
         try await Task.detached { try self.warmup() }.value
     }
+
+    /// Unload the model, freeing its memory, without blocking the calling
+    /// thread or actor.
+    func unloadAsync() async throws {
+        try await Task.detached { try self.unload() }.value
+    }
 }
 
 /// Input data for model inference.

--- a/bindings/flutter/lib/src/model_loader.dart
+++ b/bindings/flutter/lib/src/model_loader.dart
@@ -592,4 +592,35 @@ class XybridModel {
       );
     }
   }
+
+  /// Warm up the model so the first real inference pays no cold-start cost.
+  ///
+  /// Runs a tiny inference on a background worker; the returned [Future] does
+  /// not block the UI isolate. Safe to call once after [XybridModelLoader.load]
+  /// completes.
+  ///
+  /// Throws [XybridException] if the warmup inference fails.
+  Future<void> warmup() async {
+    try {
+      await inner.warmup();
+    } catch (e) {
+      throw XybridException('Warmup failed: $e');
+    }
+  }
+
+  /// Unload the model, freeing its memory.
+  ///
+  /// This genuinely releases the underlying inference session: the executor is
+  /// reset and the ORT / GGUF session is dropped on the Rust side. The handle
+  /// stays valid but unloaded — call this when you are done with a model and
+  /// want its memory back without disposing the loader.
+  ///
+  /// Throws [XybridException] if unloading fails.
+  Future<void> unload() async {
+    try {
+      await inner.unload();
+    } catch (e) {
+      throw XybridException('Unload failed: $e');
+    }
+  }
 }

--- a/bindings/flutter/lib/src/rust/api/model.dart
+++ b/bindings/flutter/lib/src/rust/api/model.dart
@@ -161,6 +161,23 @@ abstract class FfiModel implements RustOpaqueInterface {
       {required FfiEnvelope envelope,
       required FfiConversationContext context,
       FfiGenerationConfig? config});
+
+  /// Unload the model, dropping the executor and freeing the underlying
+  /// ORT / GGUF inference session.
+  ///
+  /// This genuinely releases model memory: the SDK resets the executor and
+  /// the backend drops its session (ONNX session removed from cache,
+  /// llama.cpp model/context taken and dropped). The `FfiModel` handle stays
+  /// valid but unloaded; a subsequent call reloads on demand. Returns an
+  /// error string if unloading fails.
+  Future<void> unload();
+
+  /// Warm up the model by running a tiny inference so the first real call
+  /// pays no cold-start cost.
+  ///
+  /// Runs on FRB's worker pool, so the returned `Future` does not block the
+  /// Dart isolate. Returns an error string if the warmup inference fails.
+  Future<void> warmup();
 }
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FfiModelLoader>>

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class XybridRustLib extends BaseEntrypoint<XybridRustLibApi,
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -979387022;
+  int get rustContentHash => -738506137;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -226,6 +226,10 @@ abstract class XybridRustLibApi extends BaseApi {
       required FfiEnvelope envelope,
       required FfiConversationContext context,
       FfiGenerationConfig? config});
+
+  Future<void> crateApiModelFfiModelUnload({required FfiModel that});
+
+  Future<void> crateApiModelFfiModelWarmup({required FfiModel that});
 
   FfiPipeline crateApiPipelineFfiPipelineFromBundle({required String path});
 
@@ -1479,12 +1483,64 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       );
 
   @override
+  Future<void> crateApiModelFfiModelUnload({required FfiModel that}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiModel(
+            that, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 38, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiModelFfiModelUnloadConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiModelFfiModelUnloadConstMeta =>
+      const TaskConstMeta(
+        debugName: "FfiModel_unload",
+        argNames: ["that"],
+      );
+
+  @override
+  Future<void> crateApiModelFfiModelWarmup({required FfiModel that}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiModel(
+            that, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 39, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiModelFfiModelWarmupConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiModelFfiModelWarmupConstMeta =>
+      const TaskConstMeta(
+        debugName: "FfiModel_warmup",
+        argNames: ["that"],
+      );
+
+  @override
   FfiPipeline crateApiPipelineFfiPipelineFromBundle({required String path}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1509,7 +1565,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1534,7 +1590,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(yaml, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -1560,7 +1616,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiPipeline(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -1589,7 +1645,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiEnvelope(
             envelope, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 42, port: port_);
+            funcId: 44, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_result,
@@ -1614,7 +1670,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiPipeline(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_usize,
@@ -1640,7 +1696,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiPipeline(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -1663,7 +1719,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1687,7 +1743,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1710,7 +1766,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1734,7 +1790,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1757,7 +1813,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_resource_snapshot,
@@ -1781,7 +1837,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_8(percent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1806,7 +1862,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_ffi_thermal_state(state, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1833,7 +1889,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         sse_encode_String(apiKey, serializer);
         sse_encode_opt_String(ingestUrl, serializer);
         sse_encode_opt_String(resourceTelemetry, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1858,7 +1914,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1885,7 +1941,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(cacheDir, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1911,7 +1967,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(endpoint, serializer);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1936,7 +1992,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(modelId, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1959,7 +2015,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -1984,7 +2040,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -2008,7 +2064,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(apiKey, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2033,7 +2089,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(gatewayUrl, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2056,7 +2112,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -2079,7 +2135,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_ffi_generation_config,
@@ -4904,6 +4960,29 @@ class FfiModelImpl extends RustOpaque implements FfiModel {
           FfiGenerationConfig? config}) =>
       XybridRustLib.instance.api.crateApiModelFfiModelRunWithContext(
           that: this, envelope: envelope, context: context, config: config);
+
+  /// Unload the model, dropping the executor and freeing the underlying
+  /// ORT / GGUF inference session.
+  ///
+  /// This genuinely releases model memory: the SDK resets the executor and
+  /// the backend drops its session (ONNX session removed from cache,
+  /// llama.cpp model/context taken and dropped). The `FfiModel` handle stays
+  /// valid but unloaded; a subsequent call reloads on demand. Returns an
+  /// error string if unloading fails.
+  Future<void> unload() =>
+      XybridRustLib.instance.api.crateApiModelFfiModelUnload(
+        that: this,
+      );
+
+  /// Warm up the model by running a tiny inference so the first real call
+  /// pays no cold-start cost.
+  ///
+  /// Runs on FRB's worker pool, so the returned `Future` does not block the
+  /// Dart isolate. Returns an error string if the warmup inference fails.
+  Future<void> warmup() =>
+      XybridRustLib.instance.api.crateApiModelFfiModelWarmup(
+        that: this,
+      );
 }
 
 @sealed

--- a/bindings/flutter/rust/src/api/model.rs
+++ b/bindings/flutter/rust/src/api/model.rs
@@ -1015,6 +1015,27 @@ impl FfiModel {
             }
         });
     }
+
+    /// Warm up the model by running a tiny inference so the first real call
+    /// pays no cold-start cost.
+    ///
+    /// Runs on FRB's worker pool, so the returned `Future` does not block the
+    /// Dart isolate. Returns an error string if the warmup inference fails.
+    pub fn warmup(&self) -> Result<(), String> {
+        self.0.warmup().map_err(|e| e.to_string())
+    }
+
+    /// Unload the model, dropping the executor and freeing the underlying
+    /// ORT / GGUF inference session.
+    ///
+    /// This genuinely releases model memory: the SDK resets the executor and
+    /// the backend drops its session (ONNX session removed from cache,
+    /// llama.cpp model/context taken and dropped). The `FfiModel` handle stays
+    /// valid but unloaded; a subsequent call reloads on demand. Returns an
+    /// error string if unloading fails.
+    pub fn unload(&self) -> Result<(), String> {
+        self.0.unload().map_err(|e| e.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -979387022;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -738506137;
 
 // Section: executor
 
@@ -1753,6 +1753,104 @@ fn wire__crate__api__model__FfiModel_run_with_context_impl(
                         &*api_context_guard,
                         api_config,
                     )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__model__FfiModel_unload_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "FfiModel_unload",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FfiModel>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = crate::api::model::FfiModel::unload(&*api_that_guard)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__model__FfiModel_warmup_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "FfiModel_warmup",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FfiModel>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = crate::api::model::FfiModel::warmup(&*api_that_guard)?;
                     Ok(output_ok)
                 })())
             }
@@ -3529,7 +3627,9 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__pipeline__FfiPipeline_run_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__model__FfiModel_unload_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__model__FfiModel_warmup_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__pipeline__FfiPipeline_run_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3624,98 +3724,98 @@ fn pde_ffi_dispatcher_sync_impl(
         29 => {
             wire__crate__api__model__FfiModelLoader_from_registry_impl(ptr, rust_vec_len, data_len)
         }
-        38 => wire__crate__api__pipeline__FfiPipeline_from_bundle_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__pipeline__FfiPipeline_from_file_impl(ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__pipeline__FfiPipeline_from_yaml_impl(ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__pipeline__FfiPipeline_name_impl(ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__pipeline__FfiPipeline_stage_count_impl(ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__pipeline__FfiPipeline_stage_names_impl(ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__device__XybridDevice_apply_debug_memory_pressure_impl(
+        40 => wire__crate__api__pipeline__FfiPipeline_from_bundle_impl(ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__pipeline__FfiPipeline_from_file_impl(ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__pipeline__FfiPipeline_from_yaml_impl(ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__pipeline__FfiPipeline_name_impl(ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__pipeline__FfiPipeline_stage_count_impl(ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__pipeline__FfiPipeline_stage_names_impl(ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__device__XybridDevice_apply_debug_memory_pressure_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        46 => wire__crate__api__device__XybridDevice_clear_battery_level_impl(
+        48 => wire__crate__api__device__XybridDevice_clear_battery_level_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => wire__crate__api__device__XybridDevice_clear_debug_memory_pressure_impl(
+        49 => wire__crate__api__device__XybridDevice_clear_debug_memory_pressure_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        48 => wire__crate__api__device__XybridDevice_clear_thermal_state_impl(
+        50 => wire__crate__api__device__XybridDevice_clear_thermal_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => wire__crate__api__device__XybridDevice_current_snapshot_impl(
+        51 => wire__crate__api__device__XybridDevice_current_snapshot_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => wire__crate__api__device__XybridDevice_set_battery_level_impl(
+        52 => wire__crate__api__device__XybridDevice_set_battery_level_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__api__device__XybridDevice_set_thermal_state_impl(
+        53 => wire__crate__api__device__XybridDevice_set_thermal_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__sdk_client__XybridSdkClient_configure_platform_telemetry_impl(
+        54 => wire__crate__api__sdk_client__XybridSdkClient_configure_platform_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__sdk_client__XybridSdkClient_flush_platform_telemetry_impl(
+        55 => wire__crate__api__sdk_client__XybridSdkClient_flush_platform_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
+        56 => wire__crate__api__sdk_client__XybridSdkClient_init_sdk_cache_dir_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => wire__crate__api__sdk_client__XybridSdkClient_init_telemetry_impl(
+        57 => wire__crate__api__sdk_client__XybridSdkClient_init_telemetry_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
+        58 => wire__crate__api__sdk_client__XybridSdkClient_is_model_cached_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => wire__crate__api__sdk_client__XybridSdkClient_is_telemetry_initialized_impl(
+        59 => wire__crate__api__sdk_client__XybridSdkClient_is_telemetry_initialized_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__sdk_client__XybridSdkClient_runtime_features_impl(
+        60 => wire__crate__api__sdk_client__XybridSdkClient_runtime_features_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
+        61 => wire__crate__api__sdk_client__XybridSdkClient_set_api_key_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__api__sdk_client__XybridSdkClient_set_gateway_url_impl(
+        62 => wire__crate__api__sdk_client__XybridSdkClient_set_gateway_url_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__api__model__ffi_generation_config_creative_impl(
+        63 => wire__crate__api__model__ffi_generation_config_creative_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => {
+        64 => {
             wire__crate__api__model__ffi_generation_config_greedy_impl(ptr, rust_vec_len, data_len)
         }
         _ => unreachable!(),

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -204,6 +204,9 @@ suspend fun XybridModel.runAsync(
 /** Warm up the model off the caller's thread (on [Dispatchers.IO]). */
 suspend fun XybridModel.warmupAsync() = withContext(Dispatchers.IO) { this@warmupAsync.warmup() }
 
+/** Unload the model, freeing its memory, off the caller's thread (on [Dispatchers.IO]). */
+suspend fun XybridModel.unloadAsync() = withContext(Dispatchers.IO) { this@unloadAsync.unload() }
+
 /** The result of a model inference operation. */
 typealias Result = XybridResult
 

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -337,7 +337,12 @@ class XybridModel {
   });
 
   // Lifecycle
-  void unload();
+  //
+  // Both run on a background worker and return a Future — `unload()` is NOT a
+  // synchronous `void`. `unload()` genuinely frees model memory: the executor
+  // is reset and the underlying ORT / GGUF inference session is dropped.
+  Future<void> warmup();
+  Future<void> unload();
 
   // Hardware info
   ExecutionProviderInfo executionProviderInfo();
@@ -366,6 +371,13 @@ class XybridModel {
     context: ConversationContext,
     config: GenerationConfig? = null
   ): XybridResult
+
+  // Lifecycle — `unload()` frees model memory (resets the executor, drops the
+  // ORT / GGUF session). Sync on the model; `*Async` variants hop to Dispatchers.IO.
+  fun warmup()
+  fun unload()
+  suspend fun warmupAsync()
+  suspend fun unloadAsync()
 }
 ```
 
@@ -408,7 +420,8 @@ impl XybridModel {
 | `runStreamingWithContext()` | ✅ | — | — | ✅ |
 | `runStreamingWithContextOptions()` / `run_streaming_with_context_options()` | Rust ✅ | planned | planned | planned |
 | `benchmark()` | — | — | — | — |
-| `unload()` | — | — | — | — |
+| `warmup()` | ✅ | ✅ | ✅ | — |
+| `unload()` | ✅ | ✅ | ✅ | — |
 | `executionProviderInfo()` | — | — | — | — |
 
 ---

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -196,8 +196,12 @@ classes:
       benchmark:
         async: true
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
+      warmup:
+        notes: "Runs a tiny inference so the first real call pays no cold-start cost. Exposed on the model as a Future/throwing call (Dart Future<void>, Swift/Kotlin throwing/Unit + *Async variants). Not yet on the Unity C-ABI (pending Unity's migration off the pre-bolt C ABI)."
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       unload:
-        status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
+        notes: "Genuinely frees model memory: resets the SDK executor and drops the backend session (ONNX session removed from cache; llama.cpp model/context dropped). Dart binds it as Future<void> (NOT a sync void). Not yet on the Unity C-ABI (pending migration off the pre-bolt C ABI)."
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: planned }
       executionProviderInfo:
         return: ExecutionProviderInfo
         status: { dart: planned, kotlin: planned, swift: planned, csharp: planned }


### PR DESCRIPTION
## Summary

`unload()` genuinely frees model memory (resets the SDK executor; the backend drops its ORT/GGUF session), but it — and `warmup()` — were never bridged to Flutter, so Dart consumers couldn't release a loaded model. This exposes both on the high-level Dart `XybridModel` (regenerating the `flutter_rust_bridge` glue as `Future<void>`, not a silent sync `void`), and fills the matching `unloadAsync()` gap on the Swift and Kotlin wrappers (both already had `warmupAsync()` but no unload counterpart). It also corrects `docs/sdk/API_REFERENCE.md`, which had documented Dart `unload` as a sync `void` rather than the real `Future<void>`, and updates the `api-surface.yaml` contract (adds a `warmup` entry; marks `unload`/`warmup` implemented on dart/kotlin/swift, planned on csharp pending Unity's C-ABI migration). Unity/C# remains intentionally out of scope as its pre-bolt C ABI doesn't yet expose these.

## Type of Change

- [x] New feature
- [x] Documentation

## Checklist

- [x] Tests pass (`cargo check -p xybrid_flutter`, `cargo fmt --check`, `dart analyze`, `api-contract-check.sh` all green for the new methods)
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)