### PR TITLE
feat(unity): native-library resolver + release bundles (OpenUPM enablement)

### DIFF
--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -505,6 +505,95 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Unity SDK version: $VERSION"
 
+      # Per-platform native bundles consumed by the Unity editor
+      # NativeLibraryResolver (bindings/unity/Editor/NativeLibraryResolver.cs).
+      # This is the shell twin of `cargo xtask package-unity-natives` — kept in
+      # shell so this bare runner needn't compile xtask (→ xybrid-core → ORT).
+      # The manifest shape MUST match the resolver's `NativePlatform` model and
+      # the xtask `UnityNativePlatform` struct; keep all three in sync.
+      - name: Package Unity native resolver bundles
+        run: |
+          set -euo pipefail
+          VERSION=${{ steps.version.outputs.version }}
+          PLUGINS=bindings/unity/Runtime/Plugins
+          mkdir -p dist
+          # platform-key:PluginDir:primary-lib-relative-path ("" = any-ABI Android)
+          MAPPINGS=(
+            "macos:macOS:libxybrid_ffi.dylib"
+            "windows:Windows:xybrid_ffi.dll"
+            "linux:Linux:libxybrid_ffi.so"
+            "ios:iOS:libxybrid_ffi.a"
+            "android:Android:"
+          )
+          ENTRIES=()
+          for m in "${MAPPINGS[@]}"; do
+            KEY="${m%%:*}"; REST="${m#*:}"; DIR="${REST%%:*}"; LIB="${REST#*:}"
+            SRC="$PLUGINS/$DIR"
+            if [ "$KEY" = "android" ]; then
+              PRESENT=false
+              for abi in arm64-v8a armeabi-v7a x86_64; do
+                [ -f "$SRC/$abi/libxybrid_ffi.so" ] && PRESENT=true
+              done
+            else
+              PRESENT=false; [ -f "$SRC/$LIB" ] && PRESENT=true
+            fi
+            if [ "$PRESENT" != true ]; then
+              echo "skip $KEY — no native at $SRC"; continue
+            fi
+            ASSET="xybrid-unity-native-${KEY}-v${VERSION}.zip"
+            # zip root mirrors Runtime/Plugins/: <Dir>/... plus the folder .meta,
+            # so the resolver extracts it verbatim into Assets/Xybrid/Plugins/.
+            ZIP_ARGS=("$DIR")
+            [ -f "$PLUGINS/$DIR.meta" ] && ZIP_ARGS+=("$DIR.meta")
+            ( cd "$PLUGINS" && zip -r -q "$GITHUB_WORKSPACE/dist/$ASSET" "${ZIP_ARGS[@]}" )
+            SHA=$(shasum -a 256 "dist/$ASSET" | awk '{print $1}')
+            SIZE=$(wc -c < "dist/$ASSET" | tr -d ' ')
+            echo "  ✓ $ASSET ($SIZE bytes)"
+            ENTRIES+=("$KEY|$ASSET|$SHA|$SIZE")
+          done
+          if [ ${#ENTRIES[@]} -eq 0 ]; then
+            echo "No Unity native platforms present to package"; exit 1
+          fi
+          MANIFEST="dist/xybrid-unity-natives-v${VERSION}.manifest.json"
+          VERSION="$VERSION" python3 - "$MANIFEST" "${ENTRIES[@]}" <<'PY'
+          import json, os, sys
+          out, entries = sys.argv[1], sys.argv[2:]
+          plats = []
+          for e in entries:
+              k, asset, sha, size = e.split("|")
+              plats.append({"platform": k, "asset": asset, "sha256": sha, "size": int(size)})
+          json.dump({"version": os.environ["VERSION"], "platforms": plats},
+                    open(out, "w"), indent=2)
+          PY
+          echo "Wrote $MANIFEST (${#ENTRIES[@]} platform(s))"
+
+      - name: Upload native resolver bundles to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=${{ steps.version.outputs.version }}
+          for i in $(seq 1 20); do
+            if gh release view "v${VERSION}" > /dev/null 2>&1; then
+              gh release upload "v${VERSION}" \
+                dist/xybrid-unity-native-*.zip \
+                "dist/xybrid-unity-natives-v${VERSION}.manifest.json" --clobber
+              echo "Uploaded Unity native bundles + manifest to v${VERSION}."
+              exit 0
+            fi
+            echo "Waiting for release v${VERSION}... (attempt $i/20)"
+            sleep 30
+          done
+          echo "::warning::Release v${VERSION} not found within 10 min — native bundles are CI artifacts only."
+
+      - name: Upload native bundles as CI artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: unity-native-bundles
+          path: dist/xybrid-unity-native*
+          if-no-files-found: error
+
       - name: Create SDK archive
         run: |
           VERSION=${{ steps.version.outputs.version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -359,6 +359,46 @@ jobs:
           echo "::notice::Re-dispatched release-publish (flutter_only) from tag ${TAG} to publish Flutter to pub.dev."
 
   # =========================================================================
+  # Dispatch build-unity from the freshly-created tag so the Unity native
+  # resolver bundles (xybrid-unity-native-*.zip + manifest) get built and
+  # uploaded to the release. build-unity.yml triggers on `push: tags: v*`, but
+  # the tag is created here via GITHUB_TOKEN, which does NOT trigger downstream
+  # workflows (loop prevention) — so we re-dispatch explicitly. Like the pub.dev
+  # dispatch above, this needs a PAT; without RELEASE_PAT we print the one-liner.
+  # =========================================================================
+  dispatch-unity-natives:
+    name: Dispatch Unity native bundles from tag
+    needs:
+      - publish-release
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch build-unity from the tag ref (or print recovery one-liner)
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.publish-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Unity native bundles need one manual step
+
+          The release tag was created with \`GITHUB_TOKEN\`, which cannot trigger
+          \`build-unity.yml\` (GitHub loop-prevention). Run this to build and
+          upload the Unity native resolver bundles (or set \`RELEASE_PAT\` to automate it):
+
+          \`\`\`
+          gh workflow run build-unity.yml --ref ${TAG}
+          \`\`\`
+          EOF
+            echo "::warning::Unity native bundle publish skipped — no RELEASE_PAT. See the job summary."
+            exit 0
+          fi
+          gh workflow run build-unity.yml --repo "$REPO" --ref "$TAG"
+          echo "::notice::Dispatched build-unity from tag ${TAG} to publish Unity native bundles."
+
+  # =========================================================================
   # Publish Kotlin SDK to Maven Central.
   #
   # The .so files come from the just-published GitHub Release asset (the

--- a/bindings/unity/Editor/NativeLibraryBuildHook.cs
+++ b/bindings/unity/Editor/NativeLibraryBuildHook.cs
@@ -38,8 +38,10 @@ namespace Xybrid.Editor
                     "libraries can't be resolved for the build.");
             }
 
+            // No modal progress bar during batch/CI builds (-batchmode).
             var ok = NativeLibraryResolver.EnsurePlatform(
-                platform, version, interactive: true, force: false, throwOnError: true);
+                platform, version, interactive: !UnityEngine.Application.isBatchMode,
+                force: false, throwOnError: true);
             if (!ok)
             {
                 throw new BuildFailedException(

--- a/bindings/unity/Editor/NativeLibraryBuildHook.cs
+++ b/bindings/unity/Editor/NativeLibraryBuildHook.cs
@@ -1,0 +1,51 @@
+// Xybrid SDK - Editor Native Library Build Hook
+// Ensures the active build target's native libraries are downloaded and
+// verified before a player build, so a project that installed the managed-only
+// package via OpenUPM/UPM never ships without its natives.
+
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+namespace Xybrid.Editor
+{
+    /// <summary>
+    /// Build preprocessor that resolves the Xybrid natives for the target
+    /// platform before the player build proceeds. Fails the build with an
+    /// actionable message if they can't be installed (e.g. offline), rather than
+    /// producing a player that crashes on the first P/Invoke.
+    /// </summary>
+    internal sealed class NativeLibraryBuildHook : IPreprocessBuildWithReport
+    {
+        // Run early so the natives (and their .meta import settings) are present
+        // before Unity collects plugins for the build.
+        public int callbackOrder => 0;
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            var platform = NativeLibraryResolver.PlatformForBuildTarget(report.summary.platform);
+            if (platform == null)
+            {
+                // Not a platform we ship natives for — nothing to do.
+                return;
+            }
+
+            var version = NativeLibraryResolver.ResolveVersion();
+            if (version == null)
+            {
+                throw new BuildFailedException(
+                    "[Xybrid] Could not determine the package version, so native " +
+                    "libraries can't be resolved for the build.");
+            }
+
+            var ok = NativeLibraryResolver.EnsurePlatform(
+                platform, version, interactive: true, force: false, throwOnError: true);
+            if (!ok)
+            {
+                throw new BuildFailedException(
+                    $"[Xybrid] Native libraries for '{platform}' (v{version}) are not " +
+                    "available; the build would ship without them.");
+            }
+        }
+    }
+}

--- a/bindings/unity/Editor/NativeLibraryBuildHook.cs.meta
+++ b/bindings/unity/Editor/NativeLibraryBuildHook.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 006284abaa0e416db529a5471c54bb8d

--- a/bindings/unity/Editor/NativeLibraryResolver.cs
+++ b/bindings/unity/Editor/NativeLibraryResolver.cs
@@ -18,8 +18,10 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
-using UnityEditor.PackageManager;
 using UnityEngine;
+// Alias to disambiguate from UnityEditor.PackageInfo (both are in scope via
+// `using UnityEditor;`), which triggers CS0104.
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Xybrid.SDK.Tests.Editor")]
 

--- a/bindings/unity/Editor/NativeLibraryResolver.cs
+++ b/bindings/unity/Editor/NativeLibraryResolver.cs
@@ -102,14 +102,16 @@ namespace Xybrid.Editor
             bool throwOnError = false)
         {
             var markerPath = MarkerPath(platform);
-            if (!force && File.Exists(markerPath) &&
-                File.ReadAllText(markerPath).Trim() == version)
-            {
-                return true;
-            }
-
             try
             {
+                // Inside the try so a corrupt/locked marker degrades per throwOnError
+                // rather than crashing editor load or the build.
+                if (!force && File.Exists(markerPath) &&
+                    File.ReadAllText(markerPath).Trim() == version)
+                {
+                    return true;
+                }
+
                 var manifest = FetchManifest(version, interactive);
                 var entry = manifest.Find(platform);
                 if (entry == null)
@@ -204,8 +206,12 @@ namespace Xybrid.Editor
         {
             var version = ResolveVersion();
             if (version == null) return;
-            // Non-interactive, non-fatal: keep first import quiet if offline.
-            EnsurePlatform(HostPlatform(), version, interactive: true, throwOnError: false);
+            // "Quiet" = non-fatal: logs a warning and continues if offline
+            // (throwOnError: false), rather than failing editor load. Progress is
+            // shown in the GUI editor for feedback during the download, but
+            // suppressed in batch/CI where a modal bar is unwanted.
+            EnsurePlatform(HostPlatform(), version,
+                interactive: !Application.isBatchMode, throwOnError: false);
         }
 
         // ---- Networking ----------------------------------------------------------
@@ -219,8 +225,16 @@ namespace Xybrid.Editor
             var url = ReleaseAssetUrl(version, asset);
             var tmp = Path.Combine(Path.GetTempPath(), asset);
             DownloadWithProgress(url, tmp, asset, interactive);
-            var manifest = JsonUtility.FromJson<NativeManifest>(File.ReadAllText(tmp));
-            File.Delete(tmp);
+            string json;
+            try
+            {
+                json = File.ReadAllText(tmp);
+            }
+            finally
+            {
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+            var manifest = JsonUtility.FromJson<NativeManifest>(json);
             if (manifest?.platforms == null)
             {
                 throw new InvalidOperationException($"Malformed native manifest at {url}.");
@@ -239,6 +253,7 @@ namespace Xybrid.Editor
             float progress = 0f;
             string hashHex = null;
             Exception failure = null;
+            using var cts = new CancellationTokenSource();
 
             var task = Task.Run(() =>
             {
@@ -246,7 +261,7 @@ namespace Xybrid.Editor
                 {
                     using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(30) };
                     using var resp = client
-                        .GetAsync(url, HttpCompletionOption.ResponseHeadersRead)
+                        .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cts.Token)
                         .GetAwaiter().GetResult();
                     resp.EnsureSuccessStatusCode();
                     long total = resp.Content.Headers.ContentLength ?? -1L;
@@ -260,6 +275,7 @@ namespace Xybrid.Editor
                     int n;
                     while ((n = src.Read(buffer, 0, buffer.Length)) > 0)
                     {
+                        cts.Token.ThrowIfCancellationRequested();
                         dst.Write(buffer, 0, n);
                         sha.TransformBlock(buffer, 0, n, null, 0);
                         read += n;
@@ -276,7 +292,9 @@ namespace Xybrid.Editor
                 if (interactive && EditorUtility.DisplayCancelableProgressBar(
                         "Xybrid — downloading native libraries", label, progress))
                 {
-                    // Best-effort: let the background copy finish/abort, then bail.
+                    // Abort the in-flight request/read so we don't keep pulling
+                    // bytes (up to ~326 MB for iOS) after the user cancelled.
+                    cts.Cancel();
                     throw new OperationCanceledException($"Download of {label} cancelled.");
                 }
                 Thread.Sleep(100);
@@ -307,7 +325,35 @@ namespace Xybrid.Editor
                 }
 
                 Directory.CreateDirectory(Path.GetDirectoryName(destPath));
+                FreeExistingFile(destPath);
                 entry.ExtractToFile(destPath, overwrite: true);
+            }
+        }
+
+        /// <summary>
+        /// Frees <paramref name="path"/> so a new native can be written even when
+        /// the current one is loaded into the Editor process (Windows/macOS lock a
+        /// loaded <c>.dll</c>/<c>.dylib</c>, so a plain overwrite throws). Deletes
+        /// it, or — if it's locked — renames it aside so the path is reusable; the
+        /// stale copy is cleaned up on a later run or editor restart.
+        /// </summary>
+        private static void FreeExistingFile(string path)
+        {
+            if (!File.Exists(path)) return;
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+                var parked = path + "." + Guid.NewGuid().ToString("N") + ".old";
+                // If even the rename fails, let ExtractToFile surface the original error.
+                try { File.Move(path, parked); } catch { /* fall through */ }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                var parked = path + "." + Guid.NewGuid().ToString("N") + ".old";
+                try { File.Move(path, parked); } catch { /* fall through */ }
             }
         }
 

--- a/bindings/unity/Editor/NativeLibraryResolver.cs
+++ b/bindings/unity/Editor/NativeLibraryResolver.cs
@@ -21,6 +21,8 @@ using UnityEditor;
 using UnityEditor.PackageManager;
 using UnityEngine;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Xybrid.SDK.Tests.Editor")]
+
 namespace Xybrid.Editor
 {
     /// <summary>
@@ -298,10 +300,7 @@ namespace Xybrid.Editor
             {
                 if (string.IsNullOrEmpty(entry.Name)) continue; // directory entry
 
-                // Guard against zip-slip: resolved path must stay under destRoot.
-                var destPath = Path.GetFullPath(Path.Combine(destRoot, entry.FullName));
-                var rootFull = Path.GetFullPath(destRoot) + Path.DirectorySeparatorChar;
-                if (!destPath.StartsWith(rootFull, StringComparison.Ordinal))
+                if (!TryResolveSafeExtractPath(destRoot, entry.FullName, out var destPath))
                 {
                     throw new InvalidOperationException(
                         $"Refusing to extract '{entry.FullName}' outside {destRoot}.");
@@ -310,6 +309,19 @@ namespace Xybrid.Editor
                 Directory.CreateDirectory(Path.GetDirectoryName(destPath));
                 entry.ExtractToFile(destPath, overwrite: true);
             }
+        }
+
+        /// <summary>
+        /// Resolves <paramref name="entryName"/> under <paramref name="destRoot"/>
+        /// and rejects it (returns <c>false</c>) if it would escape the root
+        /// (zip-slip). Pure/host-agnostic so it can be unit-tested.
+        /// </summary>
+        internal static bool TryResolveSafeExtractPath(
+            string destRoot, string entryName, out string destPath)
+        {
+            destPath = Path.GetFullPath(Path.Combine(destRoot, entryName));
+            var rootFull = Path.GetFullPath(destRoot) + Path.DirectorySeparatorChar;
+            return destPath.StartsWith(rootFull, StringComparison.Ordinal);
         }
 
         private static string MarkerPath(string platform) =>

--- a/bindings/unity/Editor/NativeLibraryResolver.cs
+++ b/bindings/unity/Editor/NativeLibraryResolver.cs
@@ -1,0 +1,352 @@
+// Xybrid SDK - Editor Native Library Resolver
+// Downloads the per-platform native libraries (libxybrid_ffi.*) from the GitHub
+// Release matching the installed package version and installs them into the
+// consuming project's Assets/ folder.
+//
+// Why this exists: the Unity package is distributed managed-only (via OpenUPM /
+// UPM), so the heavy native binaries — desktop dylib/dll/so, Android per-ABI
+// .so, and the ~326 MB iOS static .a — cannot ship inside the package (size
+// limits, and a UPM package installs read-only under Library/PackageCache/).
+// Instead they are published as Release assets and fetched on demand here, into
+// the project-writable Assets/Xybrid/Plugins/ tree. See tracking issue #319.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+
+namespace Xybrid.Editor
+{
+    /// <summary>
+    /// Resolves and installs the Xybrid native libraries for a given platform by
+    /// downloading them from the matching GitHub Release, verifying their
+    /// SHA-256, and extracting them into <c>Assets/Xybrid/Plugins/</c>.
+    /// </summary>
+    /// <remarks>
+    /// The natives are keyed by the installed package version (see
+    /// <see cref="ResolveVersion"/>) and downloaded from
+    /// <c>https://github.com/xybrid-ai/xybrid/releases/download/v{version}/…</c>.
+    /// A per-platform <c>.xybrid-native-{platform}-version</c> marker records
+    /// what was installed so repeated imports/builds don't re-download.
+    ///
+    /// <para>
+    /// On editor load the <b>host</b> platform native is ensured (so Play mode
+    /// works immediately); the active <b>build target</b>'s natives are ensured
+    /// by <c>NativeLibraryBuildHook</c> before a player build. Both paths route
+    /// through <see cref="EnsurePlatform"/>.
+    /// </para>
+    /// </remarks>
+    [InitializeOnLoad]
+    internal static class NativeLibraryResolver
+    {
+        private const string RepoSlug = "xybrid-ai/xybrid";
+        private const string ManifestAssetPrefix = "xybrid-unity-natives-v";
+
+        /// <summary>Root under the consuming project where natives are installed.</summary>
+        private static string InstallRoot =>
+            Path.Combine(Application.dataPath, "Xybrid", "Plugins");
+
+        static NativeLibraryResolver()
+        {
+            // Defer off the domain-load path so we never block a reload; the
+            // ensure itself is a no-op once the marker matches the version.
+            EditorApplication.delayCall += EnsureHostPlatformQuiet;
+        }
+
+        // ---- Public entry points -------------------------------------------------
+
+        [MenuItem("Xybrid/Native Libraries/Download for Current Editor")]
+        private static void MenuDownloadHost()
+        {
+            var version = ResolveVersion();
+            if (version == null)
+            {
+                EditorUtility.DisplayDialog("Xybrid",
+                    "Could not determine the Xybrid package version.", "OK");
+                return;
+            }
+            EnsurePlatform(HostPlatform(), version, interactive: true, force: true);
+        }
+
+        [MenuItem("Xybrid/Native Libraries/Download for Active Build Target")]
+        private static void MenuDownloadActiveTarget()
+        {
+            var version = ResolveVersion();
+            var platform = PlatformForBuildTarget(EditorUserBuildSettings.activeBuildTarget);
+            if (version == null || platform == null)
+            {
+                EditorUtility.DisplayDialog("Xybrid",
+                    "No Xybrid native bundle maps to the active build target.", "OK");
+                return;
+            }
+            EnsurePlatform(platform, version, interactive: true, force: true);
+        }
+
+        /// <summary>
+        /// Ensures the natives for <paramref name="platform"/> at
+        /// <paramref name="version"/> are present under <see cref="InstallRoot"/>,
+        /// downloading and verifying them if missing (or if <paramref name="force"/>).
+        /// </summary>
+        /// <returns><c>true</c> if the natives are present on return.</returns>
+        /// <remarks>Throws on a hard failure only when <paramref name="throwOnError"/>.</remarks>
+        internal static bool EnsurePlatform(
+            string platform, string version, bool interactive, bool force = false,
+            bool throwOnError = false)
+        {
+            var markerPath = MarkerPath(platform);
+            if (!force && File.Exists(markerPath) &&
+                File.ReadAllText(markerPath).Trim() == version)
+            {
+                return true;
+            }
+
+            try
+            {
+                var manifest = FetchManifest(version, interactive);
+                var entry = manifest.Find(platform);
+                if (entry == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Release v{version} has no Unity native bundle for '{platform}'.");
+                }
+
+                var url = ReleaseAssetUrl(version, entry.asset);
+                var tmpZip = Path.Combine(Path.GetTempPath(), entry.asset);
+                var actualSha = DownloadWithProgress(url, tmpZip, entry.asset, interactive);
+                if (!string.Equals(actualSha, entry.sha256, StringComparison.OrdinalIgnoreCase))
+                {
+                    File.Delete(tmpZip);
+                    throw new InvalidOperationException(
+                        $"SHA-256 mismatch for {entry.asset}: expected {entry.sha256}, got {actualSha}.");
+                }
+
+                ExtractInto(tmpZip, InstallRoot);
+                File.Delete(tmpZip);
+
+                Directory.CreateDirectory(InstallRoot);
+                File.WriteAllText(markerPath, version);
+                AssetDatabase.Refresh();
+                Debug.Log($"[Xybrid] Installed native libraries for '{platform}' (v{version}).");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                var msg = $"[Xybrid] Failed to install native libraries for '{platform}' " +
+                          $"(v{version}): {ex.Message}\nRun " +
+                          "'Xybrid ▸ Native Libraries ▸ Download for …' to retry.";
+                if (throwOnError) throw new InvalidOperationException(msg, ex);
+                Debug.LogWarning(msg);
+                return false;
+            }
+            finally
+            {
+                if (interactive) EditorUtility.ClearProgressBar();
+            }
+        }
+
+        // ---- Version / platform resolution --------------------------------------
+
+        /// <summary>The GitHub Release tag body — the installed package version.</summary>
+        internal static string ResolveVersion()
+        {
+            var pkg = PackageInfo.FindForAssembly(typeof(NativeLibraryResolver).Assembly);
+            if (pkg != null && !string.IsNullOrEmpty(pkg.version))
+            {
+                return pkg.version;
+            }
+            // Local/embedded fallback: read package.json next to the package root.
+            try
+            {
+                if (pkg != null)
+                {
+                    var json = File.ReadAllText(Path.Combine(pkg.resolvedPath, "package.json"));
+                    var parsed = JsonUtility.FromJson<PackageJson>(json);
+                    if (!string.IsNullOrEmpty(parsed?.version)) return parsed.version;
+                }
+            }
+            catch { /* fall through */ }
+            return null;
+        }
+
+        internal static string HostPlatform()
+        {
+            switch (Application.platform)
+            {
+                case RuntimePlatform.OSXEditor: return "macos";
+                case RuntimePlatform.WindowsEditor: return "windows";
+                case RuntimePlatform.LinuxEditor: return "linux";
+                default: return "linux";
+            }
+        }
+
+        internal static string PlatformForBuildTarget(BuildTarget target)
+        {
+            switch (target)
+            {
+                case BuildTarget.StandaloneOSX: return "macos";
+                case BuildTarget.StandaloneWindows64: return "windows";
+                case BuildTarget.StandaloneLinux64: return "linux";
+                case BuildTarget.Android: return "android";
+                case BuildTarget.iOS: return "ios";
+                default: return null;
+            }
+        }
+
+        private static void EnsureHostPlatformQuiet()
+        {
+            var version = ResolveVersion();
+            if (version == null) return;
+            // Non-interactive, non-fatal: keep first import quiet if offline.
+            EnsurePlatform(HostPlatform(), version, interactive: true, throwOnError: false);
+        }
+
+        // ---- Networking ----------------------------------------------------------
+
+        private static string ReleaseAssetUrl(string version, string asset) =>
+            $"https://github.com/{RepoSlug}/releases/download/v{version}/{asset}";
+
+        private static NativeManifest FetchManifest(string version, bool interactive)
+        {
+            var asset = $"{ManifestAssetPrefix}{version}.manifest.json";
+            var url = ReleaseAssetUrl(version, asset);
+            var tmp = Path.Combine(Path.GetTempPath(), asset);
+            DownloadWithProgress(url, tmp, asset, interactive);
+            var manifest = JsonUtility.FromJson<NativeManifest>(File.ReadAllText(tmp));
+            File.Delete(tmp);
+            if (manifest?.platforms == null)
+            {
+                throw new InvalidOperationException($"Malformed native manifest at {url}.");
+            }
+            return manifest;
+        }
+
+        /// <summary>
+        /// Streams <paramref name="url"/> to <paramref name="destPath"/> on a
+        /// background thread (so the editor stays responsive and large iOS slices
+        /// don't buffer in memory), hashing as it goes. Returns the hex SHA-256.
+        /// </summary>
+        private static string DownloadWithProgress(
+            string url, string destPath, string label, bool interactive)
+        {
+            float progress = 0f;
+            string hashHex = null;
+            Exception failure = null;
+
+            var task = Task.Run(() =>
+            {
+                try
+                {
+                    using var client = new HttpClient { Timeout = TimeSpan.FromMinutes(30) };
+                    using var resp = client
+                        .GetAsync(url, HttpCompletionOption.ResponseHeadersRead)
+                        .GetAwaiter().GetResult();
+                    resp.EnsureSuccessStatusCode();
+                    long total = resp.Content.Headers.ContentLength ?? -1L;
+
+                    using var src = resp.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+                    using var dst = File.Create(destPath);
+                    using var sha = SHA256.Create();
+
+                    var buffer = new byte[81920];
+                    long read = 0;
+                    int n;
+                    while ((n = src.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        dst.Write(buffer, 0, n);
+                        sha.TransformBlock(buffer, 0, n, null, 0);
+                        read += n;
+                        progress = total > 0 ? (float)read / total : 0f;
+                    }
+                    sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                    hashHex = BitConverter.ToString(sha.Hash).Replace("-", "").ToLowerInvariant();
+                }
+                catch (Exception ex) { failure = ex; }
+            });
+
+            while (!task.IsCompleted)
+            {
+                if (interactive && EditorUtility.DisplayCancelableProgressBar(
+                        "Xybrid — downloading native libraries", label, progress))
+                {
+                    // Best-effort: let the background copy finish/abort, then bail.
+                    throw new OperationCanceledException($"Download of {label} cancelled.");
+                }
+                Thread.Sleep(100);
+            }
+
+            if (failure != null)
+            {
+                throw new InvalidOperationException(
+                    $"Download failed for {url}: {failure.Message}", failure);
+            }
+            return hashHex;
+        }
+
+        // ---- Extraction ----------------------------------------------------------
+
+        private static void ExtractInto(string zipPath, string destRoot)
+        {
+            Directory.CreateDirectory(destRoot);
+            using var archive = ZipFile.OpenRead(zipPath);
+            foreach (var entry in archive.Entries)
+            {
+                if (string.IsNullOrEmpty(entry.Name)) continue; // directory entry
+
+                // Guard against zip-slip: resolved path must stay under destRoot.
+                var destPath = Path.GetFullPath(Path.Combine(destRoot, entry.FullName));
+                var rootFull = Path.GetFullPath(destRoot) + Path.DirectorySeparatorChar;
+                if (!destPath.StartsWith(rootFull, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Refusing to extract '{entry.FullName}' outside {destRoot}.");
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(destPath));
+                entry.ExtractToFile(destPath, overwrite: true);
+            }
+        }
+
+        private static string MarkerPath(string platform) =>
+            Path.Combine(InstallRoot, $".xybrid-native-{platform}-version");
+
+        // ---- Serializable manifest model ----------------------------------------
+
+        [Serializable]
+        internal sealed class NativeManifest
+        {
+            public string version;
+            public NativePlatform[] platforms;
+
+            public NativePlatform Find(string platform)
+            {
+                if (platforms == null) return null;
+                foreach (var p in platforms)
+                {
+                    if (p != null && p.platform == platform) return p;
+                }
+                return null;
+            }
+        }
+
+        [Serializable]
+        internal sealed class NativePlatform
+        {
+            public string platform; // macos | windows | linux | android | ios
+            public string asset;    // release asset filename
+            public string sha256;   // lowercase hex
+            public long size;       // bytes
+        }
+
+        [Serializable]
+        private sealed class PackageJson
+        {
+            public string version;
+        }
+    }
+}

--- a/bindings/unity/Editor/NativeLibraryResolver.cs.meta
+++ b/bindings/unity/Editor/NativeLibraryResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08d00512862b4be1a7c80f2729438e7b

--- a/bindings/unity/Runtime/Native/NativeMethods.g.cs
+++ b/bindings/unity/Runtime/Native/NativeMethods.g.cs
@@ -799,6 +799,43 @@ namespace Xybrid.Native
         internal static extern void xybrid_generation_config_add_stop(XybridGenerationConfigHandle* config, byte* stop);
 
         /// <summary>
+        ///  Set a GBNF grammar constraining generation to structured output
+        ///  (local llama backend only; other backends ignore it).
+        ///
+        ///  Produce a grammar from a JSON Schema with `xybrid_json_schema_to_gbnf`,
+        ///  or pass raw GBNF. Passing null clears any previously set grammar.
+        ///
+        ///  # Safety
+        ///
+        ///  `config` must be a valid handle. `grammar`, when non-null, must be a
+        ///  null-terminated UTF-8 string.
+        ///
+        ///  # Parameters
+        ///
+        ///  - `config`: A handle to the generation config.
+        ///  - `grammar`: A null-terminated UTF-8 GBNF grammar, or null to clear.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_generation_config_set_grammar", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern void xybrid_generation_config_set_grammar(XybridGenerationConfigHandle* config, byte* grammar);
+
+        /// <summary>
+        ///  Convert a JSON Schema (as a JSON string) into a GBNF grammar suitable for
+        ///  `xybrid_generation_config_set_grammar`.
+        ///
+        ///  # Safety
+        ///
+        ///  `schema_json` must be a null-terminated UTF-8 string.
+        ///
+        ///  # Returns
+        ///
+        ///  A newly allocated null-terminated GBNF string, or null if the schema is
+        ///  invalid JSON or uses an unsupported construct. Free the returned string
+        ///  with `xybrid_free_string()`.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_json_schema_to_gbnf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* xybrid_json_schema_to_gbnf(byte* schema_json);
+
+        /// <summary>
         ///  Free a generation config handle.
         ///
         ///  After calling this function, the handle must not be used again.
@@ -1237,6 +1274,34 @@ namespace Xybrid.Native
         /// </summary>
         [DllImport(__DllName, EntryPoint = "xybrid_result_text", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern byte* xybrid_result_text(XybridResultHandle* result);
+
+        /// <summary>
+        ///  Get the chain-of-thought / reasoning text from an inference result.
+        ///
+        ///  This is the model's `&lt;think&gt;...&lt;/think&gt;` reasoning, surfaced separately
+        ///  from [`xybrid_result_text`] (which always excludes it).
+        ///
+        ///  # Parameters
+        ///
+        ///  - `result`: A handle to the inference result.
+        ///
+        ///  # Returns
+        ///
+        ///  A pointer to the reasoning string, or null if the model emitted no
+        ///  reasoning (or the handle is null/invalid). The pointer is valid until
+        ///  the result handle is freed.
+        ///
+        ///  # Example (C)
+        ///
+        ///  ```c
+        ///  const char* reasoning = xybrid_result_reasoning_content(result);
+        ///  if (reasoning != NULL) {
+        ///      printf("Model reasoning: %s\n", reasoning);
+        ///  }
+        ///  ```
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "xybrid_result_reasoning_content", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern byte* xybrid_result_reasoning_content(XybridResultHandle* result);
 
         /// <summary>
         ///  Get the latency in milliseconds from an inference result.

--- a/bindings/unity/Tests/Editor/NativeLibraryResolverTests.cs
+++ b/bindings/unity/Tests/Editor/NativeLibraryResolverTests.cs
@@ -1,0 +1,81 @@
+// Xybrid SDK - Native Library Resolver EditMode Tests
+// Covers the host-independent logic of the editor NativeLibraryResolver:
+// build-target → platform mapping, manifest JSON parsing/lookup, and the
+// zip-slip extraction guard. Network/download and Unity-import paths are not
+// exercised here (they require a real release + player build).
+
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Xybrid.Editor;
+
+namespace Xybrid.Tests.Editor
+{
+    /// <summary>EditMode tests for <see cref="NativeLibraryResolver"/> pure logic.</summary>
+    [TestFixture]
+    public class NativeLibraryResolverTests
+    {
+        [TestCase(BuildTarget.StandaloneOSX, "macos")]
+        [TestCase(BuildTarget.StandaloneWindows64, "windows")]
+        [TestCase(BuildTarget.StandaloneLinux64, "linux")]
+        [TestCase(BuildTarget.Android, "android")]
+        [TestCase(BuildTarget.iOS, "ios")]
+        public void PlatformForBuildTarget_MapsSupportedTargets(BuildTarget target, string expected)
+        {
+            Assert.AreEqual(expected, NativeLibraryResolver.PlatformForBuildTarget(target));
+        }
+
+        [Test]
+        public void PlatformForBuildTarget_ReturnsNullForUnsupported()
+        {
+            Assert.IsNull(NativeLibraryResolver.PlatformForBuildTarget(BuildTarget.WebGL));
+        }
+
+        [Test]
+        public void Manifest_ParsesAndLooksUpPlatforms()
+        {
+            const string json =
+                "{\"version\":\"0.2.2\",\"platforms\":[" +
+                "{\"platform\":\"macos\",\"asset\":\"xybrid-unity-native-macos-v0.2.2.zip\"," +
+                "\"sha256\":\"deadbeef\",\"size\":1165}," +
+                "{\"platform\":\"ios\",\"asset\":\"xybrid-unity-native-ios-v0.2.2.zip\"," +
+                "\"sha256\":\"cafebabe\",\"size\":342177280}]}";
+
+            var manifest = JsonUtility.FromJson<NativeLibraryResolver.NativeManifest>(json);
+
+            Assert.AreEqual("0.2.2", manifest.version);
+            Assert.AreEqual(2, manifest.platforms.Length);
+
+            var macos = manifest.Find("macos");
+            Assert.IsNotNull(macos);
+            Assert.AreEqual("xybrid-unity-native-macos-v0.2.2.zip", macos.asset);
+            Assert.AreEqual("deadbeef", macos.sha256);
+            Assert.AreEqual(1165, macos.size);
+
+            Assert.AreEqual(342177280L, manifest.Find("ios").size, "iOS size must survive as a 64-bit value");
+            Assert.IsNull(manifest.Find("windows"), "absent platform resolves to null");
+        }
+
+        [Test]
+        public void ExtractPath_AcceptsEntriesInsideRoot()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "xybrid-extract-root");
+            Assert.IsTrue(
+                NativeLibraryResolver.TryResolveSafeExtractPath(root, "macOS/libxybrid_ffi.dylib", out var dest));
+            StringAssert.Contains("libxybrid_ffi.dylib", dest);
+        }
+
+        [Test]
+        public void ExtractPath_RejectsZipSlipEscape()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "xybrid-extract-root");
+            Assert.IsFalse(
+                NativeLibraryResolver.TryResolveSafeExtractPath(root, "../evil.dll", out _),
+                "a parent-traversal entry must be rejected");
+            Assert.IsFalse(
+                NativeLibraryResolver.TryResolveSafeExtractPath(root, "macOS/../../evil.dll", out _),
+                "a nested traversal that escapes the root must be rejected");
+        }
+    }
+}

