### PR TITLE
docs: document reasoning (thinking) models across guides + SDK READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ All models run entirely on-device. No cloud, no API keys required. Browse the fu
 | Gemma 3 1B | 1B | GGUF Q4_K_M | Google's mobile-optimized LLM |
 | LFM2.5 230M | 230M | GGUF Q4_K_M | Liquid AI's smallest hybrid conv+attention LLM for edge devices |
 | LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AI's hybrid conv+attention, 9 languages, tool calling |
+| LFM2.5 1.2B Thinking | 1.2B | GGUF Q4_K_M | Liquid AI reasoning model — chain-of-thought via `reasoningContent` ([guide](https://docs.xybrid.dev/en/docs/guides/reasoning)) |
 | Llama 3.2 1B | 1B | GGUF Q4_K_M | Meta's general purpose, 128K context |
 | Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | Compact on-device chat |
 | Qwen 3.5 0.8B | 800M | GGUF Q4_K_M | Latest Qwen with reasoning (thinking mode) |

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -67,9 +67,9 @@ answer text and surfaces it on `reasoningContent` — `nil` for non-thinking
 models. Nothing to enable; just read it if you want it.
 
 ```swift
-let model = try XybridModelLoader.fromRegistry(modelId: "lfm2.5-1.2b-thinking").load()
+let model = try XybridModel(fromRegistry: "lfm2.5-1.2b-thinking")
 let result = try model.run(envelope: XybridEnvelope.text(
-    text: "Is 97 a prime number? Reason, then answer."))
+    "Is 97 a prime number? Reason, then answer."))
 
 if let answer = result.text { print("Answer:", answer) }
 if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -59,6 +59,22 @@ if result.success {
 }
 ```
 
+### Reasoning (thinking models)
+
+Reasoning models (metadata `reasoning: true`, e.g. `lfm2.5-1.2b-thinking`)
+produce a chain-of-thought before their answer. Xybrid keeps it out of the
+answer text and surfaces it on `reasoningContent` — `nil` for non-thinking
+models. Nothing to enable; just read it if you want it.
+
+```swift
+let model = try XybridModelLoader.fromRegistry(modelId: "lfm2.5-1.2b-thinking").load()
+let result = try model.run(envelope: XybridEnvelope.text(
+    text: "Is 97 a prime number? Reason, then answer."))
+
+if let answer = result.text { print("Answer:", answer) }
+if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
+```
+
 ### Available Types
 
 | Type | Description |

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -147,6 +147,21 @@ if (result.success) {
 }
 ```
 
+### Reasoning (thinking models)
+
+Reasoning models (metadata `reasoning: true`, e.g. `lfm2.5-1.2b-thinking`)
+produce a chain-of-thought before their answer. Xybrid keeps it out of the
+answer text and surfaces it on `reasoningContent` — `null` for non-thinking
+models. Nothing to enable; just read it if you want it.
+
+```dart
+final result = await model.run(XybridEnvelope.text(
+    'Is 97 a prime number? Reason, then answer.'));
+
+if (result.text != null) print('Answer: ${result.text}');
+if (result.reasoningContent != null) print('Reasoning: ${result.reasoningContent}');
+```
+
 ### LLM Streaming
 
 Stream tokens in real-time as the LLM generates:

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -124,6 +124,21 @@ if (result.success) {
 }
 ```
 
+### Reasoning (thinking models)
+
+Reasoning models (metadata `reasoning: true`, e.g. `lfm2.5-1.2b-thinking`)
+produce a chain-of-thought before their answer. Xybrid keeps it out of the
+answer text and surfaces it on `reasoningContent` — `null` for non-thinking
+models. Nothing to enable; just read it if you want it.
+
+```kotlin
+import ai.xybrid.reasoningContent
+
+val result = model.run(Envelope.text("Is 97 a prime number? Reason, then answer."))
+result.text?.let { println("Answer: $it") }
+result.reasoningContent?.let { println("Reasoning: $it") }
+```
+
 ### Error Handling
 
 ```kotlin

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -3,5 +3,5 @@
   "description": "End-to-end implementation guides",
   "icon": "BookOpen",
   "root": true,
-  "pages": ["tool-calling", "vision-models"]
+  "pages": ["tool-calling", "reasoning", "vision-models"]
 }

--- a/docs/content/docs/guides/reasoning.mdx
+++ b/docs/content/docs/guides/reasoning.mdx
@@ -1,0 +1,151 @@
+---
+title: Reasoning
+description: Read a thinking model's chain-of-thought — on-device, kept out of the answer
+---
+
+Some local models are trained to *think before they answer*: they emit a
+chain-of-thought, then the final response. Xybrid keeps that reasoning out of
+the answer text and surfaces it separately, so you get a clean answer plus an
+optional window into how the model got there — all on-device.
+
+Xybrid's design rule is that **capabilities are data, not entry points**.
+Reasoning rides the existing types with **zero new run methods**:
+
+1. Load a reasoning model (flagged `reasoning: true` in its metadata).
+2. `run` the request as usual — nothing to enable.
+3. Read the answer from `text` and the chain-of-thought from `reasoningContent`.
+
+The answer in `text` never contains the `<think>…</think>` markup, and
+`reasoningContent` is `null` for models that aren't reasoning models (or that
+emitted no reasoning). It's purely additive: existing code that reads `text` is
+unaffected.
+
+<Callout type="info">
+Reasoning capture runs on the local llama.cpp backend. Thinking models gate
+their `<think>` block behind a chat-template flag that llama.cpp's legacy
+template applier doesn't render, so xybrid primes the channel itself for models
+flagged `reasoning: true` — you don't enable anything, you only choose whether
+to read `reasoningContent`.
+</Callout>
+
+## Supported Models
+
+Any bundle whose `model_metadata.json` sets `reasoning: true`. The reference
+model is **`lfm2.5-1.2b-thinking`** (Liquid AI's 1.2B reasoning model), which
+emits a chain-of-thought before every answer.
+
+| Model | Emits reasoning | Notes |
+|-------|-----------------|-------|
+| `lfm2.5-1.2b-thinking` | yes | hybrid conv+attention reasoning model, ~697 MB |
+| `qwen3.5-0.8b` / `qwen3.5-2b` | sometimes | Qwen 3.5 thinking mode |
+
+## Reading Reasoning
+
+Same `run`, same result — reasoning is a sibling of `text`.
+
+### Swift
+
+```swift
+let model = try XybridModelLoader.fromRegistry(modelId: "lfm2.5-1.2b-thinking").load()
+let result = try model.run(envelope: XybridEnvelope.text(
+    text: "Is 97 a prime number? Reason, then answer."))
+
+if let answer = result.text { print("Answer:", answer) }
+if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
+```
+
+### Kotlin
+
+```kotlin
+val model = XybridModelLoader.fromRegistry("lfm2.5-1.2b-thinking").load()
+val result = model.run(XybridEnvelope.Text(
+    text = "Is 97 a prime number? Reason, then answer."))
+
+result.text?.let { println("Answer: $it") }
+result.reasoningContent?.let { println("Reasoning: $it") }
+```
+
+### Dart (Flutter)
+
+```dart
+final model = await XybridModelLoader.fromRegistry('lfm2.5-1.2b-thinking').load();
+final result = await model.run(XybridEnvelope.text(
+    'Is 97 a prime number? Reason, then answer.'));
+
+if (result.text != null) print('Answer: ${result.text}');
+if (result.reasoningContent != null) print('Reasoning: ${result.reasoningContent}');
+```
+
+### Rust
+
+```rust
+use xybrid_sdk::ModelLoader;
+use xybrid_sdk::ir::{Envelope, EnvelopeKind};
+
+let model = ModelLoader::from_registry("lfm2.5-1.2b-thinking").load()?;
+let result = model.run(
+    &Envelope::new(EnvelopeKind::Text("Is 97 a prime number? Reason, then answer.".into())),
+    None,
+)?;
+
+println!("Answer: {}", result.text().unwrap_or_default());
+if let Some(reasoning) = result.reasoning_content() {
+    println!("Reasoning: {reasoning}");
+}
+```
+
+The value is the same in every SDK (`String?` / `Option<&str>`, `null`/`None`
+when absent). The C ABI exposes it as `xybrid_result_reasoning_content()`, and
+the React Native and Unity bindings surface `reasoningContent` too.
+
+## Reasoning in the CLI (`xybrid run`)
+
+The `--show-reasoning` flag prints the chain-of-thought in a separate section
+under the answer:
+
+```bash
+xybrid run --model lfm2.5-1.2b-thinking \
+  --input-text "Is 97 a prime number? Reason, then answer." \
+  --show-reasoning
+```
+
+```text
+  ── Results ──
+    …no divisors other than 1 and itself. Thus, 97 is prime.
+    \boxed{Yes}
+
+  ── Reasoning ──
+    Check divisibility by primes ≤ √97 ≈ 9.85: 2, 3, 5, 7. None divide 97…
+```
+
+Non-reasoning models print `No reasoning emitted` instead. `xybrid repl` also
+honors `--show-reasoning`, printing each turn's reasoning as a dimmed block
+above what the turn produced.
+
+## Declaring Support in Your Own Bundles
+
+Flag a reasoning model in `model_metadata.json` so xybrid primes and captures
+its chain-of-thought (the `/xybrid-init` skill can generate metadata):
+
+```json
+{
+  "metadata": {
+    "reasoning": true
+  }
+}
+```
+
+Without the flag, xybrid treats the model as a normal LLM: any `<think>` blocks
+it emits on its own are still stripped from `text` and captured, but xybrid
+won't prime the channel, so a model that only thinks *when asked to* stays quiet.
+
+## What Isn't Reasoning
+
+- **Whitespace-only blocks** — a model that opens and immediately closes
+  `<think></think>` produces no `reasoningContent` (`null`), not an empty string.
+- **Non-`<think>` formats** — only literal `<think>…</think>` is captured today.
+  Anthropic-style `<thinking>` and gemma-4's channel-based reasoning are not yet
+  parsed.
+- **Streaming** — reasoning lands on the final (non-streaming) result;
+  during streaming it's suppressed from the token callback so it never leaks
+  into the live answer.

--- a/docs/content/docs/guides/reasoning.mdx
+++ b/docs/content/docs/guides/reasoning.mdx
@@ -46,9 +46,9 @@ Same `run`, same result — reasoning is a sibling of `text`.
 ### Swift
 
 ```swift
-let model = try XybridModelLoader.fromRegistry(modelId: "lfm2.5-1.2b-thinking").load()
+let model = try XybridModel(fromRegistry: "lfm2.5-1.2b-thinking")
 let result = try model.run(envelope: XybridEnvelope.text(
-    text: "Is 97 a prime number? Reason, then answer."))
+    "Is 97 a prime number? Reason, then answer."))
 
 if let answer = result.text { print("Answer:", answer) }
 if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
