### PR TITLE
ci: advisory Bazel workflow — graph check + RBE-proven targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,10 +6,14 @@ common --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=False
 # rules_rust allocator-library handling used by the known-good e2e config.
 common --@rules_rust//rust/settings:experimental_use_allocator_libraries_with_mangled_symbols
 
-# Bazelified LINUX NDK (see MODULE.bazel): force the linux-x86_64 host tag so the
-# fetched-on-mac NDK repo carries Linux binaries for the RBE workers. NOTE: with
-# this set, android targets only build remotely (--config=remote) — the Linux
-# clang cannot execute on this Mac.
+# Bazelified LINUX NDK (see MODULE.bazel + rules_android_ndk.patch): the NDK is
+# DOWNLOADED as a pinned repository input (r27 = the CI pin, sha256-verified) —
+# no local install, no machine setup, works identically on any host/CI. The
+# host tag forces the linux-x86_64 toolchain so the binaries run on the RBE
+# workers. NOTE: android targets build remotely only (--config=remote) — the
+# Linux clang cannot execute on a macOS host.
+common --repo_env=XYBRID_NDK_URL=https://dl.google.com/android/repository/android-ndk-r27-linux.zip
+common --repo_env=XYBRID_NDK_SHA256=2f17eb8bcbfdc40201c0b36e9a70826fcd2524ab7a2a235e2c71186c302da1dc
 common --repo_env=XYBRID_NDK_HOST_TAG=linux-x86_64
 
 # py_binary tools (rules_pkg's build_zip) must run on the python-less RBE

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -45,10 +45,6 @@ concurrency:
   group: bazel-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Must match build-android.yml (and the NDK the AAR was validated against).
-  NDK_VERSION: "27.0.12077973"
-
 jobs:
   bazel:
     name: Bazel graph + RBE targets
@@ -71,26 +67,9 @@ jobs:
           sudo docker image prune --all --force || true
           df -h /
 
