### PR TITLE
docs: add Liquid LFM2.5 230M support

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ All models run entirely on-device. No cloud, no API keys required. Browse the fu
 | Model | Params | Format | Description |
 |-------|--------|--------|-------------|
 | Gemma 3 1B | 1B | GGUF Q4_K_M | Google's mobile-optimized LLM |
+| LFM2.5 230M | 230M | GGUF Q4_K_M | Liquid AI's smallest hybrid conv+attention LLM for edge devices |
 | LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AI's hybrid conv+attention, 9 languages, tool calling |
 | Llama 3.2 1B | 1B | GGUF Q4_K_M | Meta's general purpose, 128K context |
 | Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | Compact on-device chat |


### PR DESCRIPTION
## Summary

- Add Liquid LFM2.5 230M to the top-level README supported language models table.
- Document it as a GGUF Q4_K_M on-device language model alongside the existing LFM2.5 350M entry.

## Validation

- `git diff --check -- README.md`
- `cargo fmt --all -- --check`
- verified Liquid's Hugging Face model metadata for `LiquidAI/LFM2.5-230M-GGUF` and `LFM2.5-230M-Q4_K_M.gguf`
- confirmed `docs/superpowers` is absent from status and tracked files