### PR TITLE
docs: fix stale UniFFI references in Apple/Kotlin READMEs

### DIFF
--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -2,7 +2,7 @@
 
 > **Status**: Coming Soon — Swift bindings are in development. Use [Flutter](../flutter/) or [Kotlin](../kotlin/) for production use today.
 
-Native iOS and macOS SDK for [Xybrid](https://github.com/xybrid-ai/xybrid), providing on-device ML inference via UniFFI-generated Swift bindings.
+Native iOS and macOS SDK for [Xybrid](https://github.com/xybrid-ai/xybrid), providing on-device ML inference via BoltFFI-generated Swift bindings.
 
 ## Installation
 

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -111,13 +111,8 @@ apple/
 ├── Sources/
 │   └── Xybrid/                      # Swift source
 │       ├── Xybrid.swift             # Public API, extensions, type aliases
-│       └── xybrid_uniffi.swift      # UniFFI-generated Swift bindings (DO NOT EDIT)
-├── Sources/xybrid_uniffiFFI/        # C FFI headers (bundled into XCFramework)
-│   ├── include/
-│   │   ├── xybrid_uniffiFFI.h       # C header for FFI
-│   │   └── module.modulemap         # Clang module map
-│   └── shim.c                       # Placeholder (symbols from XCFramework)
-└── XCFrameworks/                    # Pre-built binary frameworks
+│       └── xybrid_bolt.swift        # BoltFFI-generated Swift bindings (DO NOT EDIT)
+└── XCFrameworks/                    # Pre-built binary frameworks (C headers bundled inside)
     ├── XybridFFI.xcframework/       # Latest build (for local dev)
     └── XybridFFI-{version}.xcframework/  # Versioned copy
 ```
@@ -183,11 +178,11 @@ After a successful build:
 bindings/apple/XCFrameworks/
 ├── XybridFFI.xcframework/
 │   ├── ios-arm64/
-│   │   └── libxybrid_uniffi.a
+│   │   └── libxybrid-bolt.a
 │   ├── ios-arm64_x86_64-simulator/
-│   │   └── libxybrid_uniffi.a
+│   │   └── libxybrid-bolt.a
 │   └── macos-arm64_x86_64/
-│       └── libxybrid_uniffi.a
+│       └── libxybrid-bolt.a
 └── XybridFFI-{version}.xcframework/    # Versioned copy
 ```
 
@@ -239,8 +234,8 @@ XCFramework builds require macOS with Xcode. If you're developing on Linux or Wi
 
 ## FFI Strategy
 
-The Swift bindings are generated from `crates/xybrid-uniffi/` using [UniFFI](https://mozilla.github.io/uniffi-rs/):
-- Single Rust source generates both Swift and Kotlin
+The Swift bindings are generated from `crates/xybrid-bolt/` using [BoltFFI](https://crates.io/crates/boltffi):
+- Single Rust source generates Swift, Kotlin, Java, C#, WASM, and a C header
 - Native async/await support
 - Memory-safe wrappers
 - Automatic error handling

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -191,31 +191,31 @@ try {
 kotlin/
 ├── build.gradle.kts                     # Gradle build configuration
 ├── README.md                            # This file
-├── libs/                                # Native libraries (libxybrid_uniffi.so built locally/CI, not committed)
+├── libs/                                # Native libraries (libxybrid-bolt.so built locally/CI, not committed)
 │   ├── armeabi-v7a/
-│   │   └── libxybrid_uniffi.so
+│   │   └── libxybrid-bolt.so
 │   ├── arm64-v8a/
-│   │   ├── libxybrid_uniffi.so
+│   │   ├── libxybrid-bolt.so
 │   │   ├── libonnxruntime.so            # ORT shared library (symlink → vendor/)
 │   │   └── libc++_shared.so             # C++ runtime (symlink → vendor/)
 │   └── x86_64/
-│       ├── libxybrid_uniffi.so
+│       ├── libxybrid-bolt.so
 │       ├── libonnxruntime.so            # ORT shared library (symlink → vendor/)
 │       └── libc++_shared.so             # C++ runtime (symlink → vendor/)
 └── src/main/kotlin/ai/xybrid/
     ├── Xybrid.kt                         # Public convenience API
-    └── xybrid_uniffi.kt                 # UniFFI-generated bindings
+    └── XybridBolt.kt                     # BoltFFI-generated bindings
 ```
 
 ## Native Dependencies
 
-The SDK bundles ONNX Runtime (`libonnxruntime.so`) and the C++ shared library (`libc++_shared.so`) alongside `libxybrid_uniffi.so`. These are included automatically in the AAR — no manual setup required.
+The SDK bundles ONNX Runtime (`libonnxruntime.so`) and the C++ shared library (`libc++_shared.so`) alongside `libxybrid-bolt.so`. These are included automatically in the AAR — no manual setup required.
 
-> **Note:** `libxybrid_uniffi.so` is a build output and is **not** committed to the repository. The AAR published to Maven Central includes it (built in CI). For a **local** build, generate it first with `cargo xtask build-android` (see [Building Native Libraries](#building-native-libraries) below) so `libs/<abi>/` is populated before running `./gradlew`.
+> **Note:** `libxybrid-bolt.so` is a build output and is **not** committed to the repository. The AAR published to Maven Central includes it (built in CI). For a **local** build, generate it first with `cargo xtask build-android` (see [Building Native Libraries](#building-native-libraries) below) so `libs/<abi>/` is populated before running `./gradlew`.
 
 | Library | Purpose | Source |
 |---------|---------|--------|
-| `libxybrid_uniffi.so` | Xybrid Rust SDK via UniFFI | Built from `crates/xybrid-uniffi/` |
+| `libxybrid-bolt.so` | Xybrid Rust SDK via BoltFFI | Built from `crates/xybrid-bolt/` |
 | `libonnxruntime.so` | ONNX Runtime inference engine | Vendored at `vendor/ort-android/` |
 | `libc++_shared.so` | C++ standard library runtime | Vendored at `vendor/ort-android/` |
 
@@ -223,10 +223,9 @@ ORT libraries are symlinked from the shared `vendor/ort-android/` directory (mat
 
 ## FFI Strategy
 
-The Kotlin bindings are generated from `crates/xybrid-uniffi/` using UniFFI:
-- Single Rust source generates both Swift and Kotlin bindings
+The Kotlin bindings are generated from `crates/xybrid-bolt/` using [BoltFFI](https://crates.io/crates/boltffi):
+- Single Rust source generates Swift, Kotlin, Java, C#, WASM, and a C header
 - Memory-safe wrappers with proper resource cleanup
-- Uses JNA for native library loading
 
 ## Building Native Libraries
 
@@ -318,9 +317,9 @@ export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$ANDROID_NDK_HOME/toolchains
 export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/x86_64-linux-android21-clang"
 
 # Build each target
-cargo build -p xybrid-uniffi --lib --release --target aarch64-linux-android
-cargo build -p xybrid-uniffi --lib --release --target armv7-linux-androideabi
-cargo build -p xybrid-uniffi --lib --release --target x86_64-linux-android
+cargo build -p xybrid-bolt --lib --release --target aarch64-linux-android
+cargo build -p xybrid-bolt --lib --release --target armv7-linux-androideabi
+cargo build -p xybrid-bolt --lib --release --target x86_64-linux-android
 ```
 
 ### Build Output
@@ -330,24 +329,24 @@ After a successful build:
 ```
 bindings/kotlin/libs/
 ├── arm64-v8a/
-│   ├── libxybrid_uniffi.so
+│   ├── libxybrid-bolt.so
 │   ├── libonnxruntime.so         # Bundled from vendor/ort-android/
 │   └── libc++_shared.so          # Bundled from vendor/ort-android/
 ├── armeabi-v7a/
-│   └── libxybrid_uniffi.so
+│   └── libxybrid-bolt.so
 ├── x86_64/
-│   ├── libxybrid_uniffi.so
+│   ├── libxybrid-bolt.so
 │   ├── libonnxruntime.so         # Bundled from vendor/ort-android/
 │   └── libc++_shared.so          # Bundled from vendor/ort-android/
 └── {version}/                    # Versioned copy
     ├── arm64-v8a/
-    │   ├── libxybrid_uniffi.so
+    │   ├── libxybrid-bolt.so
     │   ├── libonnxruntime.so
     │   └── libc++_shared.so
     ├── armeabi-v7a/
-    │   └── libxybrid_uniffi.so
+    │   └── libxybrid-bolt.so
     └── x86_64/
-        ├── libxybrid_uniffi.so
+        ├── libxybrid-bolt.so
         ├── libonnxruntime.so
         └── libc++_shared.so
 ```
@@ -398,7 +397,7 @@ export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/26.1.10909125"
 **Cause**: Missing native library or corrupted .so file.
 
 **Fix**:
-1. Verify the .so file is valid: `file libs/arm64-v8a/libxybrid_uniffi.so`
+1. Verify the .so file is valid: `file libs/arm64-v8a/libxybrid-bolt.so`
 2. Should show: `ELF 64-bit LSB shared object, ARM aarch64`
 3. Rebuild with `cargo xtask build-android`
 

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -2,7 +2,7 @@
 
 > **Status**: Active - Real inference via TemplateExecutor
 
-This directory contains the Android library for Xybrid, providing native Kotlin/Java support via UniFFI-generated bindings. The SDK supports real ML inference (TTS, ASR, embeddings) on-device via ONNX Runtime.
+This directory contains the Android library for Xybrid, providing native Kotlin/Java support via BoltFFI-generated bindings. The SDK supports real ML inference (TTS, ASR, embeddings) on-device via ONNX Runtime.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

The Apple and Kotlin binding READMEs still described the bindings as "UniFFI-generated" in their intro lines, but both SDKs migrated to BoltFFI. This updates the description line in each README to say "BoltFFI-generated".

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)