### PR TITLE
feat(bindings): expose GBNF grammar constraint across all FFI surfaces

### DIFF
--- a/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
@@ -68,8 +68,13 @@ public struct XybridGenerationConfig: Hashable, Equatable, Sendable {
     public var topK: UInt32?
     public var repetitionPenalty: Float?
     public var stopSequences: [String]
+    /// Optional GBNF grammar constraining generation to structured output
+    /// (local llama backend only). Produce one from a JSON Schema with
+    /// [`json_schema_to_gbnf`], or pass raw GBNF. Appended last: `#[data]`
+    /// PODs serialize by field order across the FFI boundary.
+    public var grammar: String?
 
-    public init(maxTokens: UInt32? = nil, temperature: Float? = nil, topP: Float? = nil, minP: Float? = nil, topK: UInt32? = nil, repetitionPenalty: Float? = nil, stopSequences: [String]) {
+    public init(maxTokens: UInt32? = nil, temperature: Float? = nil, topP: Float? = nil, minP: Float? = nil, topK: UInt32? = nil, repetitionPenalty: Float? = nil, stopSequences: [String], grammar: String? = nil) {
         self.maxTokens = maxTokens
         self.temperature = temperature
         self.topP = topP
@@ -77,13 +82,14 @@ public struct XybridGenerationConfig: Hashable, Equatable, Sendable {
         self.topK = topK
         self.repetitionPenalty = repetitionPenalty
         self.stopSequences = stopSequences
+        self.grammar = grammar
     }
 
 }
 
 extension XybridGenerationConfig: WireCodable {
     @inlinable static func decode(from reader: inout WireReader) -> XybridGenerationConfig {
-        XybridGenerationConfig(maxTokens: reader.readOptional { reader in reader.readU32() }, temperature: reader.readOptional { reader in reader.readF32() }, topP: reader.readOptional { reader in reader.readF32() }, minP: reader.readOptional { reader in reader.readF32() }, topK: reader.readOptional { reader in reader.readU32() }, repetitionPenalty: reader.readOptional { reader in reader.readF32() }, stopSequences: reader.readArray { reader in reader.readString() })
+        XybridGenerationConfig(maxTokens: reader.readOptional { reader in reader.readU32() }, temperature: reader.readOptional { reader in reader.readF32() }, topP: reader.readOptional { reader in reader.readF32() }, minP: reader.readOptional { reader in reader.readF32() }, topK: reader.readOptional { reader in reader.readU32() }, repetitionPenalty: reader.readOptional { reader in reader.readF32() }, stopSequences: reader.readArray { reader in reader.readString() }, grammar: reader.readOptional { reader in reader.readString() })
     }
     @inlinable func encode(to writer: inout WireWriter) {
         writer.writeOptional(self.maxTokens) { writer, v in writer.writeU32(v) }
@@ -93,6 +99,7 @@ extension XybridGenerationConfig: WireCodable {
         writer.writeOptional(self.topK) { writer, v in writer.writeU32(v) }
         writer.writeOptional(self.repetitionPenalty) { writer, v in writer.writeF32(v) }
         writer.writeArray(self.stopSequences) { writer, item in writer.writeString(item) }
+        writer.writeOptional(self.grammar) { writer, v in writer.writeString(v) }
     }
 }
 
@@ -591,6 +598,18 @@ public enum XybridThermalState: Int32, Hashable, Sendable, CaseIterable {
 extension XybridThermalState: WireCodable {
     @inlinable static func decode(from reader: inout WireReader) -> XybridThermalState { XybridThermalState(wireTag: reader.readI32()) }
     @inlinable func encode(to writer: inout WireWriter) { writer.writeI32(wireTag) }
+}
+
+/// Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+/// [`XybridGenerationConfig::grammar`]. Fails on invalid JSON or schema
+/// constructs outside the supported subset.
+public func jsonSchemaToGbnf(schemaJson: String) throws -> String {
+    var schemaJson = schemaJson
+    return try schemaJson.withUTF8 { schemaJsonBuf in
+        let buf = boltffi_json_schema_to_gbnf(schemaJsonBuf.baseAddress!, UInt(schemaJsonBuf.count))
+        defer { boltffi_free_buf(buf) }
+        return try boltffiDecodeOwnedBuf(buf.ptr, Int(buf.len)) { reader in try { let tag = reader.readU8(); if tag == 0 { return reader.readString() } else { throw XybridError.decode(from: &reader) } }() }
+    }
 }
 
 public func setThermalState(state: XybridThermalState) {

--- a/bindings/flutter/lib/src/rust/api/model.dart
+++ b/bindings/flutter/lib/src/rust/api/model.dart
@@ -19,6 +19,15 @@ part 'model.freezed.dart';
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `FlutterFallbackResourceProvider`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `current_snapshot`, `fmt`, `from`
 
+/// Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+/// [`FfiGenerationConfig::grammar`].
+///
+/// Fails (as a `String` error, per this crate's FRB convention) when the
+/// schema is not valid JSON or uses a construct outside the supported subset.
+String jsonSchemaToGbnf({required String schemaJson}) =>
+    XybridRustLib.instance.api
+        .crateApiModelJsonSchemaToGbnf(schemaJson: schemaJson);
+
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FfiCancellationToken>>
 abstract class FfiCancellationToken implements RustOpaqueInterface {
   /// Request cooperative cancellation of the associated run.
@@ -242,6 +251,11 @@ class FfiGenerationConfig {
   /// Stop sequences. When `None` or empty, only EOS token stops generation.
   final List<String>? stopSequences;
 
+  /// Optional GBNF grammar constraining generation to structured output
+  /// (local llama backend only; other backends ignore it). Produce one from
+  /// a JSON Schema with `jsonSchemaToGbnf`, or pass raw GBNF.
+  final String? grammar;
+
   const FfiGenerationConfig({
     this.maxTokens,
     this.temperature,
@@ -250,6 +264,7 @@ class FfiGenerationConfig {
     this.topK,
     this.repetitionPenalty,
     this.stopSequences,
+    this.grammar,
   });
 
   /// Create a creative generation config (higher temperature).
@@ -268,7 +283,8 @@ class FfiGenerationConfig {
       minP.hashCode ^
       topK.hashCode ^
       repetitionPenalty.hashCode ^
-      stopSequences.hashCode;
+      stopSequences.hashCode ^
+      grammar.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -281,7 +297,8 @@ class FfiGenerationConfig {
           minP == other.minP &&
           topK == other.topK &&
           repetitionPenalty == other.repetitionPenalty &&
-          stopSequences == other.stopSequences;
+          stopSequences == other.stopSequences &&
+          grammar == other.grammar;
 }
 
 @freezed

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class XybridRustLib extends BaseEntrypoint<XybridRustLibApi,
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -738506137;
+  int get rustContentHash => 1092953575;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -287,6 +287,8 @@ abstract class XybridRustLibApi extends BaseApi {
   FfiGenerationConfig crateApiModelFfiGenerationConfigCreative();
 
   FfiGenerationConfig crateApiModelFfiGenerationConfigGreedy();
+
+  String crateApiModelJsonSchemaToGbnf({required String schemaJson});
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_FfiCancellationToken;
@@ -2153,6 +2155,30 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         argNames: [],
       );
 
+  @override
+  String crateApiModelJsonSchemaToGbnf({required String schemaJson}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(schemaJson, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiModelJsonSchemaToGbnfConstMeta,
+      argValues: [schemaJson],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiModelJsonSchemaToGbnfConstMeta =>
+      const TaskConstMeta(
+        debugName: "json_schema_to_gbnf",
+        argNames: ["schemaJson"],
+      );
+
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_FfiCancellationToken => wire
           .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFfiCancellationToken;
@@ -2527,8 +2553,8 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   FfiGenerationConfig dco_decode_ffi_generation_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7)
-      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return FfiGenerationConfig(
       maxTokens: dco_decode_opt_box_autoadd_u_32(arr[0]),
       temperature: dco_decode_opt_box_autoadd_f_32(arr[1]),
@@ -2537,6 +2563,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
       topK: dco_decode_opt_box_autoadd_u_32(arr[4]),
       repetitionPenalty: dco_decode_opt_box_autoadd_f_32(arr[5]),
       stopSequences: dco_decode_opt_list_String(arr[6]),
+      grammar: dco_decode_opt_String(arr[7]),
     );
   }
 
@@ -3285,6 +3312,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     var var_topK = sse_decode_opt_box_autoadd_u_32(deserializer);
     var var_repetitionPenalty = sse_decode_opt_box_autoadd_f_32(deserializer);
     var var_stopSequences = sse_decode_opt_list_String(deserializer);
+    var var_grammar = sse_decode_opt_String(deserializer);
     return FfiGenerationConfig(
         maxTokens: var_maxTokens,
         temperature: var_temperature,
@@ -3292,7 +3320,8 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
         minP: var_minP,
         topK: var_topK,
         repetitionPenalty: var_repetitionPenalty,
-        stopSequences: var_stopSequences);
+        stopSequences: var_stopSequences,
+        grammar: var_grammar);
   }
 
   @protected
@@ -4186,6 +4215,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_opt_box_autoadd_u_32(self.topK, serializer);
     sse_encode_opt_box_autoadd_f_32(self.repetitionPenalty, serializer);
     sse_encode_opt_list_String(self.stopSequences, serializer);
+    sse_encode_opt_String(self.grammar, serializer);
   }
 
   @protected

--- a/bindings/flutter/rust/src/api/model.rs
+++ b/bindings/flutter/rust/src/api/model.rs
@@ -36,6 +36,10 @@ pub struct FfiGenerationConfig {
     pub repetition_penalty: Option<f32>,
     /// Stop sequences. When `None` or empty, only EOS token stops generation.
     pub stop_sequences: Option<Vec<String>>,
+    /// Optional GBNF grammar constraining generation to structured output
+    /// (local llama backend only; other backends ignore it). Produce one from
+    /// a JSON Schema with `jsonSchemaToGbnf`, or pass raw GBNF.
+    pub grammar: Option<String>,
 }
 
 impl FfiGenerationConfig {
@@ -50,6 +54,7 @@ impl FfiGenerationConfig {
             top_k: Some(0),
             repetition_penalty: None,
             stop_sequences: None,
+            grammar: None,
         }
     }
 
@@ -64,6 +69,7 @@ impl FfiGenerationConfig {
             top_k: Some(50),
             repetition_penalty: None,
             stop_sequences: None,
+            grammar: None,
         }
     }
 
@@ -81,12 +87,23 @@ impl FfiGenerationConfig {
             top_k: self.top_k,
             repetition_penalty: self.repetition_penalty,
             stop_sequences: self.stop_sequences.clone().unwrap_or_default(),
+            grammar: self.grammar.clone(),
         }
     }
 
     pub(crate) fn to_sdk(&self) -> GenerationConfig {
         self.to_facade().to_sdk()
     }
+}
+
+/// Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+/// [`FfiGenerationConfig::grammar`].
+///
+/// Fails (as a `String` error, per this crate's FRB convention) when the
+/// schema is not valid JSON or uses a construct outside the supported subset.
+#[frb(sync)]
+pub fn json_schema_to_gbnf(schema_json: String) -> Result<String, String> {
+    xybrid_sdk::json_schema_str_to_gbnf(&schema_json).map_err(|e| e.to_string())
 }
 
 /// Opaque cooperative cancellation handle shared across the FFI boundary.
@@ -208,6 +225,7 @@ impl FfiRunOptions {
                 top_k: Some(cfg.top_k as u32),
                 repetition_penalty: Some(cfg.repetition_penalty),
                 stop_sequences: cfg.stop_sequences.clone(),
+                grammar: cfg.grammar.clone(),
             });
         let mut options = self.to_facade(facade_gc).to_sdk(None);
 

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -738506137;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1092953575;
 
 // Section: executor
 
@@ -2714,6 +2714,36 @@ fn wire__crate__api__model__ffi_generation_config_greedy_impl(
         },
     )
 }
