### PR TITLE
docs: add Chinese localization for feature matrix, installation and vision model usage

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@
 | 目标 | 路径 |
 |------|------|
 | 最快上手（2 分钟） | [安装 CLI →](#快速开始) |
-| 构建移动端或桌面应用 | [Flutter SDK →](bindings/flutter/) |
+| 开发移动端或桌面应用 | [Flutter SDK →](bindings/flutter/) |
 | 为游戏添加 AI NPC | [Unity SDK →](bindings/unity/)，体验 [3D 酒馆示例](https://github.com/xybrid-ai/xybrid-unity-tavern) |
 | Android 原生开发 | [Kotlin SDK →](bindings/kotlin/) |
 | Rust / 嵌入式 | [核心 crate →](crates/) |
@@ -225,7 +225,7 @@ let result = model.run(&Envelope::text("国破山河在，城春草木深"))?;
 // 输出 → 24kHz WAV 音频
 ```
 
-完整安装选项、硬件加速与 CLI 参考请参阅 [Installation Guide](docs/INSTALLATION.md)。各平台的详细设置请参阅对应 SDK 的 README：[Flutter](bindings/flutter/) · [Unity](bindings/unity/) · [Swift](bindings/apple/) · [Kotlin](bindings/kotlin/) · [Rust](crates/)。
+完整安装选项、硬件加速与 CLI 参考请参阅 [安装指南](docs/INSTALLATION.zh.md)。各平台的详细设置请参阅对应 SDK 的 README：[Flutter](bindings/flutter/) · [Unity](bindings/unity/) · [Swift](bindings/apple/) · [Kotlin](bindings/kotlin/) · [Rust](crates/)。
 
 <details>
 <summary><h3>多模型推理流水线 — MMP（实验性）</h3></summary>
@@ -309,6 +309,7 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | 模型 | 参数量 | 格式 | 简介 |
 |------|--------|------|------|
 | Gemma 3 1B | 1B | GGUF Q4_K_M | Google 为移动端优化的模型 |
+| LFM2.5 230M | 230M | GGUF Q4_K_M | 最小的使用Liquid AI 混合卷积+注意力架构的LLM, 适合边缘设备 |
 | LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AI 混合卷积+注意力架构，9 种语言，工具调用 |
 | Llama 3.2 1B | 1B | GGUF Q4_K_M | Meta 的通用模型，128K 上下文 |
 | Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | 紧凑的本地聊天模型 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -309,7 +309,7 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 | 模型 | 参数量 | 格式 | 简介 |
 |------|--------|------|------|
 | Gemma 3 1B | 1B | GGUF Q4_K_M | Google 为移动端优化的模型 |
-| LFM2.5 230M | 230M | GGUF Q4_K_M | 最小的使用Liquid AI 混合卷积+注意力架构的LLM, 适合边缘设备 |
+| LFM2.5 230M | 230M | GGUF Q4_K_M | 最小的采用 Liquid AI 混合卷积+注意力架构的 LLM，适合边缘设备 |
 | LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AI 混合卷积+注意力架构，9 种语言，工具调用 |
 | Llama 3.2 1B | 1B | GGUF Q4_K_M | Meta 的通用模型，128K 上下文 |
 | Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | 紧凑的本地聊天模型 |

--- a/docs/FEATURE_MATRIX.zh.md
+++ b/docs/FEATURE_MATRIX.zh.md
@@ -1,0 +1,436 @@
+# Feature 矩阵
+
+本文档为 xybrid crate 层级中的所有 feature 标志、平台预设及有效组合提供全面参考。
+
+## 目录
+
+1. [xybrid-core Feature 标志](#xybrid-core-feature-标志)
+2. [xybrid-sdk Feature 标志](#xybrid-sdk-feature-标志)
+3. [xybrid-ffi Feature 标志](#xybrid-ffi-feature-标志)
+4. [xybrid-cli Feature 标志](#xybrid-cli-feature-标志)
+5. [平台预设](#平台预设)
+6. [受 Feature 控制的类型与模块](#受-feature-控制的类型与模块)
+7. [无效的 Feature 组合](#无效的-feature-组合)
+8. [发布门禁](#发布门禁)
+9. [ORT 加载策略](#ort-加载策略)
+10. [xtask 命令](#xtask-命令)
+11. [构建架构](#构建架构)
+
+---
+
+## xybrid-core Feature 标志
+
+| Feature | 说明 | 启用 |
+|---------|-------------|---------|
+| **default** | 默认特性 | `ort-download`（通过 `llm-llamacpp` 或平台预设启用 llama.cpp） |
+| **ort-download** | 下载预编译的 ONNX Runtime 二进制文件 | `ort/download-binaries`、`ort/tls-native` |
+| **ort-dynamic** | 在运行时加载 ONNX Runtime 的 .so | `ort/load-dynamic` |
+| **ort-coreml** | Apple Neural Engine 加速 | `ort/coreml` |
+| **candle** | 纯 Rust ML 框架（Whisper）— 兼容 Android | `candle-core`、`candle-nn`、`candle-transformers`、`safetensors`、`byteorder`、`num-traits` |
+| **candle-hub** | Candle + HuggingFace Hub 下载支持 | `candle`、`hf-hub`（需要 OpenSSL — **不适用于 Android**） |
+| **candle-metal** | 带 Metal 显卡加速的 Candle | `candle`、`candle-core/metal`、`candle-nn/metal` |
+| **candle-cuda** | 带 CUDA 显卡加速的 Candle | `candle`、`candle-core/cuda` |
+| **llm-mistral** | mistral.rs LLM 后端（CPU） | `mistralrs` |
+| **llm-mistral-metal** | 带 Metal 加速的 mistral.rs | `llm-mistral`、`mistralrs/metal` |
+| **llm-mistral-cuda** | 带 CUDA 加速的 mistral.rs | `llm-mistral`、`mistralrs/cuda` |
+| **vision** | 图像 Envelope 原语与图像预处理 | *（无额外依赖；使用始终存在的 `image` crate）* |
+| **llm-llamacpp** | llama.cpp 后端（cmake 构建 + 链接） | `llama-cpp-sys/bindings`、`xybrid-llama/bindings` |
+| **llm-llamacpp-vision** | 支持 `mmproj` / `mtmd` 的 llama.cpp VLM 路径 | `llm-llamacpp`、`vision`、`llama-cpp-sys/vision`、`xybrid-llama/vision` |
+
+### 说明
+
+- 启用 **`llm-llamacpp`** 会激活 `llama-cpp-sys/bindings`（llama.cpp 的 cmake
+  构建 + `wrapper.cpp` shim）和 `xybrid-llama/bindings`（安全的 RAII 包装）。
+  它**默认不启用** — 需要 cmake、C++ 工具链以及一份 llama.cpp 源码克隆。
+  `xybrid-sdk` 上的全部四个 `platform-*` 预设都依赖它。不启用该特性的构建
+  不会不暴露 llama.cpp 后端类型。
+- 三层 crate 结构：
+  `llama-cpp-sys`（原始 FFI + cmake 构建）→ `xybrid-llama`（安全包装、
+  类型化错误）→ `xybrid-core::runtime_adapter::llama_cpp`（轻量适配器）。
+- 单独启用 `vision` 可获得图像 Envelope 与图像预处理。本地 llama.cpp
+  VLM 生成需要 `llm-llamacpp-vision`，它将 `vision` 与 llama.cpp 后端组合，
+  并链接随附的 `mtmd` 辅助库。
+
+---
+
+## xybrid-sdk Feature 标志
+
+| Feature | 说明 | 转发到 xybrid-core |
+|---------|-------------|-------------------------|
+| **default** | 无默认特性 | *（无）* |
+| **platform-android** | Android 预设 | `ort-dynamic`、`candle`、`llm-llamacpp` |
+| **platform-ios** | iOS 预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` |
+| **platform-macos** | macOS 预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` |
+| **platform-desktop** | 桌面（Linux/Windows）预设 | `ort-download`、`llm-llamacpp` |
+| **ort-download** | 转发到 core | `xybrid-core/ort-download` |
+| **ort-dynamic** | 转发到 core | `xybrid-core/ort-dynamic` |
+| **ort-coreml** | 转发到 core | `xybrid-core/ort-coreml` |
+| **candle** | 转发到 core | `xybrid-core/candle` |
+| **candle-hub** | 转发到 core | `xybrid-core/candle-hub` |
+| **candle-metal** | 转发到 core | `xybrid-core/candle-metal` |
+| **candle-cuda** | 转发到 core | `xybrid-core/candle-cuda` |
+| **llm-mistral** | 转发到 core | `xybrid-core/llm-mistral` |
+| **llm-mistral-metal** | 转发到 core | `xybrid-core/llm-mistral-metal` |
+| **llm-mistral-cuda** | 转发到 core | `xybrid-core/llm-mistral-cuda` |
+| **llm-llamacpp** | 转发到 core | `xybrid-core/llm-llamacpp` |
+| **vision** | 转发到 core | `xybrid-core/vision` |
+| **llm-llamacpp-vision** | 转发到 core 的 VLM 路径 | `xybrid-core/llm-llamacpp-vision`、`llm-llamacpp`、`vision` |
+
+---
+
+## xybrid-ffi Feature 标志
+
+| Feature | 说明 | 转发到 xybrid-sdk |
+|---------|-------------|------------------------|
+| **default** | 无默认特性 | *（无）* |
+| **csharp** | 为 Unity 生成 C# 绑定 | *（仅构建期）* |
+| **platform-android** | Android 预设 | `xybrid-sdk/platform-android` |
+| **platform-ios** | iOS 预设 | `xybrid-sdk/platform-ios` |
+| **platform-macos** | macOS 预设 | `xybrid-sdk/platform-macos` |
+| **platform-desktop** | 桌面预设 | `xybrid-sdk/platform-desktop` |
+| **ort-download** | 转发到 SDK | `xybrid-sdk/ort-download` |
+| **ort-dynamic** | 转发到 SDK | `xybrid-sdk/ort-dynamic` |
+| **ort-coreml** | 转发到 SDK | `xybrid-sdk/ort-coreml` |
+| **candle** | 转发到 SDK | `xybrid-sdk/candle` |
+| **candle-metal** | 转发到 SDK | `xybrid-sdk/candle-metal` |
+| **candle-cuda** | 转发到 SDK | `xybrid-sdk/candle-cuda` |
+| **llm-mistral** | 转发到 SDK | `xybrid-sdk/llm-mistral` |
+| **llm-mistral-metal** | 转发到 SDK | `xybrid-sdk/llm-mistral-metal` |
+| **llm-mistral-cuda** | 转发到 SDK | `xybrid-sdk/llm-mistral-cuda` |
+| **llm-llamacpp** | 转发到 SDK | `xybrid-sdk/llm-llamacpp` |
+| **vision** | 转发到 SDK 的图像 Envelope 原语 | `xybrid-sdk/vision` |
+| **llm-llamacpp-vision** | 转发到 SDK 的 llama.cpp VLM 路径 | `xybrid-sdk/llm-llamacpp-vision` |
+| **huggingface** | 转发到 SDK 的注册表/HuggingFace 加载 | `xybrid-sdk/huggingface` |
+
+---
+
+## xybrid-cli Feature 标志
+
+| Feature | 说明 | 启用 |
+|---------|-------------|---------|
+| **default** | CLI 默认支持带图像的输入，使得 `xybrid run --input-image` 在 `cargo install xybrid-cli` 的构建中无需额外标志即可工作 | `vision` |
+| **huggingface** | 为 `xybrid run --huggingface` 提供直接的 HuggingFace 加载 | `xybrid-sdk/huggingface` |
+| **onnx-inspect** | 为 `xybrid init` 提供 ONNX 元数据检查 | `xybrid-sdk/onnx-inspect` |
+| **vision** | 为 VLM 对话提供 `xybrid run --input-image` 和 REPL `/image` 的 Envelope 构建 | `xybrid-core/vision`、`xybrid-sdk/vision` |
+| **llm-llamacpp-vision** | llama.cpp VLM 运行时以及 CLI 图像输入支持 | `llm-llamacpp`、`vision`、`xybrid-sdk/llm-llamacpp-vision` |
+| **platform-android** | Android 发布预设 | `ort-dynamic`、`llm-llamacpp`、`candle`、`huggingface` |
+| **platform-ios** | iOS 发布预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp`、`huggingface` |
+| **platform-macos** | macOS 发布预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp`、`huggingface` |
+| **platform-desktop** | Linux/Windows 发布预设 | `ort-download`、`llm-llamacpp`、`huggingface` |
+
+---
+
+## 平台预设
+
+平台预设是平台专属特性组合的**单一事实来源**。它们定义在 `xybrid-sdk/Cargo.toml` 中，并通过 crate 层级向下转发。
+
+当前所有平台预设默认仅提供**纯文本**的 llama.cpp 支持。视觉语言构建必须将平台预设与 `llm-llamacpp-vision` 组合；仅当某个 crate 需要图像 Envelope/预处理类型而不需要 llama.cpp VLM 运行时时，才单独使用 `vision`。
+
+| 预设 | 目标平台 | 启用的 Core 特性 | VLM 默认 | 理由 |
+|--------|-----------------|----------------------|-------------|-----------|
+| **platform-android** | Android（所有 ABI） | `ort-dynamic`、`candle`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 用于 AAR 分发的动态 ORT 加载；用于 Whisper ASR 的 Candle（CPU）；llama.cpp 具备运行时 SIMD 检测；mistral.rs 在不具备 ARMv8.2-A FP16 的设备上会导致 SIGILL |
+| **platform-ios** | iOS（arm64、模拟器） | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 静态 ORT 链接；用于 ANE 加速的 CoreML；用于 GPU 的 Metal |
+| **platform-macos** | macOS（arm64、x86_64） | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 与 iOS 相同 — 统一的 Apple 平台特性 |
+| **platform-desktop** | Linux、Windows | `ort-download`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 静态 ORT 链接；用于 LLM 推理的 llama.cpp（所有平台统一） |
+
+> **注意**：CLI（`xybrid-cli`）会为其所有平台预设添加 `huggingface`，使 `xybrid run --huggingface` 在发布构建中可用。SDK/FFI 预设默认不包含 `huggingface` — 如有需要请单独添加。
+
+VLM 构建示例：
+
+```bash
+cargo build -p xybrid-cli --features platform-macos,llm-llamacpp-vision
+cargo check -p xybrid-sdk --features platform-desktop,llm-llamacpp-vision
+cargo check -p xybrid-ffi --features platform-ios,llm-llamacpp-vision
+```
+
+### 为什么 llm-mistral 不用于 Android
+
+mistral.rs 在 ARM 上以 `+fp16` 目标特性编译，这需要 ARMv8.2-A FP16 扩展。许多 Android 设备（包括流行的 Samsung 和 Pixel 设备）不具备这些扩展，会在运行时导致 **SIGILL**（非法指令）崩溃。
+
+llama.cpp 通过 ggml 使用**运行时 SIMD 检测**，因此对所有 Android 设备都是安全的。
+
+---
+
+## 受 Feature 控制的类型与模块
+
+以下类型和模块会根据 feature 标志进行条件编译：
+
+### runtime_adapter/mod.rs
+
+| 模块 | 条件 | 说明 |
+|--------|-----------|-------------|
+| `coreml` | `target_os = "macos" OR target_os = "ios" OR test` | CoreML 运行时适配器 |
+| `candle` | `feature = "candle"` | Candle（纯 Rust）运行时适配器 |
+| `llm` | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | LLM 共享类型与适配器 |
+| `mistral` | `feature = "llm-mistral"` | MistralBackend 实现 |
+| `llama_cpp` | `feature = "llm-llamacpp"` | LlamaCppBackend 实现 |
+
+### execution/executor.rs
+
+| 项 | 条件 | 说明 |
+|------|-----------|-------------|
+| `LlmRuntimeAdapter` 导入 | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | LLM 适配器导入 |
+| `llm_adapter_cache` 字段 | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | TemplateExecutor 中缓存的 LLM 适配器 |
+| `ExecutionTemplate::Gguf` 处理 | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | GGUF 模型执行路径 |
+| `execute_streaming()` 完整实现 | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | 带回调的流式 |
+| `execute_streaming()` 桩 | `NOT (llm-mistral OR llm-llamacpp)` | 回退到常规执行 |
+| `execute_streaming_with_context()` | 同上 | 带对话上下文的流式 |
+| `execute_llm()` | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | 内部 LLM 执行 |
+| `execute_llm_streaming()` | 同上 | 内部流式执行 |
+
+### runtime_adapter/mod.rs 中的重新导出
+
+| 导出 | 条件 |
+|--------|-----------|
+| `ONNXMobileRuntimeAdapter` | `target_os = "android" OR test` |
+| `CoreMLRuntimeAdapter` | `target_os = "macos" OR target_os = "ios" OR test` |
+| `CandleBackend`、`CandleRuntimeAdapter` | `feature = "candle"` |
+| `ChatMessage`、`GenerationConfig`、`GenerationOutput`、`LlmBackend`、`LlmConfig`、`LlmResult`、`LlmRuntimeAdapter` | `feature = "llm-mistral" OR feature = "llm-llamacpp"` |
+| `MistralBackend` | `feature = "llm-mistral"` |
+| `LlamaCppBackend` | `feature = "llm-llamacpp"` |
+| `llama_log_get_verbosity`、`llama_log_set_verbosity` | `feature = "llm-llamacpp"` |
+
+---
+
+## 无效的 Feature 组合
+
+以下 feature 组合无效，应该会产生编译错误：
+
+| 组合 | 原因 | 推荐替代方案 |
+|-------------|--------|------------------------|
+| 在 `target_os = "android"` 上使用 `llm-mistral` | 在不具备 ARMv8.2-A FP16 的设备上发生 SIGILL 崩溃 | 改用 `llm-llamacpp` 或平台预设 |
+| 同时启用 `ort-download` 与 `ort-dynamic` | 互斥的 ORT 加载策略 | 根据平台二选一 |
+| 在非 Apple 目标上使用 `candle-metal` | Metal 仅限 Apple | 使用 `candle`（CPU）或 `candle-cuda` |
+| 在 Apple 目标上使用 `candle-cuda` | Apple 上不提供 CUDA | 使用 `candle-metal` |
+| 在非 Apple 目标上使用 `ort-coreml` | CoreML 仅限 Apple | 使用 `ort-download` |
+| `cargo … --all-features` | 因目标而异：在每个受支持的目标三元组上，`--all-features` 都会触发上面至少一行（ORT 加载模式冲突是普遍的；Candle Metal/CUDA + ORT CoreML 这几行会在其受支持目标的相反目标上触发）。它还会启用仅作标记的 `llm-mistral*` 特性，而其背后的 crate 目前已从 workspace 中注释掉，因此无论目标如何，构建都会因缺少 `mistralrs` 导入而失败。 | 使用下方的[发布门禁](#发布门禁)；切勿将 `--all-features` 用作 CI 门禁。 |
+
+**注意**：上表中列出的逐行 `compile_error!` 守卫已在 [`crates/xybrid-core/src/lib.rs`](../crates/xybrid-core/src/lib.rs) 中**实现**。每个冲突都会触发一个带修复提示信息的类型化编译错误 — 参见针对 Android 上 `llm-mistral`、`ort-download` 与 `ort-dynamic`、非 Apple 上 `candle-metal`、Apple 上 `candle-cuda`、以及非 Apple 上 `ort-coreml` 的 `compile_error!` 代码块。`--all-features` 这一行通过这些逐行守卫外加仅作标记的 `llm-mistral*` 构建中断来强制约束。
+
+---
+
+## 发布门禁
+
+以下是 CI 为发布把关时必须运行的规范 feature 组合。任何要求 `cargo … --all-features -- -D warnings` 的验收标准都是错误的（参见上文[无效的 Feature 组合](#无效的-feature-组合)） — 将审阅者指向此处。
+
+### 全工作区 clippy
+
+| 门禁 | 命令 | 覆盖范围 |
+|------|---------|--------|
+| 默认特性的工作区 clippy | `cargo clippy --workspace -- -D warnings` | 默认的 `ort-download` 形态；在不启用其他任何特性时，随附的 crate 也能干净编译。 |
+| Vision 总括的工作区 clippy | `cargo clippy --workspace --features llm-llamacpp-vision --tests --examples -- -D warnings` | 经由 llama.cpp `mtmd` 的完整 VLM 路径，包括以 `llm-llamacpp-vision` 为门禁的 vision 测试/示例。 |
+| **禁止使用 `--all-features`。** | — | 参见上文的冲突表。 |
+
+### 平台预设矩阵
+
+在每个目标主机上运行（或在 CI 矩阵作业中运行）。每一行都与发布工作流实际构建的内容相匹配 — 即发布的构件，按 CI 的方式构建。在本地机器上与此不一致（例如对宿主三元组执行 clippy 而非交叉编译）会漏掉真实的平台相关 bug。
+
+| 平台 | 构建主机 | 规范门禁 |
+|---------|-----------|---------|
+| macOS arm64 / x86_64 | macOS | `cargo clippy --workspace --features platform-macos -- -D warnings` + `cargo test --workspace --features platform-macos` |
+| iOS arm64 + 模拟器 | macOS | `cargo xtask build-xcframework --release`（为 `aarch64-apple-ios`、`aarch64-apple-ios-sim`、`x86_64-apple-ios` 交叉编译 `xybrid-uniffi`）。CI 变体（含 vision 矩阵作业）参见 [`.github/workflows/build-apple.yml`](../.github/workflows/build-apple.yml)。 |
+| Android arm64-v8a / armeabi-v7a / x86_64 | 装有 NDK 的 Linux 或 macOS | `cargo xtask build-android --release`（针对全部三个 ABI 对 `xybrid-uniffi` 驱动 `cargo ndk`）。矩阵并行化的 CI 变体参见 [`.github/workflows/build-android.yml`](../.github/workflows/build-android.yml)。 |
+| 桌面 Linux x86_64 | Linux | `cargo clippy --workspace --features platform-desktop -- -D warnings` + `cargo test --workspace --features platform-desktop` |
+| 桌面 Windows x86_64 | Windows | 与 Linux 桌面相同 |
+
+对于 iOS 或 Android 上的视觉语言 CI 门禁，上述规范 xtask 命令必须在 `xybrid-uniffi` 上组合 `llm-llamacpp-vision` 特性。build-apple/build-android 工作流已经接受这种组合 — 不要自创新的本地 clippy 调用；使用 CI 所用的方式。
+
+### 格式与 diff 门禁
+
+以下检查在每个主机上运行，且不产生平台专属构件：
+
+```bash
+cargo fmt --all --check
+git diff --check          # 无空白字符错误
+```
+
+### 在 Apple Silicon 开发机上快速验证
+
+前三条是提交 PR 前的规范本地检查：
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --features llm-llamacpp-vision --tests --examples -- -D warnings
+cargo test --workspace --features llm-llamacpp-vision
+```
+
+这套检查在 2026-05-23 于 `codex/vision-models-support` 分支上通过（clippy 耗时 2 分 20 秒，远低于提交 PR 前健全性检查的时间预算）。复现这套检查是推送前的最低要求。
+
+---
+
+## ORT 加载策略
+
+ONNX Runtime 的加载方式因平台而异：
+
+| 平台 | 策略 | Feature | 环境变量 | 说明 |
+|----------|----------|---------|---------------------|-------|
+| 桌面（Linux/Windows） | 下载预编译 | `ort-download` | - | 在构建时下载 ORT 二进制文件 |
+| macOS | 下载预编译 | `ort-download` | - | 在构建时下载 ORT 二进制文件 |
+| iOS | XCFramework | `ort-download` | `ORT_IOS_XCFWK_LOCATION` | 必须指向 `onnxruntime.xcframework` |
+| Android | 动态加载 | `ort-dynamic` | - | 在运行时从 AAR 加载 `libonnxruntime.so` |
+
+### iOS XCFramework 设置
+
+对于 iOS 构建，你必须设置 `ORT_IOS_XCFWK_LOCATION` 指向预编译的 ONNX Runtime iOS XCFramework：
+
+```bash
+# 方式 1：从 VOICEVOX 下载
+# https://github.com/VOICEVOX/onnxruntime-builder/releases
+
+# 方式 2：从 HuggingFace 下载
+# https://huggingface.co/csukuangfj/ios-onnxruntime
+
+# 方式 3：从源码构建
+# https://onnxruntime.ai/docs/build/ios.html
+
+export ORT_IOS_XCFWK_LOCATION=/path/to/onnxruntime.xcframework
+```
+
+---
+
+## xtask 命令
+
+`xtask` crate 提供构建自动化命令。运行 `cargo xtask --help` 查看完整文档。
+
+| 命令 | 用途 | 平台 | 示例 |
+|---------|---------|----------|---------|
+| `setup-test-env` | 为集成测试下载模型 | 任意 | `cargo xtask setup-test-env` |
+| `build-ffi` | 构建 xybrid-ffi 库（C ABI） | 任意 | `cargo xtask build-ffi --release` |
+| `build-xcframework` | 通过 boltffi 构建 Apple XCFramework（Swift 绑定 + xcframework） | 仅 macOS | `cargo xtask build-xcframework --release` |
+| `build-android` | 构建 Android .so 文件 | 任意 | `cargo xtask build-android --release` |
+| `build-flutter` | 构建 Flutter 原生库 | 视情况而定 | `cargo xtask build-flutter --platform macos` |
+| `setup-targets` | 安装 Rust 交叉编译目标 | 任意 | `cargo xtask setup-targets` |
+| `build-all` | 构建所有平台 | 视情况而定 | `cargo xtask build-all --release` |
+| `package` | 打包用于分发的构件 | 任意 | `cargo xtask package --version 0.2.0` |
+
+### xtask 与 Feature 预设的映射
+
+| xtask 命令 | 使用的平台预设 | 构建的目标 |
+|---------------|---------------------|---------------|
+| `build-xcframework` | `platform-macos` / `platform-ios` | iOS arm64、iOS Simulator（arm64、x86_64）、macOS（arm64、x86_64） |
+| `build-android` | `platform-android` | arm64-v8a、armeabi-v7a、x86_64 |
+| `build-flutter --platform ios` | `platform-ios` | aarch64-apple-ios、aarch64-apple-ios-sim |
+| `build-flutter --platform android` | `platform-android` | aarch64-linux-android、armv7-linux-androideabi、x86_64-linux-android |
+| `build-flutter --platform macos` | `platform-macos` | aarch64-apple-darwin、x86_64-apple-darwin |
+| `build-flutter --platform linux` | `platform-desktop` | x86_64-unknown-linux-gnu |
+| `build-flutter --platform windows` | `platform-desktop` | x86_64-pc-windows-msvc |
+
+这些自动的 xtask 映射使用上面的纯文本平台预设。VLM 构建必须在该构建路径所用的 Cargo feature 集合中显式添加 `llm-llamacpp-vision`。
+
+---
+
+## 构建架构
+
+Xybrid 使用**两层构建架构**：
+
+### 第 1 层：xtask（编排）
+
+**位置**：`xtask/src/main.rs`
+
+**职责**：
+- 交叉编译目标选择
+- 多目标构建（例如所有 Android ABI）
+- 平台专属工具（lipo、xcodebuild、cargo-ndk）
+- 打包与分发（zip、tar.gz）
+- CI/CD 集成
+
+**不负责**：
+- 原生依赖编译
+- 链接器配置
+- CMake 调用
+
+### 第 2 层：llama-cpp-sys build.rs（编译）
+
+**位置**：`crates/llama-cpp-sys/build.rs`
+
+**职责**：
+- 通过 CMake 编译随附的 llama.cpp
+- 为 CMake 工具链检测 Android NDK
+- 平台专属链接（Metal、Accelerate 等）
+- 设置 `cargo:rustc-link-lib` 和 `cargo:rustc-link-search`
+
+**触发条件**：
+- 通过 `xybrid-core/llm-llamacpp` 触达的 `llama-cpp-sys/bindings` 特性
+- 编译 llm-llamacpp 时的 Cargo 构建流程
+
+### NDK 检测的重复
+
+xtask 和 build.rs 都需要检测 Android NDK：
+
+| 组件 | 用途 | 检查的环境变量 |
+|-----------|---------|------------------------------|
+| **xtask** | 为 `cargo-ndk` 调用定位 NDK | `ANDROID_NDK_HOME`，并检查 `cargo ndk --version` |
+| **llama-cpp-sys build.rs** | 为 CMake 工具链文件定位 NDK | `ANDROID_NDK_HOME`、`NDK_HOME`、`CC_*`、`ANDROID_HOME`、`ANDROID_SDK_ROOT`、常见路径 |
+
+存在这种重复的原因：
+1. xtask 在 cargo 构建该 crate **之前**运行
+2. build.rs 在 cargo 构建**期间**运行
+3. cargo-ndk 设置了 Rust 交叉编译器，但不会将 NDK 位置传递给 CMake
+
+### 构建流程图
+
+```
+用户运行: cargo xtask build-android --release
+
+┌─────────────────────────────────────────────────────────────┐
+│ xtask (Orchestration)                                       │
+├─────────────────────────────────────────────────────────────┤
+│ 1. Parse command-line arguments                             │
+│ 2. Detect NDK (for cargo-ndk)                               │
+│ 3. For each ABI (arm64-v8a, armeabi-v7a, x86_64):           │
+│    └─ Run: cargo ndk --target <rust-target> build           │
+│       ├─ cargo-ndk sets CC/CXX environment variables        │
+│       └─ cargo-ndk invokes cargo build                      │
+│ 4. Copy .so files to bindings/kotlin/libs/                  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│ llama-cpp-sys build.rs (Compilation) - runs for each target │
+├─────────────────────────────────────────────────────────────┤
+│ 1. Runs when llama-cpp-sys/bindings is enabled              │
+│ 2. If enabled:                                              │
+│    a. Find Android NDK (from CC env var or ANDROID_NDK_HOME)│
+│    b. Configure CMake with NDK toolchain file               │
+│    c. Build llama.cpp static libraries                      │
+│    d. Build wrapper.cpp                                     │
+│    e. Output cargo:rustc-link-lib directives                │
+│ 3. Cargo links everything together                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 快速参考
+
+### 最小构建（无 LLM）
+
+```bash
+cargo check -p xybrid-core --no-default-features --features ort-download
+```
+
+### macOS 开发
+
+```bash
+cargo build -p xybrid-core --features "ort-download,ort-coreml,llm-llamacpp"
+```
+
+### macOS 视觉语言开发
+
+```bash
+cargo build -p xybrid-core --features "ort-download,ort-coreml,llm-llamacpp-vision"
+```
+
+### Android 构建
+
+```bash
+# 需要：Android NDK、cargo-ndk
+cargo xtask build-android --release
+```
+
+### 完整特性检查
+
+```bash
+# 仅 macOS（包含 Metal 特性）
+cargo check -p xybrid-core --features "ort-download,ort-coreml,candle-metal,llm-llamacpp"
+```

--- a/docs/FEATURE_MATRIX.zh.md
+++ b/docs/FEATURE_MATRIX.zh.md
@@ -43,7 +43,7 @@
   构建 + `wrapper.cpp` shim）和 `xybrid-llama/bindings`（安全的 RAII 包装）。
   它**默认不启用** — 需要 cmake、C++ 工具链以及一份 llama.cpp 源码克隆。
   `xybrid-sdk` 上的全部四个 `platform-*` 预设都依赖它。不启用该特性的构建
-  不会不暴露 llama.cpp 后端类型。
+  不会暴露 llama.cpp 后端类型。
 - 三层 crate 结构：
   `llama-cpp-sys`（原始 FFI + cmake 构建）→ `xybrid-llama`（安全包装、
   类型化错误）→ `xybrid-core::runtime_adapter::llama_cpp`（轻量适配器）。

--- a/docs/INSTALLATION.zh.md
+++ b/docs/INSTALLATION.zh.md
@@ -1,0 +1,305 @@
+# 安装
+
+## 快速安装（推荐）
+
+安装脚本会检测你的操作系统与架构，下载最新的发布版二进制文件，并将其添加到 PATH。
+
+**macOS / Linux：**
+
+```bash
+curl -sSL https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.sh | sh
+```
+
+**Windows（PowerShell）：**
+
+```powershell
+irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
+```
+
+## 下载二进制文件
+
+[Releases](https://github.com/xybrid-ai/xybrid/releases) 页面提供以下平台的预编译二进制文件：
+
+| 平台 | 架构 | 二进制文件 |
+|----------|-------------|--------|
+| macOS | Apple Silicon（M1+） | `xybrid-v*-macos-arm64` |
+| Linux | x86_64 | `xybrid-v*-linux-x86_64` |
+| Windows | x86_64 | `xybrid-v*-windows-x86_64.exe` |
+
+下载适用于你平台的二进制文件，赋予可执行权限，并将其移动到 PATH 中：
+
+```bash
+# 示例：macOS Apple Silicon
+chmod +x xybrid-v*-macos-arm64
+sudo mv xybrid-v*-macos-arm64 /usr/local/bin/xybrid
+```
+
+## 从源码安装
+
+需要 [Rust 工具链](https://rustup.rs/)（1.75+）。
+
+```bash
+cargo install --git https://github.com/xybrid-ai/xybrid xybrid-cli
+```
+
+### 平台特性
+
+默认情况下，`cargo install` 构建时不包含硬件加速。为获得最佳性能，请添加平台特性：
+
+```bash
+# macOS — Metal GPU + Apple Neural Engine + llama.cpp
+cargo install --git https://github.com/xybrid-ai/xybrid xybrid-cli --features platform-macos
+
+# Linux / Windows — ONNX + llama.cpp
+cargo install --git https://github.com/xybrid-ai/xybrid xybrid-cli --features platform-desktop
+```
+
+安装脚本提供的预编译二进制已经为每个平台包含了正确的特性。
+
+<details>
+<summary>所有可用的 Feature 标志</summary>
+
+| Feature | 说明 |
+|---------|-------------|
+| **平台预设** | |
+| `platform-macos` | ONNX 下载 + CoreML + Metal + 纯文本输入llama.cpp |
+| `platform-ios` | ONNX 下载 + CoreML + Metal + 纯文本输入llama.cpp |
+| `platform-android` | ONNX 动态加载 + 纯文本输入llama.cpp |
+| `platform-desktop` | ONNX 下载 + 纯文本输入llama.cpp |
+| **独立标志** | |
+| `ort-download` | 下载预编译的 ONNX Runtime 二进制文件 |
+| `ort-dynamic` | 在运行时加载 ONNX Runtime 的 .so |
+| `ort-coreml` | Apple Neural Engine 加速 |
+| `candle` | Candle ML 后端（Whisper 模型） |
+| `candle-metal` | Candle 的 Metal 显卡加速 |
+| `candle-cuda` | Candle 的 CUDA 显卡加速 |
+| `llm-llamacpp` | llama.cpp 语言模型运行时后端（推荐） |
+| `vision` | 图像 Envelope 与预处理支持 |
+| `llm-llamacpp-vision` | llama.cpp 视觉语言支持（`mmproj` / `mtmd`） |
+| `llm-mistral` | mistral.rs 语言模型后端（备选） |
+
+</details>
+
+### 从本地克隆构建
+
+```bash
+git clone https://github.com/xybrid-ai/xybrid.git
+cd xybrid
+cargo build --release -p xybrid-cli --features platform-macos
+# 二进制文件位于 target/release/xybrid
+```
+
+## 验证安装
+
+```bash
+xybrid --help
+```
+
+预期输出：
+
+```
+Xybrid CLI - Run hybrid cloud-edge AI inference pipelines
+
+Usage: xybrid [OPTIONS] <COMMAND>
+
+Commands:
+  init     Generate model_metadata.json by inspecting model files
+  models   Manage models from the registry
+  run      Run a pipeline, model, or GGUF file
+  repl     Interactive REPL mode
+  fetch    Pre-download models from the registry
+  cache    Manage the local model cache
+  ...
+```
+
+查看可用模型：
+
+```bash
+xybrid models list
+```
+
+## 快速开始
+
+### 文字转语音 (TTS)
+
+```bash
+xybrid run --model kokoro-82m --input-text "Hello world" --output hello.wav
+```
+
+### 语音识别 (STT)
+
+```bash
+xybrid run --model whisper-tiny --input-audio recording.wav
+```
+
+### 与LLM对话
+
+```bash
+# 交互式对话（消息之间保持模型加载）
+xybrid repl --model smollm2-360m --stream
+
+# 单次推理
+xybrid run --model smollm2-360m --input-text "What is the capital of France?"
+```
+
+### 视觉模型输入
+
+视觉语言模型需要启用 `vision` 或 `llm-llamacpp-vision` 编译的版本，
+以及包含视觉编码器构件的模型Bundle。仅使用平台预设时仅支持纯文本输入；
+如需本地 VLM 生成，请将预设与 `llm-llamacpp-vision` 组合。
+
+```bash
+cargo build --release -p xybrid-cli --features platform-macos,llm-llamacpp-vision
+```
+
+```bash
+# 单次视觉对话
+xybrid run --model lfm2-vl-450m \
+  --input-text "Describe this image" \
+  --input-image photo.jpg
+
+# 交互式视觉对话
+xybrid repl --model lfm2-vl-450m --stream
+/image photo.jpg
+What is in this image?
+```
+
+### 运行HuggingFace上任意的GGUF
+
+无需注册表条目 — 直接指向 HuggingFace 仓库：
+
+```bash
+xybrid run --huggingface "unsloth/SmolLM2-360M-Instruct-GGUF:Q4_K_M" \
+  --input-text "Hello!"
+
+# 交互式对话
+xybrid repl --huggingface "unsloth/SmolLM2-360M-Instruct-GGUF:Q4_K_M" --stream
+```
+
+### 运行本地 GGUF 文件
+
+```bash
+xybrid run --model-file ./my-model.gguf --input-text "Hello!"
+```
+
+### 流水线
+
+使用 YAML 文件将多个模型串联起来：
+
+```yaml
+# voice-assistant.yaml
+name: voice-assistant
+stages:
+  - model: whisper-tiny
+  - model: smollm2-360m
+  - model: kokoro-82m
+```
+
+```bash
+xybrid run --config voice-assistant.yaml --input-audio question.wav --output response.wav
+```
+
+## CLI 参考
+
+### 命令
+
+| 命令 | 说明 |
+|---------|-------------|
+| `xybrid run` | 使用模型、流水线、Bundle 或 GGUF 文件运行推理 |
+| `xybrid repl` | 交互式 REPL — 保持模型加载以快速重复推理 |
+| `xybrid init` | 通过检查模型目录生成 `model_metadata.json` |
+| `xybrid models list` | 列出注册表中的所有模型 |
+| `xybrid models search <query>` | 按名称、任务或描述搜索模型 |
+| `xybrid models info <id>` | 显示指定模型的详细信息 |
+| `xybrid models voices <id>` | 列出 TTS 模型的可用语音 |
+| `xybrid fetch --model <id>` | 从注册表预下载模型 |
+| `xybrid fetch --huggingface <repo>` | 从 HuggingFace 预下载模型 |
+| `xybrid cache list` | 列出已缓存的模型 |
+| `xybrid cache status` | 显示缓存大小与统计信息 |
+| `xybrid cache clear [id]` | 清除已缓存的模型（全部或指定） |
+| `xybrid prepare <file>` | 校验流水线 YAML |
+| `xybrid plan <file>` | 显示流水线的执行计划 |
+| `xybrid bundle <model>` | 拉取模型并创建 `.xyb` Bundle |
+| `xybrid pack <name>` | 将本地模型构件打包为 `.xyb` Bundle |
+| `xybrid trace` | 查看并分析历史会话的遥测数据 |
+
+### 全局标志
+
+| 标志 | 说明 |
+|------|-------------|
+| `-v`、`-vv` | 提升输出详细程度 |
+| `-q`、`--quiet` | 抑制输出，仅显示错误 |
+| `--api-key` | 用于遥测的平台 API Key（或使用 `XYBRID_API_KEY` 环境变量） |
+
+### `run` 输入源
+
+`run` 命令接受多种输入源（互斥）：
+
+| 标志 | 说明 | 示例 |
+|------|-------------|---------|
+| `--model <id>` | 注册表模型 | `--model kokoro-82m` |
+| `--config <file>` | 流水线 YAML | `--config pipeline.yaml` |
+| `--pipeline <name>` | 内置流水线 | `--pipeline hiiipe` |
+| `--bundle <file>` | `.xyb` Bundle | `--bundle model.xyb` |
+| `--directory <dir>` | 本地模型目录 | `--directory ./my-model/` |
+| `--huggingface <repo>` | HuggingFace 仓库 | `--huggingface "org/model:Q4_K_M"` |
+| `--model-file <path>` | 本地 GGUF 文件 | `--model-file model.gguf` |
+
+### `run` 选项
+
+| 标志 | 说明 |
+|------|-------------|
+| `--input-text <text>` | 文本输入（用于 TTS、LLM） |
+| `--input-audio <file>` | 音频输入 WAV 文件（用于 ASR） |
+| `--input-image <file>` | 视觉语言模型的图像输入；可重复 |
+| `--voice <id>` | TTS 语音 ID（如 `af_bella`） |
+| `--output <file>` | 输出文件（音频为 .wav，文本为 .txt） |
+| `--target <format>` | 目标格式（onnx、coreml、tflite） |
+| `--dry-run` | 仅校验，不执行 |
+| `--trace` | 启用执行追踪 |
+| `--trace-export <file>` | 将追踪数据导出为 JSON（Chrome trace 格式） |
+
+### `repl` 选项
+
+| 标志 | 说明 |
+|------|-------------|
+| `--model <id>` | 要加载的注册表模型 |
+| `--huggingface <repo>` | 要加载的 HuggingFace 模型 |
+| `--model-file <path>` | 要加载的本地 GGUF 文件 |
+| `--stream` | 生成时流式输出词元（token）（LLM） |
+| `--system <prompt>` | 对话的系统提示词 |
+| `--voice <id>` | TTS 语音 ID |
+
+## 模型缓存
+
+下载的模型缓存在 `~/.xybrid/cache/`。管理方式：
+
+```bash
+xybrid cache status    # 显示缓存大小
+xybrid cache list      # 列出已缓存的模型
+xybrid cache clear     # 清除全部
+xybrid cache clear kokoro-82m  # 清除指定模型
+```
+
+## 卸载
+
+**通过脚本安装：**
+
+```bash
+rm $(which xybrid)
+# （可选）删除缓存
+rm -rf ~/.xybrid
+```
+
+**通过 cargo 安装：**
+
+```bash
+cargo uninstall xybrid-cli
+rm -rf ~/.xybrid
+```
+
+**Windows：**
+
+```powershell
+Remove-Item "$env:USERPROFILE\.xybrid" -Recurse -Force
+```

--- a/docs/content/docs/guides/meta.zh.json
+++ b/docs/content/docs/guides/meta.zh.json
@@ -1,0 +1,7 @@
+{
+  "title": "指南",
+  "description": "端到端实现指南",
+  "icon": "BookOpen",
+  "root": true,
+  "pages": ["vision-models"]
+}

--- a/docs/content/docs/guides/vision-models.zh.mdx
+++ b/docs/content/docs/guides/vision-models.zh.mdx
@@ -9,7 +9,7 @@ description: 使用文本加图像输入运行本地视觉语言模型
 模型加载与流式 API 运行所选的 VLM。
 
 <Callout type="warn">
-视觉支持是 v0.2.0 的预览路径。构建必须包含 `llm-llamacpp-vision`，且云端视觉视觉模型的
+视觉支持是 v0.2.0 的预览路径。构建必须包含 `llm-llamacpp-vision`，且云端视觉模型的
 回退在本次发布中有意排除在外。带图像的对话轮次要么在本地运行，要么以“类型化
 能力错误”失败。
 </Callout>

--- a/docs/content/docs/guides/vision-models.zh.mdx
+++ b/docs/content/docs/guides/vision-models.zh.mdx
@@ -1,0 +1,280 @@
+---
+title: 视觉模型
+description: 使用文本加图像输入运行本地视觉语言模型
+---
+
+视觉语言模型（VLM）接受包含文本和一张或多张图像的用户消息，然后从本地运行时
+流式返回文本答案。Xybrid 将其建模为一次普通的对话轮次：构建图像 Envelope，
+将它们与提示词文本组合到用户消息 Envelope 中，并通过与纯文本 LLM 相同的
+模型加载与流式 API 运行所选的 VLM。
+
+<Callout type="warn">
+视觉支持是 v0.2.0 的预览路径。构建必须包含 `llm-llamacpp-vision`，且云端视觉视觉模型的
+回退在本次发布中有意排除在外。带图像的对话轮次要么在本地运行，要么以“类型化
+能力错误”失败。
+</Callout>
+
+## 支持的模型
+
+| 模型 | 用途 | 构件 | 建议下限 |
+|-------|---------|-----------|-----------------|
+| `lfm2-vl-450m` | 小规模验证 | Q4 语言 GGUF 加 Q8 mmproj，总计约 308 MB | 4 GB 内存 |
+| `gemma-4-e2b` | 重量级高准确度 | Q8 语言 GGUF 加 Q8 mmproj，总计约 5.5 GB | 8 GB 内存，iPhone 15 Pro+ 级别的移动设备 |
+
+每个模型都必须包含其语言模型及其视觉投影器（`mmproj`）或等效的视觉编码器。
+如果缺少配套构件，模型加载会在生成之前失败，并抛出指明所引用路径的
+`MissingArtifact` 错误。
+
+## 启用视觉功能的构建
+
+默认的平台预设仍为纯文本。请为将要运行 VLM 的构建添加 `llm-llamacpp-vision`：
+
+```bash
+cargo build -p xybrid --features platform-macos,llm-llamacpp-vision
+```
+
+对于直接使用 Rust crate 的应用，将目标平台预设与 `llm-llamacpp-vision` 组合。
+对于 Flutter、Kotlin、Swift 和 Unity 包，请使用以相同特性构建的发布构件或
+本地原生构建。
+
+## CLI
+
+将 `--input-image` 与 `--input-text` 搭配使用，发送单次多模态用户轮次：
+
+```bash
+xybrid run \
+  --model gemma-4-e2b \
+  --input-text "Describe this image." \
+  --input-image ./cat.png
+```
+
+在注册表条目发布之前，用于本地 fixture 验证：
+
+```bash
+./integration-tests/download.sh gemma-4-e2b
+cargo test -p xybrid-cli --features llm-llamacpp-vision \
+  run_input_image_captions_gemma_4_e2b_fixture
+```
+
+REPL 也支持为下一轮次暂存图像：
+
+```text
+/image ./cat.png
+what is in this picture?
+```
+
+暂存的图像列表会在提示词发送后被清空。
+
+## Flutter
+
+```dart
+import 'dart:io';
+import 'package:xybrid_flutter/xybrid_flutter.dart';
+
+await Xybrid.init();
+
+final model = await Xybrid.model('gemma-4-e2b').load();
+final image = XybridEnvelope.image(
+  bytes: await File('cat.jpg').readAsBytes(),
+  format: 'jpeg',
+);
+final prompt = XybridEnvelope.userMessage(
+  text: 'Describe this image.',
+  images: [image],
+);
+
+await for (final token in model.runStreaming(prompt)) {
+  stdout.write(token.token);
+}
+```
+
+Studio 使用相同的 Envelope 形态。只有在所选模型支持图像输入、原生构建包含
+视觉后端、mmproj 构件存在且满足设备内存下限时，才应启用附加图像的控件。
+
+## Kotlin
+
+```kotlin
+import ai.xybrid.Envelope
+import java.io.File
+
+val model = XybridModelLoader.fromRegistry("gemma-4-e2b").load()
+val image = Envelope.image(File("cat.jpg").readBytes(), format = "jpeg")
+val prompt = Envelope.userMessage(
+    text = "Describe this image.",
+    images = listOf(image),
+)
+
+val result = model.run(prompt)
+println(result.text)
+```
+
+## Swift
+
+```swift
+import Foundation
+import Xybrid
+
+let model = try ModelLoader.fromRegistry(modelId: "gemma-4-e2b").load()
+let imageData = try Data(contentsOf: URL(fileURLWithPath: "cat.jpg"))
+let image = try XybridEnvelope.image(imageData, format: "jpeg")
+let prompt = try XybridEnvelope.userMessage(
+    "Describe this image.",
+    images: [image]
+)
+
+let result = try model.run(envelope: prompt)
+print(result.text ?? "")
+```
+
+对于 Q8 Gemma 4 E2B 路径，在声称支持移动端之前，请在 iPhone 15 Pro 或更新
+机型上验证。内存较低的设备应该会在加载 Bundle 之前被（设备）能力检查拦截。
+
+## Unity
+
+```csharp
+using System.IO;
+using Xybrid;
+
+using var model = XybridClient.LoadModel("gemma-4-e2b");
+byte[] imageBytes = File.ReadAllBytes("cat.jpg");
+using var image = Envelope.Image(imageBytes, "jpeg");
+using var prompt = Envelope.UserMessage("Describe this image.", new[] { image });
+
+using var result = model.Run(prompt);
+result.ThrowIfFailed();
+
+Debug.Log(result.Text);
+```
+
+## 多轮对话
+
+对话历史可以包含此前的文本以及带图像的用户消息。回放历史时，请保留有序的
+文本/图像部分，而不要将图像轮次压平为文本。后端允许在后续轮次重新预填充
+图像 token；v0.2.0 不引入跨后端的图像嵌入缓存。
+
+## 实时 / 实况相机视觉
+
+<Callout type="warn">
+实时相机视觉是一项特性分支能力（`feat/realtime-vision`），代码已完成并经过
+评审，但**尚未在真实设备上验证**，也未发布。下文的运行时/SDK 原语描述的是
+可编译且经过单元测试的行为；设备端图像描述一致性与持续会话验证仍在进行中。
+请将本节视为前瞻性指南，而非稳定的约定。
+</Callout>
+
+实况相机画面并不是视频模型。设备端 VLM 无法为每一帧生成描述，因此设计要点是
+**理解事件，而非每秒帧数**。Xybrid 将实况相机视图建模为一个*级联*：一个廉价的
+常开门控判断场景是否发生了有意义的变化，只有此时才唤醒昂贵的 VLM 处理单帧。
+取景器无论如何都持续运行；理解在设计上滞后于相机。
+
+### 级联结构
+
+```
+相机帧 ──► 廉价亮度变化门控 ──► [仅在变化时触发]
+                                    │
+                            单次在途, 最新帧优先
+                                    │
+                        单帧 ──► VLM (mtmd) ──► 流式输出的答案
+                                    │
+                            原地替换答案 + 历史日志
+```
+
+门控在降采样网格上计算一个感知格式的亮度（luma）签名，并比较连续帧。静态场景
+产生近乎为零的 VLM 触发（空闲 ≈ 无推理）；门控正是防止重复答案刷屏、并将
+每帧 token 成本——主要的成本驱动因素——控制在有界范围内的机制。VLM 始终只
+看到经过门控的单帧。
+
+### 预期：尽力而为，绝不阻塞
+
+**没有流畅视频承诺，也没有延迟 SLA**。现实的设备端速率大约为**每秒 1–5 个
+理解事件**，在热负载下或在低端设备上还会进一步下降。约定如下：
+
+- VLM 忙碌时取景器（门控）绝不冻结。
+- 当场景变化且模型完成一次轮次时，答案会刷新。
+- 在高温或内存压力下，触发会放缓（优雅降速），而不是冻结 UI 或崩溃。
+
+这是一个叠加在既有无状态流式 VLM 路径之上的尽力而为的理解循环，而非实时
+感知引擎。
+
+### 最新帧优先（drop-if-busy → cancel-and-replace）
+
+该循环是单次在途（single-flight） 的——同一时刻只运行一个 VLM 生成。有两种策略约束新的
+门控帧如何与在途帧交互：
+
+- **drop-if-busy**（仅应用层的基线）：当一次生成在途时，新帧被忽略。简单，但
+  答案可能滞后于场景，因为循环要等待当前轮次完成。
+- **cancel-and-replace**（借助运行时原语）：更新的门控帧会抢占在途的生成。这
+  建立在**可达的流式取消**之上——现在取消 Dart 流会驱动一次真正的运行时中止
+  （生成会在下一个 token 处停止并释放模型锁），而不仅仅是在 Dart 中取消订阅
+  ——外加模型句柄上一个抢占式的取消当前运行槽位。最终效果是*最新帧优先*：最新
+  的场景获得优先，陈旧的帧不会造成队头阻塞。
+
+### 能力与设备下限
+
+实况视觉的进入与单图像视觉以相同方式门控——所选模型必须声明图像输入、原生
+构建必须包含视觉后端、mmproj 构件必须存在、且设备必须满足内存下限。低于这些
+下限的设备或模型会在相机循环启动之前、而非会话中途，以类型化能力错误被拦截。
+
+### 原始帧路径（`imageRaw`）
+
+基线实况循环会在把每个触发帧交给 VLM 之前对其进行 JPEG 编码。运行时还额外
+暴露了一条跳过逐帧 JPEG 编码的**原始帧路径**：相机像素缓冲区（打包 RGB，并从
+常见相机格式转换）通过 `imageRaw` Envelope 绑定而非 `image` 直接流入 `mtmd`。
+编码路径保持不变，仍作为回退。
+
+在 Studio 中，原始路径**受标志门控且默认关闭**
+（`--dart-define=XYBRID_STUDIO_RAW_FRAMES=true`）。在设备端确认原始帧与编码帧的
+图像描述一致性之前，它始终保持关闭；未设置该标志时，Studio 使用编码路径。
+一致性检查参见验证手册（runbook）。
+
+```dart
+// 原始帧 Envelope（跳过逐帧 JPEG 编码）。
+final image = XybridEnvelope.imageRaw(
+  bytes: rgbBytes,      // 打包 RGB 像素缓冲区
+  width: width,
+  height: height,
+);
+final prompt = XybridEnvelope.userMessage(
+  text: 'What does this label say?',
+  images: [image],
+);
+```
+
+### 仅限设备端
+
+带图像的对话轮次在设备端运行，否则失败——与单图像视觉一样，实况模式下
+**图像轮次也没有云端回退机制**。温度/内存压力的中止机制与路由层共享，但在实况模式下
+它会限流或停止本地循环，而不是溢出到云端。
+
+### 实况模式遥测
+
+一个朴素的实况循环会为每个触发帧发出一行遥测，从而淹没追踪后端。取而代之，
+实况模式的推理会被**打标签**（一个 `live_mode` 标志加上一个用于归组同一相机
+会话的 `frame_session_id`），并由每会话采样器**限流**（大致每会话每秒一行，受
+TTL 限制），因此一次实况会话产生的是采样汇总，而非逐帧刷屏。
+
+## 故障排查
+
+### `MissingArtifact`
+
+模型元数据引用了一个 mmproj 或视觉编码器文件，但它并不在语言模型旁边。请重新
+拉取模型 Bundle，或核实注册表条目包含了每个配套构件。
+
+### `UnsupportedModelCapability`
+
+所选模型为纯文本，但输入 Envelope 包含图像或多部分用户消息。请选择诸如
+`lfm2-vl-450m` 或 `gemma-4-e2b` 的 VLM。
+
+### `UnsupportedBackendCapability`
+
+模型声明了图像输入，但已加载的后端/构建无法满足它。请使用 `llm-llamacpp-vision`
+重新构建，或切换到包含视觉后端的发布构件。
+
+### 设备低于下限
+
+所选 VLM 需要的内存超过当前设备所报告的容量。对于 Gemma 4 E2B Q8，请使用
+8 GB 级别的设备或选择更小的 VLM。应用应在生成开始之前将此呈现为能力门控。
+
+### 无效的图像格式
+
+请使用编码后的 PNG、JPEG 或 WebP 字节。HEIC 与相机原生的原始像素缓冲区是
+独立的接入路径，在调用 `Envelope.image` 之前可能需要平台专属的转换。


### PR DESCRIPTION
docs: add Chinese localization for feature matrix, installation and vision model usage

## Summary

<!-- What does this PR do and why? -->

Added `docs/FEATURE_MATRIX.zh.md`, `docs/INSTALLATION.zh.md`, `docs/content/docs/guides/vision-models.zh.mdx`

Fixed references the installation guide in `README.zh-CN.md`

Polished one line in `README.zh-CN.md`

Added Liquid LFM2.5 230M support line in the CN docs as per Commit 511d30d.

The other docs, such as `docs/telemetry` and `docs/sdk` are left untranslated to keep this PR more focused, they will be translated soon.

The other documentations (the READMEs in `examples/`) are left untouched as well, could do them as well if the maintainers deem necessary.

Edits: followed the edit suggestions from Gemini code assisst bot, most of it is from the Chinese input method on Linux :(

## Suggestion

Currently the Chinese and English docs (the `.md` docs that aren't for the website) are mixed together and can be very hard to navigate for new comers that wants to get started.

I could move all the Chinese `.md` docs into a separate folder and point to them in the Chinese README (docs/README.zh.md`), this would require a substantial change in the current `docs/` directory and will introduce additional files that are Chinese only.

As such this is only a suggestion, if the maintainers agree with this idea I can do this after I finish translating the remaining docs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [ ] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)