-      # The android_ndk repo rule runs on ANY bazel invocation (toolchain
-      # registration), so the NDK must exist before the first bazel command —
-      # same install as build-android.yml. (Phase-1 follow-up: extend
-      # rules_android_ndk.patch to download_and_extract a pinned NDK instead.)
-      - name: Cache Android NDK
-        id: cache-ndk
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
-          key: android-ndk-bazel-${{ env.NDK_VERSION }}
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-
-      - name: Install NDK
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
-        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
-
-      - name: Set NDK environment
-        run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
+      # No NDK install: the android_ndk repo rule downloads a pinned Linux NDK
+      # r27 as a normal Bazel repository input (rules_android_ndk.patch +
+      # XYBRID_NDK_URL/SHA256 in the committed .bazelrc).
 
       # .bazelrc try-imports this gitignored file; in CI it's materialized from
       # the secret. Absent secret (forks) → no :remote config → RBE steps skip.

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,144 @@
+# Bazel — ADVISORY (Phase 1 of the migration; see .context/bazel-per-platform-today-vs-ideal.md
+# in the spike workspace and PR #326). This job is NOT a required check: cargo remains the
+# build of record. It validates the Bazel graph on every PR and builds the RBE-proven targets
+# (the hermetic linux llama chain + the Android AAR) against the shared BuildBuddy cache.
+#
+# Fork-safe: PRs from forks have no secrets, so the RBE steps skip and only the
+# analyze-everything phase runs (no remote, no network beyond repo fetches).
+name: Bazel (advisory)
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "MODULE.bazel"
+      - ".bazelrc"
+      - ".bazelversion"
+      - ".bazelignore"
+      - "BUILD.bazel"
+      - "**/BUILD.bazel"
+      - "rules_android_ndk.patch"
+      - "rules_foreign_cc.patch"
+      - "crates/**"
+      - "bindings/kotlin/**"
+      - "macros/**"
+      - "vendor/llama-cpp"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/bazel.yml"
+  push:
+    branches: [master]
+    paths:
+      - "MODULE.bazel"
+      - "BUILD.bazel"
+      - "**/BUILD.bazel"
+      - "crates/**"
+      - "bindings/kotlin/**"
+      - "Cargo.lock"
+      - ".github/workflows/bazel.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bazel-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Must match build-android.yml (and the NDK the AAR was validated against).
+  NDK_VERSION: "27.0.12077973"
+
+jobs:
+  bazel:
+    name: Bazel graph + RBE targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      # Repo fetches (LLVM prebuilt, rustc, NDK symlink tree) + downloaded
+      # toplevel outputs need headroom; reclaim toolchains this job never
+      # touches (keep /usr/local/lib/android — the SDK/NDK setup uses it).
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
+      # The android_ndk repo rule runs on ANY bazel invocation (toolchain
+      # registration), so the NDK must exist before the first bazel command —
+      # same install as build-android.yml. (Phase-1 follow-up: extend
+      # rules_android_ndk.patch to download_and_extract a pinned NDK instead.)
+      - name: Cache Android NDK
+        id: cache-ndk
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
+          key: android-ndk-bazel-${{ env.NDK_VERSION }}
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install NDK
+        if: steps.cache-ndk.outputs.cache-hit != 'true'
+        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
+
+      - name: Set NDK environment
+        run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
+
+      # .bazelrc try-imports this gitignored file; in CI it's materialized from
+      # the secret. Absent secret (forks) → no :remote config → RBE steps skip.
+      - name: Configure BuildBuddy remote config
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote --remote_executor=grpcs://remote.buildbuddy.io
+          common:remote --remote_cache_compression
+          common:remote --remote_download_toplevel
+          common:remote --remote_timeout=600
+          common:remote --jobs=200
+          common:remote --extra_execution_platforms=@llvm//:rbe_linux_x86_64
+          EOF
+
+      # Structural gate (always, fork-safe): every BUILD file in the workspace
+      # must configure. Same target set Gate 5 proved (13 targets analyze-clean).
+      - name: Analyze workspace (no build)
+        run: |
+          bazelisk build --nobuild \
+            //crates/... //bindings/... //macros/... //xtask/... //integration-tests/... //:llama
+
+      # The RBE-proven hermetic linux chain (PR #326 gates 3B/4).
+      - name: Build llama chain on RBE (linux, hermetic)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote \
+            //:llama \
+            //crates/llama-cpp-sys:llama_cpp_sys \
+            //crates/xybrid-llama:xybrid_llama
+
+      # The RBE-proven Android row (PR #326 gates 6-10): NDK cross-compile +
+      # one-link .so + complete AAR.
+      - name: Build Android AAR on RBE
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote --config=android-arm64 \
+            //bindings/kotlin:xybrid_kotlin_aar
+
+      - name: Upload AAR artifact
+        if: env.BUILDBUDDY_API_KEY != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bazel-xybrid-kotlin-aar
+          path: bazel-bin/bindings/kotlin/xybrid-kotlin.aar
+          retention-days: 7

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -26,14 +26,24 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/bazel.yml"
+  # Same path set as pull_request: a master merge touching any Bazel input
+  # re-warms the shared cache so the next PR starts warm.
   push:
     branches: [master]
     paths:
       - "MODULE.bazel"
+      - ".bazelrc"
+      - ".bazelversion"
+      - ".bazelignore"
       - "BUILD.bazel"
       - "**/BUILD.bazel"
+      - "rules_android_ndk.patch"
+      - "rules_foreign_cc.patch"
       - "crates/**"
       - "bindings/kotlin/**"
+      - "macros/**"
+      - "vendor/llama-cpp"
+      - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/bazel.yml"
   workflow_dispatch:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,30 +7,11 @@
 
 module(name = "xybrid_bazel_spike", version = "0.0.0")
 
