### PR TITLE
fix(cache)!: rationalize model cache clear and discovery

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -383,8 +383,19 @@ jobs:
         run: |
           set -u
           sdk="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
+          # `sdkmanager` isn't on PATH in a plain run step (the emulator-runner
+          # action wires it up itself), so resolve it under the SDK root.
+          sdkmanager="$(command -v sdkmanager || true)"
+          if [ -z "$sdkmanager" ]; then
+            sdkmanager="$(ls "$sdk"/cmdline-tools/latest/bin/sdkmanager \
+              "$sdk"/cmdline-tools/*/bin/sdkmanager 2>/dev/null | head -1 || true)"
+          fi
+          if [ -z "$sdkmanager" ]; then
+            echo "::error::sdkmanager not found under $sdk"; exit 1
+          fi
+          echo "using sdkmanager: $sdkmanager"
           for i in $(seq 1 3); do
-            if yes | sdkmanager --install emulator --channel=0; then
+            if yes | "$sdkmanager" --install emulator --channel=0; then
               echo "emulator installed (attempt $i)"
               exit 0
             fi

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -371,6 +371,30 @@ jobs:
           name: android-dlopen-gate
           path: dlopen-gate
 
+      # `android-emulator-runner` installs the "latest emulator" with a single,
+      # un-retried `sdkmanager --install emulator` call. That download
+      # intermittently lands corrupt on the runner and fails the whole job with
+      # "Error on ZipFile unknown archive" — an infra hiccup, not a regression
+      # in the .so this gate checks. Pre-install it here with retries (wiping
+      # any partial download between attempts so a wedged cache can't be reused)
+      # so a bad fetch can't sink the run; the action's own install then sees
+      # the package already current and no-ops.
+      - name: Pre-install Android Emulator (retry corrupt downloads)
+        run: |
+          set -u
+          sdk="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
+          for i in $(seq 1 3); do
+            if yes | sdkmanager --install emulator --channel=0; then
+              echo "emulator installed (attempt $i)"
+              exit 0
+            fi
+            echo "::warning::emulator install attempt $i failed; clearing partial download and retrying"
+            rm -rf "$sdk/emulator" "$sdk/.temp" "$sdk/.downloadIntermediates" || true
+            sleep 10
+          done
+          echo "::error::emulator install failed after 3 attempts"
+          exit 1
+
       # api-level 35 = Android 15 bionic, which is strict enough to reject the
       # DT_GNU_HASH corruption this gate guards against.
       - name: dlopen libxybrid-bolt.so (as built + after AGP strip)

