### PR TITLE
feat(react-native): RunOptions, warmup/unload, presets to SDK parity

### DIFF
--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -6,9 +6,11 @@ to JavaScript through a TurboModule.
 
 ## Status
 
-**Spike / pre-release.** Surface covers loader → `run()` plus voice
-introspection and platform-state push. Streaming (ASR partials, LLM token
-streams) and per-call generation config are not yet wired through — see
+**Pre-release.** The synchronous surface is at 1:1 parity with the Apple and
+Kotlin SDKs: loader → `run()` with full `RunOptions` (sampling config plus
+cloud fallback / abort-on-stress / correlation ID), `warmup`/`unload`,
+`GenerationConfigs` presets, voice introspection, and platform-state push.
+Streaming (ASR partials, LLM token streams) is the remaining gap — see
 "Open work" below.
 
 ## Architecture
@@ -43,6 +45,7 @@ bindings/react-native/
 ├── src/
 │   ├── index.ts             # Public TS facade (Xybrid, ModelLoader, Model)
 │   ├── NativeXybrid.ts      # TurboModule spec (codegen input)
+│   ├── presets.ts           # GenerationConfigs.greedy() / .creative()
 │   └── types.ts
 ├── ios/
 │   ├── XybridModule.{h,mm}  # ObjC++ TurboModule registration
@@ -86,6 +89,37 @@ await model.release();
 > stability even though the native bolt layer collapsed the loader into the
 > `XybridModel` factories — `index.ts` maps the old shape onto the new calls.
 
+### Run options, warmup/unload, presets
+
+`run()` takes a `RunOptions` second argument mirroring the bolt
+`XybridRunOptions` the Apple/Kotlin SDKs expose — sampling config plus the
+platform-plane knobs. A bare `GenerationConfig` is still accepted as shorthand
+for `{ generationConfig }`.
+
+```ts
+import { ModelLoader, GenerationConfigs } from 'react-native-xybrid';
+
+const model = await ModelLoader.fromRegistry('llama-3.2-1b').load();
+
+// Optional: prime the model so first-token latency is inference, not cold start.
+await model.warmup();
+
+const result = await model.run(
+  { kind: 'text', text: 'Write a haiku about the sea.' },
+  {
+    generationConfig: GenerationConfigs.creative(),
+    fallbackToCloud: true,                 // allow cloud under device stress
+    abortOn: ['thermalCritical'],          // bail early if the device overheats
+    maxGraceTokens: 16,
+    correlationId: 'req-42',               // threaded into telemetry
+  },
+);
+console.log(result.text);
+
+// Shed weights under memory pressure; the handle stays valid and reloads on next run.
+await model.unload();
+```
+
 ## Requirements
 
 - React Native ≥ 0.74 (TurboModules + codegen).
@@ -103,16 +137,15 @@ await model.release();
 
 1. **Streaming.** ASR partial results and LLM token streams aren't surfaced to
    JS yet — they need an `EventEmitter` (legacy) or a JSI `HostObject` wrapper
-   for low-jitter token delivery.
-2. **Generation config on `run`.** The bolt `XybridModel.run(envelope)` does
-   not yet accept a per-call `GenerationConfig`; the JS `config` argument is
-   currently ignored. Unblocks once the facade/bolt surface threads config
-   through `run`.
-3. **Binary payloads.** Audio bytes ride as base64 strings today. Move to
+   for low-jitter token delivery. This is the last synchronous-surface parity
+   gap with the native SDKs.
+2. **Binary payloads.** Audio bytes ride as base64 strings today. Move to
    `ArrayBuffer` via JSI to drop the encode/decode hop on every chunk.
-4. **TypeScript codegen.** The `Spec` interface is hand-written; once the
-   surface stabilizes, generate `NativeXybrid.ts` from the same bolt `#[data]`
-   definitions the other bindings derive from, to keep them in lockstep.
-5. **Example app + automated smoke test.** No `example/` directory yet.
-   The CI workflow builds and lints the package but does not yet run a
-   sample app end-to-end.
+3. **TypeScript codegen.** The `Spec` interface and the native shim mappers are
+   hand-written, so RN is the one binding not generated from the bolt
+   `#[data]`/facade source of truth — every new core field must be hand-wired
+   here (as `RunOptions` / `warmup` / `unload` just were). Generate them from
+   the same definitions the other bindings derive from to keep parity
+   structural rather than a manual chase. See the JSI re-architecture plan.
+4. **End-to-end smoke test.** The `example/` Expo app and CI build/lint the
+   package, but CI does not yet run inference end-to-end on a device/emulator.

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
@@ -11,6 +11,7 @@ package ai.xybrid.reactnative
 
 import ai.xybrid.Envelope
 import ai.xybrid.Xybrid
