### PR TITLE
feat(examples): iOS structured-extraction demo (LFM2.5-230M + GBNF)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -43,6 +43,19 @@ rustflags = ["-C", "link-args=/NODEFAULTLIB:LIBCMT"]
 # can't satisfy those symbols — they need to be declared as a direct dep.
 # Without this flag dlopen fails with:
 #   cannot locate symbol "_ZTISt13runtime_error" referenced by libxybrid-bolt.so
+# iOS aarch64 (device + simulator): enable +fp16 so the assembler accepts the
+# FP16 SIMD inline asm in gemm-common (candle dependency). Unlike Android this
+# needs no runtime gate: the iOS 16 deployment target implies A12 or newer,
+# and every A12+ (and Apple-Silicon simulator host) supports fp16. Newer rustc
+# stables (observed on 1.95) no longer imply fullfp16 in the default
+# aarch64-apple-ios feature set, so gemm's `fmla ….8h` asm fails to assemble
+# without this.
+[target.aarch64-apple-ios]
+rustflags = ["-C", "target-feature=+fp16"]
+
+[target.aarch64-apple-ios-sim]
+rustflags = ["-C", "target-feature=+fp16"]
+
 [target.aarch64-linux-android]
 rustflags = [
     "-C", "target-feature=+fp16",

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -8,9 +8,10 @@ A native iOS example app demonstrating Xybrid SDK integration using SwiftUI.
 - **Model Loading**: Downloads models from the xybrid registry with async/await
 - **Text-to-Speech** (Speech tab): Run TTS inference with voice selection + audio playback
 - **Live camera vision** (Vision tab): point the camera at a scene and get an on-device VLM caption that refreshes as the scene changes — AVFoundation capture + a cheap luma change-gate firing batch multimodal turns
+- **Structured extraction** (Extract tab): LFM2.5-230M turns messy text (receipts, email signatures) into schema-valid JSON via GBNF constrained decoding — a JSON Schema is converted with `jsonSchemaToGbnf` and attached as `XybridGenerationConfig.grammar`, so the model *cannot* emit output that violates the schema. Toggle the constraint off to watch the raw model drift into markdown fences and made-up keys.
 - **Error Handling**: User-friendly error messages with retry capability
 
-The two demos live behind a `TabView` once the SDK is initialized.
+The three demos live behind a `TabView` once the SDK is initialized.
 
 ### Live vision: responsiveness model
 
@@ -38,7 +39,17 @@ latest-frame-wins. See `LiveVision.swift` for the gate + batch-VLM wiring.
 # From the xybrid repo root
 rustup target add aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin
 cargo xtask build-xcframework --release
+
+# Point the Swift package at the local build. Without this, SPM downloads the
+# published release xcframework, whose headers may predate symbols the checked-
+# out wrapper calls — the failure mode is a Swift error like
+# "Cannot find 'boltffi_json_schema_to_gbnf' in scope".
+./bindings/apple/scripts/set-natives-mode.sh --set-local
 ```
+
+> `useLocalNatives = true` is a local-dev setting — run
+> `./bindings/apple/scripts/set-natives-mode.sh --set-remote` before committing
+> anything that touches `Package.swift`.
 
 ### 2. Open in Xcode
 

--- a/examples/ios/XybridExample.xcodeproj/project.pbxproj
+++ b/examples/ios/XybridExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3B1A00012B0000010000000A /* XybridExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1A00002B0000000000000A /* XybridExampleApp.swift */; };
 		3B1A00022B0000020000000A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1A00012B0000010000000B /* ContentView.swift */; };
 		3B1A00052B0000050000000A /* LiveVision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1A00052B0000050000000B /* LiveVision.swift */; };
+		3B1A00052B0000050000000C /* ExtractionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1A00052B0000050000000D /* ExtractionView.swift */; };
 		3B1A00032B0000030000000A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B1A00022B0000020000000B /* Assets.xcassets */; };
 		E3C7BD052F600DA900A10DD1 /* Xybrid in Frameworks */ = {isa = PBXBuildFile; productRef = E3C7BD042F600DA900A10DD1 /* Xybrid */; };
 /* End PBXBuildFile section */
@@ -18,6 +19,7 @@
 		3B1A00002B0000000000000A /* XybridExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XybridExampleApp.swift; sourceTree = "<group>"; };
 		3B1A00012B0000010000000B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3B1A00052B0000050000000B /* LiveVision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveVision.swift; sourceTree = "<group>"; };
+		3B1A00052B0000050000000D /* ExtractionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtractionView.swift; sourceTree = "<group>"; };
 		3B1A00022B0000020000000B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3B1A00032B0000030000000B /* XybridExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XybridExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B1A00042B0000040000000B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -49,6 +51,7 @@
 				3B1A00002B0000000000000A /* XybridExampleApp.swift */,
 				3B1A00012B0000010000000B /* ContentView.swift */,
 				3B1A00052B0000050000000B /* LiveVision.swift */,
+				3B1A00052B0000050000000D /* ExtractionView.swift */,
 				3B1A00022B0000020000000B /* Assets.xcassets */,
 				3B1A00042B0000040000000B /* Info.plist */,
 			);
@@ -138,6 +141,7 @@
 				3B1A00012B0000010000000A /* XybridExampleApp.swift in Sources */,
 				3B1A00022B0000020000000A /* ContentView.swift in Sources */,
 				3B1A00052B0000050000000A /* LiveVision.swift in Sources */,
+				3B1A00052B0000050000000C /* ExtractionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/ios/XybridExample/ContentView.swift
+++ b/examples/ios/XybridExample/ContentView.swift
@@ -46,6 +46,8 @@ struct ContentView: View {
                     .tabItem { Label("Speech", systemImage: "waveform") }
                 navigation { LiveVisionView() }
                     .tabItem { Label("Vision", systemImage: "camera.viewfinder") }
+                navigation { ExtractionView() }
+                    .tabItem { Label("Extract", systemImage: "doc.text.magnifyingglass") }
             }
         case .error(let message):
             navigation { ErrorView(message: message, onRetry: initializeSDK) }

--- a/examples/ios/XybridExample/ExtractionView.swift
+++ b/examples/ios/XybridExample/ExtractionView.swift
@@ -1,0 +1,412 @@
+//
+//  ExtractionView.swift
+//  XybridExample
+//
+//  On-device structured data extraction with LFM2.5-230M and GBNF
+//  constrained decoding. A JSON Schema is converted to a GBNF grammar
+//  (`jsonSchemaToGbnf`) and attached to `XybridGenerationConfig.grammar`,
+//  which guarantees the model can only emit schema-valid JSON — fully
+//  offline, no API key, no post-hoc parsing or retries.
+//
+//  Flip "Constrain to schema" off to see what the raw 230M model does with
+//  the same prompt: it typically wraps output in markdown fences and invents
+//  its own keys, which fails JSON parsing. The grammar is the difference
+//  between a demo and something you can ship.
+//
+
+import SwiftUI
+import Xybrid
+
+// MARK: - Presets
+
+struct ExtractionPreset: Identifiable {
+    let id: String
+    let name: String
+    let input: String
+    let schemaJson: String
+}
+
+private let extractionPresets: [ExtractionPreset] = [
+    ExtractionPreset(
+        id: "receipt",
+        name: "Receipt",
+        input: """
+        STARBUCKS STORE #1123
+        2x Latte         9.00
+        1x Croissant     3.50
+        TOTAL           12.50 USD
+        03/15/2026
+        """,
+        schemaJson: """
+        {
+          "type": "object",
+          "properties": {
+            "merchant": { "type": "string" },
+            "total":    { "type": "number" },
+            "currency": { "enum": ["USD", "EUR", "GBP"] },
+            "date":     { "type": "string" },
+            "items":    { "type": "array", "items": { "type": "string" } }
+          }
+        }
+        """
+    ),
+    ExtractionPreset(
+        id: "contact",
+        name: "Signature",
+        input: """
+        Thanks so much, talk soon!
+
+        --
+        Dr. Maria N. Alvarez
+        Head of Radiology, St. Vincent Hospital
+        maria.alvarez@stvincent.org | +33 6 12 34 56 78
+        Paris, France
+        """,
+        schemaJson: """
+        {
+          "type": "object",
+          "properties": {
+            "name":    { "type": "string" },
+            "title":   { "type": "string" },
+            "company": { "type": "string" },
+            "email":   { "type": "string" },
+            "phone":   { "type": "string" },
+            "city":    { "type": "string" }
+          }
+        }
+        """
+    ),
+]
+
+// MARK: - Extraction View
+
+struct ExtractionView: View {
+    private let modelId = "lfm2.5-230m"
+
+    @State private var presetId: String = extractionPresets[0].id
+    @State private var inputText: String = extractionPresets[0].input
+    @State private var constrained: Bool = true
+    @State private var model: XybridModel? = nil
+    @State private var inferenceState: InferenceState = .idle
+
+    private var preset: ExtractionPreset {
+        extractionPresets.first { $0.id == presetId } ?? extractionPresets[0]
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Model loading
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Model")
+                        .font(.headline)
+
+                    HStack {
+                        Text(modelId)
+                            .font(.system(.body, design: .monospaced))
+                        Spacer()
+                        if model != nil {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                        }
+                    }
+
+                    Button(action: loadModel) {
+                        HStack {
+                            if case .loading = inferenceState {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    .scaleEffect(0.8)
+                            }
+                            Text(model != nil ? "Model Loaded" : "Load Model (~146 MB)")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isLoadingOrRunning || model != nil)
+                }
+
+                Divider()
+
+                // Input
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Input")
+                        .font(.headline)
+
+                    Picker("Preset", selection: $presetId) {
+                        ForEach(extractionPresets) { p in
+                            Text(p.name).tag(p.id)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: presetId) { newValue in
+                        if let p = extractionPresets.first(where: { $0.id == newValue }) {
+                            inputText = p.input
+                        }
+                    }
+
+                    TextEditor(text: $inputText)
+                        .font(.system(.footnote, design: .monospaced))
+                        .frame(minHeight: 110, maxHeight: 150)
+                        .padding(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                        )
+
+                    DisclosureGroup("JSON Schema") {
+                        Text(preset.schemaJson)
+                            .font(.system(.caption2, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                            .background(Color.secondary.opacity(0.1))
+                            .cornerRadius(4)
+                    }
+                    .font(.subheadline)
+
+                    Toggle(isOn: $constrained) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Constrain to schema (GBNF)")
+                                .font(.subheadline)
+                            Text(constrained
+                                ? "Output is guaranteed schema-valid JSON"
+                                : "Raw model output — expect parse failures")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    Button(action: runExtraction) {
+                        HStack {
+                            if case .running = inferenceState {
+                                ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                    .scaleEffect(0.8)
+                            }
+                            Text(isRunning ? "Extracting…" : "Extract")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model == nil || isLoadingOrRunning || inputText.isEmpty)
+                }
+
+                // Result
+                if case .completed(let result) = inferenceState {
+                    Divider()
+                    ExtractionResultView(result: result)
+                }
+
+                // Error
+                if case .error(let message) = inferenceState {
+                    Divider()
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Error", systemImage: "exclamationmark.triangle.fill")
+                            .font(.headline)
+                            .foregroundColor(.red)
+                        Text(message)
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                    }
+                }
+
+                Spacer(minLength: 40)
+            }
+            .padding(.horizontal)
+            .padding(.top, 16)
+        }
+        .navigationTitle("Structured Extraction")
+    }
+
+    // MARK: - Computed
+
+    private var isLoadingOrRunning: Bool {
+        switch inferenceState {
+        case .loading, .running:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private var isRunning: Bool {
+        if case .running = inferenceState { return true }
+        return false
+    }
+
+    // MARK: - Actions
+
+    private func loadModel() {
+        inferenceState = .loading
+        let modelId = self.modelId
+
+        // `Task.detached`, NOT `Task {}`: the synchronous, blocking
+        // `XybridModel(fromRegistry:)` (resolve + download + load) must not
+        // run on the main actor. Same discipline as InferenceView.
+        Task.detached {
+            do {
+                let loadedModel = try XybridModel(fromRegistry: modelId)
+                await MainActor.run {
+                    self.model = loadedModel
+                    inferenceState = .idle
+                }
+            } catch {
+                await MainActor.run {
+                    inferenceState = .error("Failed to load model: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func runExtraction() {
+        guard let model = model else { return }
+        inferenceState = .running
+
+        // Capture @State inputs on the main actor before detaching.
+        let inputText = self.inputText
+        let schemaJson = preset.schemaJson
+        let constrained = self.constrained
+
+        Task.detached {
+            do {
+                // JSON Schema → GBNF. This is the whole feature: with the
+                // grammar attached, sampling masks every token that would
+                // take the output off a schema-valid path.
+                let grammar: String? = constrained
+                    ? try jsonSchemaToGbnf(schemaJson: schemaJson)
+                    : nil
+
+                // Greedy decoding (temperature 0) — extraction wants the
+                // most likely tokens, reproducibly, not creative sampling.
+                let config = XybridGenerationConfig(
+                    maxTokens: 200,
+                    temperature: 0.0,
+                    topP: 1.0,
+                    topK: 0,
+                    stopSequences: [],
+                    grammar: grammar
+                )
+                let options = XybridRunOptions(
+                    generationConfig: config,
+                    abortOn: [],
+                    fallbackToCloud: false,
+                    maxGraceTokens: 0
+                )
+
+                let envelope = XybridEnvelope(
+                    kind: .text(text: "Extract the fields from this text:\n" + inputText),
+                    metadata: [
+                        XybridMetadataEntry(
+                            key: "system_prompt",
+                            value: "You extract structured data. Respond with a single JSON object, nothing else."
+                        )
+                    ]
+                )
+
+                let result = try model.run(envelope: envelope, options: options)
+                await MainActor.run {
+                    inferenceState = .completed(result)
+                }
+            } catch {
+                await MainActor.run {
+                    inferenceState = .error("Extraction failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Result View
+
+struct ExtractionResultView: View {
+    let result: XybridResult
+
+    /// Parsed key/value pairs when the output is a valid JSON object.
+    private var parsedFields: [(String, String)]? {
+        guard let text = result.text,
+              let data = text.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object
+            .map { key, value in (key, stringify(value)) }
+            .sorted { $0.0 < $1.0 }
+    }
+
+    private func stringify(_ value: Any) -> String {
+        if let array = value as? [Any] {
+            return array.map { "\($0)" }.joined(separator: ", ")
+        }
+        return "\(value)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Result", systemImage: "doc.text.magnifyingglass")
+                    .font(.headline)
+
+                Spacer()
+
+                // The badge the demo hinges on: schema-constrained runs are
+                // always valid; unconstrained runs usually aren't.
+                if parsedFields != nil {
+                    Label("Valid JSON", systemImage: "checkmark.seal.fill")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                } else {
+                    Label("Not valid JSON", systemImage: "xmark.seal.fill")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+
+            if let fields = parsedFields {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(fields, id: \.0) { field in
+                        HStack(alignment: .top) {
+                            Text(field.0)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(.secondary)
+                                .frame(width: 90, alignment: .leading)
+                            Text(field.1)
+                                .font(.system(.caption, design: .monospaced))
+                                .fontWeight(.medium)
+                        }
+                    }
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.green.opacity(0.1))
+                .cornerRadius(8)
+            }
+
+            if let text = result.text {
+                DisclosureGroup("Raw output") {
+                    Text(text)
+                        .font(.system(.caption2, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                        .background(Color.secondary.opacity(0.1))
+                        .cornerRadius(4)
+                }
+                .font(.subheadline)
+            }
+
+            MetricsSection(metrics: result.metrics)
+        }
+    }
+}
+
+// MARK: - Preview
+
+struct ExtractionView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { ExtractionView() }
+    }
+}

--- a/examples/ios/XybridExample/ExtractionView.swift
+++ b/examples/ios/XybridExample/ExtractionView.swift
@@ -328,17 +328,24 @@ struct ExtractionResultView: View {
     let result: XybridResult
 
     /// Parsed key/value pairs when the output is a valid JSON object.
-    private var parsedFields: [(String, String)]? {
-        guard let text = result.text,
-              let data = text.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
-        return object
-            .map { key, value in (key, stringify(value)) }
-            .sorted { $0.0 < $1.0 }
+    /// Stored, not computed: `body` reads this more than once per render,
+    /// and a computed property would re-run JSONSerialization each time.
+    private let parsedFields: [(String, String)]?
+
+    init(result: XybridResult) {
+        self.result = result
+        if let text = result.text,
+           let data = text.trimmingCharacters(in: .whitespacesAndNewlines).data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            self.parsedFields = object
+                .map { key, value in (key, Self.stringify(value)) }
+                .sorted { $0.0 < $1.0 }
+        } else {
+            self.parsedFields = nil
+        }
     }
 
-    private func stringify(_ value: Any) -> String {
+    private static func stringify(_ value: Any) -> String {
         if let array = value as? [Any] {
             return array.map { "\($0)" }.joined(separator: ", ")
         }


### PR DESCRIPTION
## Summary

Adds an **Extract** tab to the iOS example app demonstrating on-device structured data extraction: LFM2.5-230M (from the registry) turns messy text — receipt and email-signature presets — into schema-valid JSON via the GBNF constrained-decoding surface shipped in #310/#311 (`jsonSchemaToGbnf` → `XybridGenerationConfig.grammar` → `model.run`, greedy decoding). A "Constrain to schema" toggle makes the feature legible in one tap: constrained runs render a Valid-JSON badge and parsed fields, unconstrained runs show the raw model drifting into markdown fences and invented keys, with tok/s metrics on both. The change also fixes local Apple builds on current stable Rust by adding `+fp16` rustflags for `aarch64-apple-ios{,-sim}` in `.cargo/config.toml` (rustc 1.95 no longer implies `fullfp16`, breaking gemm-common's FP16 inline asm; mirrors the documented Android block, and the iOS 16 deployment target implies A12+ so no runtime gate is needed). The example README now documents the Extract tab plus the `set-natives-mode.sh --set-local` step, naming the "Cannot find 'boltffi_json_schema_to_gbnf' in scope" failure you hit when building against stale release headers. Verified by compiling and linking the app for the arm64 iOS simulator against a locally built xcframework containing the new symbol; `Package.swift` is committed in remote-natives mode as required.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)