### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ preset: vision-language inference works out of the box, at a measured
 
 ### Fixed
 
+- **Unrecognized GGUF chat templates now render** (#304): when llama.cpp's
+  hardcoded template matcher rejects a model's embedded chat template, xybrid
+  falls back to a real Jinja engine (minijinja) to render it instead of failing
+  — so GGUF models with custom or non-standard chat templates load and run
+  correctly. Gated into `llm-llamacpp`, so non-llama builds pay zero cost.
 - **Readable Apple FFI errors** (#296): `FfiError` now conforms to
   `LocalizedError`, so model-load and other low-level FFI failures surface their
   real message (e.g. a registry `ModelNotFound`) instead of the opaque

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2026-06-25
+
+The native VLM ships enabled. `0.2.0` landed the vision *foundation* — image
+envelopes, preprocessing, and the mtmd backend in the codebase — but kept the
+native VLM backend opt-in, so the default mobile/desktop binaries could not
+actually run a vision-language model. `0.2.1` turns it on in every platform
+preset: vision-language inference works out of the box, at a measured
+~0.7–1.5 MiB stripped size cost.
+
+### Added
+
+- **Native VLM backend shipped enabled** (#296): `llm-llamacpp-vision`
+  (llama.cpp's mtmd/clip) is now part of every platform preset
+  (`platform-android` / `platform-ios` / `platform-macos` / `platform-desktop`),
+  so the default XCFramework, Android AAR, Flutter/React Native natives, and CLI
+  run vision-language models with no build-from-source step. The prebuilt-natives
+  CI now publishes `vision` slices alongside `base`, so vision builds stay on the
+  fast cached path instead of recompiling llama.cpp.
+
+### Fixed
+
+- **Readable Apple FFI errors** (#296): `FfiError` now conforms to
+  `LocalizedError`, so model-load and other low-level FFI failures surface their
+  real message (e.g. a registry `ModelNotFound`) instead of the opaque
+  "The operation couldn't be completed. (Xybrid.FfiError error 1.)".
+- **Release tooling**: `version-sync` is now React-Native-aware (#298), and a
+  spurious `bindings/flutter/rust/Cargo.lock` that broke dependency resolution
+  was removed (#300).
+
+---
+
 ## [0.2.0-rc1] - 2026-06-21
 
 Release candidate for `0.2.0`. This is the stable `0.2.0` tree under a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -6759,14 +6759,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6803,7 +6803,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "tokio",
  "xybrid-core",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -6907,7 +6907,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "5067e2804139e1cb12419b5a79686be114aefc068bebbe841d7f6b337625f151"
+let xybridFFIChecksum = "4c31acec0b1091a09d44dca4a440812b3ed35f598b612da4a5d85e58ad033ecc"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "947cabac1ede013255a0bbdd9424f93a5100505a43770c2333ced58975e2b1df"
+let xybridFFIChecksum = "e86f7b8f914e349c481e5d281177aad00fd3f59789791804bca931063dcd2fcd"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.2.0"
+let sdkVersion = "0.2.1"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "e86f7b8f914e349c481e5d281177aad00fd3f59789791804bca931063dcd2fcd"
+let xybridFFIChecksum = "5067e2804139e1cb12419b5a79686be114aefc068bebbe841d7f6b337625f151"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.2.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "bf0293279b65c1407c76aa909104a342d3c146a36d24995a5ec1d826184f00f3"
+let xybridFFIChecksum = "947cabac1ede013255a0bbdd9424f93a5100505a43770c2333ced58975e2b1df"
 
 let package = Package(
     name: "Xybrid",

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -145,7 +145,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.1
 ```
 
 **モデルを実行:**
@@ -162,7 +162,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.1")
 }
 ```
 
@@ -180,7 +180,7 @@ val result = model.run(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.1")
 ]
 ```
 
@@ -214,7 +214,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.2.0"
+xybrid = "0.2.1"
 ```
 
 **モデルを実行:**
@@ -316,6 +316,12 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | Qwen 3.5 2B | 2B | GGUF Q4_K_M | 拡張推論機能付き大型Qwen 3.5 |
 | SmolLM2 360M | 360M | GGUF Q4_K_M | 最高の小型LLM、優れた品質/サイズ比 |
 
+### 視覚言語モデル（VLM）
+
+| モデル | パラメータ数 | フォーマット | 説明 |
+|-------|--------|--------|-------------|
+| LFM2-VL 450M | 450M | GGUF Q4_0 + mmproj | Liquid AIのコンパクトVLM（SigLIP2ビジョン）— 画像＋テキスト入力、llama.cpp mtmdで動作 |
+
 ### 近日公開
 
 | モデル | タイプ | パラメータ数 | 優先度 | ステータス |
@@ -325,7 +331,6 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | Trinity Nano | LLM (MoE) | 6B (1Bアクティブ) | P2 | 計画中 |
 | LFM2-VL 700M | Vision+LLM | 700M | P2 | 計画中 |
 | Nomic Embed Text v1.5 | Embeddings | 137M | P1 | ブロック中（Tokenize/MeanPoolステップが必要） |
-| LFM2-VL 450M | Vision | 450M | P2 | 計画中 |
 | Whisper Tiny CoreML | ASR | 39M | P2 | 計画中 |
 | Qwen3-TTS 0.6B | TTS | 600M | P2 | ブロック中（カスタムSafeTensorsランタイムが必要） |
 | Chatterbox Turbo | TTS | 350M | P3 | ブロック中（ModelGraphテンプレートが必要） |
@@ -376,7 +381,7 @@ claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
 | 音声認識 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | テキスト読み上げ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 言語モデル | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 画像認識モデル | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
+| 画像認識モデル | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 埋め込み | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | マルチモデルパイプライン（MMP） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | モデルのダウンロードとキャッシュ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.1
 ```
 
 **Run a model:**
@@ -147,7 +147,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.1")
 }
 ```
 
@@ -165,7 +165,7 @@ val result = model.run(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.1")
 ]
 ```
 
@@ -199,7 +199,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.2.0"
+xybrid = "0.2.1"
 ```
 
 **Run a model:**
@@ -321,6 +321,12 @@ All models run entirely on-device. No cloud, no API keys required. Browse the fu
 | Qwen 3.5 2B | 2B | GGUF Q4_K_M | Larger Qwen 3.5 with extended reasoning |
 | SmolLM2 360M | 360M | GGUF Q4_K_M | Best tiny LLM, excellent quality/size ratio |
 
+### Vision-Language
+
+| Model | Params | Format | Description |
+|-------|--------|--------|-------------|
+| LFM2-VL 450M | 450M | GGUF Q4_0 + mmproj | Liquid AI's compact VLM (SigLIP2 vision) — image + text in, runs via llama.cpp mtmd |
+
 ### Coming Soon
 
 | Model | Type | Params | Priority | Status |
@@ -330,7 +336,6 @@ All models run entirely on-device. No cloud, no API keys required. Browse the fu
 | Trinity Nano | LLM (MoE) | 6B (1B active) | P2 | Planned |
 | LFM2-VL 700M | Vision+LLM | 700M | P2 | Planned |
 | Nomic Embed Text v1.5 | Embeddings | 137M | P1 | Blocked (needs Tokenize/MeanPool steps) |
-| LFM2-VL 450M | Vision | 450M | P2 | Planned |
 | Whisper Tiny CoreML | ASR | 39M | P2 | Planned |
 | Qwen3-TTS 0.6B | TTS | 600M | P2 | Blocked (needs custom SafeTensors runtime) |
 | Chatterbox Turbo | TTS | 350M | P3 | Blocked (needs ModelGraph template) |
@@ -381,7 +386,7 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 | Speech-to-Text | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Text-to-Speech | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Language Models | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Vision Models | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
+| Vision Models | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Embeddings | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | Multi-Model Pipelines (MMP) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Model Download & Caching | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,7 +145,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.1
 ```
 
 **运行模型：**
@@ -162,7 +162,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.1")
 }
 ```
 
@@ -180,7 +180,7 @@ val result = model.run(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.1")
 ]
 ```
 
@@ -214,7 +214,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.2.0"
+xybrid = "0.2.1"
 ```
 
 **运行模型：**
@@ -316,6 +316,12 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | Qwen 3.5 2B | 2B | GGUF Q4_K_M | 更大的 Qwen 3.5，扩展推理能力 |
 | SmolLM2 360M | 360M | GGUF Q4_K_M | 最佳的微型模型，优秀的质量/体积比 |
 
+### 视觉语言模型（VLM）
+
+| 模型 | 参数量 | 格式 | 简介 |
+|------|--------|------|------|
+| LFM2-VL 450M | 450M | GGUF Q4_0 + mmproj | Liquid AI 的紧凑型 VLM（SigLIP2 视觉）— 图像+文本输入，通过 llama.cpp mtmd 运行 |
+
 ### 即将推出
 
 | 模型 | 类型 | 参数量 | 优先级 | 状态 |
@@ -325,7 +331,6 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | Trinity Nano | LLM (MoE) | 6B（1B 活跃） | P2 | 计划中 |
 | LFM2-VL 700M | Vision+LLM | 700M | P2 | 计划中 |
 | Nomic Embed Text v1.5 | 嵌入 | 137M | P1 | 受阻（需要 Tokenize/MeanPool 步骤） |
-| LFM2-VL 450M | 视觉 | 450M | P2 | 计划中 |
 | Whisper Tiny CoreML | ASR | 39M | P2 | 计划中 |
 | Qwen3-TTS 0.6B | TTS | 600M | P2 | 受阻（需要自定义 SafeTensors 运行时） |
 | Chatterbox Turbo | TTS | 350M | P3 | 受阻（需要 ModelGraph 模板） |
@@ -376,7 +381,7 @@ Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚�
 | 语音转文本 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 文本转语音 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 语言模型 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 视觉模型 | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
+| 视觉模型 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 嵌入模型 | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | 多模型流水线（MMP） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 模型下载与缓存 | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -8,6 +8,8 @@ vision on Android and iOS; `0.2.1` brings the native VLM backend
 macOS, Linux, and Windows — so a Flutter desktop app can run a vision-language
 model out of the box, matching mobile (xybrid-ai/xybrid#296).
 
+* Fixed: GGUF models with custom or non-standard chat templates now load and run — when llama.cpp's built-in template matcher rejects the embedded template, it is rendered via a real Jinja engine (minijinja) instead of failing (xybrid-ai/xybrid#304)
+
 ## 0.2.0-rc1
 
 Release candidate for `0.2.0`, published so consumers can validate the vision

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.1
+
+Vision (VLM) now runs on every Flutter target. `0.2.0` shipped on-device
+vision on Android and iOS; `0.2.1` brings the native VLM backend
+(`llm-llamacpp-vision`, llama.cpp's mtmd) to the **desktop** targets too —
+macOS, Linux, and Windows — so a Flutter desktop app can run a vision-language
+model out of the box, matching mobile (xybrid-ai/xybrid#296).
+
 ## 0.2.0-rc1
 
 Release candidate for `0.2.0`, published so consumers can validate the vision

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.2.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.2.1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.2.0"
+version = "0.2.1"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.2.0-rc1"
+  implementation "ai.xybrid:xybrid-kotlin:0.2.1"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.2.0-rc1",
+  "version": "0.2.1",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.2.0", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.1", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.2.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.1" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.2.0", path = "../../macros" }
+xybrid-macros = { version = "0.2.1", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.2.1", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.2.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.2.1", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.2.0", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.2.1", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Release **v0.2.1**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.2.1).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.2.1`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.