### PR TITLE
feat(vision): ship native VLM (mtmd) backend in all platform presets

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -182,7 +182,7 @@ jobs:
           DEST="$RUNNER_TEMP/natives"
           got_any=0
           for triple in aarch64-linux-android armv7-linux-androideabi x86_64-linux-android; do
-            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+            if tools/scripts/natives-pull.sh "$triple" vision "$DEST"; then
               echo "prebuilt natives staged for $triple (will skip cmake)"
               got_any=1
             else
@@ -253,14 +253,13 @@ jobs:
             done
           done
 
-      - name: Check Android vision build (compile-only, not shipped)
-        # Compile-only gate for the OPT-IN native llama.cpp vision backend
-        # (mtmd) — in NO platform preset and NOT packaged in the AAR above.
-        # Proves the `llm-llamacpp-vision` (mtmd) chain still cross-compiles
-        # for Android, the gate the UniFFI->bolt migration dropped (it pointed
-        # at the deleted `xybrid-uniffi`; retargeted here at `xybrid-sdk`:
-        # platform-android + llm-llamacpp-vision -> xybrid-core/llm-llamacpp-vision
-        # -> xybrid-llama-sys/vision; -sys crate at crates/llama-cpp-sys/).
+      - name: Check Android vision build (fast early-fail smoke)
+        # Fast `cargo check` smoke for the native llama.cpp vision backend
+        # (mtmd). As of 0.2.1 `platform-android` ships this backend, so the AAR
+        # above already packages it — this step is a redundant but cheap
+        # early-fail signal that surfaces an mtmd cross-compile break sooner.
+        # Chain: platform-android -> xybrid-core/llm-llamacpp-vision ->
+        # xybrid-llama-sys/vision (-sys crate at crates/llama-cpp-sys/).
         # One ABI (arm64-v8a) exercises the C++/mtmd cmake build, matching the
         # baseline. `check` is sufficient: crates/llama-cpp-sys/build.rs
         # compiles llama.cpp + mtmd via cmake on `check` (gated on

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -130,7 +130,7 @@ jobs:
           DEST="$RUNNER_TEMP/natives"
           got_any=0
           for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
-            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+            if tools/scripts/natives-pull.sh "$triple" vision "$DEST"; then
               echo "prebuilt natives staged for $triple (will skip cmake)"
               got_any=1
             else
@@ -199,16 +199,14 @@ jobs:
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO
 
-      - name: Check iOS vision build (compile-only, not shipped)
-        # Compile-only gate for the OPT-IN native llama.cpp vision backend
-        # (mtmd). This backend is in NO platform preset and is NOT shipped in
-        # the XCFramework above — this step only proves the
-        # `llm-llamacpp-vision` (mtmd) chain still cross-compiles for iOS, the
-        # gate the UniFFI->bolt migration dropped (it pointed at the deleted
-        # `xybrid-uniffi`; retargeted here at `xybrid-sdk`, which now carries
-        # both `platform-ios` and `llm-llamacpp-vision`: xybrid-sdk ->
-        # xybrid-core/llm-llamacpp-vision -> xybrid-llama-sys/vision; the -sys
-        # crate lives at crates/llama-cpp-sys/, package `xybrid-llama-sys`).
+      - name: Check iOS vision build (fast early-fail smoke)
+        # Fast `cargo check` smoke for the native llama.cpp vision backend
+        # (mtmd). As of 0.2.1 `platform-ios` ships this backend, so the
+        # XCFramework above already compiles it — this step is a redundant but
+        # cheap early-fail signal that surfaces an mtmd cross-compile break in
+        # ~1-2 min instead of waiting on the full xcframework cycle. The chain:
+        # xybrid-sdk -> xybrid-core/llm-llamacpp-vision -> xybrid-llama-sys/vision
+        # (the -sys crate lives at crates/llama-cpp-sys/, package `xybrid-llama-sys`).
         #
         # `check` (not `build`) is sufficient and matches the old gate: the
         # crates/llama-cpp-sys/build.rs runs on `check` and is what compiles

--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -177,7 +177,7 @@ jobs:
           XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
         run: |
           DEST="$RUNNER_TEMP/natives"
