### PR TITLE
docs: bump SDK install pins to 0.2.2 across READMEs and docs

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -145,7 +145,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.1
+  xybrid_flutter: ^0.2.2
 ```
 
 **モデルを実行:**
@@ -162,7 +162,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 
@@ -180,7 +180,7 @@ val result = model.run(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.2")
 ]
 ```
 
@@ -214,7 +214,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.2.1"
+xybrid = "0.2.2"
 ```
 
 **モデルを実行:**

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.1
+  xybrid_flutter: ^0.2.2
 ```
 
 **Run a model:**
@@ -147,7 +147,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 
@@ -165,7 +165,7 @@ val result = model.run(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.2")
 ]
 ```
 
@@ -199,7 +199,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.2.1"
+xybrid = "0.2.2"
 ```
 
 **Run a model:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,7 +145,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.1
+  xybrid_flutter: ^0.2.2
 ```
 
 **运行模型：**
@@ -162,7 +162,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 
@@ -180,7 +180,7 @@ val result = model.run(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.2.2")
 ]
 ```
 
@@ -214,7 +214,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.2.1"
+xybrid = "0.2.2"
 ```
 
 **运行模型：**

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -12,14 +12,14 @@ Add Xybrid to your Xcode project:
 
 1. In Xcode, select **File > Add Package Dependencies...**
 2. Enter: `https://github.com/xybrid-ai/xybrid`
-3. Set **Dependency Rule** to **Up to Next Major Version** → `0.2.0`
+3. Set **Dependency Rule** to **Up to Next Major Version** → `0.2.2`
 4. Select the **Xybrid** library product
 
 Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.2")
 ]
 ```
 

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -15,7 +15,7 @@ Or add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.2
 ```
 
 <details>

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -12,7 +12,7 @@ Add to your `build.gradle.kts`:
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -11,7 +11,7 @@ Add the Xybrid SDK from Maven Central:
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -11,7 +11,7 @@ Android SDK 通过 UniFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支�
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/flutter.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.mdx
@@ -11,7 +11,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.2
 ```
 
 ## Initialization

--- a/docs/content/docs/(integration)/sdks/flutter.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.zh.mdx
@@ -11,7 +11,7 @@ Flutter SDK（`xybrid_flutter`）通过 FFI 提供到 Xybrid Rust 核心的 Dart
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.2
 ```
 
 ## 初始化

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -15,7 +15,7 @@ Add the Xybrid package via Swift Package Manager:
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.2")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -15,7 +15,7 @@ Swift SDK 处于早期访问阶段。正式版本通过 Swift Package Manager �
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.2")
 ]
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Get Xybrid running in your app with a few lines of code. Choose your SDK below.
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.2
 ```
 
 ```bash
@@ -54,7 +54,7 @@ Or add to `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.2")
 ]
 ```
 
@@ -86,7 +86,7 @@ let result = try model.run(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 
@@ -150,7 +150,7 @@ Debug.Log($"Latency: {result.LatencyMs}ms");
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.2.0"
+xybrid = "0.2.2"
 ```
 
 **Run inference**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -12,7 +12,7 @@ description: 几分钟内开始使用 Xybrid
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.2.0
+  xybrid_flutter: ^0.2.2
 ```
 
 ```bash
@@ -54,7 +54,7 @@ https://github.com/xybrid-ai/xybrid
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.2.2")
 ]
 ```
 
@@ -86,7 +86,7 @@ let result = try model.run(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.2.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.2.2")
 }
 ```
 
@@ -151,7 +151,7 @@ Debug.Log($"延迟: {result.LatencyMs}ms");
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.2.0"
+xybrid = "0.2.2"
 ```
 
 **运行推理**


### PR DESCRIPTION
## Summary

Bumps the Flutter / Kotlin / SPM / Cargo install-version pins to **0.2.2** (matching the just-published release) across the top-level READMEs (en/ja/zh), `docs/content` quickstart + SDK integration pages (en/zh), and the per-binding READMEs (Apple/Kotlin/Flutter). This also fixes pre-existing drift: the top-level READMEs were on `0.2.1` but `docs/content/**` and the binding READMEs were never bumped past `0.2.0`. Only copy-paste install snippets changed — historical "as of 0.2.x" comments and `cargo xtask --version` examples were left as-is.

Two things intentionally **not** touched here (flagged for follow-up): `bindings/unity/README.md` still points at `#upm/v0.2.0`, but no `upm/v0.2.x` tag exists (Unity UPM publishing stopped at `v0.1.0-rc4`; OpenUPM is the "Planned" path), so bumping it would just swap one broken ref for another. And the `xybrid-llama` / `xybrid-llama-sys` internal path-dep pins in `xybrid-core`/`xybrid-llama` are still `0.2.1` — a manifest fix, out of scope for a docs PR.

## Type of Change

- [x] Documentation

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

_Docs-only; no code touched, so `cargo test` not run._