### PR TITLE
ci(build-natives): scope packages:write to the publishing job

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -42,7 +42,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -55,6 +54,9 @@ env:
 jobs:
   publish-native:
     name: Publish native (${{ matrix.target }}, base)
+    permissions:
+      contents: read
+      packages: write   # oras login + push of the prebuilt native slice to ghcr
     runs-on: ${{ matrix.runner }}
     strategy:
       # One slice miss must not abort the others — write-once makes every row


### PR DESCRIPTION
## Summary

`build-natives.yml` was granting **`packages: write` at the workflow (top) level**, which regressed the OpenSSF Scorecard **Token-Permissions** check from 10 back to **0** (a single top-level write token fails the check). Only the one `publish-native` job needs it — for `oras login` + pushing the prebuilt llama.cpp slice to ghcr. This moves the write scope to that job and leaves the workflow-level token read-only, restoring least privilege.

Verified by the latest Scorecard run, where Token-Permissions flagged exactly: `topLevel 'packages' permission set to 'write': .github/workflows/build-natives.yml:45`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (CI / least-privilege hardening)

## Checklist

- [x] YAML validated; no top-level write remains, `packages: write` scoped to `publish-native`
- [x] No functional change — the publishing job retains the exact permission it needs
- [x] No breaking changes