-          if tools/scripts/natives-pull.sh x86_64-unknown-linux-gnu base "$DEST"; then
+          if tools/scripts/natives-pull.sh x86_64-unknown-linux-gnu vision "$DEST"; then
             echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
             echo "prebuilt natives staged at $DEST (linux will skip cmake)"
           else

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -54,13 +54,27 @@ env:
 
 jobs:
   publish-native:
-    name: Publish native (${{ matrix.target }}, base)
+    name: Publish native (${{ matrix.target }}, ${{ matrix.feature }})
     runs-on: ${{ matrix.runner }}
     strategy:
       # One slice miss must not abort the others — write-once makes every row
       # idempotent, so let them attempt independently.
       fail-fast: false
       matrix:
+        # Two feature-sets per target: `base` (shipped llm-llamacpp) and
+        # `vision` (+ the mtmd/clip VLM backend). As of 0.2.1 every platform
+        # preset ships vision, so the consumer workflows pull the `vision`
+        # slice; `base` is kept published for custom non-vision builds. The
+        # feature × target cartesian is merged with the per-target runner /
+        # needs-ndk via the include list below.
+        feature: [base, vision]
+        target:
+          - aarch64-linux-android
+          - armv7-linux-androideabi
+          - x86_64-linux-android
+          - aarch64-apple-ios
+          - aarch64-apple-ios-sim
+          - x86_64-unknown-linux-gnu
         include:
           # --- Android (cross-compiled on Linux via cargo-ndk + NDK) ---
           - target: aarch64-linux-android
@@ -163,17 +177,24 @@ jobs:
           XYBRID_NATIVES_EXPORT_DIR: ${{ runner.temp }}/natives-export
         run: |
           set -euo pipefail
-          FP="$(tools/scripts/natives-fingerprint.sh ${{ matrix.target }} base)"
+          FP="$(tools/scripts/natives-fingerprint.sh ${{ matrix.target }} ${{ matrix.feature }})"
           echo "fingerprint=$FP"
           if oras manifest fetch --descriptor "$XYBRID_NATIVES_PKG:$FP" >/dev/null 2>&1; then
             echo "already published — nothing to build"
             exit 0
           fi
+          # `vision` adds the -sys crate's `vision` feature (mtmd/clip); `base`
+          # is plain `bindings`. Both transitively trigger the cmake compile.
+          if [ "${{ matrix.feature }}" = "vision" ]; then
+            FEATURES="bindings,vision"
+          else
+            FEATURES="bindings"
+          fi
           if [ "${{ matrix.needs-ndk }}" = "true" ]; then
             cargo ndk --target ${{ matrix.target }} --platform 28 \
-              build --release -p xybrid-llama-sys --features bindings
+              build --release -p xybrid-llama-sys --features "$FEATURES"
           else
-            cargo build --release -p xybrid-llama-sys --features bindings \
+            cargo build --release -p xybrid-llama-sys --features "$FEATURES" \
               --target ${{ matrix.target }}
           fi
-          tools/scripts/natives-push.sh ${{ matrix.target }} base "$XYBRID_NATIVES_EXPORT_DIR"
+          tools/scripts/natives-push.sh ${{ matrix.target }} ${{ matrix.feature }} "$XYBRID_NATIVES_EXPORT_DIR"

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -251,10 +251,17 @@ jobs:
       # Keep LLVM (large-packages: false): the bolt build runs bindgen for
       # the llama/ggml C++ via libclang. Removing system LLVM breaks it with
       # "'stdbool.h' file not found".
+      #
+      # tool-cache: true reclaims /opt/hostedtoolcache (~10 GB). This step runs
+      # first, before Set up JDK / Use Node.js, so those re-provision their
+      # toolchains afterward — the build never reads the preinstalled cache.
+      # The extra headroom is needed because the from-source path compiles
+      # llama.cpp + the bolt .so for every ABI and then assembles the APK,
+      # which exhausted the runner ("No space left on device") at assembleDebug.
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: false
           dotnet: true
           haskell: true

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -124,7 +124,7 @@ jobs:
           DEST="$RUNNER_TEMP/natives"
           got_any=0
           for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