--- a/bindings/unity/Tests/Editor/NativeLibraryResolverTests.cs.meta
+++ b/bindings/unity/Tests/Editor/NativeLibraryResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d34b5793038428aa17105daad16966e

--- a/bindings/unity/Tests/Editor/Xybrid.SDK.Tests.Editor.asmdef
+++ b/bindings/unity/Tests/Editor/Xybrid.SDK.Tests.Editor.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "Xybrid.Tests",
     "references": [
         "Xybrid.SDK.Runtime",
+        "Xybrid.SDK.Editor",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"
     ],

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -393,6 +393,23 @@ enum Commands {
         #[arg(long)]
         skip_flutter: bool,
     },
+
+    /// Package per-platform Unity native bundles + resolver manifest into dist/.
+    ///
+    /// Zips each present `bindings/unity/Runtime/Plugins/<Platform>` tree (as
+    /// deployed by `build-unity --deploy`) into
+    /// `xybrid-unity-native-<platform>-v<ver>.zip` and writes
+    /// `xybrid-unity-natives-v<ver>.manifest.json` (the manifest the Unity
+    /// editor `NativeLibraryResolver` downloads and verifies against).
+    PackageUnityNatives {
+        /// Override the version (defaults to Cargo.toml version or git tag)
+        #[arg(long)]
+        version: Option<String>,
+
+        /// Output directory for bundles (default: dist/)
+        #[arg(long, default_value = "dist")]
+        output_dir: PathBuf,
+    },
 }
 
 #[derive(Clone, Copy, ValueEnum, Debug, PartialEq, Eq)]
