### PR TITLE
fix(llama): render unrecognized chat templates via minijinja fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,6 +3319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3359,26 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+dependencies = [
+ "memo-map",
+ "serde",
+]
+
+[[package]]
+name = "minijinja-contrib"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85342f6fac0be8ccd5bd00d9066be538f34f393f577b75d81b17c8398a6b43bb"
+dependencies = [
+ "minijinja",
+ "serde",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -6824,6 +6850,8 @@ dependencies = [
  "libc",
  "log",
  "mel_spec",
+ "minijinja",
+ "minijinja-contrib",
  "ndarray 0.17.2",
  "ndarray-npy 0.10.0",
  "num-complex",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -27,6 +27,12 @@ path = "src/lib.rs"
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
 xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.0", optional = true }
 xybrid-llama = { path = "../xybrid-llama", version = "0.2.0", optional = true }
+# Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
+# hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
+# we render that template here instead. Gated with the deps below into
+# `llm-llamacpp` so non-llama builds pay zero cost.
+minijinja = { version = "2.5", default-features = false, features = ["builtins", "loader", "macros", "serde"], optional = true }
+minijinja-contrib = { version = "2.5", features = ["pycompat"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
@@ -149,6 +155,8 @@ llm-llamacpp = [
     "xybrid-llama-sys/bindings",
     "dep:xybrid-llama",
     "xybrid-llama/bindings",
+    "dep:minijinja",
+    "dep:minijinja-contrib",
 ]
 # The Rust vision pipeline (envelopes, preprocessing, strategy dispatch) is
 # always compiled in. This feature gates only the *native* llama multimodal

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/chat.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/chat.rs
@@ -1,26 +1,107 @@
 //! Chat prompt formatting policy for the llama.cpp adapter.
 
+use super::jinja_template::{JinjaChatTemplate, RenderOptions};
 use crate::runtime_adapter::llm::LlmResult;
-use crate::runtime_adapter::ChatMessage;
+use crate::runtime_adapter::{AdapterError, ChatMessage};
+use xybrid_llama::LlamaError;
 
 pub(super) fn format_chat_prompt(
     model: &xybrid_llama::LlamaModel,
     messages: &[ChatMessage],
 ) -> LlmResult<String> {
-    let roles: Vec<&str> = messages
-        .iter()
-        .map(|message| message.role.as_str())
-        .collect();
-    let contents: Vec<&str> = messages
-        .iter()
-        .map(|message| message.content.as_str())
-        .collect();
+    let roles: Vec<&str> = messages.iter().map(|m| m.role.as_str()).collect();
+    let contents: Vec<&str> = messages.iter().map(|m| m.content.as_str()).collect();
 
-    if let Some(prompt) = xybrid_llama::format_chat(model, &roles, &contents)? {
-        return Ok(prompt);
+    match xybrid_llama::format_chat(model, &roles, &contents) {
+        Ok(Some(prompt)) => Ok(prompt),
+        Ok(None) => Ok(format_chat_chatml(messages)),
+        // Template is present but llama.cpp's non-Jinja matcher rejected it
+        // (e.g. gemma-4 returns code -1): fall back to rendering the model's
+        // own embedded template through minijinja.
+        Err(err @ LlamaError::ChatTemplateFailed { .. }) => {
+            render_embedded_fallback(model, messages, err)
+        }
+        Err(err) => Err(err.into()),
     }
+}
 
-    Ok(format_chat_chatml(messages))
+/// Render the model's own embedded chat template through minijinja and return
+/// it as a raw prompt. This is the fallback for when llama.cpp's non-Jinja
+/// matcher rejects an otherwise-valid embedded template (e.g. gemma-4, which
+/// returns code -1) — the same engine the MLX path uses.
+///
+/// Policy: never substitute a different prompt family. If minijinja also fails,
+/// surface an error chaining both causes (the original llama rejection and the
+/// minijinja failure) rather than silently swapping templates.
+///
+/// `model.chat_template()` is re-read here and is expected to be `Some`:
+/// `format_chat` only returns `ChatTemplateFailed` when a template is present
+/// (it returns `Ok(None)` otherwise). The `None` guard is defensive — if that
+/// cross-crate invariant ever changed it re-surfaces the original `err` rather
+/// than panicking.
+fn render_embedded_fallback(
+    model: &xybrid_llama::LlamaModel,
+    messages: &[ChatMessage],
+    err: LlamaError,
+) -> LlmResult<String> {
+    let Some(template) = model.chat_template() else {
+        return Err(err.into());
+    };
+
+    // BOS is deliberately suppressed (passed as `None`): `tokenize_chat_prompt`
+    // tokenizes this prompt with `add_special = true`, so llama.cpp prepends the
+    // BOS token itself. HF Jinja templates (gemma-4's included) emit a literal
+    // `{{ bos_token }}` which `parse_special` would turn into a *second* BOS —
+    // and gemma degrades badly on a doubled BOS. llama.cpp's own native gemma
+    // template likewise emits no leading BOS and relies on `add_special`; we
+    // match that contract. This assumes the model adds BOS at tokenization,
+    // which holds for every template that reaches this chat path.
+    //
+    // EOS is passed through for templates that interpolate `{{ eos_token }}` to
+    // terminate prior assistant turns; where it appears it is mid-prompt, so
+    // `add_special` does not duplicate it. (gemma-4 itself uses the literal
+    // `<turn|>` marker and never references `eos_token`, so this is a no-op for
+    // the motivating model but keeps other templates correct.)
+    let tpl = JinjaChatTemplate::new(template, None, detokenize_special(model, model.token_eos()));
+
+    // `enable_thinking = false`: xybrid's llama.cpp backend is a raw
+    // tokenize → generate → detokenize loop with no parser for gemma-4's
+    // `<|channel>thought … <channel|>` reasoning blocks (unlike llama.cpp's own
+    // chat server). Requesting a reasoning channel would leak its markers and
+    // reasoning text into the user-facing output, which the post-processing
+    // stop/strip patterns don't yet understand. Asking for a direct answer makes
+    // gemma-4's template pre-fill an empty thought and emit the response
+    // straight away.
+    let options = RenderOptions {
+        add_generation_prompt: true,
+        enable_thinking: false,
+    };
+
+    match tpl.render(messages, &options) {
+        Ok(prompt) => Ok(prompt),
+        Err(render_err) => {
+            tracing::warn!(
+                target: "xybrid_core",
+                "minijinja chat template fallback failed: {render_err}"
+            );
+            Err(AdapterError::RuntimeError(format!(
+                "llama.cpp did not recognize the embedded chat template ({err}); minijinja fallback also failed ({render_err})"
+            )))
+        }
+    }
+}
+
+/// Detokenize a single special token (the EOS token) to its text form for the
+/// Jinja context. Never panics: a negative/invalid token id or a detokenize
+/// error yields `None`, so the template sees an empty `eos_token`.
+fn detokenize_special(model: &xybrid_llama::LlamaModel, token: i32) -> Option<String> {
+    if token < 0 {
+        return None;
+    }
+    match model.detokenize(&[token]) {
+        Ok(s) if !s.is_empty() => Some(s),
+        _ => None,
+    }
 }
 
 fn format_chat_chatml(messages: &[ChatMessage]) -> String {

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/jinja_template.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/jinja_template.rs
@@ -1,0 +1,268 @@
+//! Minijinja fallback renderer for a GGUF's embedded chat template.
+//!
+//! llama.cpp ships a hardcoded, *non-Jinja* matcher for chat templates: it
+//! recognises a fixed set of known families by sniffing for literal markers
+//! (`<start_of_turn>`, `<|im_start|>`, …) in the embedded template string.
+//! When a GGUF carries a real Jinja template that the matcher can't classify
+//! — e.g. gemma-4's 16 KB tool-calling template, which contains no literal
+//! `<start_of_turn>` — `llama_chat_apply_template` returns error code `-1`
+//! and native formatting hard-fails.
+//!
+//! This module renders that same embedded template through [`minijinja`], a
+//! real Jinja engine, so the resulting raw prompt can be fed back into
+//! llama.cpp directly. It is the exact engine and context shape the MLX
+//! adapter uses for HuggingFace templates. It is used *only* as a fallback by
+//! [`super::chat::format_chat_prompt`] when native formatting reports a
+//! template is present but unrenderable; if minijinja also fails, the caller
+//! surfaces an error chaining both the original llama rejection and this
+//! render failure.
+//!
+//! There is no file I/O here: the template string and BOS/EOS tokens are
+//! supplied by the caller, which already holds the loaded [`LlamaModel`].
+
+use minijinja::{context, Environment, Value};
+use minijinja_contrib::pycompat::unknown_method_callback;
+
+use crate::runtime_adapter::ChatMessage;
+
+/// Error from compiling or rendering a GGUF's embedded Jinja chat template.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum JinjaTemplateError {
+    /// Template failed to compile (Jinja2 syntax error) or render (undefined
+    /// variable, type mismatch, etc.). Wraps the minijinja error message.
+    #[error("chat template render failed: {0}")]
+    Render(String),
+}
+
+/// Options the caller passes at render time. Kept tiny on purpose —
+/// expanding it is cheaper than inventing a second rendering path.
+#[derive(Debug, Clone)]
+pub(super) struct RenderOptions {
+    /// Whether to append the assistant-turn scaffolding so the LLM continues
+    /// mid-turn. Almost always `true` when the caller plans to call
+    /// `generate` on the rendered prompt.
+    pub add_generation_prompt: bool,
+    /// Whether reasoning-model templates should enter their thinking mode.
+    /// Templates that honor this switch skip reasoning-channel scaffolding
+    /// for direct user-facing answers.
+    pub enable_thinking: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            add_generation_prompt: true,
+            enable_thinking: true,
+        }
+    }
+}
+
+/// A GGUF's embedded Jinja chat template, ready to render message lists into
+/// raw prompt text.
+#[derive(Debug, Clone)]
+pub(super) struct JinjaChatTemplate {
+    /// The raw Jinja template string, as embedded in the GGUF.
+    template: String,
+    /// Optional BOS token (e.g. `<s>`) passed into the Jinja context as
+    /// `bos_token` for templates that interpolate it.
+    bos_token: Option<String>,
+    /// Optional EOS token (e.g. `</s>`) — same passthrough.
+    eos_token: Option<String>,
+}
+
+impl JinjaChatTemplate {
+    /// Construct a template from a raw Jinja string plus optional BOS/EOS
+    /// tokens. The tokens flow into the render context; pass `None` when the
+    /// model exposes no special-token text.
+    pub(super) fn new(
+        template: impl Into<String>,
+        bos_token: Option<String>,
+        eos_token: Option<String>,
+    ) -> Self {
+        Self {
+            template: template.into(),
+            bos_token,
+            eos_token,
+        }
+    }
+
+    /// Render a message list to a prompt string. The Jinja context mirrors
+    /// the HuggingFace transformers tokenizer's `apply_chat_template`, so a
+    /// template copied verbatim from a GGUF renders without modification.
+    pub(super) fn render(
+        &self,
+        messages: &[ChatMessage],
+        options: &RenderOptions,
+    ) -> Result<String, JinjaTemplateError> {
+        // Build an Environment per-call. minijinja's envs are cheap to
+        // construct (~1us) and the alternative — caching a compiled template
+        // on the struct — would require a self-referential lifetime or
+        // `Arc<Environment<'static>>` with a leaked template string. The
+        // per-call cost is invisible relative to the forward pass.
+        let mut env = Environment::new();
+        env.set_unknown_method_callback(unknown_method_callback);
+        env.add_template("chat", &self.template)
+            .map_err(|e| JinjaTemplateError::Render(format!("compile: {e}")))?;
+
+        // Messages flow into the template as a list of maps. Using
+        // `Value::from_serialize` preserves the `{role, content}` shape
+        // every HF template expects.
+        let messages_value: Vec<Value> = messages
+            .iter()
+            .map(|m| {
+                Value::from_serialize(serde_json::json!({
+                    "role": m.role.as_str(),
+                    "content": &m.content,
+                }))
+            })
+            .collect();
+
+        let ctx = context! {
+            messages => messages_value,
+            add_generation_prompt => options.add_generation_prompt,
+            enable_thinking => options.enable_thinking,
+            bos_token => self.bos_token.clone().unwrap_or_default(),
+            eos_token => self.eos_token.clone().unwrap_or_default(),
+        };
+
+        let tmpl = env
+            .get_template("chat")
+            .map_err(|e| JinjaTemplateError::Render(format!("lookup: {e}")))?;
+        tmpl.render(ctx)
+            .map_err(|e| JinjaTemplateError::Render(format!("render: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_supports_macro_templates() {
+        let tmpl = JinjaChatTemplate::new(
+            concat!(
+                "{%- macro turn(message) -%}",
+                "<start_of_turn>{{ message.role }}\n{{ message.content }}<end_of_turn>\n",
+                "{%- endmacro -%}",
+                "{%- for message in messages -%}",
+                "{{ turn(message) }}",
+                "{%- endfor -%}",
+                "{%- if add_generation_prompt -%}<start_of_turn>assistant\n{%- endif -%}"
+            ),
+            None,
+            None,
+        );
+        let out = tmpl
+            .render(&[ChatMessage::user("hello")], &RenderOptions::default())
+            .unwrap();
+        assert!(out.contains("<start_of_turn>user\nhello<end_of_turn>"));
+        assert!(out.ends_with("<start_of_turn>assistant"));
+    }
+
+    #[test]
+    fn render_applies_trim_filter() {
+        let tmpl = JinjaChatTemplate::new("{{ messages[0].content | trim }}", None, None);
+        let out = tmpl
+            .render(&[ChatMessage::user(" hi ")], &RenderOptions::default())
+            .unwrap();
+        assert_eq!(out, "hi");
+    }
+
+    #[test]
+    fn bos_eos_flow_through_to_context() {
+        let tmpl = JinjaChatTemplate::new(
+            "{{ bos_token }}[{{ messages[0].content }}]{{ eos_token }}",
+            Some("<s>".into()),
+            Some("</s>".into()),
+        );
+        let out = tmpl
+            .render(&[ChatMessage::user("x")], &RenderOptions::default())
+            .unwrap();
+        assert_eq!(out, "<s>[x]</s>");
+    }
+
+    #[test]
+    fn add_generation_prompt_false_skips_scaffold() {
+        let tmpl = JinjaChatTemplate::new(
+            concat!(
+                "{%- macro turn(message) -%}",
+                "<start_of_turn>{{ message.role }}\n{{ message.content }}<end_of_turn>\n",
+                "{%- endmacro -%}",
+                "{%- for message in messages -%}",
+                "{{ turn(message) }}",
+                "{%- endfor -%}",
+                "{%- if add_generation_prompt -%}<start_of_turn>assistant\n{%- endif -%}"
+            ),
+            None,
+            None,
+        );
+        let opts = RenderOptions {
+            add_generation_prompt: false,
+            enable_thinking: true,
+        };
+        let out = tmpl.render(&[ChatMessage::user("hello")], &opts).unwrap();
+        assert!(!out.contains("<start_of_turn>assistant"));
+    }
+
+    /// Mirrors gemma-4's `enable_thinking` gating: with thinking off the
+    /// template must NOT inject a `<|think|>` reasoning block and instead
+    /// pre-fills an empty thought, steering the model to answer directly.
+    /// This is the shape the llama.cpp fallback requests (it cannot parse
+    /// reasoning channels in the raw-decode path).
+    #[test]
+    fn enable_thinking_false_suppresses_reasoning_block() {
+        let gemma4_shaped = concat!(
+            "{%- if enable_thinking -%}<|turn>system\n<|think|>\n<turn|>\n{%- endif -%}",
+            "{%- for message in messages -%}",
+            "<|turn>{{ message.role }}\n{{ message.content }}<turn|>\n",
+            "{%- endfor -%}",
+            "{%- if add_generation_prompt -%}<|turn>model\n",
+            "{%- if not enable_thinking -%}<|channel>thought\n<channel|>{%- endif -%}",
+            "{%- endif -%}"
+        );
+        let tmpl = JinjaChatTemplate::new(gemma4_shaped, None, None);
+
+        let off = tmpl
+            .render(
+                &[ChatMessage::user("Hello")],
+                &RenderOptions {
+                    add_generation_prompt: true,
+                    enable_thinking: false,
+                },
+            )
+            .unwrap();
+        assert!(
+            !off.contains("<|think|>"),
+            "thinking-off must not inject a reasoning block: {off}"
+        );
+        assert!(off.contains("<|turn>user\nHello<turn|>"));
+        // thinking-off pre-fills an empty thought channel after the model turn,
+        // steering gemma-4 to answer directly.
+        assert!(off.contains("<|turn>model"));
+        assert!(off.contains("<|channel>thought") && off.contains("<channel|>"));
+
+        // Contrast: thinking-on injects the reasoning block and does NOT
+        // pre-fill the empty-thought suppressor (proves both gates work).
+        let on = tmpl
+            .render(
+                &[ChatMessage::user("Hello")],
+                &RenderOptions {
+                    add_generation_prompt: true,
+                    enable_thinking: true,
+                },
+            )
+            .unwrap();
+        assert!(on.contains("<|think|>"));
+        assert!(!on.contains("<|channel>thought"));
+    }
+
+    /// A syntactically broken template must surface as `Err`, never panic —
+    /// the caller relies on this to surface an error chaining the original
+    /// llama rejection and this render failure.
+    #[test]
+    fn invalid_template_returns_err_not_panic() {
+        let tmpl = JinjaChatTemplate::new("{% for x in %}", None, None);
+        let result = tmpl.render(&[ChatMessage::user("hi")], &RenderOptions::default());
+        assert!(matches!(result, Err(JinjaTemplateError::Render(_))));
+    }
+}

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/jinja_template.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/jinja_template.rs
@@ -104,16 +104,16 @@ impl JinjaChatTemplate {
         env.add_template("chat", &self.template)
             .map_err(|e| JinjaTemplateError::Render(format!("compile: {e}")))?;
 
-        // Messages flow into the template as a list of maps. Using
-        // `Value::from_serialize` preserves the `{role, content}` shape
-        // every HF template expects.
+        // Messages flow into the template as a list of `{role, content}` maps —
+        // the shape every HF template expects. `context!` builds each map as a
+        // minijinja `Value` directly, without an intermediate `serde_json::Value`.
         let messages_value: Vec<Value> = messages
             .iter()
             .map(|m| {
-                Value::from_serialize(serde_json::json!({
-                    "role": m.role.as_str(),
-                    "content": &m.content,
-                }))
+                context! {
+                    role => m.role.as_str(),
+                    content => m.content.as_str(),
+                }
             })
             .collect();
 

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -28,6 +28,7 @@
 // `crate::telemetry::events` and the `runtime_adapter::mod` re-export
 // keep their existing identifiers.
 mod chat;
+mod jinja_template;
 pub use xybrid_llama::{
     get_verbosity as llama_log_get_verbosity, set_verbosity as llama_log_set_verbosity,
 };

--- a/integration-tests/tests/llm_chat_template.rs
+++ b/integration-tests/tests/llm_chat_template.rs
@@ -269,3 +269,83 @@ fn test_gemma_executor_output_clean() {
 
     assert!(!response.trim().is_empty(), "Response should not be empty");
 }
+
+// =============================================================================
+// Regression: unrecognized embedded template renders via minijinja fallback
+// =============================================================================
+
+/// Regression: gemma-4's GGUF embeds a 16KB tool-calling Jinja template with
+/// no `<start_of_turn>` literal, so llama.cpp's non-Jinja matcher returns -1.
+/// Before the minijinja fallback, chat-mode generate() hard-failed with
+/// "Chat template render failed: native formatter initial render returned
+/// error code -1". This asserts chat generation now succeeds.
+#[test]
+fn test_gemma4_unrecognized_template_renders_via_minijinja() {
+    let model_name = "gemma-4-e2b";
+
+    let Some(model_dir) = fixtures::model_if_available(model_name) else {
+        eprintln!(
+            "Skipping {}: model not downloaded. Run: ./integration-tests/download.sh {}",
+            model_name, model_name
+        );
+        return;
+    };
+
+    // The fixture dir ships a committed `model_metadata.json` (it doubles as
+    // the VLM correctness fixture), so `model_if_available` returns `Some`
+    // even when the multi-GB GGUFs themselves were never downloaded. Skip
+    // cleanly in that case rather than panicking — the GGUF is the real
+    // prerequisite for this regression.
+    let gguf_path = std::fs::read_dir(&model_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.extension().map(|ext| ext == "gguf").unwrap_or(false)
+                && !p
+                    .file_name()
+                    .map(|n| n.to_string_lossy().starts_with("mmproj"))
+                    .unwrap_or(false)
+        });
+    let Some(gguf_path) = gguf_path else {
+        eprintln!(
+            "Skipping {}: GGUF not downloaded. Run: ./integration-tests/download.sh {}",
+            model_name, model_name
+        );
+        return;
+    };
+
+    let mut backend = LlamaCppBackend::new().expect("Failed to create backend");
+    let config = LlmConfig::new(gguf_path.to_str().unwrap()).with_context_length(2048);
+    backend.load(&config).expect("Failed to load model");
+
+    let gen_config = GenerationConfig {
+        max_tokens: 16,
+        temperature: 0.0,
+        ..Default::default()
+    };
+
+    let output = backend
+        .generate(&[ChatMessage::user("Hello")], &gen_config)
+        .expect("gemma-4 chat generate must succeed via minijinja fallback");
+
+    // Primary regression: before the fallback this hard-failed with code -1.
+    // It must now produce tokens.
+    assert!(
+        !output.text.trim().is_empty(),
+        "gemma-4 fallback produced empty output"
+    );
+
+    // No-leakage: turn headers live only in the prompt and `<turn|>` is an EOG
+    // stop marker, so none of these structural markers may appear in the
+    // user-facing reply. (gemma-4's `<|channel>thought…<channel|>` reasoning
+    // markers are suppressed at the prompt level via `enable_thinking=false`;
+    // full channel-aware output stripping is tracked as a separate follow-up.)
+    for marker in ["<start_of_turn>", "<|turn>", "<turn|>"] {
+        assert!(
+            !output.text.contains(marker),
+            "template marker {marker:?} leaked into gemma-4 output: {:?}",
+            output.text
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The llama.cpp backend hard-failed chat generation for any GGUF whose embedded
template llama.cpp's matcher can't recognize — notably **gemma-4** (16 KB
tool-calling Jinja template, no literal `<start_of_turn>`). `llama_chat_apply_template`
isn't a Jinja parser; it substring-matches ~30 known families and returns `-1`
otherwise, surfacing as `Chat template render failed: … error code -1`.

This renders the model's **own** embedded template with `minijinja` as a
fallback when the native matcher rejects it, then feeds the result back as a raw
prompt — without switching prompt families. (The `-1` became a hard error rather
than a silent ChatML fallback in #166; gemma-4 is the first shipped model to
trip it.)

## What changed

- New `pub(super)` minijinja renderer in `llama_cpp/jinja_template.rs`;
  `format_chat_prompt` delegates the rejected-template case to it. On a minijinja
  failure it logs and surfaces a combined error (never a silent family switch).
- `minijinja` + `minijinja-contrib` added as **optional** deps gated on
  `llm-llamacpp` — non-llama builds pull nothing new.

## Key decisions

- **BOS suppressed** — this path tokenizes with `add_special=true`, so the HF
  template's `{{ bos_token }}` would double the BOS (gemma degrades on that);
  matches llama.cpp's native gemma template, which emits none.
- **`enable_thinking=false`** — the raw decode path can't parse gemma-4's
  `<|channel>thought…<channel|>` blocks, so it requests a direct answer.
- Recognized templates (Qwen/Llama/…) return `Ok(Some)` and never hit the fallback.

## Testing

6 renderer unit tests + an integration regression test gated on the `gemma-4-e2b`
fixture (skips without the GGUF; runs in CI `test-llm`). Verified: fmt, clippy
`-D warnings`, full `xybrid-core` lib suite (1018 passed), no-default-features.

> Not run end-to-end locally (GGUF not staged). Channel-aware output stripping
> and the shared-renderer merge with `feat/mlx-backend` are tracked as follow-ups.