-            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+            if tools/scripts/natives-pull.sh "$triple" vision "$DEST"; then
               echo "prebuilt natives staged for $triple (will skip cmake)"
               got_any=1
             else
@@ -340,7 +340,7 @@ jobs:
           DEST="$RUNNER_TEMP/natives"
           got_any=0
           for triple in aarch64-linux-android armv7-linux-androideabi x86_64-linux-android; do
-            if tools/scripts/natives-pull.sh "$triple" base "$DEST"; then
+            if tools/scripts/natives-pull.sh "$triple" vision "$DEST"; then
               echo "prebuilt natives staged for $triple (will skip cmake)"
               got_any=1
             else

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -447,3 +447,20 @@ extension XybridError: LocalizedError {
         }
     }
 }
+
+// MARK: - FfiError Extensions
+
+// `FfiError` (in the generated `xybrid_bolt.swift`) is thrown by the low-level
+// FFI paths that don't carry a typed `XybridError` wire payload — the model-load
+// inits (`fromRegistry`/`fromDirectory`/`fromBundle`/`fromHuggingface`, via
+// `boltffi_last_error_message`) and the `checkStatus` ABI guard. It already holds
+// the real Rust error string in `.message`, but as a bare `Error` struct its
+// `localizedDescription` collapses to the opaque "The operation couldn't be
+// completed. (Xybrid.FfiError error 1.)". Conforming to `LocalizedError` here
+// (regen-safe — this hand-written file is never overwritten by `boltffi
+// generate`) surfaces the actual message to callers' error UI.
+extension FfiError: LocalizedError {
+    public var errorDescription: String? {
+        message.isEmpty ? "Unknown FFI error" : message
+    }
+}

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -46,15 +46,15 @@ xybrid-sdk = { path = "../../../crates/xybrid-sdk", default-features = false, fe
 ort = { version = "2.0.0-rc.11", default-features = false, features = ["ndarray", "std", "coreml"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# SDK preset handles: ort-download, ort-coreml, candle-metal, llm-llamacpp
+# SDK preset handles: ort-download, ort-coreml, candle-metal, llm-llamacpp-vision
 xybrid-sdk = { path = "../../../crates/xybrid-sdk", features = ["platform-macos"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-# SDK preset handles: ort-download, llm-llamacpp
+# SDK preset handles: ort-download, llm-llamacpp-vision
 xybrid-sdk = { path = "../../../crates/xybrid-sdk", features = ["platform-desktop"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-# SDK preset handles: ort-download, llm-llamacpp
+# SDK preset handles: ort-download, llm-llamacpp-vision
 xybrid-sdk = { path = "../../../crates/xybrid-sdk", features = ["platform-desktop"] }
 
 [features]

--- a/crates/xybrid-bolt/Cargo.toml
+++ b/crates/xybrid-bolt/Cargo.toml
@@ -34,12 +34,11 @@ platform-ios = ["xybrid-sdk/platform-ios"]
 platform-macos = ["xybrid-sdk/platform-macos"]
 platform-desktop = ["xybrid-sdk/platform-desktop"]
 
-# MEASUREMENT-ONLY. Forwards xybrid-sdk's vision backend so the native
-# mtmd/vision size delta can be built through this crate (which, unlike
-# xybrid-sdk, emits a real shippable staticlib/cdylib to size). Used by
-# tools/scripts/measure-binary-size.sh. Deliberately NOT added to any
-# platform-* preset, so NO shipped mobile artifact links the mtmd backend —
-# it is reachable only via an explicit `--features platform-macos,llm-llamacpp-vision`
-# build. Do not add this to a preset (see the binary-size measurement note).
+# Explicit forwarder for the native VLM (mtmd/clip) backend. As of 0.2.1 the
+# platform-* presets above already pull this in transitively (via
+# `xybrid-sdk/platform-*`), so every shipped mobile artifact links mtmd; the
+# measured cost is ~0.7 MiB stripped on the Android cdylib proxy. This standalone
+# feature is kept for tools/scripts/measure-binary-size.sh, which builds the
+# base-vs-vision delta through this crate's real staticlib/cdylib.
 # `xybrid-sdk/llm-llamacpp-vision` already pulls `llm-llamacpp` transitively.
 llm-llamacpp-vision = ["xybrid-sdk/llm-llamacpp-vision"]

--- a/crates/xybrid-bolt/Cargo.toml
+++ b/crates/xybrid-bolt/Cargo.toml
@@ -34,11 +34,13 @@ platform-ios = ["xybrid-sdk/platform-ios"]
 platform-macos = ["xybrid-sdk/platform-macos"]
 platform-desktop = ["xybrid-sdk/platform-desktop"]
 
-# Explicit forwarder for the native VLM (mtmd/clip) backend. As of 0.2.1 the
-# platform-* presets above already pull this in transitively (via
+# Explicit llama.cpp forwarders. As of 0.2.1 the platform-* presets above
+# already pull the VLM (mtmd/clip) backend in transitively (via
 # `xybrid-sdk/platform-*`), so every shipped mobile artifact links mtmd; the
-# measured cost is ~0.7 MiB stripped on the Android cdylib proxy. This standalone
-# feature is kept for tools/scripts/measure-binary-size.sh, which builds the
-# base-vs-vision delta through this crate's real staticlib/cdylib.
-# `xybrid-sdk/llm-llamacpp-vision` already pulls `llm-llamacpp` transitively.
+# measured cost is ~0.7 MiB stripped on the Android cdylib proxy. These
+# standalone features exist so tools/scripts/measure-binary-size.sh can build
+# the base-vs-vision delta through this crate's real staticlib/cdylib:
+# `llm-llamacpp` is the no-mtmd baseline, `llm-llamacpp-vision` adds mtmd
+# (and pulls `llm-llamacpp` transitively via xybrid-sdk).
+llm-llamacpp = ["xybrid-sdk/llm-llamacpp"]
 llm-llamacpp-vision = ["xybrid-sdk/llm-llamacpp-vision"]

--- a/crates/xybrid-cli/Cargo.toml
+++ b/crates/xybrid-cli/Cargo.toml
@@ -39,10 +39,12 @@ llm-llamacpp-vision = ["llm-llamacpp", "xybrid-sdk/llm-llamacpp-vision"]
 
 # PLATFORM PRESETS (composed from individual features above)
 # This ensures #[cfg(feature = "...")] checks work correctly in this crate.
-platform-android = ["ort-dynamic", "llm-llamacpp", "candle", "huggingface"]
-platform-ios = ["ort-download", "ort-coreml", "candle-metal", "candle-hub", "llm-llamacpp", "huggingface"]
-platform-macos = ["ort-download", "ort-coreml", "candle-metal", "candle-hub", "llm-llamacpp", "huggingface"]
-platform-desktop = ["ort-download", "llm-llamacpp", "huggingface"]
+# These mirror xybrid-sdk's presets and ship the native VLM (mtmd) backend via
+# `llm-llamacpp-vision` so the CLI can run vision-language models out of the box.
+platform-android = ["ort-dynamic", "llm-llamacpp-vision", "candle", "huggingface"]
+platform-ios = ["ort-download", "ort-coreml", "candle-metal", "candle-hub", "llm-llamacpp-vision", "huggingface"]
+platform-macos = ["ort-download", "ort-coreml", "candle-metal", "candle-hub", "llm-llamacpp-vision", "huggingface"]
+platform-desktop = ["ort-download", "llm-llamacpp-vision", "huggingface"]
 
 
 [dependencies]

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -58,18 +58,24 @@ huggingface = ["dep:hf-hub"]
 onnx-inspect = ["dep:ort", "ort/download-binaries", "ort/tls-native"]
 
 # PLATFORM PRESETS (SINGLE SOURCE OF TRUTH)
+#
+# The platform presets ship the native VLM (mtmd/clip) backend via
+# `llm-llamacpp-vision` (which transitively enables `llm-llamacpp`). The
+# measured size cost is ~0.7 MiB stripped on the Android `.so` proxy and
+# ~1.5 MiB on the iOS static-lib proxy — noise against the ~30/160 MiB
+# baselines — so vision runs out of the box rather than being a BYO-build.
 
 # Android: Dynamic ORT loading + Candle + llama.cpp (mistral.rs has SIGILL issues on ARM)
-platform-android = ["xybrid-core/ort-dynamic", "xybrid-core/candle", "llm-llamacpp"]
+platform-android = ["xybrid-core/ort-dynamic", "xybrid-core/candle", "llm-llamacpp-vision"]
 
 # iOS: CoreML + Metal acceleration + llama.cpp
-platform-ios = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp"]
+platform-ios = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp-vision"]
 
 # macOS: CoreML + Metal + llama.cpp
-platform-macos = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp"]
+platform-macos = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp-vision"]
 
 # Desktop (Linux/Windows): CPU with llama.cpp
-platform-desktop = ["xybrid-core/ort-download", "llm-llamacpp"]
+platform-desktop = ["xybrid-core/ort-download", "llm-llamacpp-vision"]
 
 # INDIVIDUAL FEATURE FORWARDING (for custom builds)
 

--- a/tools/scripts/measure-binary-size.sh
+++ b/tools/scripts/measure-binary-size.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 # measure-binary-size.sh — size the native mtmd/vision delta on the host.
 #
-# The native vision backend (`llm-llamacpp-vision`, llama.cpp's mtmd/clip) is
-# OPT-IN and ships in NO mobile artifact. This script answers "how many bytes
-# would it add?" by building the xybrid-bolt staticlib + cdylib for the host
+# The native vision backend (`llm-llamacpp-vision`, llama.cpp's mtmd/clip) ships
+# in every `platform-*` preset as of 0.2.1. This script answers "how many bytes
+# does it add?" by building the xybrid-bolt staticlib + cdylib for the host
 # platform twice and diffing them:
 #
-#   baseline : --features <PRESET>                     (platform preset; no vision)
-#   vision   : --features <PRESET>,llm-llamacpp-vision (adds the native mtmd backend)
+#   baseline : --features llm-llamacpp         (llama.cpp, no mtmd)
+#   vision   : --features llm-llamacpp-vision  (adds the native mtmd backend)
+#
+# The accelerators (ORT / Candle) the presets add are constant on both sides, so
+# they cancel out of the delta — the figure below is the pure mtmd cost.
 #
 # This is a LOCAL PROXY for the per-platform shipped-artifact delta (iOS .a /
-# Android .so), not a substitute: the host is aarch64-apple-darwin with
-# platform-macos (CoreML/Metal ORT + Candle-metal), so the mtmd/llama.cpp delta
-# is directionally representative but absolute byte counts differ per target.
+# Android .so), not a substitute: it builds for the host triple, so the
+# mtmd/llama.cpp delta is directionally representative but absolute byte counts
+# differ per target.
 # The staticlib (.a) is the closest proxy for the shipped iOS .a; the cdylib
 # (.dylib) for the Android .so. Prefer the STRIPPED delta as the meaningful
 # figure. For the true shipped numbers, read the per-ABI / per-slice sizes the
@@ -22,15 +25,13 @@
 # this is invoked explicitly — it is NOT wired into CI.
 #
 # Usage:
-#   tools/scripts/measure-binary-size.sh                    # platform-macos (default on this host)
-#   PRESET=platform-desktop tools/scripts/measure-binary-size.sh   # CPU-only preset (no Metal/CoreML)
+#   tools/scripts/measure-binary-size.sh    # builds for the host platform
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PRESET="${PRESET:-platform-macos}"
 PKG="xybrid-bolt"
 LIB="libxybrid_bolt"   # crate lib name (xybrid-bolt -> underscored)
-# cdylib extension is .dylib on macOS, .so on Linux (e.g. PRESET=platform-desktop).
+# cdylib extension is .dylib on macOS, .so on Linux.
 SO_EXT="so"; [ "$(uname)" = "Darwin" ] && SO_EXT="dylib"
 
 # Separate target dirs: the two builds differ only by the mtmd cmake target;
@@ -43,8 +44,12 @@ build () {  # $1=target-dir  $2=feature-list
   CARGO_TARGET_DIR="$1" cargo build --release -p "$PKG" --features "$2"
 }
 
-build "$BASE_TGT" "$PRESET"
-build "$VIS_TGT"  "$PRESET,llm-llamacpp-vision"
+# As of 0.2.1 every `platform-*` preset bundles `llm-llamacpp-vision`, so a
+# preset can no longer serve as the no-vision baseline. The mtmd delta is
+# independent of the ORT/Candle accelerators (identical on both sides), so we
+# isolate it by diffing the llama backend with vs without mtmd directly.
+build "$BASE_TGT" "llm-llamacpp"
+build "$VIS_TGT"  "llm-llamacpp-vision"
 
 # Correctness guard: the vision build must actually link the native mtmd code,
 # otherwise a broken sdk->core->llama-sys/vision chain would silently report a
@@ -90,5 +95,5 @@ printf '%-30s %10s %10s %9s %12s %12s %10s\n' \
 row "$LIB.a  (staticlib ~ iOS .a)"   "$BASE_TGT/release/$LIB.a"     "$VIS_TGT/release/$LIB.a"
 row "$LIB.$SO_EXT (cdylib ~ Android .so)" "$BASE_TGT/release/$LIB.$SO_EXT" "$VIS_TGT/release/$LIB.$SO_EXT"
 echo
-echo "Preset: $PRESET   Host: $(rustc -vV | sed -n 's/^host: //p')"
+echo "Host: $(rustc -vV | sed -n 's/^host: //p')"
 echo "Note: host proxy, not the shipped per-platform delta (see header)."


### PR DESCRIPTION
## Summary

Enables the on-device **native VLM (vision-language) backend out of the box**. The llama.cpp `mtmd`/`clip` backend already existed but was opt-in — present in *no* platform preset — so the default 0.2.0 mobile/desktop artifacts could not actually run a vision-language model. This flips it on across every shipped surface, targeting **0.2.1** (the "vision actually ships" follow-up to 0.2.0).

The size objection that originally justified gating is gone: the measured cost is **~0.7 MiB stripped** on the Android `.so` proxy and **~1.5 MiB** on the iOS static-lib proxy — noise against the ~30/160 MiB baselines (`tools/scripts/measure-binary-size.sh`).

### Presets (the actual product change)
- `crates/xybrid-sdk` — `platform-{android,ios,macos,desktop}` now pull `llm-llamacpp-vision`. This is the single source of truth, so it propagates to `xybrid-bolt` (Swift/Kotlin/RN), `xybrid-ffi` (Unity/C), the `xybrid` umbrella, and Flutter macos/desktop via forwarding. Flutter android/ios already carried it explicitly.
- `crates/xybrid-cli` — defines its own composed presets; flipped to `llm-llamacpp-vision` too so the CLI can run VLMs.

### CI native slices (keeps builds fast)
- `build-natives.yml` — publishes both `base` and `vision` slices via a `feature × target` matrix. Write-once keeps the existing 6 `base` slices valid; only the 6 new `vision` slices compile.
- `build-{android,apple,react-native,flutter}.yml` — pull the `vision` slice. `build.rs` safely falls back to a source compile on a slice miss (no ABI-mismatch risk), so the first builds before the slices publish are correct, just slower.

> Note: `release-prep.yml` source-compiles natives (it doesn't use slices), so the shipped 0.2.1 artifacts compile mtmd from source — fine, since arm64/armv7/x86_64 + iOS all compile it (only i686 ever failed, already dropped in 0.2.0).

### Housekeeping for the un-gating
- `measure-binary-size.sh` — presets can no longer serve as the no-vision baseline, so it now diffs `llm-llamacpp` vs `llm-llamacpp-vision` directly (accelerators cancel out of the delta).
- Refreshed the now-false "not shipped / opt-in" comments on the iOS/Android vision compile-check gates and the `xybrid-bolt` vision-feature note.

## Type of Change

- [x] New feature
- [ ] Other: distribution/CI change to publish the vision native slices

## Checklist

- [ ] Tests pass (`cargo test`) — CI to confirm; verified the feature graph resolves (`platform-* → xybrid-llama-sys/vision`) and YAML/shell lint clean locally
- [x] Code follows project style
- [ ] Documentation updated — CHANGELOG/headline framing handled in the 0.2.1 release prep
- [x] No breaking changes (additive; mtmd backend now on by default)