+import ai.xybrid.XybridAbortSignal
 import ai.xybrid.XybridEnvelope
 import ai.xybrid.XybridError
 import ai.xybrid.XybridGenerationConfig
@@ -122,6 +123,18 @@ class XybridModule(reactContext: ReactApplicationContext) :
   fun releaseModel(handle: String, promise: Promise) {
     models.remove(handle)?.close()
     promise.resolve(null)
+  }
+
+  // -- Model lifecycle --
+
+  @ReactMethod
+  fun warmup(handle: String, promise: Promise) {
+    runVoid(handle, promise) { it.warmup() }
+  }
+
+  @ReactMethod
+  fun unload(handle: String, promise: Promise) {
+    runVoid(handle, promise) { it.unload() }
   }
 
   // -- Inference --
@@ -251,6 +264,27 @@ class XybridModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  // Run a void-returning model op (warmup / unload) off the RN thread,
+  // resolving on success and mapping XybridError on failure.
+  private fun runVoid(handle: String, promise: Promise, op: suspend (XybridModel) -> Unit) {
+    val model = models[handle]
+    if (model == null) {
+      promise.reject("xybrid_handle", "Unknown model handle: $handle")
+      return
+    }
+    scope.launch {
+      try {
+        op(model)
+        promise.resolve(null)
+      } catch (e: XybridError) {
+        rejectXybrid(promise, e)
+      } catch (t: Throwable) {
+        if (t is CancellationException) throw t
+        promise.reject("xybrid", t.message, t)
+      }
+    }
+  }
+
   // Build a bolt [XybridEnvelope] via the `Envelope` factories, which fold the
   // well-known TTS / ASR options (sample_rate, channels, voice_id, speed) into
   // envelope metadata entries — the bolt `XybridEnvelopeKind` variants
@@ -292,10 +326,46 @@ class XybridModule(reactContext: ReactApplicationContext) :
     return out
   }
 