@@ -57,9 +57,8 @@ if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
 ### Kotlin
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("lfm2.5-1.2b-thinking").load()
-val result = model.run(XybridEnvelope.Text(
-    text = "Is 97 a prime number? Reason, then answer."))
+val model = XybridModel.fromRegistry("lfm2.5-1.2b-thinking")
+val result = model.run(Envelope.text("Is 97 a prime number? Reason, then answer."))
 
 result.text?.let { println("Answer: $it") }
 result.reasoningContent?.let { println("Reasoning: $it") }


### PR DESCRIPTION
## Summary

Documents the reasoning/thinking-model feature (chain-of-thought via `reasoningContent`), which shipped in #312 but wasn't discoverable. Adds a dedicated `docs/content/docs/guides/reasoning.mdx` guide — what thinking models are, that xybrid primes and captures the `<think>` chain-of-thought automatically, how to read `reasoningContent` in Swift/Kotlin/Dart/Rust, the CLI `--show-reasoning` flag, and declaring `reasoning: true` in bundle metadata. Also adds `LFM2.5 1.2B Thinking` to the README model table and a short "Reasoning (thinking models)" section to the Apple, Kotlin, and Flutter binding READMEs. Docs-only, English for now (the `.zh` guide/meta are left for a separate translation pass, as was done for tool-calling).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)