### PR TITLE
fix(release): make version-sync RN-aware; bump RN package to 0.2.0-rc1

### DIFF
--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.1.0-beta12",
+  "version": "0.2.0-rc1",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/tools/scripts/version-sync.sh
+++ b/tools/scripts/version-sync.sh
@@ -66,10 +66,9 @@ get_swift_version() {
     grep '^let sdkVersion = ' "$SWIFT_PACKAGE" | sed 's/let sdkVersion = "\(.*\)"/\1/'
 }
 
-# Extract version from React Native package.json (top-level "version" only —
-# nested keys live at deeper indentation, so the 2-space anchor is exact).
+# Extract version from React Native package.json (parsed, like Unity's).
 get_rn_version() {
-    grep '^  "version":' "$RN_PACKAGE" | head -1 | sed 's/.*: *"\(.*\)".*/\1/'
+    python3 -c "import json; print(json.load(open('$RN_PACKAGE'))['version'])"
 }
 
 # Extract the ai.xybrid:xybrid-kotlin AAR version the RN Android binding pins.
@@ -132,12 +131,19 @@ set_swift_version() {
     rm -f "$SWIFT_PACKAGE.bak"
 }
 
-# Set version in React Native package.json. Anchored to the 2-space top-level
-# "version" line so nested keys (codegenConfig, deps) are untouched.
+# Set version in React Native package.json (parsed + rewritten, like Unity's —
+# robust against reformatting; preserves the file's standard 2-space layout).
 set_rn_version() {
     local version="$1"
-    sed -i.bak "s/^  \"version\": \".*\"/  \"version\": \"$version\"/" "$RN_PACKAGE"
-    rm -f "$RN_PACKAGE.bak"
+    python3 -c "
+import json
+with open('$RN_PACKAGE', 'r') as f:
+    data = json.load(f)
+data['version'] = '$version'
+with open('$RN_PACKAGE', 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+"
 }
 
 # Set the ai.xybrid:xybrid-kotlin AAR pin in the RN Android build.gradle so the

--- a/tools/scripts/version-sync.sh
+++ b/tools/scripts/version-sync.sh
@@ -25,6 +25,12 @@ FLUTTER_RUST_CARGO="$REPO_ROOT/bindings/flutter/rust/Cargo.toml"
 # URL for SPM consumers in remote mode and MUST match the cargo workspace
 # version.
 SWIFT_PACKAGE="$REPO_ROOT/Package.swift"
+# React Native npm package. RN is hand-translated (not generated), so it was
+# absent from this sync and its package.json drifted. Two versions must equal
+# the workspace version: the npm package version, and the `ai.xybrid:xybrid-kotlin`
+# AAR pin its Android binding consumes from Maven Central.
+RN_PACKAGE="$REPO_ROOT/bindings/react-native/package.json"
+RN_GRADLE="$REPO_ROOT/bindings/react-native/android/build.gradle"
 
 # Extract current workspace version from Cargo.toml
 get_cargo_version() {
@@ -58,6 +64,17 @@ get_flutter_rust_version() {
 # Extract sdkVersion from root Package.swift
 get_swift_version() {
     grep '^let sdkVersion = ' "$SWIFT_PACKAGE" | sed 's/let sdkVersion = "\(.*\)"/\1/'
+}
+
+# Extract version from React Native package.json (top-level "version" only —
+# nested keys live at deeper indentation, so the 2-space anchor is exact).
+get_rn_version() {
+    grep '^  "version":' "$RN_PACKAGE" | head -1 | sed 's/.*: *"\(.*\)".*/\1/'
+}
+
+# Extract the ai.xybrid:xybrid-kotlin AAR version the RN Android binding pins.
+get_rn_aar_version() {
+    grep 'ai.xybrid:xybrid-kotlin:' "$RN_GRADLE" | head -1 | sed 's/.*xybrid-kotlin:\([^"]*\)".*/\1/'
 }
 
 # Set version in Cargo workspace (all Rust crates inherit via version.workspace = true)
@@ -115,6 +132,22 @@ set_swift_version() {
     rm -f "$SWIFT_PACKAGE.bak"
 }
 
+# Set version in React Native package.json. Anchored to the 2-space top-level
+# "version" line so nested keys (codegenConfig, deps) are untouched.
+set_rn_version() {
+    local version="$1"
+    sed -i.bak "s/^  \"version\": \".*\"/  \"version\": \"$version\"/" "$RN_PACKAGE"
+    rm -f "$RN_PACKAGE.bak"
+}
+
+# Set the ai.xybrid:xybrid-kotlin AAR pin in the RN Android build.gradle so the
+# binding resolves the matching published Kotlin SDK at consumer build time.
+set_rn_aar_version() {
+    local version="$1"
+    sed -i.bak "s/ai.xybrid:xybrid-kotlin:[^\"]*\"/ai.xybrid:xybrid-kotlin:$version\"/" "$RN_GRADLE"
+    rm -f "$RN_GRADLE.bak"
+}
+
 # Check mode: verify all versions match
 check_versions() {
     local cargo_version
@@ -124,7 +157,7 @@ check_versions() {
     echo "Cargo workspace version: $cargo_version"
     echo ""
 
-    for name_func in "Flutter:get_flutter_version" "Flutter rust crate:get_flutter_rust_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version"; do
+    for name_func in "Flutter:get_flutter_version" "Flutter rust crate:get_flutter_rust_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version" "React Native:get_rn_version" "React Native AAR:get_rn_aar_version"; do
         local name="${name_func%%:*}"
         local func="${name_func##*:}"
         local version
@@ -161,6 +194,8 @@ case "${1:-}" in
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
         set_swift_version "$VERSION"
+        set_rn_version "$VERSION"
+        set_rn_aar_version "$VERSION"
         echo "Done. Run '$0 --check' to verify."
         ;;
     --help|-h)
@@ -181,6 +216,8 @@ case "${1:-}" in
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
         set_swift_version "$VERSION"
+        set_rn_version "$VERSION"
+        set_rn_aar_version "$VERSION"
         echo ""
         echo "Rust crates inherit via version.workspace = true."
 


### PR DESCRIPTION
## Summary

`version-sync.sh` (which `just bump-version` and `release-prep.yml`'s `--check` both run) validated Cargo, Flutter, Unity, Kotlin, and Swift but never React Native — so RN's npm `package.json` silently drifted to `0.1.0-beta12` while the workspace moved to `0.2.0-rc1`, and a 0.2.x release would have shipped a mismatched RN package with the gate still green. This adds get/set/check for both RN version surfaces (the npm `package.json` version and the `ai.xybrid:xybrid-kotlin` AAR pin in its Android `build.gradle`), driven by the workspace version like every other binding, and syncs RN `0.1.0-beta12 → 0.2.0-rc1` (the AAR pin was already aligned). `version-sync.sh --check` now covers all seven manifests; verified it flags drift (exit 1) and goes green after sync (exit 0).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A, release tooling change; verified `version-sync.sh --check` behavior directly
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)