--- a/crates/xybrid-cli/src/commands/cache.rs
+++ b/crates/xybrid-cli/src/commands/cache.rs
@@ -112,7 +112,12 @@ fn clear_cache(
         ui::hint("Press Enter to continue or Ctrl+C to cancel...");
 
         let mut input = String::new();
-        std::io::stdin().read_line(&mut input).ok();
+        // EOF / closed stdin (piped input, /dev/null, CI) must not count as
+        // confirmation — a destructive clear requires an explicit keypress.
+        if std::io::stdin().read_line(&mut input).unwrap_or(0) == 0 {
+            ui::warning("Aborted: no interactive confirmation.");
+            return Ok(());
+        }
 
         let removed = client.clear_all_cache().context("Failed to clear cache")?;
 

--- a/crates/xybrid-cli/src/commands/cache.rs
+++ b/crates/xybrid-cli/src/commands/cache.rs
@@ -96,11 +96,15 @@ fn clear_cache(
     if let Some(id) = model_id {
         ui::header(&format!("Clear Cache · {}", id));
 
-        client
+        let removed = client
             .clear_cache(&id)
             .context(format!("Failed to clear cache for '{}'", id))?;
 
-        ui::ok(&format!("Cache cleared for model '{}'", id));
+        if removed == 0 {
+            ui::warning(&format!("No cached data found for model '{}'", id));
+        } else {
+            ui::ok(&format!("Cache cleared for model '{}'", id));
+        }
     } else {
         ui::header("Clear All Cache");
         println!();
@@ -110,9 +114,13 @@ fn clear_cache(
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).ok();
 
-        client.clear_all_cache().context("Failed to clear cache")?;
+        let removed = client.clear_all_cache().context("Failed to clear cache")?;
 
-        ui::ok("All cached models cleared");
+        if removed == 0 {
+            ui::warning("No cached models found");
+        } else {
+            ui::ok("All cached models cleared");
+        }
     }
 
     println!();

--- a/crates/xybrid-cli/src/commands/cache.rs
+++ b/crates/xybrid-cli/src/commands/cache.rs
@@ -21,12 +21,12 @@ pub(crate) fn handle_cache_command(command: CacheCommand) -> Result<()> {
 fn list_cache(client: &xybrid_sdk::registry_client::RegistryClient) -> Result<()> {
     ui::header("Model Cache");
 
-    let stats = client.cache_stats().context("Failed to get cache stats")?;
     let entries = client
         .cache_entries()
         .context("Failed to list cache entries")?;
+    let total_size: u64 = entries.iter().map(|entry| entry.size_bytes).sum();
 
-    ui::kv("Root", &stats.cache_root().display().to_string());
+    ui::kv("Root", &client.cache_root().display().to_string());
     println!();
 
     if entries.is_empty() {
@@ -48,8 +48,8 @@ fn list_cache(client: &xybrid_sdk::registry_client::RegistryClient) -> Result<()
 
     ui::footer(&format!(
         "{} entries · {}",
-        stats.model_count,
-        stats.total_size_human()
+        entries.len(),
+        xybrid_sdk::registry_client::CacheStats::format_size(total_size)
     ));
 
     Ok(())

--- a/crates/xybrid-cli/src/commands/cache.rs
+++ b/crates/xybrid-cli/src/commands/cache.rs
@@ -1,10 +1,9 @@
 //! `xybrid cache` command handler.
 
 use anyhow::{Context, Result};
-use std::fs;
 
 use super::types::CacheCommand;
-use super::utils::{dir_size_bytes, format_size};
+use super::utils::format_size;
 use crate::ui;
 
 /// Handle `xybrid cache` subcommands.
@@ -23,32 +22,32 @@ fn list_cache(client: &xybrid_sdk::registry_client::RegistryClient) -> Result<()
     ui::header("Model Cache");
 
     let stats = client.cache_stats().context("Failed to get cache stats")?;
+    let entries = client
+        .cache_entries()
+        .context("Failed to list cache entries")?;
 
-    ui::kv("Directory", &stats.cache_path.display().to_string());
+    ui::kv("Root", &stats.cache_root().display().to_string());
     println!();
 
-    if stats.model_count == 0 {
+    if entries.is_empty() {
         ui::hint("Cache is empty.");
         ui::hint("Use 'xybrid fetch --model <id>' to download models.");
         return Ok(());
     }
 
-    if stats.cache_path.exists() {
-        let mut table = ui::Table::new(vec!["Model", "Size"]);
-        for entry in fs::read_dir(&stats.cache_path)? {
-            let entry = entry?;
-            if entry.path().is_dir() {
-                let model_name = entry.file_name();
-                let model_name = model_name.to_string_lossy();
-                let model_size = dir_size_bytes(&entry.path()).unwrap_or(0);
-                table.row(vec![&model_name, &format_size(model_size)]);
-            }
-        }
-        table.print();
+    let mut table = ui::Table::new(vec!["Model", "Location", "Size"]);
+    for entry in &entries {
+        let size = format_size(entry.size_bytes);
+        table.row(vec![
+            entry.model_id.as_str(),
+            entry.location.as_str(),
+            size.as_str(),
+        ]);
     }
+    table.print();
 
     ui::footer(&format!(
-        "{} models · {}",
+        "{} entries · {}",
         stats.model_count,
         stats.total_size_human()
     ));
@@ -75,13 +74,13 @@ fn show_cache_status(client: &xybrid_sdk::registry_client::RegistryClient) -> Re
         format!(
             "{}    {}",
             ui::dim("Path"),
-            ui::dim(&stats.cache_path.display().to_string())
+            ui::dim(&stats.cache_root().display().to_string())
         ),
     ]);
 
-    if !stats.cache_path.exists() {
+    if !stats.cache_root().exists() {
         println!();
-        ui::hint("Cache directory does not exist yet.");
+        ui::hint("Cache root does not exist yet.");
         ui::hint("It will be created when you download your first model.");
     }
 

--- a/crates/xybrid-cli/src/commands/utils.rs
+++ b/crates/xybrid-cli/src/commands/utils.rs
@@ -28,23 +28,6 @@ pub fn format_size(bytes: u64) -> String {
     }
 }
 
-/// Calculate the total size of a directory in bytes.
-pub fn dir_size_bytes(path: &Path) -> anyhow::Result<u64> {
-    let mut total = 0u64;
-    if path.is_dir() {
-        for entry in std::fs::read_dir(path)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                total += dir_size_bytes(&path)?;
-            } else {
-                total += entry.metadata()?.len();
-            }
-        }
-    }
-    Ok(total)
-}
-
 /// Display a stage name, stripping any "@target" suffix.
 pub fn display_stage_name(name: &str) -> &str {
     name.split('@').next().unwrap_or(name)

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -671,7 +671,7 @@ impl CacheManager {
     ///
     /// Not safe to run concurrently with a load of the same model: it removes
     /// whole cache directories that an in-flight extraction may be writing to.
-    pub(crate) fn clear_model_roots(&self, model_id: &str) -> Result<u32, SdkError> {
+    pub(crate) fn clear_model_roots(&mut self, model_id: &str) -> Result<u32, SdkError> {
         if model_id.is_empty()
             || !Path::new(model_id)
                 .components()
@@ -684,8 +684,10 @@ impl CacheManager {
         }
 
         let mut roots = self.layout().model_roots(model_id);
-        for entry in self.entries.values() {
+        let mut entry_keys = Vec::new();
+        for (key, entry) in &self.entries {
             if entry.id == model_id {
+                entry_keys.push(key.clone());
                 roots.push(entry.path.clone());
             }
         }
@@ -699,6 +701,10 @@ impl CacheManager {
             if Self::remove_cache_path(&root)? {
                 removed_count += 1;
             }
+        }
+
+        for key in entry_keys {
+            self.entries.remove(&key);
         }
 
         Ok(removed_count)
@@ -861,7 +867,7 @@ mod tests {
         fs::write(extracted_model_dir.join("model_metadata.json"), b"{}").unwrap();
         fs::write(other_model_dir.join("universal.xyb"), b"bundle").unwrap();
 
-        let manager = CacheManager::with_dir(models_dir).unwrap();
+        let mut manager = CacheManager::with_dir(models_dir).unwrap();
 
         let removed = manager.clear_model_roots("kokoro-82m").unwrap();
 
@@ -889,7 +895,7 @@ mod tests {
         fs::write(hf_model_dir.join("model.gguf"), b"weights").unwrap();
         fs::write(hf_hub_model_dir.join("blob"), b"weights").unwrap();
 
-        let manager = CacheManager::with_dir(models_dir).unwrap();
+        let mut manager = CacheManager::with_dir(models_dir).unwrap();
 
         let removed = manager.clear_model_roots("owner/repo").unwrap();
 
@@ -930,7 +936,7 @@ mod tests {
         fs::create_dir_all(&sibling_sentinel).unwrap();
         fs::write(sibling_sentinel.join("keep"), b"keep").unwrap();
 
-        let manager = CacheManager::with_dir(custom_cache).unwrap();
+        let mut manager = CacheManager::with_dir(custom_cache).unwrap();
 
         let removed = manager.clear_model_roots("legacy-model").unwrap();
 
@@ -949,7 +955,7 @@ mod tests {
         fs::create_dir_all(&outside_dir).unwrap();
         fs::write(outside_dir.join("sentinel"), b"keep").unwrap();
 
-        let manager = CacheManager::with_dir(models_dir).unwrap();
+        let mut manager = CacheManager::with_dir(models_dir).unwrap();
 
         let result = manager.clear_model_roots("../outside");
 
@@ -958,6 +964,31 @@ mod tests {
             outside_dir.join("sentinel").exists(),
             "invalid model IDs must not delete outside cache paths"
         );
+    }
+
+    #[test]
+    fn clear_model_roots_removes_legacy_bundle_from_memory_index() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("models");
+        fs::create_dir_all(&cache_dir).unwrap();
+        let bundle_path = cache_dir.join("test-model@1.0.xyb");
+        fs::write(&bundle_path, b"bundle").unwrap();
+
+        let mut manager = CacheManager::with_dir(cache_dir).unwrap();
+        assert!(manager.is_cached("test-model"));
+        assert_eq!(manager.status().unwrap().total_models, 1);
+        assert_eq!(
+            manager.get_cached_path("test-model"),
+            Some(bundle_path.clone())
+        );
+
+        let removed = manager.clear_model_roots("test-model").unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!bundle_path.exists());
+        assert!(!manager.is_cached("test-model"));
+        assert_eq!(manager.status().unwrap().total_models, 0);
+        assert_eq!(manager.get_cached_path("test-model"), None);
     }
 
     // =========================================================================

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -17,6 +17,7 @@
 //! # }
 //! ```
 
+use super::layout::{CacheEntryInfo, CacheLayout};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
@@ -179,28 +180,20 @@ impl CacheManager {
         &self.cache_dir
     }
 
-    fn cache_root(&self) -> &Path {
-        self.cache_dir.parent().unwrap_or(&self.cache_dir)
+    pub(crate) fn layout_from_config() -> Result<CacheLayout, SdkError> {
+        Ok(CacheLayout::from_registry_root(Self::get_cache_dir()?))
     }
 
-    fn extracted_root(&self) -> PathBuf {
-        self.cache_root().join("extracted")
+    fn layout(&self) -> CacheLayout {
+        CacheLayout::from_registry_root(self.cache_dir.clone())
     }
 
-    fn sibling_root_when_cache_dir_is_models(&self, root_name: &str) -> Option<PathBuf> {
-        self.cache_dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .filter(|name| name.eq_ignore_ascii_case("models"))
-            .map(|_| self.cache_root().join(root_name))
+    pub(crate) fn registry_bundle_path(&self, hf_repo: &str, file: &str) -> PathBuf {
+        self.layout().registry_bundle_path(hf_repo, file)
     }
 
-    fn sibling_hf_root(&self) -> Option<PathBuf> {
-        self.sibling_root_when_cache_dir_is_models("hf")
-    }
-
-    fn sibling_hf_hub_root(&self) -> Option<PathBuf> {
-        self.sibling_root_when_cache_dir_is_models("hf-hub")
+    pub(crate) fn cache_entries(&self) -> Result<Vec<CacheEntryInfo>, SdkError> {
+        self.layout().cache_entries()
     }
 
     /// Scans the cache directory for existing bundles.
@@ -416,8 +409,7 @@ impl CacheManager {
     ///
     /// * `model_id` - The model identifier from model_metadata.json
     pub fn extraction_dir(&self, model_id: &str) -> PathBuf {
-        // Go up from models/ to cache/, then into extracted/
-        self.extracted_root().join(model_id)
+        self.layout().extraction_dir(model_id)
     }
 
     /// Checks if a bundle has already been extracted.
@@ -459,7 +451,7 @@ impl CacheManager {
     ///
     /// This is an offline operation — it never touches the network.
     pub fn list_extracted_model_ids(&self) -> Vec<String> {
-        let extracted_root = self.extracted_root();
+        let extracted_root = self.layout().extracted_root();
 
         let Ok(entries) = std::fs::read_dir(&extracted_root) else {
             return Vec::new();
@@ -676,23 +668,7 @@ impl CacheManager {
             )));
         }
 
-        let sanitized_hf_repo = model_id.replace('/', "--");
-        let hf_hub_repo = format!("models--{}", sanitized_hf_repo);
-        let mut roots = vec![
-            self.cache_dir.join(model_id),
-            self.extraction_dir(model_id),
-            self.cache_dir.join("hf").join(model_id),
-            self.cache_dir.join("hf").join(&sanitized_hf_repo),
-            self.cache_dir.join("hf-hub").join(&hf_hub_repo),
-        ];
-
-        if let Some(hf_root) = self.sibling_hf_root() {
-            roots.push(hf_root.join(model_id));
-            roots.push(hf_root.join(&sanitized_hf_repo));
-        }
-        if let Some(hf_hub_root) = self.sibling_hf_hub_root() {
-            roots.push(hf_hub_root.join(&hf_hub_repo));
-        }
+        let mut roots = self.layout().model_roots(model_id);
         for entry in self.entries.values() {
             if entry.id == model_id {
                 roots.push(entry.path.clone());
@@ -721,12 +697,8 @@ impl CacheManager {
     pub fn clear(&mut self) -> Result<u32, SdkError> {
         let count = self.entries.len() as u32;
 
-        let mut roots = vec![self.cache_dir.clone(), self.extracted_root()];
-        roots.extend(self.sibling_hf_root());
-        roots.extend(self.sibling_hf_hub_root());
-
-        for root in roots {
-            Self::remove_cache_path(&root)?;
+        for root in self.layout().entry_roots() {
+            Self::remove_cache_path(&root.path)?;
         }
 
         std::fs::create_dir_all(&self.cache_dir)

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -63,7 +63,7 @@ struct CacheEntry {
 enum CacheType {
     /// Local models persist indefinitely
     Local,
-    /// Cloud models have  weeks TTL
+    /// Cloud models have a 24h TTL
     Cloud,
 }
 

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -661,6 +661,16 @@ impl CacheManager {
         Ok(removed_count)
     }
 
+    /// Removes every managed cache root for a single model.
+    ///
+    /// # Returns
+    ///
+    /// The number of cache roots removed (0 if the model was not cached).
+    ///
+    /// # Concurrency
+    ///
+    /// Not safe to run concurrently with a load of the same model: it removes
+    /// whole cache directories that an in-flight extraction may be writing to.
     pub(crate) fn clear_model_roots(&self, model_id: &str) -> Result<u32, SdkError> {
         if model_id.is_empty()
             || !Path::new(model_id)
@@ -694,22 +704,30 @@ impl CacheManager {
         Ok(removed_count)
     }
 
-    /// Clears all cached models.
+    /// Clears all cached models across every managed cache root.
     ///
     /// # Returns
     ///
-    /// Number of entries removed
+    /// The number of cache roots removed (registry bundles, extracted runtime
+    /// caches, and HuggingFace downloads). Returns `0` when nothing was cached.
+    ///
+    /// # Concurrency
+    ///
+    /// Not safe to run concurrently with a model load: it removes whole cache
+    /// directories that an in-flight download or extraction may be writing to.
     pub fn clear(&mut self) -> Result<u32, SdkError> {
-        let count = self.entries.len() as u32;
+        let mut removed_count = 0;
 
         for root in self.layout().entry_roots() {
-            Self::remove_cache_path(&root.path)?;
+            if Self::remove_cache_path(&root.path)? {
+                removed_count += 1;
+            }
         }
 
         std::fs::create_dir_all(&self.cache_dir)
             .map_err(|e| SdkError::cache_src("Failed to recreate cache directory", e))?;
         self.entries.clear();
-        Ok(count)
+        Ok(removed_count)
     }
 
     fn remove_cache_path(path: &Path) -> Result<bool, SdkError> {
@@ -1091,6 +1109,46 @@ mod tests {
         assert!(extract_dir.exists());
         assert!(extract_dir.join("model_metadata.json").exists());
         assert!(extract_dir.join("model.onnx").exists());
+    }
+
+    #[test]
+    fn clear_leaves_cache_loadable_for_the_next_extraction() {
+        // Regression guard: clear() removes the extracted/ runtime cache and
+        // recreates only the registry root. The very next load must still
+        // succeed by re-extracting — i.e. clear() must leave the cache in a
+        // loadable state, not a half-torn-down one.
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache").join("models");
+        fs::create_dir_all(&cache_dir).unwrap();
+
+        let mut manager = CacheManager::with_dir(cache_dir.clone()).unwrap();
+        // The bundle lives outside the cache tree, so it survives clear().
+        let bundle_path = create_test_bundle(&temp_dir, "reload-model");
+
+        // First load populates extracted/reload-model/.
+        manager.ensure_extracted(&bundle_path).unwrap();
+        assert!(manager.is_extracted("reload-model"));
+
+        // Clearing wipes the extracted runtime cache and recreates the root.
+        // Exactly two managed roots exist here — the registry root (models/)
+        // and the extracted/ runtime cache — so both are counted.
+        let removed = manager.clear().unwrap();
+        assert_eq!(
+            removed, 2,
+            "clear() should count the registry + extracted roots"
+        );
+        assert!(
+            cache_dir.exists(),
+            "registry root should be recreated after clear()"
+        );
+        assert!(!manager.is_extracted("reload-model"));
+        assert!(manager.list_extracted_model_ids().is_empty());
+
+        // The next load must succeed by re-extracting from the surviving bundle.
+        let extract_dir = manager.ensure_extracted(&bundle_path).unwrap();
+        assert!(extract_dir.join("model_metadata.json").exists());
+        assert!(extract_dir.join("model.onnx").exists());
+        assert!(manager.is_extracted("reload-model"));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -179,6 +179,22 @@ impl CacheManager {
         &self.cache_dir
     }
 
+    fn cache_root(&self) -> &Path {
+        self.cache_dir.parent().unwrap_or(&self.cache_dir)
+    }
+
+    fn extracted_root(&self) -> PathBuf {
+        self.cache_root().join("extracted")
+    }
+
+    fn sibling_hf_root(&self) -> Option<PathBuf> {
+        self.cache_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| name.eq_ignore_ascii_case("models"))
+            .map(|_| self.cache_root().join("hf"))
+    }
+
     /// Scans the cache directory for existing bundles.
     fn scan_cache(&mut self) -> Result<(), SdkError> {
         if !self.cache_dir.exists() {
@@ -393,11 +409,7 @@ impl CacheManager {
     /// * `model_id` - The model identifier from model_metadata.json
     pub fn extraction_dir(&self, model_id: &str) -> PathBuf {
         // Go up from models/ to cache/, then into extracted/
-        self.cache_dir
-            .parent()
-            .unwrap_or(&self.cache_dir)
-            .join("extracted")
-            .join(model_id)
+        self.extracted_root().join(model_id)
     }
 
     /// Checks if a bundle has already been extracted.
@@ -439,11 +451,7 @@ impl CacheManager {
     ///
     /// This is an offline operation — it never touches the network.
     pub fn list_extracted_model_ids(&self) -> Vec<String> {
-        let extracted_root = self
-            .cache_dir
-            .parent()
-            .unwrap_or(&self.cache_dir)
-            .join("extracted");
+        let extracted_root = self.extracted_root();
 
         let Ok(entries) = std::fs::read_dir(&extracted_root) else {
             return Vec::new();
@@ -656,12 +664,23 @@ impl CacheManager {
     pub fn clear(&mut self) -> Result<u32, SdkError> {
         let count = self.entries.len() as u32;
 
-        for entry in self.entries.values() {
-            if entry.path.exists() {
-                let _ = std::fs::remove_file(&entry.path);
+        let mut roots = vec![self.cache_dir.clone(), self.extracted_root()];
+        if let Some(hf_root) = self.sibling_hf_root() {
+            roots.push(hf_root);
+        }
+
+        for root in roots {
+            if root.is_dir() {
+                std::fs::remove_dir_all(&root)
+                    .map_err(|e| SdkError::cache_src("Failed to remove cache directory", e))?;
+            } else if root.exists() {
+                std::fs::remove_file(&root)
+                    .map_err(|e| SdkError::cache_src("Failed to remove cache file", e))?;
             }
         }
 
+        std::fs::create_dir_all(&self.cache_dir)
+            .map_err(|e| SdkError::cache_src("Failed to recreate cache directory", e))?;
         self.entries.clear();
         Ok(count)
     }
@@ -721,6 +740,44 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let manager = CacheManager::with_dir(temp_dir.path().to_path_buf()).unwrap();
         assert!(manager.get_cached_path("test-model").is_none());
+    }
+
+    #[test]
+    fn clear_removes_managed_model_cache_roots_when_registry_entries_are_unscanned() {
+        // Given: the real cache layout produced by registry, extraction, and
+        // direct HuggingFace model-loading paths.
+        let temp_dir = TempDir::new().unwrap();
+        let cache_root = temp_dir.path().join("cache");
+        let models_dir = cache_root.join("models");
+        let registry_model_dir = models_dir.join("Kokoro-82M-v1.0-ONNX");
+        let extracted_model_dir = cache_root.join("extracted").join("kokoro-82m");
+        let hf_model_dir = cache_root.join("hf").join("owner--repo");
+        fs::create_dir_all(&registry_model_dir).unwrap();
+        fs::create_dir_all(&extracted_model_dir).unwrap();
+        fs::create_dir_all(&hf_model_dir).unwrap();
+        fs::write(registry_model_dir.join("universal.xyb"), b"bundle").unwrap();
+        fs::write(extracted_model_dir.join("model_metadata.json"), b"{}").unwrap();
+        fs::write(hf_model_dir.join("model.gguf"), b"weights").unwrap();
+
+        let mut manager = CacheManager::with_dir(models_dir.clone()).unwrap();
+
+        // When: the user clears all cached models through the cache manager.
+        manager.clear().unwrap();
+
+        // Then: every managed model-cache root is removed, including roots not
+        // represented in the legacy top-level `.xyb` entry map.
+        assert!(
+            !registry_model_dir.exists(),
+            "registry model cache should be removed by clear()"
+        );
+        assert!(
+            !extracted_model_dir.exists(),
+            "extracted runtime cache should be removed by clear()"
+        );
+        assert!(
+            !hf_model_dir.exists(),
+            "direct HuggingFace model cache should be removed by clear()"
+        );
     }
 
     // =========================================================================

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -18,8 +18,8 @@
 //! ```
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use xybrid_core::bundler::XyBundle;
 
@@ -187,12 +187,20 @@ impl CacheManager {
         self.cache_root().join("extracted")
     }
 
-    fn sibling_hf_root(&self) -> Option<PathBuf> {
+    fn sibling_root_when_cache_dir_is_models(&self, root_name: &str) -> Option<PathBuf> {
         self.cache_dir
             .file_name()
             .and_then(|name| name.to_str())
             .filter(|name| name.eq_ignore_ascii_case("models"))
-            .map(|_| self.cache_root().join("hf"))
+            .map(|_| self.cache_root().join(root_name))
+    }
+
+    fn sibling_hf_root(&self) -> Option<PathBuf> {
+        self.sibling_root_when_cache_dir_is_models("hf")
+    }
+
+    fn sibling_hf_hub_root(&self) -> Option<PathBuf> {
+        self.sibling_root_when_cache_dir_is_models("hf-hub")
     }
 
     /// Scans the cache directory for existing bundles.
@@ -656,6 +664,55 @@ impl CacheManager {
         Ok(removed_count)
     }
 
+    pub(crate) fn clear_model_roots(&self, model_id: &str) -> Result<u32, SdkError> {
+        if model_id.is_empty()
+            || !Path::new(model_id)
+                .components()
+                .all(|component| matches!(component, Component::Normal(_)))
+        {
+            return Err(SdkError::cache(format!(
+                "Invalid cache model identifier: {}",
+                model_id
+            )));
+        }
+
+        let sanitized_hf_repo = model_id.replace('/', "--");
+        let hf_hub_repo = format!("models--{}", sanitized_hf_repo);
+        let mut roots = vec![
+            self.cache_dir.join(model_id),
+            self.extraction_dir(model_id),
+            self.cache_dir.join("hf").join(model_id),
+            self.cache_dir.join("hf").join(&sanitized_hf_repo),
+            self.cache_dir.join("hf-hub").join(&hf_hub_repo),
+        ];
+
+        if let Some(hf_root) = self.sibling_hf_root() {
+            roots.push(hf_root.join(model_id));
+            roots.push(hf_root.join(&sanitized_hf_repo));
+        }
+        if let Some(hf_hub_root) = self.sibling_hf_hub_root() {
+            roots.push(hf_hub_root.join(&hf_hub_repo));
+        }
+        for entry in self.entries.values() {
+            if entry.id == model_id {
+                roots.push(entry.path.clone());
+            }
+        }
+
+        let mut removed_count = 0;
+        let mut seen = HashSet::new();
+        for root in roots {
+            if !seen.insert(root.clone()) {
+                continue;
+            }
+            if Self::remove_cache_path(&root)? {
+                removed_count += 1;
+            }
+        }
+
+        Ok(removed_count)
+    }
+
     /// Clears all cached models.
     ///
     /// # Returns
@@ -665,24 +722,31 @@ impl CacheManager {
         let count = self.entries.len() as u32;
 
         let mut roots = vec![self.cache_dir.clone(), self.extracted_root()];
-        if let Some(hf_root) = self.sibling_hf_root() {
-            roots.push(hf_root);
-        }
+        roots.extend(self.sibling_hf_root());
+        roots.extend(self.sibling_hf_hub_root());
 
         for root in roots {
-            if root.is_dir() {
-                std::fs::remove_dir_all(&root)
-                    .map_err(|e| SdkError::cache_src("Failed to remove cache directory", e))?;
-            } else if root.exists() {
-                std::fs::remove_file(&root)
-                    .map_err(|e| SdkError::cache_src("Failed to remove cache file", e))?;
-            }
+            Self::remove_cache_path(&root)?;
         }
 
         std::fs::create_dir_all(&self.cache_dir)
             .map_err(|e| SdkError::cache_src("Failed to recreate cache directory", e))?;
         self.entries.clear();
         Ok(count)
+    }
+
+    fn remove_cache_path(path: &Path) -> Result<bool, SdkError> {
+        if path.is_dir() {
+            std::fs::remove_dir_all(path)
+                .map_err(|e| SdkError::cache_src("Failed to remove cache directory", e))?;
+            Ok(true)
+        } else if path.exists() {
+            std::fs::remove_file(path)
+                .map_err(|e| SdkError::cache_src("Failed to remove cache file", e))?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -752,12 +816,15 @@ mod tests {
         let registry_model_dir = models_dir.join("Kokoro-82M-v1.0-ONNX");
         let extracted_model_dir = cache_root.join("extracted").join("kokoro-82m");
         let hf_model_dir = cache_root.join("hf").join("owner--repo");
+        let hf_hub_model_dir = cache_root.join("hf-hub").join("models--owner--repo");
         fs::create_dir_all(&registry_model_dir).unwrap();
         fs::create_dir_all(&extracted_model_dir).unwrap();
         fs::create_dir_all(&hf_model_dir).unwrap();
+        fs::create_dir_all(&hf_hub_model_dir).unwrap();
         fs::write(registry_model_dir.join("universal.xyb"), b"bundle").unwrap();
         fs::write(extracted_model_dir.join("model_metadata.json"), b"{}").unwrap();
         fs::write(hf_model_dir.join("model.gguf"), b"weights").unwrap();
+        fs::write(hf_hub_model_dir.join("blob"), b"weights").unwrap();
 
         let mut manager = CacheManager::with_dir(models_dir.clone()).unwrap();
 
@@ -777,6 +844,89 @@ mod tests {
         assert!(
             !hf_model_dir.exists(),
             "direct HuggingFace model cache should be removed by clear()"
+        );
+        assert!(
+            !hf_hub_model_dir.exists(),
+            "owned HuggingFace blob cache should be removed by clear()"
+        );
+    }
+
+    #[test]
+    fn clear_model_roots_removes_registry_and_extracted_cache_for_id() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_root = temp_dir.path().join("cache");
+        let models_dir = cache_root.join("models");
+        let model_dir = models_dir.join("kokoro-82m");
+        let extracted_model_dir = cache_root.join("extracted").join("kokoro-82m");
+        let other_model_dir = models_dir.join("other-model");
+        fs::create_dir_all(&model_dir).unwrap();
+        fs::create_dir_all(&extracted_model_dir).unwrap();
+        fs::create_dir_all(&other_model_dir).unwrap();
+        fs::write(model_dir.join("universal.xyb"), b"bundle").unwrap();
+        fs::write(extracted_model_dir.join("model_metadata.json"), b"{}").unwrap();
+        fs::write(other_model_dir.join("universal.xyb"), b"bundle").unwrap();
+
+        let manager = CacheManager::with_dir(models_dir).unwrap();
+
+        let removed = manager.clear_model_roots("kokoro-82m").unwrap();
+
+        assert_eq!(removed, 2);
+        assert!(
+            !model_dir.exists(),
+            "registry model cache should be removed"
+        );
+        assert!(
+            !extracted_model_dir.exists(),
+            "extracted model cache should be removed"
+        );
+        assert!(other_model_dir.exists(), "unrelated model should remain");
+    }
+
+    #[test]
+    fn clear_model_roots_removes_direct_hf_cache_for_repo_id() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_root = temp_dir.path().join("cache");
+        let models_dir = cache_root.join("models");
+        let hf_model_dir = cache_root.join("hf").join("owner--repo");
+        let hf_hub_model_dir = cache_root.join("hf-hub").join("models--owner--repo");
+        fs::create_dir_all(&hf_model_dir).unwrap();
+        fs::create_dir_all(&hf_hub_model_dir).unwrap();
+        fs::write(hf_model_dir.join("model.gguf"), b"weights").unwrap();
+        fs::write(hf_hub_model_dir.join("blob"), b"weights").unwrap();
+
+        let manager = CacheManager::with_dir(models_dir).unwrap();
+
+        let removed = manager.clear_model_roots("owner/repo").unwrap();
+
+        assert_eq!(removed, 2);
+        assert!(
+            !hf_model_dir.exists(),
+            "direct HuggingFace model cache should be removed"
+        );
+        assert!(
+            !hf_hub_model_dir.exists(),
+            "owned HuggingFace blob cache should be removed"
+        );
+    }
+
+    #[test]
+    fn clear_model_roots_rejects_path_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_root = temp_dir.path().join("cache");
+        let models_dir = cache_root.join("models");
+        let outside_dir = cache_root.join("outside");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::create_dir_all(&outside_dir).unwrap();
+        fs::write(outside_dir.join("sentinel"), b"keep").unwrap();
+
+        let manager = CacheManager::with_dir(models_dir).unwrap();
+
+        let result = manager.clear_model_roots("../outside");
+
+        assert!(result.is_err());
+        assert!(
+            outside_dir.join("sentinel").exists(),
+            "invalid model IDs must not delete outside cache paths"
         );
     }
 

--- a/crates/xybrid-sdk/src/cache/cache_manager.rs
+++ b/crates/xybrid-sdk/src/cache/cache_manager.rs
@@ -422,8 +422,14 @@ impl CacheManager {
     ///
     /// True if the extraction directory exists and contains model_metadata.json
     pub fn is_extracted(&self, model_id: &str) -> bool {
-        let extract_dir = self.extraction_dir(model_id);
-        Self::extraction_is_ready(&extract_dir)
+        self.existing_extraction_dir(model_id).is_some()
+    }
+
+    pub(crate) fn existing_extraction_dir(&self, model_id: &str) -> Option<PathBuf> {
+        self.layout()
+            .extraction_dirs(model_id)
+            .into_iter()
+            .find(|extract_dir| Self::extraction_is_ready(extract_dir))
     }
 
     fn extraction_is_ready(extract_dir: &Path) -> bool {
@@ -451,14 +457,12 @@ impl CacheManager {
     ///
     /// This is an offline operation — it never touches the network.
     pub fn list_extracted_model_ids(&self) -> Vec<String> {
-        let extracted_root = self.layout().extracted_root();
-
-        let Ok(entries) = std::fs::read_dir(&extracted_root) else {
-            return Vec::new();
-        };
-
-        let mut ids: Vec<String> = entries
-            .filter_map(|entry| entry.ok())
+        let mut ids: Vec<String> = self
+            .layout()
+            .extracted_roots()
+            .into_iter()
+            .filter_map(|root| std::fs::read_dir(root).ok())
+            .flat_map(|entries| entries.filter_map(|entry| entry.ok()))
             .filter(|entry| Self::extraction_is_ready(&entry.path()))
             .filter_map(|entry| {
                 entry
@@ -470,6 +474,7 @@ impl CacheManager {
             .collect();
 
         ids.sort();
+        ids.dedup();
         ids
     }
 
@@ -527,10 +532,8 @@ impl CacheManager {
         let metadata: ModelMetadata = serde_json::from_str(&metadata_json)
             .map_err(|e| SdkError::cache_src("Failed to parse model metadata", e))?;
 
-        let extract_dir = self.extraction_dir(&metadata.model_id);
-
         // Check if already extracted and all files declared by metadata exist.
-        if Self::extraction_is_ready(&extract_dir) {
+        if let Some(extract_dir) = self.existing_extraction_dir(&metadata.model_id) {
             log::debug!(
                 "Bundle already extracted for '{}' at {}",
                 metadata.model_id,
@@ -538,6 +541,8 @@ impl CacheManager {
             );
             return Ok(extract_dir);
         }
+
+        let extract_dir = self.extraction_dir(&metadata.model_id);
 
         // Create extraction directory
         std::fs::create_dir_all(&extract_dir)
@@ -574,10 +579,8 @@ impl CacheManager {
         xyb_path: &Path,
         model_id: &str,
     ) -> Result<PathBuf, SdkError> {
-        let extract_dir = self.extraction_dir(model_id);
-
         // Check if already extracted and all files declared by metadata exist.
-        if Self::extraction_is_ready(&extract_dir) {
+        if let Some(extract_dir) = self.existing_extraction_dir(model_id) {
             log::debug!(
                 "Bundle already extracted for '{}' at {}",
                 model_id,
@@ -585,6 +588,8 @@ impl CacheManager {
             );
             return Ok(extract_dir);
         }
+
+        let extract_dir = self.extraction_dir(model_id);
 
         // Need to extract - load bundle
         if !xyb_path.exists() {
@@ -882,6 +887,41 @@ mod tests {
     }
 
     #[test]
+    fn custom_root_resolves_legacy_parent_extracted_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let custom_cache = temp_dir.path().join("custom-cache");
+        let legacy_extracted_model = temp_dir.path().join("extracted").join("legacy-model");
+        write_ready_extracted_model(&legacy_extracted_model, "legacy-model");
+
+        let manager = CacheManager::with_dir(custom_cache).unwrap();
+
+        assert!(manager.is_extracted("legacy-model"));
+        assert_eq!(
+            manager.list_extracted_model_ids(),
+            vec!["legacy-model".to_string()]
+        );
+    }
+
+    #[test]
+    fn custom_root_clear_model_removes_legacy_parent_extracted_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let custom_cache = temp_dir.path().join("custom-cache");
+        let legacy_extracted_model = temp_dir.path().join("extracted").join("legacy-model");
+        let sibling_sentinel = temp_dir.path().join("sibling");
+        write_ready_extracted_model(&legacy_extracted_model, "legacy-model");
+        fs::create_dir_all(&sibling_sentinel).unwrap();
+        fs::write(sibling_sentinel.join("keep"), b"keep").unwrap();
+
+        let manager = CacheManager::with_dir(custom_cache).unwrap();
+
+        let removed = manager.clear_model_roots("legacy-model").unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!legacy_extracted_model.exists());
+        assert!(sibling_sentinel.join("keep").exists());
+    }
+
+    #[test]
     fn clear_model_roots_rejects_path_traversal() {
         let temp_dir = TempDir::new().unwrap();
         let cache_root = temp_dir.path().join("cache");
@@ -905,6 +945,24 @@ mod tests {
     // =========================================================================
     // Bundle Extraction Tests
     // =========================================================================
+
+    fn write_ready_extracted_model(model_dir: &Path, model_id: &str) {
+        fs::create_dir_all(model_dir).unwrap();
+        let metadata = format!(
+            r#"{{
+                "model_id": "{}",
+                "version": "1.0",
+                "execution_template": {{ "type": "Onnx", "model_file": "model.onnx" }},
+                "preprocessing": [],
+                "postprocessing": [],
+                "files": ["model.onnx"],
+                "metadata": {{}}
+            }}"#,
+            model_id
+        );
+        fs::write(model_dir.join("model_metadata.json"), metadata).unwrap();
+        fs::write(model_dir.join("model.onnx"), b"model").unwrap();
+    }
 
     /// Creates a test bundle with model_metadata.json
     fn create_test_bundle(temp_dir: &TempDir, model_id: &str) -> PathBuf {

--- a/crates/xybrid-sdk/src/cache/cache_provider.rs
+++ b/crates/xybrid-sdk/src/cache/cache_provider.rs
@@ -39,7 +39,6 @@ use crate::model::SdkError;
 ///
 /// - Fuzzy model ID matching (e.g., "kokoro-82m" matches "Kokoro-82M-v1.0-ONNX")
 /// - Integrates with `CacheManager` for bundle management
-/// - Optionally uses `RegistryClient` for online resolution (when available)
 ///
 /// ## Example
 ///

--- a/crates/xybrid-sdk/src/cache/layout.rs
+++ b/crates/xybrid-sdk/src/cache/layout.rs
@@ -62,7 +62,15 @@ impl CacheLayout {
 
     pub(crate) fn cache_root(&self) -> &Path {
         if is_models_dir(&self.registry_root) {
-            self.registry_root.parent().unwrap_or(&self.registry_root)
+            // `Path::parent` returns `Some("")` (an empty path), not `None`,
+            // for a bare single-component relative root like "models". Guard
+            // against that empty parent too — otherwise the sibling
+            // `extracted/`, `hf/`, and `hf-hub/` roots would resolve
+            // CWD-relative and split away from the registry bundles.
+            self.registry_root
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or(&self.registry_root)
         } else {
             &self.registry_root
         }

--- a/crates/xybrid-sdk/src/cache/layout.rs
+++ b/crates/xybrid-sdk/src/cache/layout.rs
@@ -72,8 +72,23 @@ impl CacheLayout {
         self.cache_root().join("extracted")
     }
 
+    pub(crate) fn extracted_roots(&self) -> Vec<PathBuf> {
+        let mut roots = vec![self.extracted_root()];
+        if let Some(root) = self.legacy_parent_extracted_root() {
+            roots.push(root);
+        }
+        dedup_paths(roots)
+    }
+
     pub(crate) fn extraction_dir(&self, model_id: &str) -> PathBuf {
         self.extracted_root().join(model_id)
+    }
+
+    pub(crate) fn extraction_dirs(&self, model_id: &str) -> Vec<PathBuf> {
+        self.extracted_roots()
+            .into_iter()
+            .map(|root| root.join(model_id))
+            .collect()
     }
 
     pub(crate) fn registry_bundle_path(&self, hf_repo: &str, file: &str) -> PathBuf {
@@ -88,52 +103,76 @@ impl CacheLayout {
         self.huggingface_root().join(sanitize_repo_id(repo))
     }
 
+    pub(crate) fn huggingface_repo_dirs(&self, repo: &str) -> Vec<PathBuf> {
+        let sanitized_repo = sanitize_repo_id(repo);
+        dedup_paths(vec![
+            self.huggingface_root().join(&sanitized_repo),
+            self.registry_root.join("hf").join(&sanitized_repo),
+        ])
+    }
+
     pub(crate) fn huggingface_hub_root(&self) -> PathBuf {
         self.cache_root().join("hf-hub")
     }
 
+    pub(crate) fn preferred_huggingface_hub_root(&self, repo: &str) -> PathBuf {
+        let repo_dir = huggingface_hub_repo_dir_name(repo);
+        self.huggingface_hub_roots()
+            .into_iter()
+            .find(|root| root.join(&repo_dir).exists())
+            .unwrap_or_else(|| self.huggingface_hub_root())
+    }
+
     pub(crate) fn entry_roots(&self) -> Vec<CacheEntryRoot> {
-        self.dedup_roots(vec![
-            CacheEntryRoot {
+        let extracted_roots = self
+            .extracted_roots()
+            .into_iter()
+            .map(|path| CacheEntryRoot {
+                location: CacheEntryLocation::Extracted,
+                path,
+            });
+        self.dedup_roots(
+            std::iter::once(CacheEntryRoot {
                 location: CacheEntryLocation::Registry,
                 path: self.registry_root.clone(),
-            },
-            CacheEntryRoot {
-                location: CacheEntryLocation::Extracted,
-                path: self.extracted_root(),
-            },
-            CacheEntryRoot {
-                location: CacheEntryLocation::HuggingFace,
-                path: self.huggingface_root(),
-            },
-            CacheEntryRoot {
-                location: CacheEntryLocation::HuggingFaceHub,
-                path: self.huggingface_hub_root(),
-            },
-            CacheEntryRoot {
-                location: CacheEntryLocation::HuggingFace,
-                path: self.registry_root.join("hf"),
-            },
-            CacheEntryRoot {
-                location: CacheEntryLocation::HuggingFaceHub,
-                path: self.registry_root.join("hf-hub"),
-            },
-        ])
+            })
+            .chain(extracted_roots)
+            .chain([
+                CacheEntryRoot {
+                    location: CacheEntryLocation::HuggingFace,
+                    path: self.huggingface_root(),
+                },
+                CacheEntryRoot {
+                    location: CacheEntryLocation::HuggingFaceHub,
+                    path: self.huggingface_hub_root(),
+                },
+                CacheEntryRoot {
+                    location: CacheEntryLocation::HuggingFace,
+                    path: self.registry_root.join("hf"),
+                },
+                CacheEntryRoot {
+                    location: CacheEntryLocation::HuggingFaceHub,
+                    path: self.registry_root.join("hf-hub"),
+                },
+            ])
+            .collect(),
+        )
     }
 
     pub(crate) fn model_roots(&self, model_id: &str) -> Vec<PathBuf> {
         let sanitized_repo = sanitize_repo_id(model_id);
-        let hf_hub_repo = format!("models--{}", sanitized_repo);
-        dedup_paths(vec![
+        let hf_hub_repo = huggingface_hub_repo_dir_name(model_id);
+        let mut roots = vec![
             self.registry_root.join(model_id),
-            self.extraction_dir(model_id),
             self.huggingface_root().join(model_id),
             self.huggingface_root().join(&sanitized_repo),
             self.huggingface_hub_root().join(&hf_hub_repo),
             self.registry_root.join("hf").join(model_id),
             self.registry_root.join("hf").join(&sanitized_repo),
             self.registry_root.join("hf-hub").join(&hf_hub_repo),
-        ])
+        ];
+        roots.extend(self.extraction_dirs(model_id));
+        dedup_paths(roots)
     }
 
     pub(crate) fn cache_entries(&self) -> Result<Vec<CacheEntryInfo>, SdkError> {
@@ -159,6 +198,22 @@ impl CacheLayout {
             .into_iter()
             .filter(|root| seen.insert(root.path.clone()))
             .collect()
+    }
+
+    fn legacy_parent_extracted_root(&self) -> Option<PathBuf> {
+        if is_models_dir(&self.registry_root) {
+            return None;
+        }
+
+        let root = self.registry_root.parent()?.join("extracted");
+        (root != self.extracted_root()).then_some(root)
+    }
+
+    fn huggingface_hub_roots(&self) -> Vec<PathBuf> {
+        dedup_paths(vec![
+            self.huggingface_hub_root(),
+            self.registry_root.join("hf-hub"),
+        ])
     }
 }
 
@@ -216,6 +271,10 @@ fn repo_leaf(repo: &str) -> &str {
 
 fn sanitize_repo_id(repo: &str) -> String {
     repo.replace('/', "--")
+}
+
+fn huggingface_hub_repo_dir_name(repo: &str) -> String {
+    format!("models--{}", sanitize_repo_id(repo))
 }
 
 fn is_models_dir(path: &Path) -> bool {

--- a/crates/xybrid-sdk/src/cache/layout.rs
+++ b/crates/xybrid-sdk/src/cache/layout.rs
@@ -1,0 +1,237 @@
+use crate::model::SdkError;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Logical cache location for a model entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CacheEntryLocation {
+    /// Registry bundle cache under `models/`.
+    Registry,
+    /// Runtime-ready extraction cache under `extracted/`.
+    Extracted,
+    /// Direct Hugging Face file cache under `hf/`.
+    HuggingFace,
+    /// Hugging Face hub blob cache under `hf-hub/`.
+    HuggingFaceHub,
+}
+
+impl CacheEntryLocation {
+    /// Return the stable CLI/API label for this cache location.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Registry => "models",
+            Self::Extracted => "extracted",
+            Self::HuggingFace => "hf",
+            Self::HuggingFaceHub => "hf-hub",
+        }
+    }
+}
+
+/// Summary of one cached model entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheEntryInfo {
+    /// Model or repository identifier inferred from the cache directory name.
+    pub model_id: String,
+    /// Cache location where this entry was found.
+    pub location: CacheEntryLocation,
+    /// Path to the cached model entry.
+    pub path: PathBuf,
+    /// Recursive size of this cache entry in bytes.
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CacheLayout {
+    registry_root: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CacheEntryRoot {
+    pub(crate) location: CacheEntryLocation,
+    pub(crate) path: PathBuf,
+}
+
+impl CacheLayout {
+    pub(crate) fn from_registry_root(registry_root: PathBuf) -> Self {
+        Self { registry_root }
+    }
+
+    pub(crate) fn registry_root(&self) -> &Path {
+        &self.registry_root
+    }
+
+    pub(crate) fn cache_root(&self) -> &Path {
+        if is_models_dir(&self.registry_root) {
+            self.registry_root.parent().unwrap_or(&self.registry_root)
+        } else {
+            &self.registry_root
+        }
+    }
+
+    pub(crate) fn extracted_root(&self) -> PathBuf {
+        self.cache_root().join("extracted")
+    }
+
+    pub(crate) fn extraction_dir(&self, model_id: &str) -> PathBuf {
+        self.extracted_root().join(model_id)
+    }
+
+    pub(crate) fn registry_bundle_path(&self, hf_repo: &str, file: &str) -> PathBuf {
+        self.registry_root.join(repo_leaf(hf_repo)).join(file)
+    }
+
+    pub(crate) fn huggingface_root(&self) -> PathBuf {
+        self.cache_root().join("hf")
+    }
+
+    pub(crate) fn huggingface_repo_dir(&self, repo: &str) -> PathBuf {
+        self.huggingface_root().join(sanitize_repo_id(repo))
+    }
+
+    pub(crate) fn huggingface_hub_root(&self) -> PathBuf {
+        self.cache_root().join("hf-hub")
+    }
+
+    pub(crate) fn entry_roots(&self) -> Vec<CacheEntryRoot> {
+        self.dedup_roots(vec![
+            CacheEntryRoot {
+                location: CacheEntryLocation::Registry,
+                path: self.registry_root.clone(),
+            },
+            CacheEntryRoot {
+                location: CacheEntryLocation::Extracted,
+                path: self.extracted_root(),
+            },
+            CacheEntryRoot {
+                location: CacheEntryLocation::HuggingFace,
+                path: self.huggingface_root(),
+            },
+            CacheEntryRoot {
+                location: CacheEntryLocation::HuggingFaceHub,
+                path: self.huggingface_hub_root(),
+            },
+            CacheEntryRoot {
+                location: CacheEntryLocation::HuggingFace,
+                path: self.registry_root.join("hf"),
+            },
+            CacheEntryRoot {
+                location: CacheEntryLocation::HuggingFaceHub,
+                path: self.registry_root.join("hf-hub"),
+            },
+        ])
+    }
+
+    pub(crate) fn model_roots(&self, model_id: &str) -> Vec<PathBuf> {
+        let sanitized_repo = sanitize_repo_id(model_id);
+        let hf_hub_repo = format!("models--{}", sanitized_repo);
+        dedup_paths(vec![
+            self.registry_root.join(model_id),
+            self.extraction_dir(model_id),
+            self.huggingface_root().join(model_id),
+            self.huggingface_root().join(&sanitized_repo),
+            self.huggingface_hub_root().join(&hf_hub_repo),
+            self.registry_root.join("hf").join(model_id),
+            self.registry_root.join("hf").join(&sanitized_repo),
+            self.registry_root.join("hf-hub").join(&hf_hub_repo),
+        ])
+    }
+
+    pub(crate) fn cache_entries(&self) -> Result<Vec<CacheEntryInfo>, SdkError> {
+        let mut entries = Vec::new();
+
+        for root in self.entry_roots() {
+            entries.extend(cache_entries_for_root(root.location, &root.path)?);
+        }
+
+        entries.sort_by(|left, right| {
+            left.model_id
+                .cmp(&right.model_id)
+                .then_with(|| left.location.as_str().cmp(right.location.as_str()))
+                .then_with(|| left.path.cmp(&right.path))
+        });
+
+        Ok(entries)
+    }
+
+    fn dedup_roots(&self, roots: Vec<CacheEntryRoot>) -> Vec<CacheEntryRoot> {
+        let mut seen = HashSet::new();
+        roots
+            .into_iter()
+            .filter(|root| seen.insert(root.path.clone()))
+            .collect()
+    }
+}
+
+fn cache_entries_for_root(
+    location: CacheEntryLocation,
+    root: &Path,
+) -> Result<Vec<CacheEntryInfo>, SdkError> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let Some(model_id) = entry.file_name().into_string().ok() else {
+            continue;
+        };
+
+        if model_id.starts_with('.') || is_reserved_registry_dir(location, &model_id) {
+            continue;
+        }
+
+        entries.push(CacheEntryInfo {
+            model_id,
+            location,
+            path: entry.path(),
+            size_bytes: dir_size(&entry.path())?,
+        });
+    }
+
+    Ok(entries)
+}
+
+fn dir_size(path: &Path) -> Result<u64, SdkError> {
+    let mut total: u64 = 0;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_file() {
+            total += metadata.len();
+        } else if metadata.is_dir() {
+            total += dir_size(&entry.path())?;
+        }
+    }
+    Ok(total)
+}
+
+fn repo_leaf(repo: &str) -> &str {
+    repo.split('/').next_back().unwrap_or(repo)
+}
+
+fn sanitize_repo_id(repo: &str) -> String {
+    repo.replace('/', "--")
+}
+
+fn is_models_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("models"))
+}
+
+fn is_reserved_registry_dir(location: CacheEntryLocation, model_id: &str) -> bool {
+    location == CacheEntryLocation::Registry && matches!(model_id, "extracted" | "hf" | "hf-hub")
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}

--- a/crates/xybrid-sdk/src/cache/layout_tests.rs
+++ b/crates/xybrid-sdk/src/cache/layout_tests.rs
@@ -1,0 +1,105 @@
+use super::layout::{CacheEntryLocation, CacheLayout};
+use tempfile::TempDir;
+
+#[test]
+fn layout_uses_model_cache_parent_as_cache_root() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_root = temp_dir.path().join("xybrid");
+    let models_dir = cache_root.join("models");
+    let layout = CacheLayout::from_registry_root(models_dir.clone());
+
+    assert_eq!(layout.cache_root(), cache_root.as_path());
+    assert_eq!(layout.registry_root(), models_dir.as_path());
+    assert_eq!(layout.extracted_root(), cache_root.join("extracted"));
+    assert_eq!(
+        layout.extraction_dir("lfm2.5-350m"),
+        cache_root.join("extracted").join("lfm2.5-350m")
+    );
+    assert_eq!(
+        layout.huggingface_repo_dir("owner/repo"),
+        cache_root.join("hf").join("owner--repo")
+    );
+    assert_eq!(layout.huggingface_hub_root(), cache_root.join("hf-hub"));
+}
+
+#[test]
+fn layout_keeps_custom_non_models_root_self_contained() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_root = temp_dir.path().join("custom-cache");
+    let layout = CacheLayout::from_registry_root(cache_root.clone());
+
+    assert_eq!(layout.cache_root(), cache_root.as_path());
+    assert_eq!(layout.registry_root(), cache_root.as_path());
+    assert_eq!(layout.extracted_root(), cache_root.join("extracted"));
+    assert_eq!(
+        layout.huggingface_repo_dir("owner/repo"),
+        cache_root.join("hf").join("owner--repo")
+    );
+
+    let roots: Vec<_> = layout
+        .entry_roots()
+        .into_iter()
+        .map(|root| (root.location, root.path))
+        .collect();
+
+    assert!(roots.contains(&(CacheEntryLocation::HuggingFace, cache_root.join("hf"))));
+    assert!(!roots.contains(&(CacheEntryLocation::HuggingFace, temp_dir.path().join("hf"))));
+}
+
+#[test]
+fn registry_bundle_path_uses_repo_leaf_under_models() {
+    let temp_dir = TempDir::new().unwrap();
+    let models_dir = temp_dir.path().join("cache").join("models");
+    let layout = CacheLayout::from_registry_root(models_dir.clone());
+
+    assert_eq!(
+        layout.registry_bundle_path("xybrid-ai/kokoro-82m", "universal.xyb"),
+        models_dir.join("kokoro-82m").join("universal.xyb")
+    );
+}
+
+#[test]
+fn entry_roots_include_canonical_and_legacy_direct_hf_locations() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_root = temp_dir.path().join("cache");
+    let models_dir = cache_root.join("models");
+    let layout = CacheLayout::from_registry_root(models_dir.clone());
+
+    let roots: Vec<_> = layout
+        .entry_roots()
+        .into_iter()
+        .map(|root| (root.location, root.path))
+        .collect();
+
+    assert!(roots.contains(&(CacheEntryLocation::Registry, models_dir.clone())));
+    assert!(roots.contains(&(CacheEntryLocation::Extracted, cache_root.join("extracted"))));
+    assert!(roots.contains(&(CacheEntryLocation::HuggingFace, cache_root.join("hf"))));
+    assert!(roots.contains(&(
+        CacheEntryLocation::HuggingFaceHub,
+        cache_root.join("hf-hub")
+    )));
+    assert!(roots.contains(&(CacheEntryLocation::HuggingFace, models_dir.join("hf"))));
+    assert!(roots.contains(&(
+        CacheEntryLocation::HuggingFaceHub,
+        models_dir.join("hf-hub")
+    )));
+}
+
+#[test]
+fn model_clear_roots_cover_canonical_and_legacy_repo_locations() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_root = temp_dir.path().join("cache");
+    let models_dir = cache_root.join("models");
+    let layout = CacheLayout::from_registry_root(models_dir.clone());
+
+    let roots = layout.model_roots("owner/repo");
+
+    assert!(roots.contains(&models_dir.join("owner/repo")));
+    assert!(roots.contains(&cache_root.join("extracted").join("owner/repo")));
+    assert!(roots.contains(&cache_root.join("hf").join("owner/repo")));
+    assert!(roots.contains(&cache_root.join("hf").join("owner--repo")));
+    assert!(roots.contains(&cache_root.join("hf-hub").join("models--owner--repo")));
+    assert!(roots.contains(&models_dir.join("hf").join("owner/repo")));
+    assert!(roots.contains(&models_dir.join("hf").join("owner--repo")));
+    assert!(roots.contains(&models_dir.join("hf-hub").join("models--owner--repo")));
+}

--- a/crates/xybrid-sdk/src/cache/layout_tests.rs
+++ b/crates/xybrid-sdk/src/cache/layout_tests.rs
@@ -1,4 +1,5 @@
 use super::layout::{CacheEntryLocation, CacheLayout};
+use std::fs;
 use tempfile::TempDir;
 
 #[test]
@@ -47,6 +48,29 @@ fn layout_keeps_custom_non_models_root_self_contained() {
 }
 
 #[test]
+fn custom_non_models_roots_include_legacy_parent_extracted_cache() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_root = temp_dir.path().join("custom-cache");
+    let layout = CacheLayout::from_registry_root(cache_root.clone());
+
+    let roots: Vec<_> = layout
+        .entry_roots()
+        .into_iter()
+        .map(|root| (root.location, root.path))
+        .collect();
+
+    assert!(roots.contains(&(CacheEntryLocation::Extracted, cache_root.join("extracted"))));
+    assert!(roots.contains(&(
+        CacheEntryLocation::Extracted,
+        temp_dir.path().join("extracted")
+    )));
+
+    let model_roots = layout.model_roots("legacy-model");
+    assert!(model_roots.contains(&cache_root.join("extracted").join("legacy-model")));
+    assert!(model_roots.contains(&temp_dir.path().join("extracted").join("legacy-model")));
+}
+
+#[test]
 fn registry_bundle_path_uses_repo_leaf_under_models() {
     let temp_dir = TempDir::new().unwrap();
     let models_dir = temp_dir.path().join("cache").join("models");
@@ -55,6 +79,31 @@ fn registry_bundle_path_uses_repo_leaf_under_models() {
     assert_eq!(
         layout.registry_bundle_path("xybrid-ai/kokoro-82m", "universal.xyb"),
         models_dir.join("kokoro-82m").join("universal.xyb")
+    );
+}
+
+#[test]
+fn direct_huggingface_roots_include_legacy_nested_locations() {
+    let temp_dir = TempDir::new().unwrap();
+    let cache_root = temp_dir.path().join("cache");
+    let models_dir = cache_root.join("models");
+    let layout = CacheLayout::from_registry_root(models_dir.clone());
+
+    let repo_dirs = layout.huggingface_repo_dirs("owner/repo");
+    assert_eq!(
+        repo_dirs,
+        vec![
+            cache_root.join("hf").join("owner--repo"),
+            models_dir.join("hf").join("owner--repo")
+        ]
+    );
+
+    let legacy_hub_repo = models_dir.join("hf-hub").join("models--owner--repo");
+    fs::create_dir_all(&legacy_hub_repo).unwrap();
+
+    assert_eq!(
+        layout.preferred_huggingface_hub_root("owner/repo"),
+        models_dir.join("hf-hub")
     );
 }
 

--- a/crates/xybrid-sdk/src/cache/layout_tests.rs
+++ b/crates/xybrid-sdk/src/cache/layout_tests.rs
@@ -1,5 +1,7 @@
 use super::layout::{CacheEntryLocation, CacheLayout};
 use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
 use tempfile::TempDir;
 
 #[test]
@@ -151,4 +153,65 @@ fn model_clear_roots_cover_canonical_and_legacy_repo_locations() {
     assert!(roots.contains(&models_dir.join("hf").join("owner/repo")));
     assert!(roots.contains(&models_dir.join("hf").join("owner--repo")));
     assert!(roots.contains(&models_dir.join("hf-hub").join("models--owner--repo")));
+}
+
+#[test]
+fn layout_keeps_siblings_co_located_for_bare_relative_models_root() {
+    // Regression guard for the `cache_root()` empty-parent bug: `Path::parent`
+    // of a bare single-component "models" is `Some("")`, not `None`. Without
+    // the empty-parent guard, the sibling extracted/hf/hf-hub roots would
+    // resolve CWD-relative and split away from the registry bundles.
+    let layout = CacheLayout::from_registry_root(PathBuf::from("models"));
+
+    // cache_root() collapses to the registry root itself, never an empty path.
+    assert_eq!(layout.cache_root(), Path::new("models"));
+    assert_eq!(
+        layout.extracted_root(),
+        Path::new("models").join("extracted")
+    );
+    assert_eq!(layout.huggingface_root(), Path::new("models").join("hf"));
+    assert_eq!(
+        layout.huggingface_hub_root(),
+        Path::new("models").join("hf-hub")
+    );
+
+    // Every sibling root stays nested under the registry root — none escapes to
+    // a bare CWD-relative directory.
+    for root in [
+        layout.extracted_root(),
+        layout.huggingface_root(),
+        layout.huggingface_hub_root(),
+    ] {
+        assert!(
+            root.starts_with("models"),
+            "sibling root {:?} escaped the registry root",
+            root
+        );
+    }
+}
+
+#[test]
+fn cache_root_never_splits_siblings_for_non_models_roots() {
+    // Any registry root whose leaf is not "models" is treated as the cache root
+    // itself, so the sibling areas always nest under it — never an empty or
+    // CWD-relative path. Covers the edge inputs around the bare-"models" guard:
+    // a current-dir ".", an absolute non-models dir, and a trailing-slash
+    // relative dir.
+    for raw in [".", "/var/cache/xybrid", "relative/custom/"] {
+        let root = PathBuf::from(raw);
+        let layout = CacheLayout::from_registry_root(root.clone());
+
+        assert_eq!(
+            layout.cache_root(),
+            root.as_path(),
+            "cache_root should equal the registry root for {raw:?}"
+        );
+        assert_eq!(layout.extracted_root(), root.join("extracted"));
+        assert_eq!(layout.huggingface_root(), root.join("hf"));
+        assert_eq!(layout.huggingface_hub_root(), root.join("hf-hub"));
+        assert!(
+            layout.extracted_root().starts_with(&root),
+            "extracted root escaped {raw:?}"
+        );
+    }
 }

--- a/crates/xybrid-sdk/src/cache/mod.rs
+++ b/crates/xybrid-sdk/src/cache/mod.rs
@@ -36,6 +36,10 @@
 
 mod cache_manager;
 mod cache_provider;
+pub(crate) mod layout;
+#[cfg(test)]
+mod layout_tests;
 
 pub use cache_manager::{CacheManager, CacheStatus};
 pub use cache_provider::SdkCacheProvider;
+pub use layout::{CacheEntryInfo, CacheEntryLocation};

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -416,15 +416,18 @@ pub fn init_sdk_cache_dir(cache_dir: impl Into<std::path::PathBuf>) {
             }
         }
 
-        // Set HF_HOME for hf-hub/mistralrs (used for model tokenizer/config caching)
-        // This takes priority over XDG_CACHE_HOME
+        // Defensive HF_HOME fallback for HF-aware libraries (and a future
+        // mistralrs dep). Takes priority over XDG_CACHE_HOME. Note: the SDK's
+        // own HuggingFace loader overrides this via `with_cache_dir(...)`, so
+        // SDK downloads land under `<cache_root>/hf-hub`, not here.
         let hf_cache = cache_path.join("huggingface");
         if let Some(hf_str) = hf_cache.to_str() {
             std::env::set_var("HF_HOME", hf_str);
         }
 
-        // Set HF_HUB_OFFLINE to prevent any download attempts
-        // We bundle all required files, so hf-hub should never need to fetch anything
+        // Hint offline mode to HF-aware libraries that honor it. Best-effort
+        // guard, not a guarantee: the `huggingface` feature's loader downloads
+        // deliberately, and not every hf-hub version reads this variable.
         std::env::set_var("HF_HUB_OFFLINE", "1");
 
         // Also set XDG_CACHE_HOME as a fallback for other XDG-compliant libraries

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -6,6 +6,7 @@
 //! - `ModelHandle`: Internal state management for the loaded model
 //! - `StreamEvent`: Events emitted during streaming inference
 
+use crate::cache::CacheManager;
 use crate::registry_client::RegistryClient;
 use crate::result::{InferenceResult, OutputType};
 use crate::run_options::{
@@ -1186,7 +1187,7 @@ impl ModelLoader {
                 // A local cache check only — instantiate `CacheManager` directly
                 // rather than `RegistryClient::from_env()`, which would spin up
                 // an HTTP agent and circuit breakers we don't need here.
-                crate::cache::CacheManager::new().is_ok_and(|cache| cache.is_extracted(id))
+                CacheManager::new().is_ok_and(|cache| cache.is_extracted(id))
             }
             _ => true,
         }
@@ -1333,7 +1334,7 @@ impl ModelLoader {
 
     fn load_from_bundle(&self, path: &PathBuf) -> SdkResult<XybridModel> {
         // Use CacheManager for unified extraction (single source of truth)
-        let cache = crate::cache::CacheManager::new()?;
+        let cache = CacheManager::new()?;
         let extract_dir = cache.ensure_extracted(path)?;
 
         // Load from extracted directory (extraction is permanent in cache)
@@ -1372,7 +1373,8 @@ impl ModelLoader {
         use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 
         // Determine our cache directory
-        let cache_dir = Self::hf_cache_dir(repo)?;
+        let cache_layout = CacheManager::layout_from_config()?;
+        let cache_dir = cache_layout.huggingface_repo_dir(repo);
 
         // Check if we already have a cached copy with model_metadata.json
         let metadata_path = cache_dir.join("model_metadata.json");
@@ -1385,7 +1387,7 @@ impl ModelLoader {
 
         // Create HF API client
         let api = ApiBuilder::from_env()
-            .with_cache_dir(Self::hf_hub_cache_dir()?)
+            .with_cache_dir(cache_layout.huggingface_hub_root())
             .build()
             .map_err(|e| SdkError::network_src("Failed to create HuggingFace API client", e))?;
 
@@ -1565,35 +1567,6 @@ impl ModelLoader {
              Enable it with: cargo build --features huggingface"
                 .to_string(),
         ))
-    }
-
-    /// Get the cache directory for a HuggingFace repo.
-    ///
-    /// Returns `~/.xybrid/cache/hf/{sanitized_repo}/` or the SDK-configured cache path.
-    fn hf_cache_dir(repo: &str) -> SdkResult<PathBuf> {
-        let base_cache = if let Some(sdk_cache) = crate::get_sdk_cache_dir() {
-            sdk_cache.join("hf")
-        } else {
-            Self::default_xybrid_cache_root()?.join("hf")
-        };
-
-        // Sanitize repo name for filesystem (e.g., "xybrid-ai/kokoro-82m" -> "xybrid-ai--kokoro-82m")
-        let sanitized = repo.replace('/', "--");
-        Ok(base_cache.join(sanitized))
-    }
-
-    fn hf_hub_cache_dir() -> SdkResult<PathBuf> {
-        if let Some(sdk_cache) = crate::get_sdk_cache_dir() {
-            return Ok(sdk_cache.join("hf-hub"));
-        }
-
-        Ok(Self::default_xybrid_cache_root()?.join("hf-hub"))
-    }
-
-    fn default_xybrid_cache_root() -> SdkResult<PathBuf> {
-        let home =
-            dirs::home_dir().ok_or_else(|| SdkError::cache("Cannot determine home directory"))?;
-        Ok(home.join(".xybrid").join("cache"))
     }
 
     /// Check if a file is essential and should always be downloaded.

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1374,7 +1374,11 @@ impl ModelLoader {
 
         // Determine our cache directory
         let cache_layout = CacheManager::layout_from_config()?;
-        let cache_dir = cache_layout.huggingface_repo_dir(repo);
+        let cache_dir = cache_layout
+            .huggingface_repo_dirs(repo)
+            .into_iter()
+            .find(|dir| dir.join("model_metadata.json").exists())
+            .unwrap_or_else(|| cache_layout.huggingface_repo_dir(repo));
 
         // Check if we already have a cached copy with model_metadata.json
         let metadata_path = cache_dir.join("model_metadata.json");
@@ -1387,7 +1391,7 @@ impl ModelLoader {
 
         // Create HF API client
         let api = ApiBuilder::from_env()
-            .with_cache_dir(cache_layout.huggingface_hub_root())
+            .with_cache_dir(cache_layout.preferred_huggingface_hub_root(repo))
             .build()
             .map_err(|e| SdkError::network_src("Failed to create HuggingFace API client", e))?;
 

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -1369,7 +1369,7 @@ impl ModelLoader {
     where
         F: Fn(f32),
     {
-        use hf_hub::{api::sync::Api, Repo, RepoType};
+        use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 
         // Determine our cache directory
         let cache_dir = Self::hf_cache_dir(repo)?;
@@ -1384,7 +1384,9 @@ impl ModelLoader {
         log::info!(target: "xybrid_sdk", "Downloading model from HuggingFace: {}", repo);
 
         // Create HF API client
-        let api = Api::new()
+        let api = ApiBuilder::from_env()
+            .with_cache_dir(Self::hf_hub_cache_dir()?)
+            .build()
             .map_err(|e| SdkError::network_src("Failed to create HuggingFace API client", e))?;
 
         // Create repo reference with optional revision
@@ -1572,14 +1574,26 @@ impl ModelLoader {
         let base_cache = if let Some(sdk_cache) = crate::get_sdk_cache_dir() {
             sdk_cache.join("hf")
         } else {
-            let home = dirs::home_dir()
-                .ok_or_else(|| SdkError::cache("Cannot determine home directory"))?;
-            home.join(".xybrid").join("cache").join("hf")
+            Self::default_xybrid_cache_root()?.join("hf")
         };
 
         // Sanitize repo name for filesystem (e.g., "xybrid-ai/kokoro-82m" -> "xybrid-ai--kokoro-82m")
         let sanitized = repo.replace('/', "--");
         Ok(base_cache.join(sanitized))
+    }
+
+    fn hf_hub_cache_dir() -> SdkResult<PathBuf> {
+        if let Some(sdk_cache) = crate::get_sdk_cache_dir() {
+            return Ok(sdk_cache.join("hf-hub"));
+        }
+
+        Ok(Self::default_xybrid_cache_root()?.join("hf-hub"))
+    }
+
+    fn default_xybrid_cache_root() -> SdkResult<PathBuf> {
+        let home =
+            dirs::home_dir().ok_or_else(|| SdkError::cache("Cannot determine home directory"))?;
+        Ok(home.join(".xybrid").join("cache"))
     }
 
     /// Check if a file is essential and should always be downloaded.

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -1180,7 +1180,7 @@ impl RegistryClient {
     ///
     /// Not safe to run concurrently with a load of the same model: it removes
     /// whole cache directories that an in-flight extraction may be writing to.
-    pub fn clear_cache(&self, mask: &str) -> Result<u32, SdkError> {
+    pub fn clear_cache(&mut self, mask: &str) -> Result<u32, SdkError> {
         self.cache.clear_model_roots(mask)
     }
 
@@ -1210,6 +1210,13 @@ impl RegistryClient {
             model_count: entries.len(),
             cache_path: self.cache.cache_dir().to_path_buf(),
         })
+    }
+
+    /// Return the root directory that owns all managed model cache locations.
+    pub fn cache_root(&self) -> PathBuf {
+        crate::cache::layout::CacheLayout::from_registry_root(self.cache.cache_dir().to_path_buf())
+            .cache_root()
+            .to_path_buf()
     }
 
     /// List cached model entries across all managed cache roots.
@@ -1430,7 +1437,11 @@ impl CacheStats {
 
     /// Get human-readable size.
     pub fn total_size_human(&self) -> String {
-        let bytes = self.total_size_bytes;
+        Self::format_size(self.total_size_bytes)
+    }
+
+    /// Format a byte size using the cache summary display convention.
+    pub fn format_size(bytes: u64) -> String {
         if bytes < 1024 {
             format!("{} B", bytes)
         } else if bytes < 1024 * 1024 {
@@ -1889,6 +1900,23 @@ mod tests {
         assert_eq!(stats.model_count, 5);
         assert_eq!(stats.cache_root(), custom_cache);
         assert_eq!(stats.total_size_bytes, 24);
+    }
+
+    #[test]
+    fn clear_cache_removes_legacy_bundle_from_memory_index() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("models");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("test-model@1.0.xyb"), b"bundle").unwrap();
+
+        let mut client = RegistryClient::with_url("https://example.test").unwrap();
+        client.cache = CacheManager::with_dir(cache_dir).unwrap();
+
+        let removed = client.clear_cache("test-model").unwrap();
+
+        assert_eq!(removed, 1);
+        assert_eq!(client.cache.status().unwrap().total_models, 0);
+        assert!(!client.cache.is_cached("test-model"));
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -48,7 +48,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy};
@@ -1188,28 +1188,109 @@ impl RegistryClient {
         Ok(())
     }
 
-    /// Get cache statistics.
+    /// Get aggregate cache statistics across all managed model cache roots.
     pub fn cache_stats(&self) -> Result<CacheStats, SdkError> {
-        let cache_dir = self.cache.cache_dir();
-        let mut total_size: u64 = 0;
-        let mut model_count: usize = 0;
-
-        if cache_dir.exists() {
-            for entry in std::fs::read_dir(cache_dir)? {
-                let entry = entry?;
-                if entry.path().is_dir() {
-                    model_count += 1;
-                    total_size += dir_size(&entry.path())?;
-                }
-            }
-        }
+        let entries = self.cache_entries()?;
+        let total_size = entries.iter().map(|entry| entry.size_bytes).sum();
 
         Ok(CacheStats {
             total_size_bytes: total_size,
-            model_count,
-            cache_path: cache_dir.to_path_buf(),
+            model_count: entries.len(),
+            cache_path: self.cache.cache_dir().to_path_buf(),
         })
     }
+
+    /// List cached model entries across all managed cache roots.
+    ///
+    /// Includes the legacy registry bundle cache and runtime caches such as
+    /// extracted bundles and direct Hugging Face downloads.
+    pub fn cache_entries(&self) -> Result<Vec<CacheEntryInfo>, SdkError> {
+        let mut entries = Vec::new();
+
+        for root in self.cache_entry_roots() {
+            entries.extend(cache_entries_for_root(root.location, &root.path)?);
+        }
+
+        entries.sort_by(|left, right| {
+            left.model_id
+                .cmp(&right.model_id)
+                .then_with(|| left.location.as_str().cmp(right.location.as_str()))
+        });
+
+        Ok(entries)
+    }
+
+    fn cache_entry_roots(&self) -> Vec<CacheEntryRoot> {
+        let cache_dir = self.cache.cache_dir();
+        let cache_root = cache_dir.parent().unwrap_or(cache_dir);
+        let mut roots = vec![
+            CacheEntryRoot {
+                location: CacheEntryLocation::Registry,
+                path: cache_dir.to_path_buf(),
+            },
+            CacheEntryRoot {
+                location: CacheEntryLocation::Extracted,
+                path: cache_root.join("extracted"),
+            },
+        ];
+
+        if cache_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("models"))
+        {
+            roots.push(CacheEntryRoot {
+                location: CacheEntryLocation::HuggingFace,
+                path: cache_root.join("hf"),
+            });
+            roots.push(CacheEntryRoot {
+                location: CacheEntryLocation::HuggingFaceHub,
+                path: cache_root.join("hf-hub"),
+            });
+        }
+
+        roots
+    }
+}
+
+#[derive(Debug)]
+struct CacheEntryRoot {
+    location: CacheEntryLocation,
+    path: PathBuf,
+}
+
+fn cache_entries_for_root(
+    location: CacheEntryLocation,
+    root: &Path,
+) -> Result<Vec<CacheEntryInfo>, SdkError> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let Some(model_id) = entry.file_name().into_string().ok() else {
+            continue;
+        };
+
+        if model_id.starts_with('.') {
+            continue;
+        }
+
+        entries.push(CacheEntryInfo {
+            model_id,
+            location,
+            path: entry.path(),
+            size_bytes: dir_size(&entry.path())?,
+        });
+    }
+
+    Ok(entries)
 }
 
 /// Compute SHA256 hash of a file.
@@ -1415,18 +1496,64 @@ pub struct ResolvedArtifact {
     pub sha256: String,
 }
 
-/// Cache statistics.
+/// Logical cache location for a model entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheEntryLocation {
+    /// Registry bundle cache under `models/`.
+    Registry,
+    /// Runtime-ready extraction cache under `extracted/`.
+    Extracted,
+    /// Direct Hugging Face file cache under `hf/`.
+    HuggingFace,
+    /// Hugging Face hub blob cache under `hf-hub/`.
+    HuggingFaceHub,
+}
+
+impl CacheEntryLocation {
+    /// Return the stable CLI/API label for this cache location.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Registry => "models",
+            Self::Extracted => "extracted",
+            Self::HuggingFace => "hf",
+            Self::HuggingFaceHub => "hf-hub",
+        }
+    }
+}
+
+/// Summary of one cached model entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheEntryInfo {
+    /// Model or repository identifier inferred from the cache directory name.
+    pub model_id: String,
+    /// Cache location where this entry was found.
+    pub location: CacheEntryLocation,
+    /// Path to the cached model entry.
+    pub path: PathBuf,
+    /// Recursive size of this cache entry in bytes.
+    pub size_bytes: u64,
+}
+
+/// Aggregate cache statistics across all managed model cache roots.
 #[derive(Debug, Clone)]
 pub struct CacheStats {
-    /// Total size of cached bundles in bytes
+    /// Total size of cached model entries in bytes.
     pub total_size_bytes: u64,
-    /// Number of cached models
+    /// Number of cached model entries across managed cache roots.
     pub model_count: usize,
-    /// Path to cache directory
+    /// Path to the legacy registry bundle cache directory.
     pub cache_path: PathBuf,
 }
 
 impl CacheStats {
+    /// Return the root directory that owns all managed model cache locations.
+    pub fn cache_root(&self) -> PathBuf {
+        self.cache_path
+            .parent()
+            .unwrap_or(&self.cache_path)
+            .to_path_buf()
+    }
+
     /// Get human-readable size.
     pub fn total_size_human(&self) -> String {
         let bytes = self.total_size_bytes;
@@ -1770,6 +1897,78 @@ mod tests {
 
         resolve_mock.assert_hits(2);
         bundle_mock.assert();
+    }
+
+    #[test]
+    fn cache_entries_include_extracted_runtime_cache() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let cache_root = temp_dir.path().join("cache");
+        let models_dir = cache_root.join("models");
+        let extracted_model_dir = cache_root.join("extracted").join("lfm2.5-350m");
+        let metadata = br#"{"files":[]}"#;
+        let weights = b"fake weights";
+        std::fs::create_dir_all(&extracted_model_dir).unwrap();
+        std::fs::write(extracted_model_dir.join("model_metadata.json"), metadata).unwrap();
+        std::fs::write(extracted_model_dir.join("LFM2.5-350M-Q4_K_M.gguf"), weights).unwrap();
+
+        let mut client = RegistryClient::with_url("https://example.test").unwrap();
+        client.cache = CacheManager::with_dir(models_dir).unwrap();
+
+        let entries = client.cache_entries().unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model_id, "lfm2.5-350m");
+        assert_eq!(entries[0].location, CacheEntryLocation::Extracted);
+        assert_eq!(entries[0].path, extracted_model_dir);
+        assert_eq!(
+            entries[0].size_bytes,
+            (metadata.len() + weights.len()) as u64
+        );
+
+        let stats = client.cache_stats().unwrap();
+        assert_eq!(stats.model_count, 1);
+        assert_eq!(
+            stats.total_size_bytes,
+            (metadata.len() + weights.len()) as u64
+        );
+    }
+
+    #[test]
+    fn cache_entries_include_all_managed_cache_roots() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let cache_root = temp_dir.path().join("cache");
+        let models_dir = cache_root.join("models");
+        let registry_model_dir = models_dir.join("registry-model");
+        let extracted_model_dir = cache_root.join("extracted").join("runtime-model");
+        let hf_model_dir = cache_root.join("hf").join("owner--repo");
+        let hf_hub_model_dir = cache_root.join("hf-hub").join("models--owner--repo");
+        std::fs::create_dir_all(&registry_model_dir).unwrap();
+        std::fs::create_dir_all(&extracted_model_dir).unwrap();
+        std::fs::create_dir_all(&hf_model_dir).unwrap();
+        std::fs::create_dir_all(&hf_hub_model_dir).unwrap();
+        std::fs::write(registry_model_dir.join("model.xyb"), b"bundle").unwrap();
+        std::fs::write(extracted_model_dir.join("model.gguf"), b"runtime").unwrap();
+        std::fs::write(hf_model_dir.join("model.gguf"), b"hf").unwrap();
+        std::fs::write(hf_hub_model_dir.join("blob"), b"hub").unwrap();
+
+        let mut client = RegistryClient::with_url("https://example.test").unwrap();
+        client.cache = CacheManager::with_dir(models_dir).unwrap();
+
+        let entries = client.cache_entries().unwrap();
+        let labels: Vec<_> = entries
+            .iter()
+            .map(|entry| (entry.model_id.as_str(), entry.location.as_str()))
+            .collect();
+
+        assert_eq!(entries.len(), 4);
+        assert!(labels.contains(&("registry-model", "models")));
+        assert!(labels.contains(&("runtime-model", "extracted")));
+        assert!(labels.contains(&("owner--repo", "hf")));
+        assert!(labels.contains(&("models--owner--repo", "hf-hub")));
+
+        let stats = client.cache_stats().unwrap();
+        assert_eq!(stats.model_count, 4);
+        assert_eq!(stats.total_size_bytes, 18);
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -1178,10 +1178,7 @@ impl RegistryClient {
 
     /// Clear the local cache for a specific model.
     pub fn clear_cache(&self, mask: &str) -> Result<(), SdkError> {
-        let model_dir = self.cache.cache_dir().join(mask);
-        if model_dir.exists() {
-            std::fs::remove_dir_all(&model_dir)?;
-        }
+        self.cache.clear_model_roots(mask)?;
         Ok(())
     }
 

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -1051,11 +1051,7 @@ impl RegistryClient {
     /// prefer this over `resolve()` + `fetch()` when they don't need to check for
     /// registry updates.
     pub fn resolve_offline(&self, mask: &str) -> Option<PathBuf> {
-        if self.cache.is_extracted(mask) {
-            Some(self.cache.extraction_dir(mask))
-        } else {
-            None
-        }
+        self.cache.existing_extraction_dir(mask)
     }
 
     /// List all model IDs that are currently available for offline use.
@@ -1828,6 +1824,51 @@ mod tests {
         let stats = client.cache_stats().unwrap();
         assert_eq!(stats.model_count, 4);
         assert_eq!(stats.total_size_bytes, 18);
+    }
+
+    #[test]
+    fn cache_entries_include_custom_root_and_legacy_parent_extracted_cache() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let custom_cache = temp_dir.path().join("custom-cache");
+        let registry_model_dir = custom_cache.join("registry-model");
+        let extracted_model_dir = custom_cache.join("extracted").join("runtime-model");
+        let legacy_extracted_model_dir = temp_dir.path().join("extracted").join("legacy-model");
+        let hf_model_dir = custom_cache.join("hf").join("owner--repo");
+        let hf_hub_model_dir = custom_cache.join("hf-hub").join("models--owner--repo");
+        std::fs::create_dir_all(&registry_model_dir).unwrap();
+        std::fs::create_dir_all(&extracted_model_dir).unwrap();
+        std::fs::create_dir_all(&legacy_extracted_model_dir).unwrap();
+        std::fs::create_dir_all(&hf_model_dir).unwrap();
+        std::fs::create_dir_all(&hf_hub_model_dir).unwrap();
+        std::fs::write(registry_model_dir.join("model.xyb"), b"bundle").unwrap();
+        std::fs::write(extracted_model_dir.join("model.gguf"), b"runtime").unwrap();
+        std::fs::write(legacy_extracted_model_dir.join("model.gguf"), b"legacy").unwrap();
+        std::fs::write(hf_model_dir.join("model.gguf"), b"hf").unwrap();
+        std::fs::write(hf_hub_model_dir.join("blob"), b"hub").unwrap();
+
+        let mut client = RegistryClient::with_url("https://example.test").unwrap();
+        client.cache = CacheManager::with_dir(custom_cache.clone()).unwrap();
+
+        let entries = client.cache_entries().unwrap();
+        let labels: Vec<_> = entries
+            .iter()
+            .map(|entry| (entry.model_id.as_str(), entry.location.as_str()))
+            .collect();
+
+        assert_eq!(entries.len(), 5);
+        assert!(labels.contains(&("registry-model", "models")));
+        assert!(labels.contains(&("runtime-model", "extracted")));
+        assert!(labels.contains(&("legacy-model", "extracted")));
+        assert!(labels.contains(&("owner--repo", "hf")));
+        assert!(labels.contains(&("models--owner--repo", "hf-hub")));
+        assert!(!labels.contains(&("extracted", "models")));
+        assert!(!labels.contains(&("hf", "models")));
+        assert!(!labels.contains(&("hf-hub", "models")));
+
+        let stats = client.cache_stats().unwrap();
+        assert_eq!(stats.model_count, 5);
+        assert_eq!(stats.cache_root(), custom_cache);
+        assert_eq!(stats.total_size_bytes, 24);
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -1169,15 +1169,35 @@ impl RegistryClient {
     }
 
     /// Clear the local cache for a specific model.
-    pub fn clear_cache(&self, mask: &str) -> Result<(), SdkError> {
-        self.cache.clear_model_roots(mask)?;
-        Ok(())
+    ///
+    /// # Returns
+    ///
+    /// The number of cache roots removed for `mask` across all managed cache
+    /// areas (registry bundle, extracted runtime cache, HuggingFace
+    /// downloads). Returns `0` when the model was not cached.
+    ///
+    /// # Concurrency
+    ///
+    /// Not safe to run concurrently with a load of the same model: it removes
+    /// whole cache directories that an in-flight extraction may be writing to.
+    pub fn clear_cache(&self, mask: &str) -> Result<u32, SdkError> {
+        self.cache.clear_model_roots(mask)
     }
 
     /// Clear the entire model cache.
-    pub fn clear_all_cache(&mut self) -> Result<(), SdkError> {
-        self.cache.clear()?;
-        Ok(())
+    ///
+    /// # Returns
+    ///
+    /// The number of cache roots removed across all managed cache areas.
+    /// Returns `0` when nothing was cached.
+    ///
+    /// # Concurrency
+    ///
+    /// Not safe to run concurrently with any model load: it removes whole
+    /// cache directories that in-flight downloads or extractions may be
+    /// writing to.
+    pub fn clear_all_cache(&mut self) -> Result<u32, SdkError> {
+        self.cache.clear()
     }
 
     /// Get aggregate cache statistics across all managed model cache roots.

--- a/crates/xybrid-sdk/src/registry_client.rs
+++ b/crates/xybrid-sdk/src/registry_client.rs
@@ -48,13 +48,15 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use xybrid_core::http::{CircuitBreaker, CircuitConfig, RetryPolicy};
 
 pub const DEFAULT_REGISTRY_URL: &str = "https://registry.xybrid.dev";
 pub const FALLBACK_REGISTRY_URL: &str = "https://r2.xybrid.dev";
+
+pub use crate::cache::{CacheEntryInfo, CacheEntryLocation};
 
 /// All registry URLs in priority order.
 pub const REGISTRY_URLS: &[&str] = &[DEFAULT_REGISTRY_URL, FALLBACK_REGISTRY_URL];
@@ -629,14 +631,8 @@ impl RegistryClient {
 
     /// Get the local cache path for a resolved variant.
     pub fn get_cache_path(&self, resolved: &ResolvedVariant) -> PathBuf {
-        // Extract model name from hf_repo (e.g., "xybrid-ai/kokoro-82m" -> "kokoro-82m")
-        let model_name = resolved
-            .hf_repo
-            .split('/')
-            .next_back()
-            .unwrap_or(&resolved.hf_repo);
-
-        self.cache.cache_dir().join(model_name).join(&resolved.file)
+        self.cache
+            .registry_bundle_path(&resolved.hf_repo, &resolved.file)
     }
 
     /// Fetch a model bundle, downloading if not cached.
@@ -1205,92 +1201,8 @@ impl RegistryClient {
     /// Includes the legacy registry bundle cache and runtime caches such as
     /// extracted bundles and direct Hugging Face downloads.
     pub fn cache_entries(&self) -> Result<Vec<CacheEntryInfo>, SdkError> {
-        let mut entries = Vec::new();
-
-        for root in self.cache_entry_roots() {
-            entries.extend(cache_entries_for_root(root.location, &root.path)?);
-        }
-
-        entries.sort_by(|left, right| {
-            left.model_id
-                .cmp(&right.model_id)
-                .then_with(|| left.location.as_str().cmp(right.location.as_str()))
-        });
-
-        Ok(entries)
+        self.cache.cache_entries()
     }
-
-    fn cache_entry_roots(&self) -> Vec<CacheEntryRoot> {
-        let cache_dir = self.cache.cache_dir();
-        let cache_root = cache_dir.parent().unwrap_or(cache_dir);
-        let mut roots = vec![
-            CacheEntryRoot {
-                location: CacheEntryLocation::Registry,
-                path: cache_dir.to_path_buf(),
-            },
-            CacheEntryRoot {
-                location: CacheEntryLocation::Extracted,
-                path: cache_root.join("extracted"),
-            },
-        ];
-
-        if cache_dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.eq_ignore_ascii_case("models"))
-        {
-            roots.push(CacheEntryRoot {
-                location: CacheEntryLocation::HuggingFace,
-                path: cache_root.join("hf"),
-            });
-            roots.push(CacheEntryRoot {
-                location: CacheEntryLocation::HuggingFaceHub,
-                path: cache_root.join("hf-hub"),
-            });
-        }
-
-        roots
-    }
-}
-
-#[derive(Debug)]
-struct CacheEntryRoot {
-    location: CacheEntryLocation,
-    path: PathBuf,
-}
-
-fn cache_entries_for_root(
-    location: CacheEntryLocation,
-    root: &Path,
-) -> Result<Vec<CacheEntryInfo>, SdkError> {
-    if !root.is_dir() {
-        return Ok(Vec::new());
-    }
-
-    let mut entries = Vec::new();
-    for entry in std::fs::read_dir(root)? {
-        let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-
-        let Some(model_id) = entry.file_name().into_string().ok() else {
-            continue;
-        };
-
-        if model_id.starts_with('.') {
-            continue;
-        }
-
-        entries.push(CacheEntryInfo {
-            model_id,
-            location,
-            path: entry.path(),
-            size_bytes: dir_size(&entry.path())?,
-        });
-    }
-
-    Ok(entries)
 }
 
 /// Compute SHA256 hash of a file.
@@ -1364,21 +1276,6 @@ fn write_cached_hash(bundle_path: &PathBuf, hash: &str) {
 fn remove_cached_hash(bundle_path: &PathBuf) {
     let hash_path = hash_cache_path(bundle_path);
     let _ = std::fs::remove_file(&hash_path);
-}
-
-/// Calculate total size of a directory.
-fn dir_size(path: &PathBuf) -> Result<u64, SdkError> {
-    let mut total: u64 = 0;
-    for entry in std::fs::read_dir(path)? {
-        let entry = entry?;
-        let metadata = entry.metadata()?;
-        if metadata.is_file() {
-            total += metadata.len();
-        } else if metadata.is_dir() {
-            total += dir_size(&entry.path())?;
-        }
-    }
-    Ok(total)
 }
 
 // ============================================================================
@@ -1496,44 +1393,6 @@ pub struct ResolvedArtifact {
     pub sha256: String,
 }
 
-/// Logical cache location for a model entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CacheEntryLocation {
-    /// Registry bundle cache under `models/`.
-    Registry,
-    /// Runtime-ready extraction cache under `extracted/`.
-    Extracted,
-    /// Direct Hugging Face file cache under `hf/`.
-    HuggingFace,
-    /// Hugging Face hub blob cache under `hf-hub/`.
-    HuggingFaceHub,
-}
-
-impl CacheEntryLocation {
-    /// Return the stable CLI/API label for this cache location.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Registry => "models",
-            Self::Extracted => "extracted",
-            Self::HuggingFace => "hf",
-            Self::HuggingFaceHub => "hf-hub",
-        }
-    }
-}
-
-/// Summary of one cached model entry.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CacheEntryInfo {
-    /// Model or repository identifier inferred from the cache directory name.
-    pub model_id: String,
-    /// Cache location where this entry was found.
-    pub location: CacheEntryLocation,
-    /// Path to the cached model entry.
-    pub path: PathBuf,
-    /// Recursive size of this cache entry in bytes.
-    pub size_bytes: u64,
-}
-
 /// Aggregate cache statistics across all managed model cache roots.
 #[derive(Debug, Clone)]
 pub struct CacheStats {
@@ -1548,9 +1407,8 @@ pub struct CacheStats {
 impl CacheStats {
     /// Return the root directory that owns all managed model cache locations.
     pub fn cache_root(&self) -> PathBuf {
-        self.cache_path
-            .parent()
-            .unwrap_or(&self.cache_path)
+        crate::cache::layout::CacheLayout::from_registry_root(self.cache_path.clone())
+            .cache_root()
             .to_path_buf()
     }
 
@@ -1927,6 +1785,7 @@ mod tests {
 
         let stats = client.cache_stats().unwrap();
         assert_eq!(stats.model_count, 1);
+        assert_eq!(stats.cache_root(), cache_root);
         assert_eq!(
             stats.total_size_bytes,
             (metadata.len() + weights.len()) as u64
@@ -1969,6 +1828,19 @@ mod tests {
         let stats = client.cache_stats().unwrap();
         assert_eq!(stats.model_count, 4);
         assert_eq!(stats.total_size_bytes, 18);
+    }
+
+    #[test]
+    fn cache_stats_root_keeps_custom_non_models_cache_self_contained() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let cache_path = temp_dir.path().join("custom-cache");
+        let stats = CacheStats {
+            total_size_bytes: 0,
+            model_count: 0,
+            cache_path: cache_path.clone(),
+        };
+
+        assert_eq!(stats.cache_root(), cache_path);
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/source.rs
+++ b/crates/xybrid-sdk/src/source.rs
@@ -99,7 +99,7 @@ pub enum ModelSource {
     /// Load from HuggingFace Hub repository.
     ///
     /// Downloads model files from the HuggingFace Hub and caches them locally
-    /// at `~/.xybrid/cache/hf/{repo}/`. Subsequent calls use the cached files.
+    /// at `~/.xybrid/cache/hf/{repo-with-slashes-as--}/`. Subsequent calls use the cached files.
     ///
     /// The repository must contain a `model_metadata.json` file, or one will be
     /// auto-generated in a future version.


### PR DESCRIPTION
## Summary
- Centralize cache layout handling so registry bundles, extracted runtime caches, direct Hugging Face files, and Hugging Face hub blobs are listed and cleared consistently.
- Preserve compatibility with legacy custom cache layouts, including parent `extracted/` caches and nested `models/hf` / `models/hf-hub` locations.
- Make cache clearing report how many managed roots were actually removed, so the CLI can warn when no cached data exists instead of always claiming success.
- Keep sibling cache roots co-located for bare relative `models` roots.

## Why
`xybrid cache clear` was not clearing or reporting the actual runtime model cache in all layouts. The CLI could miss models stored under `extracted/`, and custom cache roots could split managed cache areas across inconsistent paths.

## Breaking Change
- `RegistryClient::clear_cache` now returns `Result<u32, SdkError>` instead of `Result<(), SdkError>`.
- `RegistryClient::clear_all_cache` now returns `Result<u32, SdkError>` instead of `Result<(), SdkError>`.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p xybrid-sdk -p xybrid-cli --all-targets --features ort-download -- -D warnings`
- `cargo test --workspace --features ort-download`
- `cargo build -p xybrid-cli && target/debug/xybrid cache list && target/debug/xybrid cache status`
- Subagent regression review and final read-only gate review passed without destructive cache commands.