-# --- hermeticbuild stack, pinned to the exact upstream commits the spike was
-# proven against (git_override → fetchable on any machine/CI, no local setup).
-# Follow-up: move to BCR `bazel_dep` versions once we re-validate against a
-# released version set.
-bazel_dep(name = "rules_rs", version = "0.0.0")
-git_override(
-    module_name = "rules_rs",
-    commit = "6e86558cdb62ad44d8535642e1133cc6bf443bf0",
-    remote = "https://github.com/hermeticbuild/rules_rs.git",
-)
-
-bazel_dep(name = "llvm", version = "0.0.0")
-git_override(
-    module_name = "llvm",
-    commit = "bdddceafc31abb43228d2d94cb55bad7277d5d26",
-    remote = "https://github.com/hermeticbuild/hermetic-llvm.git",
-)
-
-bazel_dep(name = "hermetic_launcher", version = "0.0.0")
-git_override(
-    module_name = "hermetic_launcher",
-    commit = "1897a8c57432d5dfd7625c41757b9cfb4e50c8be",
-    remote = "https://github.com/hermeticbuild/hermetic-launcher.git",
-)
+# --- hermeticbuild stack, pinned from the Bazel Central Registry (replaces the
+# earlier git_override commit pins; re-validated on RBE at these versions).
+bazel_dep(name = "rules_rs", version = "0.0.95")
+bazel_dep(name = "llvm", version = "0.8.11")
+bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
 # rules_cc must be a direct dep so the `@rules_cc//...` flag in .bazelrc resolves.
 bazel_dep(name = "rules_cc", version = "0.2.20")
@@ -114,12 +95,9 @@ android_ndk = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_r
 android_ndk.configure(
     # android-28 matches today's cmake ANDROID_PLATFORM (build.rs / boltffi path).
     api_level = 28,
-    # NDK location comes from the ANDROID_NDK_HOME env var (machine-local; set it
-    # in the gitignored .context/local.bazelrc — see .bazelrc). Point it at a
-    # LINUX NDK r27 (27.0.12077973, android-ndk-r27-linux.zip) when building the
-    # android targets via --config=remote (XYBRID_NDK_HOST_TAG=linux-x86_64).
-    # Follow-up: extend rules_android_ndk.patch to download_and_extract a pinned
-    # NDK so no machine setup is needed at all.
+    # The NDK itself is DOWNLOADED as a pinned repo input (rules_android_ndk.patch:
+    # XYBRID_NDK_URL/SHA256 in .bazelrc) — no local install. A local NDK via
+    # ANDROID_NDK_HOME / path applies only when XYBRID_NDK_URL is unset.
 )
 use_repo(android_ndk, "androidndk")
 register_toolchains("@androidndk//:all")

--- a/rules_android_ndk.patch
+++ b/rules_android_ndk.patch
@@ -1,6 +1,31 @@
---- a/rules.bzl	2026-07-06 17:10:40
-+++ b/rules.bzl	2026-07-06 17:10:40
-@@ -32,7 +32,14 @@
+--- a/rules.bzl	2026-07-08 10:20:46
++++ b/rules.bzl	2026-07-08 10:21:17
+@@ -23,16 +23,36 @@
+     Returns:
+         A final dict of configuration attributes and values.
+     """
+-    ndk_path = ctx.attr.path or ctx.getenv("ANDROID_NDK_HOME", None)
++    # xybrid spike patch: when XYBRID_NDK_URL is set, download_and_extract a
++    # PINNED NDK into the repository instead of requiring a local install —
++    # the NDK becomes a normal fetched Bazel input (works on any machine/CI).
++    ndk_url = ctx.os.environ.get("XYBRID_NDK_URL", "")
++    if ndk_url:
++        ctx.download_and_extract(
++            url = ndk_url,
++            sha256 = ctx.os.environ.get("XYBRID_NDK_SHA256", ""),
++            output = "ndk-dl",
++            stripPrefix = ctx.os.environ.get("XYBRID_NDK_STRIP_PREFIX", "android-ndk-r27"),
++        )
++        ndk_path = str(ctx.path("ndk-dl"))
++    else:
++        ndk_path = ctx.attr.path or ctx.getenv("ANDROID_NDK_HOME", None)
+     if not ndk_path:
+-        fail("Either the ANDROID_NDK_HOME environment variable or the " +
+-             "path attribute of android_ndk_repository must be set.")
++        fail("Either the ANDROID_NDK_HOME environment variable, the path " +
++             "attribute of android_ndk_repository, or XYBRID_NDK_URL must be set.")
+     if ndk_path.startswith("$WORKSPACE_ROOT"):
+         ndk_path = str(ctx.workspace_root) + ndk_path.removeprefix("$WORKSPACE_ROOT")
  
      is_windows = False
      executable_extension = ""
@@ -16,7 +41,7 @@
          clang_directory = "toolchains/llvm/prebuilt/linux-x86_64"
      elif ctx.os.name == "mac os x":
          # Note: darwin-x86_64 does indeed contain fat binaries with arm64 slices, too.
-@@ -50,13 +57,21 @@
+@@ -50,13 +70,21 @@
  
      api_level = ctx.attr.api_level or 31
  

--- a/rules_android_ndk.patch
+++ b/rules_android_ndk.patch
@@ -1,6 +1,6 @@
---- a/rules.bzl	2026-07-08 10:20:46
-+++ b/rules.bzl	2026-07-08 10:21:17
-@@ -23,16 +23,36 @@
+--- a/rules.bzl	2026-07-08 10:46:44
++++ b/rules.bzl	2026-07-08 10:46:44
+@@ -23,16 +23,41 @@
      Returns:
          A final dict of configuration attributes and values.
      """
