### PR TITLE
feat(llm): JSON-Schema/GBNF constrained decoding for local llama backend

### DIFF
--- a/crates/llama-cpp-sys/wrapper.cpp
+++ b/crates/llama-cpp-sys/wrapper.cpp
@@ -634,17 +634,39 @@ void llama_batch_free_c(llama_batch batch) {
 // =============================================================================
 
 llama_sampler* llama_sampler_chain_create_c(
+    const llama_model* model,
     float temperature,
     float top_p,
     float min_p,
     int top_k,
     float repeat_penalty,
     int penalty_last_n,
-    uint32_t seed
+    uint32_t seed,
+    const char* grammar,
+    const char* grammar_root
 ) {
     // Create sampler chain with default params
     llama_sampler_chain_params chain_params = llama_sampler_chain_default_params();
     llama_sampler* chain = llama_sampler_chain_init(chain_params);
+
+    // Grammar constraint goes FIRST: it masks (sets logit = -inf) every token
+    // the GBNF grammar would reject, so all downstream samplers (penalties,
+    // top_k/top_p/min_p, temp, dist/greedy) only ever see grammar-valid
+    // candidates. The chain's per-token llama_sampler_accept (below, in the
+    // generation loops) advances this sub-sampler's parse state. A NULL/empty
+    // grammar (or missing model) leaves generation unconstrained.
+    if (grammar && grammar[0] && model) {
+        const llama_vocab* vocab = llama_model_get_vocab(model);
+        const char* root = (grammar_root && grammar_root[0]) ? grammar_root : "root";
+        llama_sampler* grammar_smpl = llama_sampler_init_grammar(vocab, grammar, root);
+        if (grammar_smpl) {
+            llama_sampler_chain_add(chain, grammar_smpl);
+        } else {
+            fprintf(stderr,
+                    "llama_sampler_chain_create_c: failed to compile GBNF grammar "
+                    "(root rule '%s'); continuing unconstrained.\n", root);
+        }
+    }
 
     // Add samplers in order: penalties -> top_k -> top_p -> min_p -> temp -> dist
     // Repetition penalty must come first to modify logits before sampling
@@ -769,6 +791,8 @@ int llama_generate_c(
     int top_k,
     float repeat_penalty,
     uint32_t seed,
+    const char* grammar,
+    const char* grammar_root,
     const int32_t* stop_seqs,
     const int* stop_lens,
     int n_stop_seqs
@@ -791,7 +815,8 @@ int llama_generate_c(
     // Create sampler chain with repetition penalty
     // penalty_last_n = 64 is a reasonable default (consider last 64 tokens for penalty)
     llama_sampler* sampler = llama_sampler_chain_create_c(
-        temperature, top_p, min_p, top_k, repeat_penalty, 64, seed
+        model, temperature, top_p, min_p, top_k, repeat_penalty, 64, seed,
+        grammar, grammar_root
     );
     if (!sampler) {
         return -2;
@@ -947,6 +972,8 @@ int llama_generate_from_current_logits_c(
     int top_k,
     float repeat_penalty,
     uint32_t seed,
+    const char* grammar,
+    const char* grammar_root,
     const int32_t* stop_seqs,
     const int* stop_lens,
     int n_stop_seqs,
@@ -969,7 +996,8 @@ int llama_generate_from_current_logits_c(
     const int n_vocab = llama_vocab_n_tokens(vocab);
 
     llama_sampler* sampler = llama_sampler_chain_create_c(
-        temperature, top_p, min_p, top_k, repeat_penalty, 64, seed
+        model, temperature, top_p, min_p, top_k, repeat_penalty, 64, seed,
+        grammar, grammar_root
     );
     if (!sampler) {
         return -2;
@@ -1114,6 +1142,8 @@ int llama_generate_streaming_c(
     int top_k,
     float repeat_penalty,
     uint32_t seed,
+    const char* grammar,
+    const char* grammar_root,
     const int32_t* stop_seqs,
     const int* stop_lens,
     int n_stop_seqs,
@@ -1149,7 +1179,8 @@ int llama_generate_streaming_c(
 
     // Create sampler chain with repetition penalty
     llama_sampler* sampler = llama_sampler_chain_create_c(
-        temperature, top_p, min_p, top_k, repeat_penalty, 64, seed
+        model, temperature, top_p, min_p, top_k, repeat_penalty, 64, seed,
+        grammar, grammar_root
     );
     if (!sampler) {
         return -2;

--- a/crates/llama-cpp-sys/wrapper.cpp
+++ b/crates/llama-cpp-sys/wrapper.cpp
@@ -648,6 +648,9 @@ llama_sampler* llama_sampler_chain_create_c(
     // Create sampler chain with default params
     llama_sampler_chain_params chain_params = llama_sampler_chain_default_params();
     llama_sampler* chain = llama_sampler_chain_init(chain_params);
+    if (!chain) {
+        return nullptr;
+    }
 
     // Grammar constraint goes FIRST: it masks (sets logit = -inf) every token
     // the GBNF grammar would reject, so all downstream samplers (penalties,

--- a/crates/llama-cpp-sys/wrapper.h
+++ b/crates/llama-cpp-sys/wrapper.h
@@ -134,13 +134,16 @@ llama_batch llama_batch_init_c(int n_tokens, int embd, int n_seq_max);
 void llama_batch_free_c(llama_batch batch);
 
 XYBRID_LLAMA_SAMPLER* llama_sampler_chain_create_c(
+    const XYBRID_LLAMA_MODEL* model,
     float temperature,
     float top_p,
     float min_p,
     int top_k,
     float repeat_penalty,
     int penalty_last_n,
-    uint32_t seed);
+    uint32_t seed,
+    const char* grammar,
+    const char* grammar_root);
 void llama_sampler_free_c(XYBRID_LLAMA_SAMPLER* smpl);
 
 /* Streaming-callback token type (matches Rust's `TokenCallback`). */
@@ -160,6 +163,8 @@ int  llama_generate_c(
     int top_k,
     float repeat_penalty,
     uint32_t seed,
+    const char* grammar,
+    const char* grammar_root,
     const int32_t* stop_seqs,
     const int* stop_lens,
     int n_stop_seqs);
@@ -178,6 +183,8 @@ int  llama_generate_streaming_c(
     int top_k,
     float repeat_penalty,
     uint32_t seed,
+    const char* grammar,
+    const char* grammar_root,
     const int32_t* stop_seqs,
     const int* stop_lens,
     int n_stop_seqs,
@@ -198,6 +205,8 @@ int  llama_generate_from_current_logits_c(
     int top_k,
     float repeat_penalty,
     uint32_t seed,
+    const char* grammar,
+    const char* grammar_root,
     const int32_t* stop_seqs,
     const int* stop_lens,
     int n_stop_seqs,

--- a/crates/xybrid-core/examples/lfm2_230m_grammar.rs
+++ b/crates/xybrid-core/examples/lfm2_230m_grammar.rs
@@ -18,7 +18,10 @@ use xybrid_core::ir::{Envelope, EnvelopeKind};
 use xybrid_core::runtime_adapter::llm::GenerationConfig;
 
 fn model_dir() -> PathBuf {
-    let home = std::env::var("HOME").expect("HOME not set");
+    // Windows sets USERPROFILE rather than HOME.
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .expect("neither HOME nor USERPROFILE is set");
     PathBuf::from(home).join(".xybrid/cache/extracted/lfm2.5-230m")
 }
 

--- a/crates/xybrid-core/examples/lfm2_230m_grammar.rs
+++ b/crates/xybrid-core/examples/lfm2_230m_grammar.rs
@@ -1,0 +1,151 @@
+//! Constrained decoding (GBNF / JSON-Schema) end-to-end on LFM2.5-230M.
+//!
+//! Proves the new `GenerationConfig::with_json_schema` path actually constrains
+//! a real model's output to schema-valid JSON — the on-device data-extraction
+//! use case LFM2.5-230M is built for.
+//!
+//! Fetch the model first (resolves via registry.xybrid.dev):
+//!   model dir: ~/.xybrid/cache/extracted/lfm2.5-230m/ (GGUF + model_metadata.json)
+//!
+//! Run with:
+//!   cargo run --example lfm2_230m_grammar -p xybrid-core --features llm-llamacpp
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+use xybrid_core::ir::{Envelope, EnvelopeKind};
+use xybrid_core::runtime_adapter::llm::GenerationConfig;
+
+fn model_dir() -> PathBuf {
+    let home = std::env::var("HOME").expect("HOME not set");
+    PathBuf::from(home).join(".xybrid/cache/extracted/lfm2.5-230m")
+}
+
+fn run(
+    executor: &mut TemplateExecutor,
+    metadata: &ModelMetadata,
+    prompt: &str,
+    config: Option<&GenerationConfig>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut meta = HashMap::new();
+    meta.insert(
+        "system_prompt".to_string(),
+        "You extract structured data. Respond with a single JSON object, nothing else.".to_string(),
+    );
+    let envelope = Envelope {
+        kind: EnvelopeKind::Text(prompt.to_string()),
+        metadata: meta,
+    };
+    let out = executor.execute(metadata, &envelope, config)?;
+    // Diagnostic: surface generation telemetry (finish_reason, token counts).
+    let mut diag: Vec<_> = out
+        .metadata
+        .iter()
+        .filter(|(k, _)| {
+            matches!(
+                k.as_str(),
+                "finish_reason" | "tokens_generated" | "tokens_per_second" | "stop_reason"
+            )
+        })
+        .collect();
+    diag.sort();
+    if !diag.is_empty() {
+        println!("  [telemetry] {diag:?}");
+    }
+    match out.kind {
+        EnvelopeKind::Text(t) => Ok(t),
+        other => Err(format!("expected Text output, got {other:?}").into()),
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("═══════════════════════════════════════════════════════");
+    println!("  LFM2.5-230M — GBNF constrained decoding (data extraction)");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    let dir = model_dir();
+    let gguf = dir.join("LFM2.5-230M-Q4_K_M.gguf");
+    if !gguf.exists() {
+        eprintln!("Model GGUF not found at {}", gguf.display());
+        eprintln!("Fetch lfm2.5-230m from the registry first.");
+        return Err("model not present".into());
+    }
+
+    let metadata: ModelMetadata =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("model_metadata.json"))?)?;
+    println!("Model: {} v{}", metadata.model_id, metadata.version);
+
+    let mut executor = TemplateExecutor::with_base_path(dir.to_str().unwrap());
+
+    // The extraction target: a messy receipt line → structured record.
+    let prompt = "Extract fields from this receipt:\n\
+        STARBUCKS STORE #1123\n\
+        2x Latte         9.00\n\
+        1x Croissant     3.50\n\
+        TOTAL           12.50 USD\n\
+        03/15/2026";
+
+    // JSON Schema → GBNF. The grammar forces every generated token to keep the
+    // output on a path that completes a schema-valid JSON object.
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "merchant": { "type": "string" },
+            "total":    { "type": "number" },
+            "currency": { "enum": ["USD", "EUR", "GBP"] },
+            "date":     { "type": "string" },
+            "items":    { "type": "array", "items": { "type": "string" } }
+        }
+    });
+
+    // ── Unconstrained baseline (greedy) ──────────────────────────────────────
+    println!("\n── Unconstrained (greedy) ──");
+    let base_cfg = GenerationConfig::greedy().with_max_tokens(160);
+    let baseline = run(&mut executor, &metadata, prompt, Some(&base_cfg))?;
+    println!("{baseline}");
+    let base_valid = serde_json::from_str::<serde_json::Value>(baseline.trim()).is_ok();
+    println!("→ parses as JSON: {base_valid}");
+
+    // ── Grammar-constrained (the feature under test) ─────────────────────────
+    println!("\n── Constrained (with_json_schema) ──");
+    let grammar_cfg = GenerationConfig::greedy()
+        .with_max_tokens(160)
+        .with_json_schema(&schema)?;
+    let constrained = run(&mut executor, &metadata, prompt, Some(&grammar_cfg))?;
+    println!("{constrained}");
+
+    // Hard assertions: the constrained output MUST be valid JSON of the right shape.
+    let value: serde_json::Value = serde_json::from_str(constrained.trim())
+        .map_err(|e| format!("constrained output is not valid JSON: {e}\nraw: {constrained:?}"))?;
+    let obj = value
+        .as_object()
+        .ok_or("constrained output is valid JSON but not an object")?;
+
+    let mut missing = Vec::new();
+    for key in ["merchant", "total", "currency", "date", "items"] {
+        if !obj.contains_key(key) {
+            missing.push(key);
+        }
+    }
+    if let Some(c) = obj.get("currency").and_then(|v| v.as_str()) {
+        if !["USD", "EUR", "GBP"].contains(&c) {
+            return Err(format!("currency '{c}' violates the enum constraint").into());
+        }
+    }
+    if !obj.get("total").map(|v| v.is_number()).unwrap_or(false) {
+        return Err("'total' is not a JSON number (grammar should force it)".into());
+    }
+
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("Status: PASS — constrained output is schema-valid JSON");
+    println!("  merchant : {:?}", obj.get("merchant"));
+    println!("  total    : {:?}", obj.get("total"));
+    println!("  currency : {:?}", obj.get("currency"));
+    println!("  items    : {:?}", obj.get("items"));
+    if !missing.is_empty() {
+        println!("  (note: keys not emitted by the model: {missing:?})");
+    }
+    println!("═══════════════════════════════════════════════════════");
+    Ok(())
+}

--- a/crates/xybrid-core/src/error.rs
+++ b/crates/xybrid-core/src/error.rs
@@ -29,6 +29,8 @@
 
 use thiserror::Error;
 
+use crate::runtime_adapter::grammar::GrammarError;
+
 /// The canonical error type for xybrid-core public API.
 ///
 /// All public API methods return `Result<T, XybridError>`.
@@ -80,6 +82,10 @@ pub enum XybridError {
     /// Serialization/deserialization error (JSON, YAML, etc.)
     #[error("Serialization error: {0}")]
     Serialization(String),
+
+    /// JSON-Schema → GBNF grammar conversion failed (constrained decoding).
+    #[error("Grammar error: {0}")]
+    Grammar(#[from] GrammarError),
 }
 
 /// Errors during model inference.

--- a/crates/xybrid-core/src/runtime_adapter/grammar.rs
+++ b/crates/xybrid-core/src/runtime_adapter/grammar.rs
@@ -11,7 +11,8 @@
 //! library which this build does not link, so the conversion is done here in
 //! Rust against a deliberate **subset** of JSON Schema:
 //!
-//! - `type`: `object`, `array`, `string`, `integer`, `number`, `boolean`, `null`
+//! - `type`: `object`, `array`, `string`, `integer`, `number`, `boolean`,
+//!   `null` — or an array of those (e.g. `["string", "null"]` for nullable)
 //! - `object`: `properties` (all emitted, in map order), nested objects
 //! - `array`: `items`
 //! - `enum`: scalar variants (string / number / boolean / null)
@@ -59,7 +60,7 @@ pub enum GrammarError {
 /// whitespace removes that trap; the output is still valid (minified) JSON.
 /// Unused terminals are harmless to llama.cpp's grammar parser.
 const TERMINALS: &str = "\
-string ::= \"\\\"\" ( [^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt] )* \"\\\"\"\n\
+string ::= \"\\\"\" ( [^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt] | \"\\\\u\" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] )* \"\\\"\"\n\
 integer ::= \"-\"? ( \"0\" | [1-9] [0-9]* )\n\
 number ::= \"-\"? ( \"0\" | [1-9] [0-9]* ) ( \".\" [0-9]+ )? ( [eE] [-+]? [0-9]+ )?\n\
 boolean ::= \"true\" | \"false\"\n\
@@ -112,10 +113,47 @@ impl GrammarBuilder {
             return self.convert_enum(variants);
         }
 
-        let ty = obj.get("type").and_then(Value::as_str).ok_or_else(|| {
-            GrammarError::Unsupported("schema without `type` or `enum`".to_string())
-        })?;
+        match obj.get("type") {
+            Some(Value::String(ty)) => self.convert_type(ty, obj),
+            // Array-valued `type` (e.g. `["string", "null"]` for a nullable
+            // field) becomes an alternation over the listed types.
+            Some(Value::Array(types)) => {
+                if types.is_empty() {
+                    return Err(GrammarError::Invalid(
+                        "`type` array must list at least one type".to_string(),
+                    ));
+                }
+                let alts = types
+                    .iter()
+                    .map(|t| {
+                        let ty = t.as_str().ok_or_else(|| {
+                            GrammarError::Invalid(
+                                "`type` array entries must be strings".to_string(),
+                            )
+                        })?;
+                        self.convert_type(ty, obj)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                if alts.len() == 1 {
+                    return Ok(alts.into_iter().next().expect("len checked == 1"));
+                }
+                Ok(self.add_rule(alts.join(" | ")))
+            }
+            Some(_) => Err(GrammarError::Invalid(
+                "`type` must be a string or an array of strings".to_string(),
+            )),
+            None => Err(GrammarError::Unsupported(
+                "schema without `type` or `enum`".to_string(),
+            )),
+        }
+    }
 
+    /// Convert a single named `type` against its schema node.
+    fn convert_type(
+        &mut self,
+        ty: &str,
+        obj: &serde_json::Map<String, Value>,
+    ) -> Result<String, GrammarError> {
         match ty {
             "string" => Ok("string".to_string()),
             "integer" => Ok("integer".to_string()),
@@ -145,12 +183,16 @@ impl GrammarBuilder {
         &mut self,
         obj: &serde_json::Map<String, Value>,
     ) -> Result<String, GrammarError> {
-        let props = obj.get("properties").and_then(Value::as_object);
-        let props = match props {
-            Some(p) if !p.is_empty() => p,
+        let props = match obj.get("properties") {
+            Some(p) => p.as_object().ok_or_else(|| {
+                GrammarError::Invalid("`properties` must be an object".to_string())
+            })?,
             // No declared properties → match an empty JSON object.
-            _ => return Ok(self.add_rule("\"{}\"".to_string())),
+            None => return Ok(self.add_rule("\"{}\"".to_string())),
         };
+        if props.is_empty() {
+            return Ok(self.add_rule("\"{}\"".to_string()));
+        }
 
         let mut parts = vec!["\"{\"".to_string()];
         for (i, (key, subschema)) in props.iter().enumerate() {
@@ -191,16 +233,24 @@ impl GrammarBuilder {
 
 /// GBNF literal matching the JSON-quoted form of an object key, e.g.
 /// `merchant` → `"\"merchant\""`.
+///
+/// The key is JSON-encoded first (quotes + JSON escapes, including `\u00XX`
+/// for control characters) so the grammar matches the *escaped* form the model
+/// must emit — never raw control characters, which would be invalid JSON.
+/// That JSON text is then escaped once more for the GBNF literal syntax.
 fn gbnf_json_key(key: &str) -> String {
-    let mut inner = String::with_capacity(key.len());
-    for ch in key.chars() {
+    let json = serde_json::to_string(key).expect("serializing a &str to JSON string cannot fail");
+    let mut out = String::with_capacity(json.len() + 8);
+    out.push('"');
+    for ch in json.chars() {
         match ch {
-            '"' => inner.push_str("\\\""),
-            '\\' => inner.push_str("\\\\"),
-            _ => inner.push(ch),
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(ch),
         }
     }
-    format!("\"\\\"{inner}\\\"\"")
+    out.push('"');
+    out
 }
 
 /// GBNF literal matching a single scalar `enum` variant in its JSON form.
@@ -301,5 +351,56 @@ mod tests {
     fn non_object_schema_is_invalid() {
         let err = json_schema_to_gbnf(&json!("nope")).unwrap_err();
         assert!(matches!(err, GrammarError::Invalid(_)));
+    }
+
+    #[test]
+    fn nullable_type_array_becomes_alternation() {
+        let gbnf = json_schema_to_gbnf(&json!({
+            "type": "object",
+            "properties": {
+                "nickname": { "type": ["string", "null"] }
+            }
+        }))
+        .unwrap();
+        assert!(gbnf.contains("string | null"));
+    }
+
+    #[test]
+    fn empty_or_non_string_type_array_is_invalid() {
+        let err = json_schema_to_gbnf(&json!({ "type": [] })).unwrap_err();
+        assert!(matches!(err, GrammarError::Invalid(_)));
+        let err = json_schema_to_gbnf(&json!({ "type": [42] })).unwrap_err();
+        assert!(matches!(err, GrammarError::Invalid(_)));
+    }
+
+    #[test]
+    fn non_object_properties_is_invalid() {
+        let err = json_schema_to_gbnf(&json!({
+            "type": "object",
+            "properties": true
+        }))
+        .unwrap_err();
+        assert!(matches!(err, GrammarError::Invalid(_)));
+    }
+
+    #[test]
+    fn control_chars_in_keys_match_json_escaped_form() {
+        let gbnf = json_schema_to_gbnf(&json!({
+            "type": "object",
+            "properties": {
+                "a\nb": { "type": "string" }
+            }
+        }))
+        .unwrap();
+        // The grammar must match the JSON-escaped key (`a\nb` with a
+        // backslash-n), never a raw newline, which would be invalid JSON.
+        assert!(gbnf.contains("a\\\\nb"));
+        assert!(!gbnf.contains("a\nb"));
+    }
+
+    #[test]
+    fn string_terminal_accepts_unicode_escapes() {
+        let gbnf = json_schema_to_gbnf(&json!({ "type": "string" })).unwrap();
+        assert!(gbnf.contains("[0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]"));
     }
 }

--- a/crates/xybrid-core/src/runtime_adapter/grammar.rs
+++ b/crates/xybrid-core/src/runtime_adapter/grammar.rs
@@ -50,11 +50,15 @@ pub enum GrammarError {
     Invalid(String),
 }
 
-/// Shared terminal rules appended to every generated grammar. Whitespace is
-/// permissive (the grammar masks structure, not formatting); unused terminals
-/// are harmless to llama.cpp's grammar parser.
+/// Shared terminal rules appended to every generated grammar.
+///
+/// The grammar emits **compact** JSON (no inter-token whitespace). This is
+/// deliberate: an optional-whitespace rule like `[ \t\n]*` lets a greedy model
+/// emit whitespace indefinitely instead of committing to the next structural
+/// token, burning the whole token budget on newlines. Forbidding inter-token
+/// whitespace removes that trap; the output is still valid (minified) JSON.
+/// Unused terminals are harmless to llama.cpp's grammar parser.
 const TERMINALS: &str = "\
-ws ::= [ \\t\\n]*\n\
 string ::= \"\\\"\" ( [^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt] )* \"\\\"\"\n\
 integer ::= \"-\"? ( \"0\" | [1-9] [0-9]* )\n\
 number ::= \"-\"? ( \"0\" | [1-9] [0-9]* ) ( \".\" [0-9]+ )? ( [eE] [-+]? [0-9]+ )?\n\
@@ -145,19 +149,16 @@ impl GrammarBuilder {
         let props = match props {
             Some(p) if !p.is_empty() => p,
             // No declared properties → match an empty JSON object.
-            _ => return Ok(self.add_rule("\"{\" ws \"}\"".to_string())),
+            _ => return Ok(self.add_rule("\"{}\"".to_string())),
         };
 
-        let mut parts = vec!["\"{\" ws".to_string()];
+        let mut parts = vec!["\"{\"".to_string()];
         for (i, (key, subschema)) in props.iter().enumerate() {
             let value_rule = self.convert(subschema)?;
             if i > 0 {
-                parts.push("\",\" ws".to_string());
+                parts.push("\",\"".to_string());
             }
-            parts.push(format!(
-                "{} ws \":\" ws {value_rule} ws",
-                gbnf_json_key(key)
-            ));
+            parts.push(format!("{} \":\" {value_rule}", gbnf_json_key(key)));
         }
         parts.push("\"}\"".to_string());
         Ok(self.add_rule(parts.join(" ")))
@@ -172,7 +173,7 @@ impl GrammarBuilder {
             .ok_or_else(|| GrammarError::Unsupported("array without `items`".to_string()))?;
         let item_rule = self.convert(items)?;
         Ok(self.add_rule(format!(
-            "\"[\" ws ( {item_rule} ( ws \",\" ws {item_rule} )* )? ws \"]\""
+            "\"[\" ( {item_rule} ( \",\" {item_rule} )* )? \"]\""
         )))
     }
 
@@ -237,7 +238,9 @@ mod tests {
         // Shared terminals are always present.
         assert!(gbnf.contains("string ::="));
         assert!(gbnf.contains("number ::="));
-        assert!(gbnf.contains("ws ::="));
+        // Compact JSON: no inter-token whitespace rule (avoids the greedy
+        // whitespace-loop trap).
+        assert!(!gbnf.contains("ws ::="));
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/grammar.rs
+++ b/crates/xybrid-core/src/runtime_adapter/grammar.rs
@@ -1,0 +1,302 @@
+//! JSON-Schema → GBNF grammar conversion for constrained LLM decoding.
+//!
+//! The local llama.cpp backend can constrain token sampling to a
+//! [GBNF](https://github.com/ggml-org/llama.cpp/blob/master/grammars/README.md)
+//! grammar via `llama_sampler_init_grammar`. That guarantees the model can only
+//! emit text the grammar accepts — the foundation for reliable on-device data
+//! extraction and structured output from small models, which otherwise drift
+//! off valid JSON.
+//!
+//! llama.cpp ships a C++ `json_schema_to_grammar`, but it lives in the `common`
+//! library which this build does not link, so the conversion is done here in
+//! Rust against a deliberate **subset** of JSON Schema:
+//!
+//! - `type`: `object`, `array`, `string`, `integer`, `number`, `boolean`, `null`
+//! - `object`: `properties` (all emitted, in map order), nested objects
+//! - `array`: `items`
+//! - `enum`: scalar variants (string / number / boolean / null)
+//!
+//! Advanced constructs (`$ref`, `oneOf`/`anyOf`/`allOf`, `pattern`, numeric or
+//! length bounds, tuple-form arrays) are intentionally unsupported — they would
+//! require linking llama.cpp's `common`. See `.context/gbnf-design.md`.
+//!
+//! # Examples
+//!
+//! ```
+//! use serde_json::json;
+//! use xybrid_core::runtime_adapter::grammar::json_schema_to_gbnf;
+//!
+//! let gbnf = json_schema_to_gbnf(&json!({
+//!     "type": "object",
+//!     "properties": { "name": { "type": "string" }, "age": { "type": "integer" } }
+//! }))
+//! .unwrap();
+//! assert!(gbnf.starts_with("root ::="));
+//! ```
+
+use serde_json::Value;
+
+/// Error raised when a JSON schema cannot be converted to a GBNF grammar.
+#[derive(Debug, thiserror::Error)]
+pub enum GrammarError {
+    /// The schema uses a construct this converter does not implement (e.g.
+    /// `$ref`, `oneOf`, an unknown `type`).
+    #[error("unsupported JSON schema construct: {0}")]
+    Unsupported(String),
+
+    /// The schema is structurally invalid (e.g. not an object, missing
+    /// `items` on an array).
+    #[error("invalid JSON schema: {0}")]
+    Invalid(String),
+}
+
+/// Shared terminal rules appended to every generated grammar. Whitespace is
+/// permissive (the grammar masks structure, not formatting); unused terminals
+/// are harmless to llama.cpp's grammar parser.
+const TERMINALS: &str = "\
+ws ::= [ \\t\\n]*\n\
+string ::= \"\\\"\" ( [^\"\\\\] | \"\\\\\" [\"\\\\/bfnrt] )* \"\\\"\"\n\
+integer ::= \"-\"? ( \"0\" | [1-9] [0-9]* )\n\
+number ::= \"-\"? ( \"0\" | [1-9] [0-9]* ) ( \".\" [0-9]+ )? ( [eE] [-+]? [0-9]+ )?\n\
+boolean ::= \"true\" | \"false\"\n\
+null ::= \"null\"\n";
+
+/// Convert a JSON Schema (subset) into a GBNF grammar string suitable for
+/// `GenerationConfig::with_grammar` / `llama_sampler_init_grammar`.
+///
+/// The returned grammar's entry rule is named `root`.
+///
+/// # Errors
+///
+/// Returns [`GrammarError::Invalid`] if `schema` is structurally malformed, or
+/// [`GrammarError::Unsupported`] if it uses a construct outside the supported
+/// subset (see the module docs).
+pub fn json_schema_to_gbnf(schema: &Value) -> Result<String, GrammarError> {
+    let mut builder = GrammarBuilder::default();
+    let root = builder.convert(schema)?;
+    Ok(builder.finish(&root))
+}
+
+/// Accumulates generated rules and hands out unique rule names.
+#[derive(Default)]
+struct GrammarBuilder {
+    rules: Vec<(String, String)>,
+    counter: usize,
+}
+
+impl GrammarBuilder {
+    /// Register a rule body and return its generated name.
+    fn add_rule(&mut self, body: String) -> String {
+        let name = format!("rule{}", self.counter);
+        self.counter += 1;
+        self.rules.push((name.clone(), body));
+        name
+    }
+
+    /// Convert one schema node, returning the GBNF rule/terminal name that
+    /// matches it.
+    fn convert(&mut self, schema: &Value) -> Result<String, GrammarError> {
+        let obj = schema
+            .as_object()
+            .ok_or_else(|| GrammarError::Invalid("schema node must be an object".to_string()))?;
+
+        // `enum` short-circuits `type` — match any of the literal variants.
+        if let Some(variants) = obj.get("enum") {
+            let variants = variants
+                .as_array()
+                .ok_or_else(|| GrammarError::Invalid("`enum` must be an array".to_string()))?;
+            return self.convert_enum(variants);
+        }
+
+        let ty = obj.get("type").and_then(Value::as_str).ok_or_else(|| {
+            GrammarError::Unsupported("schema without `type` or `enum`".to_string())
+        })?;
+
+        match ty {
+            "string" => Ok("string".to_string()),
+            "integer" => Ok("integer".to_string()),
+            "number" => Ok("number".to_string()),
+            "boolean" => Ok("boolean".to_string()),
+            "null" => Ok("null".to_string()),
+            "object" => self.convert_object(obj),
+            "array" => self.convert_array(obj),
+            other => Err(GrammarError::Unsupported(format!("type `{other}`"))),
+        }
+    }
+
+    fn convert_enum(&mut self, variants: &[Value]) -> Result<String, GrammarError> {
+        if variants.is_empty() {
+            return Err(GrammarError::Invalid(
+                "`enum` must list at least one variant".to_string(),
+            ));
+        }
+        let alts = variants
+            .iter()
+            .map(json_literal)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(self.add_rule(alts.join(" | ")))
+    }
+
+    fn convert_object(
+        &mut self,
+        obj: &serde_json::Map<String, Value>,
+    ) -> Result<String, GrammarError> {
+        let props = obj.get("properties").and_then(Value::as_object);
+        let props = match props {
+            Some(p) if !p.is_empty() => p,
+            // No declared properties → match an empty JSON object.
+            _ => return Ok(self.add_rule("\"{\" ws \"}\"".to_string())),
+        };
+
+        let mut parts = vec!["\"{\" ws".to_string()];
+        for (i, (key, subschema)) in props.iter().enumerate() {
+            let value_rule = self.convert(subschema)?;
+            if i > 0 {
+                parts.push("\",\" ws".to_string());
+            }
+            parts.push(format!(
+                "{} ws \":\" ws {value_rule} ws",
+                gbnf_json_key(key)
+            ));
+        }
+        parts.push("\"}\"".to_string());
+        Ok(self.add_rule(parts.join(" ")))
+    }
+
+    fn convert_array(
+        &mut self,
+        obj: &serde_json::Map<String, Value>,
+    ) -> Result<String, GrammarError> {
+        let items = obj
+            .get("items")
+            .ok_or_else(|| GrammarError::Unsupported("array without `items`".to_string()))?;
+        let item_rule = self.convert(items)?;
+        Ok(self.add_rule(format!(
+            "\"[\" ws ( {item_rule} ( ws \",\" ws {item_rule} )* )? ws \"]\""
+        )))
+    }
+
+    /// Emit the full grammar text with `root` first, then generated rules, then
+    /// the shared terminals.
+    fn finish(&self, root: &str) -> String {
+        let mut out = format!("root ::= {root}\n");
+        for (name, body) in &self.rules {
+            out.push_str(&format!("{name} ::= {body}\n"));
+        }
+        out.push_str(TERMINALS);
+        out
+    }
+}
+
+/// GBNF literal matching the JSON-quoted form of an object key, e.g.
+/// `merchant` → `"\"merchant\""`.
+fn gbnf_json_key(key: &str) -> String {
+    let mut inner = String::with_capacity(key.len());
+    for ch in key.chars() {
+        match ch {
+            '"' => inner.push_str("\\\""),
+            '\\' => inner.push_str("\\\\"),
+            _ => inner.push(ch),
+        }
+    }
+    format!("\"\\\"{inner}\\\"\"")
+}
+
+/// GBNF literal matching a single scalar `enum` variant in its JSON form.
+fn json_literal(v: &Value) -> Result<String, GrammarError> {
+    match v {
+        Value::String(s) => Ok(gbnf_json_key(s)),
+        Value::Number(n) => Ok(format!("\"{n}\"")),
+        Value::Bool(b) => Ok(format!("\"{b}\"")),
+        Value::Null => Ok("\"null\"".to_string()),
+        _ => Err(GrammarError::Unsupported(
+            "enum variants must be scalars (string / number / boolean / null)".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn object_emits_root_keys_and_terminals() {
+        let gbnf = json_schema_to_gbnf(&json!({
+            "type": "object",
+            "properties": {
+                "merchant": { "type": "string" },
+                "total": { "type": "number" }
+            }
+        }))
+        .unwrap();
+
+        assert!(gbnf.starts_with("root ::="));
+        assert!(gbnf.contains("\\\"merchant\\\""));
+        assert!(gbnf.contains("\\\"total\\\""));
+        // Shared terminals are always present.
+        assert!(gbnf.contains("string ::="));
+        assert!(gbnf.contains("number ::="));
+        assert!(gbnf.contains("ws ::="));
+    }
+
+    #[test]
+    fn nested_object_and_array() {
+        let gbnf = json_schema_to_gbnf(&json!({
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": { "name": { "type": "string" } }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        // Array produces the bracketed repetition shape.
+        assert!(gbnf.contains("\"[\""));
+        assert!(gbnf.contains("\\\"name\\\""));
+    }
+
+    #[test]
+    fn string_enum_becomes_alternation() {
+        let gbnf = json_schema_to_gbnf(&json!({
+            "type": "object",
+            "properties": {
+                "status": { "enum": ["open", "closed"] }
+            }
+        }))
+        .unwrap();
+
+        assert!(gbnf.contains("\\\"open\\\""));
+        assert!(gbnf.contains("\\\"closed\\\""));
+        assert!(gbnf.contains(" | "));
+    }
+
+    #[test]
+    fn top_level_scalar_root() {
+        let gbnf = json_schema_to_gbnf(&json!({ "type": "string" })).unwrap();
+        assert!(gbnf.starts_with("root ::= string"));
+    }
+
+    #[test]
+    fn unknown_type_is_unsupported() {
+        let err = json_schema_to_gbnf(&json!({ "type": "tuple" })).unwrap_err();
+        assert!(matches!(err, GrammarError::Unsupported(_)));
+    }
+
+    #[test]
+    fn array_without_items_is_unsupported() {
+        let err = json_schema_to_gbnf(&json!({ "type": "array" })).unwrap_err();
+        assert!(matches!(err, GrammarError::Unsupported(_)));
+    }
+
+    #[test]
+    fn non_object_schema_is_invalid() {
+        let err = json_schema_to_gbnf(&json!("nope")).unwrap_err();
+        assert!(matches!(err, GrammarError::Invalid(_)));
+    }
+}

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -562,6 +562,7 @@ impl LlamaCppBackend {
             config.top_k,
             config.repetition_penalty,
             stop_sequences,
+            config.grammar.as_deref(),
             |token_id, token_text| on_chunk(token_id, token_text, &mut tel),
             prepared.n_past,
         )?;
@@ -1139,6 +1140,7 @@ impl LlmBackend for LlamaCppBackend {
                             config.top_k,
                             config.repetition_penalty,
                             &generation_stop_patterns,
+                            config.grammar.as_deref(),
                             new_n_past as usize,
                             |_token_id, _token_text| {
                                 tel.record_chunk();
@@ -1287,6 +1289,7 @@ impl LlmBackend for LlamaCppBackend {
                     config.top_k,
                     config.repetition_penalty,
                     &generation_stop_patterns,
+                    config.grammar.as_deref(),
                     new_n_past as usize,
                     |token_id, token_text| {
                         tel.record_chunk();

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -55,6 +55,10 @@ pub mod traits;
 // Always-available types for FFI/bindings (NOT feature-gated)
 pub mod types;
 
+// JSON-Schema → GBNF conversion for constrained decoding. Pure Rust, no llama
+// dependency, so it is always compiled (referenced by `GenerationConfig`).
+pub mod grammar;
+
 // Shared vision contracts for embedding-style multimodal backends.
 pub mod vision;
 

--- a/crates/xybrid-core/src/runtime_adapter/types.rs
+++ b/crates/xybrid-core/src/runtime_adapter/types.rs
@@ -336,6 +336,16 @@ pub struct GenerationConfig {
     /// Stop sequences.
     #[serde(default)]
     pub stop_sequences: Vec<String>,
+
+    /// Optional GBNF grammar constraining generation. When set, the local
+    /// llama.cpp backend masks any token the grammar would reject, guaranteeing
+    /// structured output (e.g. schema-valid JSON for data extraction).
+    ///
+    /// Set the raw grammar via [`GenerationConfig::with_grammar`], or convert a
+    /// JSON Schema with [`GenerationConfig::with_json_schema`]. `None` = free
+    /// (unconstrained) generation. Ignored by non-llama backends.
+    #[serde(default)]
+    pub grammar: Option<String>,
 }
 
 fn default_max_tokens() -> usize {
@@ -376,6 +386,7 @@ impl Default for GenerationConfig {
             top_k: default_top_k(),
             repetition_penalty: default_repetition_penalty(),
             stop_sequences: Vec::new(),
+            grammar: None,
         }
     }
 }
@@ -417,6 +428,40 @@ impl GenerationConfig {
     pub fn with_stop(mut self, stop: impl Into<String>) -> Self {
         self.stop_sequences.push(stop.into());
         self
+    }
+
+    /// Constrain generation to a raw [GBNF] grammar (entry rule `root`).
+    ///
+    /// This is the escape hatch for callers who already have a grammar; most
+    /// callers should use [`GenerationConfig::with_json_schema`] instead. Only
+    /// the local llama.cpp backend honors this; other backends ignore it.
+    ///
+    /// [GBNF]: https://github.com/ggml-org/llama.cpp/blob/master/grammars/README.md
+    pub fn with_grammar(mut self, grammar: impl Into<String>) -> Self {
+        self.grammar = Some(grammar.into());
+        self
+    }
+
+    /// Constrain generation to a JSON Schema, converting it to a GBNF grammar.
+    ///
+    /// Guarantees the model emits schema-valid JSON — the basis for reliable
+    /// on-device data extraction. Supports a subset of JSON Schema (objects,
+    /// arrays, scalars, enums); see [`crate::runtime_adapter::grammar`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XybridError::Grammar`] if the schema is malformed or uses an
+    /// unsupported construct.
+    ///
+    /// [`XybridError::Grammar`]: crate::error::XybridError::Grammar
+    pub fn with_json_schema(
+        mut self,
+        schema: &serde_json::Value,
+    ) -> crate::error::XybridResult<Self> {
+        self.grammar = Some(crate::runtime_adapter::grammar::json_schema_to_gbnf(
+            schema,
+        )?);
+        Ok(self)
     }
 }
 

--- a/crates/xybrid-llama/src/ffi.rs
+++ b/crates/xybrid-llama/src/ffi.rs
@@ -255,7 +255,9 @@ pub(crate) unsafe fn format_chat_with_model(
 /// `ctx` and `model` must be live, non-null pointers. `input_tokens`
 /// valid for `n_input` elements. `output_tokens` writable for `max_tokens`
 /// elements. `stop_seqs` and `stop_lens` either both null with
-/// `n_stop_seqs == 0`, or both valid.
+/// `n_stop_seqs == 0`, or both valid. `grammar` / `grammar_root` are either
+/// null (unconstrained generation) or NUL-terminated C strings that outlive
+/// the call.
 #[allow(clippy::too_many_arguments)]
 pub(crate) unsafe fn generate(
     ctx: *mut c_void,
@@ -270,6 +272,8 @@ pub(crate) unsafe fn generate(
     top_k: usize,
     repeat_penalty: f32,
     seed: u32,
+    grammar: *const c_char,
+    grammar_root: *const c_char,
     stop_seqs: *const i32,
     stop_lens: *const c_int,
     n_stop_seqs: c_int,
@@ -287,6 +291,8 @@ pub(crate) unsafe fn generate(
         top_k as c_int,
         repeat_penalty,
         seed,
+        grammar,
+        grammar_root,
         stop_seqs,
         stop_lens,
         n_stop_seqs,
@@ -314,6 +320,8 @@ pub(crate) unsafe fn generate_streaming(
     top_k: usize,
     repeat_penalty: f32,
     seed: u32,
+    grammar: *const c_char,
+    grammar_root: *const c_char,
     stop_seqs: *const i32,
     stop_lens: *const c_int,
     n_stop_seqs: c_int,
@@ -334,6 +342,8 @@ pub(crate) unsafe fn generate_streaming(
         top_k as c_int,
         repeat_penalty,
         seed,
+        grammar,
+        grammar_root,
         stop_seqs,
         stop_lens,
         n_stop_seqs,
@@ -364,6 +374,8 @@ pub(crate) unsafe fn generate_from_current_logits(
     top_k: usize,
     repeat_penalty: f32,
     seed: u32,
+    grammar: *const c_char,
+    grammar_root: *const c_char,
     stop_seqs: *const i32,
     stop_lens: *const c_int,
     n_stop_seqs: c_int,
@@ -382,6 +394,8 @@ pub(crate) unsafe fn generate_from_current_logits(
         top_k as c_int,
         repeat_penalty,
         seed,
+        grammar,
+        grammar_root,
         stop_seqs,
         stop_lens,
         n_stop_seqs,

--- a/crates/xybrid-llama/src/generation.rs
+++ b/crates/xybrid-llama/src/generation.rs
@@ -198,6 +198,22 @@ fn stop_array_ptrs(stop_tokens: &[i32], stop_lens: &[c_int]) -> (*const i32, *co
 /// sequence that tokenises to zero tokens is silently dropped, matching
 /// the pre-refactor wrapper behavior. The count passed to the C side is
 /// the *filtered* length, not the original `stop_sequences.len()`.
+/// Build an owning `CString` for an optional GBNF grammar.
+///
+/// The returned `CString` must be held alive by the caller for the duration of
+/// the FFI call (the raw pointer borrows it). Returns `Ok(None)` when no
+/// grammar is requested, and errors if the grammar contains an interior NUL
+/// byte (which a GBNF grammar never legitimately does).
+fn grammar_cstring(grammar: Option<&str>) -> LlamaResult<Option<CString>> {
+    grammar
+        .map(|g| {
+            CString::new(g).map_err(|_| {
+                LlamaError::InvalidInput("grammar contains an interior NUL byte".to_string())
+            })
+        })
+        .transpose()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn generate_with_stops(
     ctx: &LlamaContext,
@@ -210,13 +226,20 @@ pub fn generate_with_stops(
     top_k: usize,
     repeat_penalty: f32,
     stop_sequences: &[String],
+    grammar: Option<&str>,
 ) -> LlamaResult<Vec<i32>> {
     let (stop_tokens, stop_lens, mut output_tokens) =
         prepare_generation(model, input_tokens, max_tokens, stop_sequences)?;
     let (stop_seqs_ptr, stop_lens_ptr, n_stop_seqs) = stop_array_ptrs(&stop_tokens, &stop_lens);
 
+    // Owns the grammar C string for the lifetime of the FFI call; `null` =
+    // unconstrained. `grammar_root` is left null so the C side defaults to the
+    // "root" entry rule (which the JSON-Schema converter always emits).
+    let grammar_cstr = grammar_cstring(grammar)?;
+    let grammar_ptr = grammar_cstr.as_ref().map_or(ptr::null(), |c| c.as_ptr());
+
     // SAFETY: all pointers checked / sourced from owned buffers; sizes
-    // honest; ctx + model live for the call.
+    // honest; ctx + model live for the call; grammar_cstr outlives it.
     let result = unsafe {
         ffi::generate(
             ctx.as_ptr(),
@@ -231,6 +254,8 @@ pub fn generate_with_stops(
             top_k,
             repeat_penalty,
             time_seed(),
+            grammar_ptr,
+            ptr::null(),
             stop_seqs_ptr,
             stop_lens_ptr,
             n_stop_seqs,
@@ -264,6 +289,7 @@ pub fn generate_streaming<F>(
     top_k: usize,
     repeat_penalty: f32,
     stop_sequences: &[String],
+    grammar: Option<&str>,
     mut on_token: F,
     n_past_in: usize,
 ) -> LlamaResult<(Vec<i32>, bool)>
@@ -274,6 +300,11 @@ where
         prepare_generation(model, input_tokens, max_tokens, stop_sequences)?;
     let (stop_seqs_ptr, stop_lens_ptr, n_stop_seqs) = stop_array_ptrs(&stop_tokens, &stop_lens);
 
+    // Owns the grammar C string for the lifetime of the FFI call (see
+    // `generate_with_stops`).
+    let grammar_cstr = grammar_cstring(grammar)?;
+    let grammar_ptr = grammar_cstr.as_ref().map_or(ptr::null(), |c| c.as_ptr());
+
     let mut streaming_ctx = StreamingContext {
         callback: &mut on_token,
         error: None,
@@ -283,7 +314,7 @@ where
 
     // SAFETY: all pointers checked / sourced from owned buffers; the
     // user_data pointer is a stack-pinned `&mut StreamingContext<F>`
-    // that lives for the duration of the C call.
+    // that lives for the duration of the C call; grammar_cstr outlives it.
     let result = unsafe {
         ffi::generate_streaming(
             ctx.as_ptr(),
@@ -298,6 +329,8 @@ where
             top_k,
             repeat_penalty,
             time_seed(),
+            grammar_ptr,
+            ptr::null(),
             stop_seqs_ptr,
             stop_lens_ptr,
             n_stop_seqs,
@@ -345,6 +378,7 @@ pub fn generate_from_current_logits_streaming<F>(
     top_k: usize,
     repeat_penalty: f32,
     stop_sequences: &[String],
+    grammar: Option<&str>,
     n_past: usize,
     mut on_token: F,
 ) -> LlamaResult<(Vec<i32>, bool)>
@@ -361,6 +395,11 @@ where
     let (stop_seqs_ptr, stop_lens_ptr, n_stop_seqs) = stop_array_ptrs(&stop_tokens, &stop_lens);
     let mut output_tokens = vec![0i32; max_tokens];
 
+    // Owns the grammar C string for the lifetime of the FFI call (see
+    // `generate_with_stops`).
+    let grammar_cstr = grammar_cstring(grammar)?;
+    let grammar_ptr = grammar_cstr.as_ref().map_or(ptr::null(), |c| c.as_ptr());
+
     let mut streaming_ctx = StreamingContext {
         callback: &mut on_token,
         error: None,
@@ -370,7 +409,7 @@ where
 
     // SAFETY: ctx/model are live; output buffer and stop arrays are owned
     // by this frame; user_data points to a stack-pinned StreamingContext
-    // that outlives the C call.
+    // that outlives the C call; grammar_cstr outlives it.
     let result = unsafe {
         ffi::generate_from_current_logits(
             ctx.as_ptr(),
@@ -383,6 +422,8 @@ where
             top_k,
             repeat_penalty,
             time_seed(),
+            grammar_ptr,
+            ptr::null(),
             stop_seqs_ptr,
             stop_lens_ptr,
             n_stop_seqs,

--- a/crates/xybrid-llama/tests/prefix_cache_hit_smoke.rs
+++ b/crates/xybrid-llama/tests/prefix_cache_hit_smoke.rs
@@ -164,6 +164,7 @@ fn qwen2_5_0_5b_three_turns_show_prefix_cache_hit_on_turn_2_and_3() {
             0,
             1.0,
             &["<|im_end|>".to_string()],
+            None,
         )
         .expect("turn must complete");
 

--- a/crates/xybrid-llama/tests/recurrent_gating_smoke.rs
+++ b/crates/xybrid-llama/tests/recurrent_gating_smoke.rs
@@ -111,6 +111,7 @@ fn lfm2_350m_two_turns_does_not_fail_with_decode_error() {
         0,
         1.0,
         &["<|im_end|>".to_string()],
+        None,
     )
     .expect("turn 1 must not fail");
 
@@ -135,6 +136,7 @@ fn lfm2_350m_two_turns_does_not_fail_with_decode_error() {
         0,
         1.0,
         &["<|im_end|>".to_string()],
+        None,
     );
 
     match result {


### PR DESCRIPTION
## Summary

Adds grammar-constrained decoding to the local llama.cpp backend so small models (LFM2.5-230M) emit guaranteed schema-valid JSON for on-device data extraction. A GBNF sampler is prepended at the single sampler-chain chokepoint in `wrapper.cpp` and threaded through `xybrid-llama` into `GenerationConfig`, with a new Rust JSON-Schema→GBNF converter (`runtime_adapter/grammar.rs`) exposed via chainable `with_json_schema()` / `with_grammar()` builders — no new run entry points. The grammar emits compact JSON after end-to-end testing on LFM2.5-230M caught a greedy whitespace-loop trap in the original permissive-whitespace grammar; the included `lfm2_230m_grammar` example reproduces that test (unconstrained output fails to parse, constrained output is schema-valid at `finish_reason=stop`). Breaking (pre-1.0, in-repo consumers updated): `xybrid-llama`'s `generate_with_stops` / `generate_streaming` / `generate_from_current_logits_streaming` gain a `grammar: Option<&str>` parameter. FFI-binding mirrors (facade/bolt/ffi/Flutter) and advanced schema constructs (`$ref`, `oneOf`, `pattern`) are deliberately deferred.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)