@@ -587,6 +604,13 @@ fn main() -> Result<()> {
         } => {
             let ver = get_version(version.as_deref());
             package_artifacts(&ver, &output_dir, skip_apple, skip_android, skip_flutter)?;
+        }
+        Commands::PackageUnityNatives {
+            version,
+            output_dir,
+        } => {
+            let ver = get_version(version.as_deref());
+            package_unity_natives(&ver, &output_dir)?;
         }
     }
 
@@ -2309,6 +2333,141 @@ fn chrono_now() -> String {
     }
     // Fallback
     "unknown".to_string()
+}
+
+/// One platform entry in the Unity native-resolver manifest.
+///
+/// Field names/shape are the wire contract consumed by
+/// `bindings/unity/Editor/NativeLibraryResolver.cs` (`NativePlatform`); keep
+/// them in sync.
+#[derive(serde::Serialize)]
+struct UnityNativePlatform {
+    /// `macos` | `windows` | `linux` | `android` | `ios`.
+    platform: String,
+    /// Release asset filename to download.
+    asset: String,
+    /// Lowercase hex SHA-256 of the asset.
+    sha256: String,
+    /// Asset size in bytes.
+    size: u64,
+}
+
+/// The `xybrid-unity-natives-v<ver>.manifest.json` document.
+#[derive(serde::Serialize)]
+struct UnityNativeManifest {
+    version: String,
+    platforms: Vec<UnityNativePlatform>,
+}
+
+/// Package each present Unity native platform tree into a zip + write the
+/// resolver manifest. Skips platforms whose native library isn't deployed yet
+/// (mirrors `package_android`'s "package what's present" behaviour, since CI
+/// assembles per-platform artifacts from separate runners before packaging).
+fn package_unity_natives(version: &str, output_dir: &Path) -> Result<()> {
+    let plugins_dir = PathBuf::from("bindings/unity/Runtime/Plugins");
+    if !plugins_dir.exists() {
+        anyhow::bail!(
+            "Unity plugins dir not found at {:?} — run \
+             `cargo xtask build-unity --all-platforms --deploy` first",
+            plugins_dir
+        );
+    }
+
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("Failed to create output directory: {:?}", output_dir))?;
+
+    // (platform key, Unity plugin subdir, primary native library relative path).
+    // Presence of the primary library gates whether the platform is packaged.
+    let platforms: [(&str, &str, &str); 5] = [
+        ("macos", "macOS", "libxybrid_ffi.dylib"),
+        ("windows", "Windows", "xybrid_ffi.dll"),
+        ("linux", "Linux", "libxybrid_ffi.so"),
+        ("ios", "iOS", "libxybrid_ffi.a"),
+        // Android has per-ABI subdirs; presence is checked separately below.
+        ("android", "Android", ""),
+    ];
+
+    println!("Packaging Unity native bundles (version {})...", version);
+    let mut entries: Vec<UnityNativePlatform> = Vec::new();
+
+    for (key, plugin_dir, primary_lib) in platforms {
+        let src_dir = plugins_dir.join(plugin_dir);
+        let present = if key == "android" {
+            // At least one ABI subdir must contain the FFI .so.
+            ["arm64-v8a", "armeabi-v7a", "x86_64"]
+                .iter()
+                .any(|abi| src_dir.join(abi).join("libxybrid_ffi.so").exists())
+        } else {
+            src_dir.join(primary_lib).exists()
+        };
+
+        if !present {
+            println!("  • skipping {key} — native not deployed at {:?}", src_dir);
+            continue;
+        }
+
+        let filename = format!("xybrid-unity-native-{key}-v{version}.zip");
+        let output_path = output_dir.join(&filename);
+        if output_path.exists() {
+            std::fs::remove_file(&output_path)?;
+        }
+
+        // Stage `<PluginDir>/…` (+ the sibling folder `.meta`) so the zip root
+        // mirrors `Runtime/Plugins/`; the resolver extracts it verbatim into
+        // the consumer's `Assets/Xybrid/Plugins/`.
+        let temp_dir = output_dir.join(format!(".unity-native-{key}-temp"));
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir)?;
+        }
+        std::fs::create_dir_all(&temp_dir)?;
+        copy_dir_recursive(&src_dir, &temp_dir.join(plugin_dir))?;
+        let folder_meta = plugins_dir.join(format!("{plugin_dir}.meta"));
+        if folder_meta.exists() {
+            std::fs::copy(&folder_meta, temp_dir.join(format!("{plugin_dir}.meta")))?;
+        }
+
+        create_zip(&temp_dir, &output_path)?;
+        std::fs::remove_dir_all(&temp_dir)?;
+
+        let size = std::fs::metadata(&output_path)?.len();
+        let sha256 = calculate_sha256(&output_path)?;
+        println!(
+            "  ✓ {filename} ({size} bytes, sha256: {}...)",
+            &sha256[..16]
+        );
+
+        entries.push(UnityNativePlatform {
+            platform: key.to_string(),
+            asset: filename,
+            sha256,
+            size,
+        });
+    }
+
+    if entries.is_empty() {
+        anyhow::bail!(
+            "No Unity native platforms were present to package — run \
+             `cargo xtask build-unity --all-platforms --deploy` first"
+        );
+    }
+
+    let manifest = UnityNativeManifest {
+        version: version.to_string(),
+        platforms: entries,
+    };
+    let manifest_name = format!("xybrid-unity-natives-v{version}.manifest.json");
+    let manifest_path = output_dir.join(&manifest_name);
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).context("Failed to serialize Unity manifest")?,
+    )
+    .context("Failed to write Unity native manifest")?;
+    println!(
+        "  ✓ {manifest_name} ({} platform(s))",
+        manifest.platforms.len()
+    );
+
+    Ok(())
 }
 
 /// Package XCFramework as a .zip file


