### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -311,6 +311,13 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+        with:
+          # Don't install the default `tools` package — it drags in the Android
+          # Emulator (~1 GB), whose download flakes ("ZipFile unknown archive").
+          # This job only builds the APK (assembleDebug); the NDK is installed
+          # below and Gradle fetches build-tools/platform on demand. platform-tools
+          # is kept for adb, which some Gradle Android tasks probe for.
+          packages: platform-tools
 
       - name: Install NDK
         run: sdkmanager --install "ndk;27.1.12297006"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2026-07-06
 
-Unity moves to OpenUPM, and on-device cache clearing is made honest. The Unity
-SDK is re-platformed onto a managed-only package that fetches its natives at
-import, and the model-cache clear/discovery paths are corrected to report what
-they actually remove.
+Local tool calling, Unity on OpenUPM, and honest cache clearing. The local
+llama.cpp backend gains function/tool calling; the Unity SDK is re-platformed
+onto a managed-only OpenUPM package that fetches its natives at import; and the
+model-cache clear/discovery paths are corrected to report what they actually
+remove.
 
 ### Changed
 
@@ -40,6 +41,10 @@ they actually remove.
 
 ### Added
 
+- **Local tool calling for the llama.cpp backend** (#323): function/tool calls
+  are parsed from local LLM output for LFM2 and Gemma-family models, with
+  streaming tool-call continuation, an example, and a CLI REPL. See the
+  tool-calling guide.
 - **Unity native-library resolver + release bundles** (#321). An editor resolver
   downloads/verifies the per-platform natives on import and before player builds;
   CI publishes `xybrid-unity-native-<platform>-v<version>.zip` bundles + a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Unity SDK distribution moved to OpenUPM.** The Unity package now ships
-  managed-only via the OpenUPM scoped registry (`ai.xybrid`); per-platform
-  native libraries are downloaded from the GitHub Release at import by an editor
-  resolver (SHA-256 verified) into `Assets/Xybrid/Plugins/`, **including the
-  ~326 MB iOS slice** that previously required manual setup. Replaces the
-  `upm` git-branch install, and the `publish-upm` CI job is retired.
-
 ### Planned
 
 - **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.3.0] - 2026-07-06
+
+Unity moves to OpenUPM, and on-device cache clearing is made honest. The Unity
+SDK is re-platformed onto a managed-only package that fetches its natives at
+import, and the model-cache clear/discovery paths are corrected to report what
+they actually remove.
+
+### Changed
+
+- **Unity SDK distribution moved to OpenUPM** (#321, #324). The Unity package now
+  ships managed-only via the OpenUPM scoped registry (`ai.xybrid`); per-platform
+  native libraries are downloaded from the GitHub Release at import by an editor
+  resolver (SHA-256 verified) into `Assets/Xybrid/Plugins/`, **including the
+  ~326 MB iOS slice** that previously required manual setup. **Breaking for Unity
+  consumers:** the `#upm` git-branch install is replaced (install via OpenUPM or
+  the `?path=/bindings/unity` git URL), and the `publish-upm` CI job is retired.
+- **Model cache clearing reports what it removed** (#309). **Breaking:** `clear()`
+  / `clear_model_roots()` now return the number of cache *roots* removed (was the
+  scanned `.xyb` entry count, ~0 for the nested registry-bundle layout), and the
+  CLI now warns when nothing was cached instead of always reporting success.
+  `cache_root()` keeps `extracted/`, `hf/`, and `hf-hub/` co-located under the
+  cache root for a bare relative `models` root instead of resolving them
+  CWD-relative. `clear*` operations are documented as unsafe against concurrent
+  loads.
+
+### Added
+
+- **Unity native-library resolver + release bundles** (#321). An editor resolver
+  downloads/verifies the per-platform natives on import and before player builds;
+  CI publishes `xybrid-unity-native-<platform>-v<version>.zip` bundles + a
+  SHA-256 manifest as release assets (managed by `cargo xtask package-unity-natives`).
+
+### Fixed
+
+- **Internal path-dep pins** realigned to the workspace version (#318).
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap 4.6.1",
@@ -6612,14 +6612,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6656,7 +6656,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6723,7 +6723,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "cbindgen",
  "csbindgen",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "tokio",
  "xybrid-core",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6771,7 +6771,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6797,7 +6797,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.3.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "daf14db1c42132b8a451d800522c9be9915bb94fc55d8158cb9d245788554f0d"
+let xybridFFIChecksum = "97222ac4acb6d26edc0ce708d829250c5254b462f5f09c50dd776c975834981c"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.3.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "e022a07ace33ece5ec1fea03b56de4dab40655da0050a55feccc81597d2aa48c"
+let xybridFFIChecksum = "18948ed9dcb38bc0a309a3b30bec583a802498f032b1c98e997ccdcb99f00e7a"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.3.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "97222ac4acb6d26edc0ce708d829250c5254b462f5f09c50dd776c975834981c"
+let xybridFFIChecksum = "e022a07ace33ece5ec1fea03b56de4dab40655da0050a55feccc81597d2aa48c"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.2.2"
+let sdkVersion = "0.3.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Fixed: model cache clearing now reports the number of cache roots actually removed (previously counted scanned `.xyb` entries, ~0 for the nested registry-bundle layout), so "clear cache" no longer reports success when nothing was cached; `extracted/`, `hf/`, and `hf-hub/` stay co-located under a relative cache root (xybrid-ai/xybrid#309)
+
 ## 0.2.2
 
 Structured output on Flutter. Local llama generation can now be constrained to a

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.2.2
+version: 0.3.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.2.2"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.3.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.2.2"
+version = "0.3.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.2.2"
+  implementation "ai.xybrid:xybrid-kotlin:0.3.0"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.2", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.2.2", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.3.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.3.0", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.2.2" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.3.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.2.2", path = "../../macros" }
+xybrid-macros = { version = "0.3.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.2.2", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.3.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.2.2", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.3.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.2.2", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.3.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Release **v0.3.0**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.3.0).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.3.0`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.