@@ -8,13 +8,18 @@
 +    # xybrid spike patch: when XYBRID_NDK_URL is set, download_and_extract a
 +    # PINNED NDK into the repository instead of requiring a local install —
 +    # the NDK becomes a normal fetched Bazel input (works on any machine/CI).
-+    ndk_url = ctx.os.environ.get("XYBRID_NDK_URL", "")
++    # ctx.getenv (not os.environ) so pin bumps invalidate the repository.
++    ndk_url = ctx.getenv("XYBRID_NDK_URL", "")
 +    if ndk_url:
++        ndk_sha256 = ctx.getenv("XYBRID_NDK_SHA256", "")
++        if not ndk_sha256:
++            fail("XYBRID_NDK_SHA256 must be set when XYBRID_NDK_URL is set " +
++                 "(unverified toolchain downloads are not allowed).")
 +        ctx.download_and_extract(
 +            url = ndk_url,
-+            sha256 = ctx.os.environ.get("XYBRID_NDK_SHA256", ""),
++            sha256 = ndk_sha256,
 +            output = "ndk-dl",
-+            stripPrefix = ctx.os.environ.get("XYBRID_NDK_STRIP_PREFIX", "android-ndk-r27"),
++            stripPrefix = ctx.getenv("XYBRID_NDK_STRIP_PREFIX", "android-ndk-r27"),
 +        )
 +        ndk_path = str(ctx.path("ndk-dl"))
 +    else:
@@ -34,14 +39,14 @@
 +    # xybrid spike patch: allow forcing the NDK host tag (e.g. linux-x86_64) so
 +    # a LINUX NDK can be fetched on a macOS host purely as remote-execution
 +    # (RBE) action inputs. Set via --repo_env=XYBRID_NDK_HOST_TAG=linux-x86_64.
-+    host_tag_override = ctx.os.environ.get("XYBRID_NDK_HOST_TAG", "")
++    host_tag_override = ctx.getenv("XYBRID_NDK_HOST_TAG", "")
 +    if host_tag_override:
 +        clang_directory = "toolchains/llvm/prebuilt/" + host_tag_override
 +    elif ctx.os.name == "linux":
          clang_directory = "toolchains/llvm/prebuilt/linux-x86_64"
      elif ctx.os.name == "mac os x":
          # Note: darwin-x86_64 does indeed contain fat binaries with arm64 slices, too.
-@@ -50,13 +70,21 @@
+@@ -50,13 +75,21 @@
  
      api_level = ctx.attr.api_level or 31
  


### PR DESCRIPTION
## Summary

Phase 1 of the Bazel rollout (follow-up to #326): adds a **non-required, advisory** \`bazel.yml\` workflow that analyzes the whole Bazel graph on every touching PR (\`--nobuild\` over the Gate-5 target set, fork-safe with no secrets) and, when \`BUILDBUDDY_API_KEY\` is present, builds the RBE-proven targets against the shared BuildBuddy cache — the hermetic linux llama chain and the complete Android AAR (uploaded as a run artifact). The NDK r27 install mirrors \`build-android.yml\` (the \`android_ndk\` repo rule needs \`ANDROID_NDK_HOME\` before any bazel command); the remote config is materialized from the secret into the gitignored rc file \`.bazelrc\` already try-imports. This is also the first CI exercise of \`//:host_linux_gnu\` (bazel on a Linux host). cargo remains the build of record — **do not add this check to required checks yet**.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below)

CI: advisory Bazel job (Phase-1 rollout step 1).

## Checklist

- [ ] Tests pass (\`cargo test\`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)