### PR DESCRIPTION
## Summary

PR 1 of the Unity → OpenUPM migration (#319). Decouples the heavy per-platform
natives from the Unity package so it can ship managed-only via OpenUPM, with the
binaries fetched from the GitHub Release at import:

1. **Editor resolver** (`NativeLibraryResolver.cs`) — reads the installed package
   version, downloads `xybrid-unity-native-<platform>-v<ver>.zip` from the
   matching Release, **verifies SHA-256**, and extracts into the project-writable
   `Assets/Xybrid/Plugins/` (a UPM package installs read-only). Host native
   resolved on editor load; the active build target's natives resolved before a
   player build via `IPreprocessBuildWithReport`; manual menu items. Includes a
   zip-slip guard and streamed download/hash so the ~326 MB iOS slice never
   buffers in memory.
2. **xtask `package-unity-natives`** — zips each deployed `Runtime/Plugins/<Platform>`
   tree and emits `xybrid-unity-natives-v<ver>.manifest.json` (the resolver's
   download contract).
3. **CI** — `build-unity.yml` zips + uploads the bundles to the Release (shell
   twin of the xtask command; iOS included, since Release assets have no
   100 MB/file git limit). `release-publish.yml` gains `dispatch-unity-natives`,
   which re-dispatches `build-unity` from the freshly-created tag — the tag is
   made with `GITHUB_TOKEN`, which can't trigger workflows (loop prevention),
   the exact reason Unity has been unpublished across all of 0.2.x.

Chosen defaults (approved): editor-import download + SHA-256 verification.

## Draft — why, and what still needs validation

CI does **not** compile/run the Unity C# (`check-csharp-bindings` only diffs the
generated bindings; no Unity license/GameCI), so a green pipeline says nothing
about the resolver.

- ✅ Verified here: Rust (`cargo check`/`clippy`/`fmt`) + `package-unity-natives`
  smoke-tested; the CI packaging shell (`bash -n` + real-run parity with xtask);
  EditMode unit tests for the resolver's pure logic (platform mapping, manifest
  parse, zip-slip guard).
- ⚠️ Needs Unity + a real release run: the resolver end-to-end (download →
  plugin import → device build) and the CI publish/dispatch path.
- ⚠️ **Requires the `RELEASE_PAT` secret** for the auto-dispatch (same
  prerequisite as the existing pub.dev flow); without it the release prints a
  one-liner: `gh workflow run build-unity.yml --ref v<tag>`.

Follow-up **PR 2** (per #319): rewrite `bindings/unity/README.md` to the OpenUPM
scoped-registry flow, add the `openupm/openupm` submission YAML, retire the
`publish-upm` job / `upm` branch.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (CI / release tooling)

## Checklist

- [ ] Tests pass (`cargo test`) — Rust checks green; C# EditMode + CI paths need Unity + a release run
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)