### PR TITLE
fix(release): bump xybrid-llama/-sys internal pins to 0.2.2

### DIFF
--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.1", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.2.1", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.2", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.2.2", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.1" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.2" }
 thiserror = { workspace = true }
 tracing = "0.1"


### PR DESCRIPTION
## Summary

Bumps the three internal path-dep version pins on `xybrid-llama` / `xybrid-llama-sys` (in `xybrid-core` and `xybrid-llama`) from `0.2.1` to `0.2.2`, matching the workspace version. These were missed by the v0.2.2 release bump (`just bump-version` only rewrites the workspace `version`, not sibling path-dep pins). v0.2.2 published fine because `^0.2.1` accepts `0.2.2`, but the drift would break the next minor bump — `0.3.0` won't satisfy `^0.2.x`, failing lockfile regen / publish — which is the trap AGENTS.md flags. `Cargo.lock` is unchanged and the workspace resolves under `--locked`.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

_Manifest-only pin bump; `cargo metadata --locked` resolves cleanly. `cargo test` not run separately._