+fn wire__crate__api__model__json_schema_to_gbnf_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "json_schema_to_gbnf",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_schema_json = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::model::json_schema_to_gbnf(api_schema_json)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 
 // Section: related_funcs
 
@@ -2986,6 +3016,7 @@ impl SseDecode for crate::api::model::FfiGenerationConfig {
         let mut var_topK = <Option<u32>>::sse_decode(deserializer);
         let mut var_repetitionPenalty = <Option<f32>>::sse_decode(deserializer);
         let mut var_stopSequences = <Option<Vec<String>>>::sse_decode(deserializer);
+        let mut var_grammar = <Option<String>>::sse_decode(deserializer);
         return crate::api::model::FfiGenerationConfig {
             max_tokens: var_maxTokens,
             temperature: var_temperature,
@@ -2994,6 +3025,7 @@ impl SseDecode for crate::api::model::FfiGenerationConfig {
             top_k: var_topK,
             repetition_penalty: var_repetitionPenalty,
             stop_sequences: var_stopSequences,
+            grammar: var_grammar,
         };
     }
 }
@@ -3818,6 +3850,7 @@ fn pde_ffi_dispatcher_sync_impl(
         64 => {
             wire__crate__api__model__ffi_generation_config_greedy_impl(ptr, rust_vec_len, data_len)
         }
+        65 => wire__crate__api__model__json_schema_to_gbnf_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3963,6 +3996,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::model::FfiGenerationConfig {
             self.top_k.into_into_dart().into_dart(),
             self.repetition_penalty.into_into_dart().into_dart(),
             self.stop_sequences.into_into_dart().into_dart(),
+            self.grammar.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -4631,6 +4665,7 @@ impl SseEncode for crate::api::model::FfiGenerationConfig {
         <Option<u32>>::sse_encode(self.top_k, serializer);
         <Option<f32>>::sse_encode(self.repetition_penalty, serializer);
         <Option<Vec<String>>>::sse_encode(self.stop_sequences, serializer);
+        <Option<String>>::sse_encode(self.grammar, serializer);
     }
 }
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
@@ -1081,7 +1081,14 @@ data class XybridGenerationConfig(
     val minP: Float? = null,
     val topK: UInt? = null,
     val repetitionPenalty: Float? = null,
-    val stopSequences: List<String>
+    val stopSequences: List<String>,
+    /**
+     * Optional GBNF grammar constraining generation to structured output
+     * (local llama backend only). Produce one from a JSON Schema with
+     * [`json_schema_to_gbnf`], or pass raw GBNF. Appended last: `#[data]`
+     * PODs serialize by field order across the FFI boundary.
+     */
+    val grammar: String? = null
 ) {
     companion object {
         fun decode(reader: WireReader): XybridGenerationConfig = XybridGenerationConfig(
@@ -1091,7 +1098,8 @@ data class XybridGenerationConfig(
             reader.readOptional { reader.readF32() },
             reader.readOptional { reader.readU32() },
             reader.readOptional { reader.readF32() },
-            reader.readList { reader.readString() }
+            reader.readList { reader.readString() },
+            reader.readOptional { reader.readString() }
         )
     }
     fun wireEncodedSize(): Int =
@@ -1101,7 +1109,8 @@ data class XybridGenerationConfig(
         (minP?.let { v -> 1 + 4 } ?: 1.toInt()) +
         (topK?.let { v -> 1 + 4 } ?: 1.toInt()) +
         (repetitionPenalty?.let { v -> 1 + 4 } ?: 1.toInt()) +
-        (4 + stopSequences.sumOf { item -> (4 + Utf8Codec.maxBytes(item)) })
+        (4 + stopSequences.sumOf { item -> (4 + Utf8Codec.maxBytes(item)) }) +
+        (grammar?.let { v -> 1 + (4 + Utf8Codec.maxBytes(v)) } ?: 1.toInt())
 
     fun wireEncodeTo(wire: WireWriter) {
         maxTokens?.let { v -> wire.writeU8(1u); wire.writeU32(v) } ?: wire.writeU8(0u)
@@ -1111,6 +1120,7 @@ data class XybridGenerationConfig(
         topK?.let { v -> wire.writeU8(1u); wire.writeU32(v) } ?: wire.writeU8(0u)
         repetitionPenalty?.let { v -> wire.writeU8(1u); wire.writeF32(v) } ?: wire.writeU8(0u)
         wire.writeU32(stopSequences.size.toUInt()); stopSequences.forEach { item -> wire.writeString(item) }
+        grammar?.let { v -> wire.writeU8(1u); wire.writeString(v) } ?: wire.writeU8(0u)
     }
 }
 
@@ -1273,6 +1283,20 @@ data class XybridVoiceInfo(
         language?.let { v -> wire.writeU8(1u); wire.writeString(v) } ?: wire.writeU8(0u)
         style?.let { v -> wire.writeU8(1u); wire.writeString(v) } ?: wire.writeU8(0u)
     }
+}
+
+/**
+ * Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+ * [`XybridGenerationConfig::grammar`]. Fails on invalid JSON or schema
+ * constructs outside the supported subset.
+ */
+
+@Throws(XybridError::class)
+fun jsonSchemaToGbnf(schemaJson: String): String {
+    val buf = Native.boltffi_json_schema_to_gbnf(schemaJson.toByteArray(Charsets.UTF_8))
+        ?: throw FfiException(-1, "Null buffer returned")
+    val reader = WireReader(buf)
+    return reader.readResult({ reader.readString() }, { XybridError.decode(reader) }).getOrThrow()
 }
 
 fun setThermalState(state: XybridThermalState) {
@@ -1634,6 +1658,7 @@ private object Native {
 
     @JvmStatic external fun boltffi_free_string(ptr: Long)
     @JvmStatic external fun boltffi_last_error_message(): ByteArray
+    @JvmStatic external fun boltffi_json_schema_to_gbnf(schema_json: ByteArray): ByteArray?
     @JvmStatic external fun boltffi_set_thermal_state(state: Int): Unit
     @JvmStatic external fun boltffi_clear_thermal_state(): Unit
     @JvmStatic external fun boltffi_set_battery_level(percent: Byte): Unit

--- a/crates/xybrid-bolt/src/lib.rs
+++ b/crates/xybrid-bolt/src/lib.rs
@@ -304,6 +304,11 @@ pub struct XybridGenerationConfig {
     pub top_k: Option<u32>,
     pub repetition_penalty: Option<f32>,
     pub stop_sequences: Vec<String>,
+    /// Optional GBNF grammar constraining generation to structured output
+    /// (local llama backend only). Produce one from a JSON Schema with
+    /// [`json_schema_to_gbnf`], or pass raw GBNF. Appended last: `#[data]`
+    /// PODs serialize by field order across the FFI boundary.
+    pub grammar: Option<String>,
 }
 
 impl From<XybridGenerationConfig> for facade::GenerationConfig {
@@ -316,8 +321,17 @@ impl From<XybridGenerationConfig> for facade::GenerationConfig {
             top_k: c.top_k,
             repetition_penalty: c.repetition_penalty,
             stop_sequences: c.stop_sequences,
+            grammar: c.grammar,
         }
     }
+}
+
+/// Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+/// [`XybridGenerationConfig::grammar`]. Fails on invalid JSON or schema
+/// constructs outside the supported subset.
+#[export]
+pub fn json_schema_to_gbnf(schema_json: String) -> Result<String, XybridError> {
+    facade::json_schema_to_gbnf(&schema_json).map_err(XybridError::from)
 }
 
 #[data]

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -193,6 +193,11 @@ name = "neutts_tts"
 # Real inference — needs llama.cpp linked.
 required-features = ["llm-llamacpp"]
 
+[[example]]
+name = "lfm2_230m_grammar"
+# Real inference — needs llama.cpp linked.
+required-features = ["llm-llamacpp"]
+
 [[bench]]
 name = "inference_backends"
 harness = false

--- a/crates/xybrid-core/examples/streaming_llm.rs
+++ b/crates/xybrid-core/examples/streaming_llm.rs
@@ -26,13 +26,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!(
             "Run with: cargo run --example streaming_llm -p xybrid-core --features llm-llamacpp"
         );
-        return Ok(());
     }
 
     #[cfg(feature = "llm-llamacpp")]
     {
-        run_streaming_example()
+        run_streaming_example()?;
     }
+
+    Ok(())
 }
 
 #[cfg(feature = "llm-llamacpp")]

--- a/crates/xybrid-core/src/runtime_adapter/grammar.rs
+++ b/crates/xybrid-core/src/runtime_adapter/grammar.rs
@@ -82,6 +82,21 @@ pub fn json_schema_to_gbnf(schema: &Value) -> Result<String, GrammarError> {
     Ok(builder.finish(&root))
 }
 
+/// Convert a JSON Schema provided as a JSON string.
+///
+/// Convenience for FFI bindings, where the schema crosses the language
+/// boundary as text rather than a parsed value.
+///
+/// # Errors
+///
+/// Returns [`GrammarError::Invalid`] if `schema_json` is not valid JSON, plus
+/// everything [`json_schema_to_gbnf`] returns.
+pub fn json_schema_str_to_gbnf(schema_json: &str) -> Result<String, GrammarError> {
+    let schema: Value = serde_json::from_str(schema_json)
+        .map_err(|e| GrammarError::Invalid(format!("schema is not valid JSON: {e}")))?;
+    json_schema_to_gbnf(&schema)
+}
+
 /// Accumulates generated rules and hands out unique rule names.
 #[derive(Default)]
 struct GrammarBuilder {
@@ -350,6 +365,17 @@ mod tests {
     #[test]
     fn non_object_schema_is_invalid() {
         let err = json_schema_to_gbnf(&json!("nope")).unwrap_err();
+        assert!(matches!(err, GrammarError::Invalid(_)));
+    }
+
+    #[test]
+    fn str_variant_parses_then_converts() {
+        let gbnf =
+            json_schema_str_to_gbnf(r#"{"type":"object","properties":{"x":{"type":"string"}}}"#)
+                .unwrap();
+        assert!(gbnf.starts_with("root ::="));
+
+        let err = json_schema_str_to_gbnf("not json {").unwrap_err();
         assert!(matches!(err, GrammarError::Invalid(_)));
     }
 

--- a/crates/xybrid-ffi-facade/src/lib.rs
+++ b/crates/xybrid-ffi-facade/src/lib.rs
@@ -628,6 +628,10 @@ pub struct GenerationConfig {
     pub top_k: Option<u32>,
     pub repetition_penalty: Option<f32>,
     pub stop_sequences: Vec<String>,
+    /// Optional GBNF grammar constraining generation to structured output
+    /// (local llama backend only; other backends ignore it). Produce one from
+    /// a JSON Schema with [`json_schema_to_gbnf`], or pass raw GBNF.
+    pub grammar: Option<String>,
 }
 
 impl GenerationConfig {
@@ -679,8 +683,23 @@ impl GenerationConfig {
         if !self.stop_sequences.is_empty() {
             cfg.stop_sequences = self.stop_sequences.clone();
         }
+        if let Some(g) = &self.grammar {
+            cfg.grammar = Some(g.clone());
+        }
         cfg
     }
+}
+
+/// Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+/// [`GenerationConfig::grammar`].
+///
+/// Kept as a free function rather than folded into `to_sdk` so the
+/// option-bag → SDK mapping stays infallible; schema conversion is the one
+/// step that can fail (invalid JSON, unsupported schema construct).
+pub fn json_schema_to_gbnf(schema_json: &str) -> Result<String> {
+    sdk::json_schema_str_to_gbnf(schema_json).map_err(|e| Error::ConfigError {
+        message: e.to_string(),
+    })
 }
 
 /// Abort signals the caller can observe. FFI-safe subset of

--- a/crates/xybrid-ffi/include/xybrid.h
+++ b/crates/xybrid-ffi/include/xybrid.h
@@ -958,6 +958,42 @@ void xybrid_generation_config_add_stop(struct XybridGenerationConfigHandle *conf
                                        const char *stop);
 
 /*
+ Set a GBNF grammar constraining generation to structured output
+ (local llama backend only; other backends ignore it).
+
+ Produce a grammar from a JSON Schema with `xybrid_json_schema_to_gbnf`,
+ or pass raw GBNF. Passing null clears any previously set grammar.
+
+ # Safety
+
+ `config` must be a valid handle. `grammar`, when non-null, must be a
+ null-terminated UTF-8 string.
+
+ # Parameters
+
+ - `config`: A handle to the generation config.
+ - `grammar`: A null-terminated UTF-8 GBNF grammar, or null to clear.
+ */
+void xybrid_generation_config_set_grammar(struct XybridGenerationConfigHandle *config,
+                                          const char *grammar);
+
+/*
+ Convert a JSON Schema (as a JSON string) into a GBNF grammar suitable for
+ `xybrid_generation_config_set_grammar`.
+
+ # Safety
+
+ `schema_json` must be a null-terminated UTF-8 string.
+
+ # Returns
+
+ A newly allocated null-terminated GBNF string, or null if the schema is
+ invalid JSON or uses an unsupported construct. Free the returned string
+ with `xybrid_free_string()`.
+ */
+char *xybrid_json_schema_to_gbnf(const char *schema_json);
+
+/*
  Free a generation config handle.
 
  After calling this function, the handle must not be used again.

--- a/crates/xybrid-ffi/src/lib.rs
+++ b/crates/xybrid-ffi/src/lib.rs
@@ -462,6 +462,7 @@ pub(crate) struct GenerationConfigData {
     pub top_k: Option<usize>,
     pub repetition_penalty: Option<f32>,
     pub stop_sequences: Vec<String>,
+    pub grammar: Option<String>,
 }
 
 // Note: the previous `pub(crate) type BoxedFoo = Box<FooState>` aliases
@@ -689,6 +690,9 @@ fn generation_config_data_to_sdk(data: &GenerationConfigData) -> GenerationConfi
     }
     if !data.stop_sequences.is_empty() {
         config.stop_sequences = data.stop_sequences.clone();
+    }
+    if let Some(g) = &data.grammar {
+        config.grammar = Some(g.clone());
     }
     config
 }
@@ -2407,6 +2411,7 @@ pub extern "C" fn xybrid_generation_config_new() -> *mut XybridGenerationConfigH
             top_k: None,
             repetition_penalty: None,
             stop_sequences: Vec::new(),
+            grammar: None,
         });
         XybridGenerationConfigHandle::from_boxed(config)
     })
@@ -2428,6 +2433,7 @@ pub extern "C" fn xybrid_generation_config_greedy() -> *mut XybridGenerationConf
             top_k: Some(0),
             repetition_penalty: None,
             stop_sequences: Vec::new(),
+            grammar: None,
         });
         XybridGenerationConfigHandle::from_boxed(config)
     })
@@ -2449,6 +2455,7 @@ pub extern "C" fn xybrid_generation_config_creative() -> *mut XybridGenerationCo
             top_k: Some(50),
             repetition_penalty: None,
             stop_sequences: Vec::new(),
+            grammar: None,
         });
         XybridGenerationConfigHandle::from_boxed(config)
     })
@@ -2553,6 +2560,68 @@ pub unsafe extern "C" fn xybrid_generation_config_add_stop(
             if let Ok(s) = CStr::from_ptr(stop).to_str() {
                 data.stop_sequences.push(s.to_string());
             }
+        }
+    })
+}
+
+/// Set a GBNF grammar constraining generation to structured output
+/// (local llama backend only; other backends ignore it).
+///
+/// Produce a grammar from a JSON Schema with `xybrid_json_schema_to_gbnf`,
+/// or pass raw GBNF. Passing null clears any previously set grammar.
+///
+/// # Safety
+///
+/// `config` must be a valid handle. `grammar`, when non-null, must be a
+/// null-terminated UTF-8 string.
+///
+/// # Parameters
+///
+/// - `config`: A handle to the generation config.
+/// - `grammar`: A null-terminated UTF-8 GBNF grammar, or null to clear.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_generation_config_set_grammar(
+    config: *mut XybridGenerationConfigHandle,
+    grammar: *const c_char,
+) {
+    ffi_guard!("xybrid_generation_config_set_grammar", (), {
+        if let Some(data) = XybridGenerationConfigHandle::as_mut(config) {
+            if grammar.is_null() {
+                data.grammar = None;
+            } else if let Ok(s) = CStr::from_ptr(grammar).to_str() {
+                data.grammar = Some(s.to_string());
+            }
+        }
+    })
+}
+
+/// Convert a JSON Schema (as a JSON string) into a GBNF grammar suitable for
+/// `xybrid_generation_config_set_grammar`.
+///
+/// # Safety
+///
+/// `schema_json` must be a null-terminated UTF-8 string.
+///
+/// # Returns
+///
+/// A newly allocated null-terminated GBNF string, or null if the schema is
+/// invalid JSON or uses an unsupported construct. Free the returned string
+/// with `xybrid_free_string()`.
+#[no_mangle]
+pub unsafe extern "C" fn xybrid_json_schema_to_gbnf(schema_json: *const c_char) -> *mut c_char {
+    if schema_json.is_null() {
+        return std::ptr::null_mut();
+    }
+    ffi_guard!("xybrid_json_schema_to_gbnf", std::ptr::null_mut(), {
+        let Ok(schema) = CStr::from_ptr(schema_json).to_str() else {
+            return std::ptr::null_mut();
+        };
+        match xybrid_sdk::json_schema_str_to_gbnf(schema) {
+            Ok(gbnf) => match CString::new(gbnf) {
+                Ok(c) => c.into_raw(),
+                Err(_) => std::ptr::null_mut(),
+            },
+            Err(_) => std::ptr::null_mut(),
         }
     })
 }

--- a/crates/xybrid-sdk/src/lib.rs
+++ b/crates/xybrid-sdk/src/lib.rs
@@ -195,6 +195,13 @@ pub use xybrid_core::runtime_adapter::types::{
     GenerationConfig, PartialToken, StreamingCallback, StreamingError,
 };
 
+// Re-export JSON-Schema → GBNF conversion for constrained decoding, so SDK
+// consumers and binding crates can produce `GenerationConfig::grammar` values
+// without depending on xybrid-core directly.
+pub use xybrid_core::runtime_adapter::grammar::{
+    json_schema_str_to_gbnf, json_schema_to_gbnf, GrammarError,
+};
+
 // Backwards compatibility re-exports
 #[doc(hidden)]
 pub use xybrid_core::execution as template_executor;


### PR DESCRIPTION
## Summary

Propagates `GenerationConfig.grammar` (#310) from the Rust SDK to every binding surface, so on-device structured output (the LFM2.5-230M extraction path) is usable from Swift, Kotlin, C/C++/Unity, and Dart. Each mirror gains a `grammar` field plus a `json_schema_to_gbnf` conversion entry point (`#[export]` fn in bolt, `xybrid_json_schema_to_gbnf` returning a `xybrid_free_string`-freed string in the C ABI, `jsonSchemaToGbnf` in Flutter); conversion stays a separate fallible call so the option-bag → SDK mapping remains infallible, and the bolt POD field is appended last to preserve `#[data]` serialization order. Committed generated artifacts are refreshed in the same change (boltffi Swift/Kotlin wrappers, FRB Rust/Dart, cbindgen C header). Also registers the `lfm2_230m_grammar` example under `required-features` and drops a needless `return` in `streaming_llm` — both of which fail the current no-feature `clippy --all-targets` CI gate. React Native is deliberately excluded (hand-translated binding; tracked by the RN-parity effort), as is cloud `ResponseFormat` unification.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)