-  // Map the JS generation-config payload onto bolt's XybridRunOptions. The JS
-  // surface only exposes sampling params today, so the abort / cloud-fallback
-  // fields are left at their defaults.
+  // Map the JS `RunOptions` payload onto bolt's XybridRunOptions. The JS facade
+  // normalizes its argument to `{ generationConfig, abortOn, fallbackToCloud,
+  // maxGraceTokens, correlationId }`, so every field the Apple/Kotlin SDKs
+  // expose is reachable from React Native.
   private fun decodeRunOptions(map: ReadableMap): XybridRunOptions {
+    val gc = if (map.hasKey("generationConfig") && !map.isNull("generationConfig")) {
+      map.getMap("generationConfig")?.let(::decodeGenerationConfig)
+    } else {
+      null
+    }
+    val abortOn = if (map.hasKey("abortOn") && !map.isNull("abortOn")) {
+      val arr = map.getArray("abortOn")!!
+      val out = ArrayList<XybridAbortSignal>(arr.size())
+      for (i in 0 until arr.size()) {
+        decodeAbortSignal(arr.getString(i))?.let(out::add)
+      }
+      out
+    } else {
+      emptyList()
+    }
+    val maxGrace = if (map.hasKey("maxGraceTokens") && !map.isNull("maxGraceTokens")) {
+      map.getInt("maxGraceTokens").coerceAtLeast(0).toUInt()
+    } else {
+      0u
+    }
+    return XybridRunOptions(
+      generationConfig = gc,
+      abortOn = abortOn,
+      fallbackToCloud = map.hasKey("fallbackToCloud") && !map.isNull("fallbackToCloud") &&
+        map.getBoolean("fallbackToCloud"),
+      maxGraceTokens = maxGrace,
+      correlationId = if (map.hasKey("correlationId") && !map.isNull("correlationId")) {
+        map.getString("correlationId")
+      } else {
+        null
+      },
+    )
+  }
+
+  private fun decodeGenerationConfig(map: ReadableMap): XybridGenerationConfig {
     fun uintOrNull(key: String): UInt? {
       if (!map.hasKey(key) || map.isNull(key)) return null
       // Guard against negative JS values wrapping around to a huge UInt.
@@ -312,21 +382,23 @@ class XybridModule(reactContext: ReactApplicationContext) :
     } else {
       emptyList()
     }
-    return XybridRunOptions(
-      generationConfig = XybridGenerationConfig(
-        maxTokens = uintOrNull("maxTokens"),
-        temperature = floatOrNull("temperature"),
-        topP = floatOrNull("topP"),
-        minP = floatOrNull("minP"),
-        topK = uintOrNull("topK"),
-        repetitionPenalty = floatOrNull("repetitionPenalty"),
-        stopSequences = stops,
-      ),
-      abortOn = emptyList(),
-      fallbackToCloud = false,
-      maxGraceTokens = 0u,
-      correlationId = null,
+    return XybridGenerationConfig(
+      maxTokens = uintOrNull("maxTokens"),
+      temperature = floatOrNull("temperature"),
+      topP = floatOrNull("topP"),
+      minP = floatOrNull("minP"),
+      topK = uintOrNull("topK"),
+      repetitionPenalty = floatOrNull("repetitionPenalty"),
+      stopSequences = stops,
     )
+  }
+
+  private fun decodeAbortSignal(raw: String?): XybridAbortSignal? = when (raw) {
+    "memoryPressureWarn" -> XybridAbortSignal.MEMORY_PRESSURE_WARN
+    "memoryPressureCritical" -> XybridAbortSignal.MEMORY_PRESSURE_CRITICAL
+    "thermalHot" -> XybridAbortSignal.THERMAL_HOT
+    "thermalCritical" -> XybridAbortSignal.THERMAL_CRITICAL
+    else -> null
   }
 
   private fun encodeResult(r: XybridResult): WritableMap {

--- a/bindings/react-native/example/App.tsx
+++ b/bindings/react-native/example/App.tsx
@@ -65,6 +65,7 @@ export default function App() {
         const voices = await timed('model.voices()', () => loaded.voices(), push);
         push({ label: `→ ${voices?.length ?? 0} voices`, durationMs: 0, ok: true });
       } else {
+        await timed('model.warmup()', () => loaded.warmup(), push);
         const result = await timed(
           'model.run(text envelope)',
           () => loaded.run({ kind: 'text', text: 'hello from expo' }),

--- a/bindings/react-native/ios/XybridModule.mm
+++ b/bindings/react-native/ios/XybridModule.mm
@@ -71,6 +71,22 @@ RCT_REMAP_METHOD(releaseModel,
   [_impl releaseModel:handle resolve:resolve reject:reject];
 }
 
+#pragma mark - Model lifecycle
+
+RCT_REMAP_METHOD(warmup,
+                 warmup:(NSString *)handle
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl warmup:handle resolve:resolve reject:reject];
+}
+
+RCT_REMAP_METHOD(unload,
+                 unload:(NSString *)handle
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl unload:handle resolve:resolve reject:reject];
+}
+
 #pragma mark - Inference
 
 RCT_REMAP_METHOD(run,

--- a/bindings/react-native/ios/XybridModuleImpl.swift
+++ b/bindings/react-native/ios/XybridModuleImpl.swift
@@ -83,6 +83,20 @@ public final class XybridModuleImpl: NSObject {
     resolve(nil)
   }
 
+  // -- Model lifecycle --
+
+  @objc public func warmup(_ handle: String,
+                           resolve: @escaping RCTPromiseResolveBlock,
+                           reject: @escaping RCTPromiseRejectBlock) {
+    runAsyncVoid(handle: handle, resolve: resolve, reject: reject) { try $0.warmup() }
+  }
+
+  @objc public func unload(_ handle: String,
+                           resolve: @escaping RCTPromiseResolveBlock,
+                           reject: @escaping RCTPromiseRejectBlock) {
+    runAsyncVoid(handle: handle, resolve: resolve, reject: reject) { try $0.unload() }
+  }
+
   // -- Inference --
 
   @objc public func run(_ handle: String,
@@ -220,6 +234,28 @@ public final class XybridModuleImpl: NSObject {
     }
   }
 
+  // Run a throwing, void-returning model op (warmup / unload) off the RN
+  // thread, resolving on success and mapping XybridError on failure.
+  private func runAsyncVoid(handle: String,
+                            resolve: @escaping RCTPromiseResolveBlock,
+                            reject: @escaping RCTPromiseRejectBlock,
+                            _ op: @escaping (XybridModel) throws -> Void) {
+    guard let model = lookup(handle) else {
+      reject("xybrid_handle", "Unknown model handle: \(handle)", nil)
+      return
+    }
+    Task.detached {
+      do {
+        try op(model)
+        resolve(nil)
+      } catch let error as XybridError {
+        self.rejectXybrid(error, reject)
+      } catch {
+        reject("xybrid", error.localizedDescription, error)
+      }
+    }
+  }
+
   // Build a bolt [XybridEnvelope] via the `XybridEnvelope` factories in
   // Xybrid.swift, which fold the well-known TTS / ASR options (sample_rate,
   // channels, voice_id, speed) into envelope metadata entries — the bolt
@@ -254,16 +290,27 @@ public final class XybridModuleImpl: NSObject {
     }
   }
 
-  // Map the JS generation-config payload onto bolt's XybridRunOptions. The JS
-  // surface only exposes sampling params today, so the abort / cloud-fallback
-  // fields are left at their defaults.
+  // Map the JS `RunOptions` payload onto bolt's XybridRunOptions. The JS facade
+  // normalizes its argument to `{ generationConfig, abortOn, fallbackToCloud,
+  // maxGraceTokens, correlationId }`, so every field the Apple/Kotlin SDKs
+  // expose is reachable from React Native.
   private func decodeRunOptions(_ dict: NSDictionary) -> XybridRunOptions {
+    return XybridRunOptions(
+      generationConfig: (dict["generationConfig"] as? NSDictionary).map(decodeGenerationConfig),
+      abortOn: (dict["abortOn"] as? [String])?.compactMap(decodeAbortSignal) ?? [],
+      fallbackToCloud: (dict["fallbackToCloud"] as? NSNumber)?.boolValue ?? false,
+      maxGraceTokens: (dict["maxGraceTokens"] as? NSNumber).flatMap { $0.intValue >= 0 ? $0.uint32Value : nil } ?? 0,
+      correlationId: dict["correlationId"] as? String
+    )
+  }
+
+  private func decodeGenerationConfig(_ dict: NSDictionary) -> XybridGenerationConfig {
     // Guard against negative JS values wrapping around to a huge UInt32.
     func uint32OrNil(_ key: String) -> UInt32? {
       guard let n = dict[key] as? NSNumber, n.intValue >= 0 else { return nil }
       return n.uint32Value
     }
-    let gc = XybridGenerationConfig(
+    return XybridGenerationConfig(
       maxTokens: uint32OrNil("maxTokens"),
       temperature: (dict["temperature"] as? NSNumber)?.floatValue,
       topP: (dict["topP"] as? NSNumber)?.floatValue,
@@ -272,13 +319,16 @@ public final class XybridModuleImpl: NSObject {
       repetitionPenalty: (dict["repetitionPenalty"] as? NSNumber)?.floatValue,
       stopSequences: dict["stopSequences"] as? [String] ?? []
     )
-    return XybridRunOptions(
-      generationConfig: gc,
-      abortOn: [],
-      fallbackToCloud: false,
-      maxGraceTokens: 0,
-      correlationId: nil
-    )
+  }
+
+  private func decodeAbortSignal(_ raw: String) -> XybridAbortSignal? {
+    switch raw {
+    case "memoryPressureWarn": return .memoryPressureWarn
+    case "memoryPressureCritical": return .memoryPressureCritical
+    case "thermalHot": return .thermalHot
+    case "thermalCritical": return .thermalCritical
+    default: return nil
+    }
   }
 
   private func encodeResult(_ r: XybridResult) -> [String: Any] {

--- a/bindings/react-native/src/NativeXybrid.ts
+++ b/bindings/react-native/src/NativeXybrid.ts
@@ -24,11 +24,21 @@ export interface Spec extends TurboModule {
   loadFromHuggingface(repo: string): Promise<string>;
   releaseModel(handle: string): Promise<void>;
 
+  // -- Model lifecycle --
+  // Warm up the model (runs a priming inference so first-token latency is
+  // attributable to warmup vs. inference) and unload it (frees native memory
+  // while keeping the handle valid for a later reload). Mirror the
+  // Apple/Kotlin/Flutter `warmup`/`unload` surface.
+  warmup(handle: string): Promise<void>;
+  unload(handle: string): Promise<void>;
+
   // -- Inference --
-  // `envelope` and `config` cross as Objects; the TS facade narrows to the
-  // discriminated `Envelope` union. Native side validates `kind` and rejects
-  // with an Error if it doesn't match a known variant.
-  run(handle: string, envelope: Object, config: Object | null): Promise<Object>;
+  // `envelope` and `options` cross as Objects; the TS facade narrows to the
+  // discriminated `Envelope` union and normalizes the second arg to a
+  // `RunOptions` shape (`{ generationConfig, abortOn, fallbackToCloud,
+  // maxGraceTokens, correlationId }`). Native side validates `kind` and
+  // rejects with an Error if it doesn't match a known variant.
+  run(handle: string, envelope: Object, options: Object | null): Promise<Object>;
 
   // -- TTS introspection --
   voices(handle: string): Promise<Object[] | null>;

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -4,21 +4,49 @@ import type {
   GenerationConfig,
   InferenceResult,
   ModelHandle,
+  RunOptions,
   ThermalState,
   VoiceInfo,
 } from './types';
 
 export type {
+  AbortSignalKind,
   AudioEnvelope,
   EmbeddingEnvelope,
   Envelope,
   GenerationConfig,
   InferenceResult,
   ModelHandle,
+  RunOptions,
   TextEnvelope,
   ThermalState,
   VoiceInfo,
 } from './types';
+
+export { GenerationConfigs, creative, greedy } from './presets';
+
+// Keys that only appear on `RunOptions`, never on a bare `GenerationConfig`.
+// Used to tell the two apart when a caller passes either form to `run()`.
+const RUN_OPTION_KEYS = [
+  'generationConfig',
+  'abortOn',
+  'fallbackToCloud',
+  'maxGraceTokens',
+  'correlationId',
+] as const;
+
+// Accept either the canonical `RunOptions` or a bare `GenerationConfig`
+// (the pre-RunOptions shorthand) and produce the wire object the native
+// shims decode — or `null` when there's nothing to send.
+function normalizeRunOptions(
+  options: RunOptions | GenerationConfig | undefined,
+): RunOptions | null {
+  if (!options) return null;
+  const isRunOptions = RUN_OPTION_KEYS.some((k) => k in options);
+  return isRunOptions
+    ? (options as RunOptions)
+    : { generationConfig: options as GenerationConfig };
+}
 
 // Cache the in-flight init promise so concurrent callers all await the same
 // underlying native call. The native side is documented as idempotent, but
@@ -114,13 +142,41 @@ export class Model {
     return this.handle;
   }
 
-  async run(envelope: Envelope, config?: GenerationConfig): Promise<InferenceResult> {
+  /**
+   * Run inference. The second argument is a {@link RunOptions} carrying the
+   * sampling config plus the platform-plane knobs (cloud fallback,
+   * abort-on-stress, telemetry correlation), mirroring the Apple/Kotlin SDKs.
+   *
+   * A bare {@link GenerationConfig} is also accepted as shorthand for
+   * `{ generationConfig }`.
+   */
+  async run(
+    envelope: Envelope,
+    options?: RunOptions | GenerationConfig,
+  ): Promise<InferenceResult> {
     const result = (await NativeXybrid.run(
       this.handle,
       envelope,
-      config ?? null,
+      normalizeRunOptions(options),
     )) as InferenceResult;
     return result;
+  }
+
+  /**
+   * Warm up the model with a priming inference, so first-token latency on the
+   * next `run` is attributable to inference rather than cold start.
+   */
+  warmup(): Promise<void> {
+    return NativeXybrid.warmup(this.handle);
+  }
+
+  /**
+   * Unload the model's weights to free native memory while keeping this handle
+   * valid — a later `run` transparently reloads. Use this to shed memory under
+   * pressure without discarding the handle (contrast with {@link release}).
+   */
+  unload(): Promise<void> {
+    return NativeXybrid.unload(this.handle);
   }
 
   async voices(): Promise<VoiceInfo[] | null> {

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -41,7 +41,9 @@ const RUN_OPTION_KEYS = [
 function normalizeRunOptions(
   options: RunOptions | GenerationConfig | undefined,
 ): RunOptions | null {
-  if (!options) return null;
+  // Guard the `in` checks below: a JS caller can pass a non-object despite the
+  // TS types, and `in` on a primitive throws a TypeError.
+  if (!options || typeof options !== 'object') return null;
   const isRunOptions = RUN_OPTION_KEYS.some((k) => k in options);
   return isRunOptions
     ? (options as RunOptions)

--- a/bindings/react-native/src/presets.ts
+++ b/bindings/react-native/src/presets.ts
@@ -1,0 +1,28 @@
+import type { GenerationConfig } from './types';
+
+// Generation-config presets, mirroring `ai.xybrid.GenerationConfigs` in the
+// Kotlin SDK 1:1 so a React Native caller reaches for the same named defaults
+// as every other binding. Pure TS — no bridge hop.
+
+/** Greedy decoding preset (deterministic, temperature 0). */
+export function greedy(): GenerationConfig {
+  return {
+    temperature: 0.0,
+    topP: 1.0,
+    topK: 0,
+    stopSequences: [],
+  };
+}
+
+/** Creative generation preset (higher temperature). */
+export function creative(): GenerationConfig {
+  return {
+    temperature: 0.9,
+    topP: 0.95,
+    topK: 50,
+    stopSequences: [],
+  };
+}
+
+/** Preset factory functions for {@link GenerationConfig}. */
+export const GenerationConfigs = { greedy, creative };

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -40,6 +40,36 @@ export interface GenerationConfig {
   stopSequences?: string[];
 }
 
+/**
+ * Device-stress signals that abort an in-flight run early. Mirrors the bolt
+ * `XybridAbortSignal` enum 1:1; the native shims map each string onto the
+ * corresponding enum case.
+ */
+export type AbortSignalKind =
+  | 'memoryPressureWarn'
+  | 'memoryPressureCritical'
+  | 'thermalHot'
+  | 'thermalCritical';
+
+/**
+ * Per-call execution policy, mirroring the bolt `XybridRunOptions` surface the
+ * Apple/Kotlin SDKs expose. `generationConfig` carries the sampling params;
+ * the remaining fields drive the platform plane (cloud fallback, abort-on-stress,
+ * telemetry correlation).
+ */
+export interface RunOptions {
+  /** Sampling parameters for LLM inference. */
+  generationConfig?: GenerationConfig;
+  /** Device-stress signals that abort the run early. */
+  abortOn?: AbortSignalKind[];
+  /** Allow this call to fall back to the cloud gateway under device stress. */
+  fallbackToCloud?: boolean;
+  /** Tokens to emit after an abort signal before stopping (grace window). */
+  maxGraceTokens?: number;
+  /** Correlation ID threaded into telemetry for this call. */
+  correlationId?: string;
+}
+
 export interface InferenceResult {
   success: boolean;
   text?: string;


### PR DESCRIPTION
## Summary

Brings the React Native binding to 1:1 parity with the Apple/Kotlin SDKs on the synchronous surface, ahead of the 0.2.x publish: `run()` now takes a `RunOptions` mirroring bolt `XybridRunOptions` (`generationConfig` plus `fallbackToCloud` / `abortOn` / `maxGraceTokens` / `correlationId`, which both native shims previously hardcoded to defaults — a bare `GenerationConfig` is still accepted as shorthand so no callers break). Adds `warmup`/`unload` across the spec, both shims, the ObjC++ registration, and the `Model` facade (mirroring Apple/Kotlin `*Async`; Flutter got these in #293), plus `GenerationConfigs.greedy()/.creative()` presets. `abortOn` crosses as an `AbortSignalKind` string enum mapped to `XybridAbortSignal` in each shim, and the README is de-staled (its "config ignored" / "no example" open items were already false). Streaming remains the one open synchronous-surface gap, and the publishing pipeline (version-sync, npm publish, iOS xcframework delivery) is tracked separately.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A, no Rust changed; TS types typecheck, Swift/Kotlin shims compile-checked in CI
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (bare `GenerationConfig` still accepted via `normalizeRunOptions`)