### PR TITLE
docs: fix stale loader/envelope APIs in Apple + Kotlin READMEs

### DIFF
--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -37,9 +37,8 @@ Then add the dependency to your target:
 ```swift
 import Xybrid
 
-// Load a model from the registry
-let loader = XybridModelLoader.fromRegistry(modelId: "kokoro-82m")
-let model = try loader.load()
+// Load a model from the registry (the initializer resolves + loads it)
+let model = try XybridModel(fromRegistry: "kokoro-82m")
 
 // Create an envelope for TTS
 let envelope = XybridEnvelope.text(
@@ -79,8 +78,7 @@ if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
 
 | Type | Description |
 |------|-------------|
-| `XybridModelLoader` | Loads models from registry or local bundles |
-| `XybridModel` | Represents a loaded model ready for inference |
+| `XybridModel` | A loaded model ready for inference — construct via `XybridModel(fromRegistry:)`, `(fromBundle:)`, `(fromDirectory:)`, or `(fromHuggingface:)` |
 | `XybridEnvelope` | Input data container (audio, text, embedding, image, or multi-part user message) |
 | `XybridResult` | Inference result with success status and output data |
 | `XybridError` | Error enum for error handling |

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -140,12 +140,12 @@ import ai.xybrid.XybridException
 try {
     val model = XybridModel("unknown-model")
 } catch (e: XybridException.ModelNotFound) {
-    println("Model not found: ${e.modelId}")
-} catch (e: XybridException.InferenceFailed) {
+    println("Model not found: ${e.id}")
+} catch (e: XybridException.LoadError) {
+    println("Load error: ${e.message}")
+} catch (e: XybridException.InferenceError) {
     println("Inference failed: ${e.message}")
-} catch (e: XybridException.InvalidInput) {
-    println("Invalid input: ${e.message}")
-} catch (e: XybridException.IoException) {
+} catch (e: XybridException.IoError) {
     println("I/O error: ${e.message}")
 }
 ```
@@ -160,7 +160,7 @@ try {
 | `Envelope` | Factory for `XybridEnvelope` inputs (`text`, `audio`, `embedding`, `image`, `userMessage`) |
 | `XybridEnvelope` | Input data container |
 | `XybridResult` | Inference output with success/error and result data |
-| `XybridException` | Error types (ModelNotFound, InferenceFailed, etc.) |
+| `XybridException` | Error types (ModelNotFound, InferenceError, etc.) |
 
 ### XybridModel (loading)
 

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -36,20 +36,14 @@ dependencies {
 ### Loading a Model from Registry
 
 ```kotlin
-import ai.xybrid.XybridModelLoader
-import ai.xybrid.XybridEnvelope
-import ai.xybrid.XybridException
+import ai.xybrid.XybridModel
+import ai.xybrid.Envelope
 
-// Load a model from the registry
-val loader = XybridModelLoader.fromRegistry("kokoro-82m")
-val model = loader.load()
+// Load a model from the registry (the constructor resolves + loads it)
+val model = XybridModel("kokoro-82m")
 
 // Run text-to-speech
-val envelope = XybridEnvelope.Text(
-    text = "Hello, world!",
-    voiceId = "af_bella",
-    speed = 1.0
-)
+val envelope = Envelope.text("Hello, world!", voiceId = "af_bella", speed = 1.0)
 val result = model.run(envelope)
 
 if (result.success) {
@@ -63,11 +57,10 @@ if (result.success) {
 ### Loading a Model from Bundle
 
 ```kotlin
-import ai.xybrid.XybridModelLoader
+import ai.xybrid.XybridModel
 
 // Load from a local bundle path
-val loader = XybridModelLoader.fromBundle("/path/to/model/bundle")
-val model = loader.load()
+val model = XybridModel.fromBundle("/path/to/model/bundle")
 ```
 
 ### Speech Recognition (ASR)
@@ -145,8 +138,7 @@ result.reasoningContent?.let { println("Reasoning: $it") }
 import ai.xybrid.XybridException
 
 try {
-    val loader = XybridModelLoader.fromRegistry("unknown-model")
-    val model = loader.load()
+    val model = XybridModel("unknown-model")
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.modelId}")
 } catch (e: XybridException.InferenceFailed) {
@@ -164,19 +156,23 @@ try {
 
 | Type | Description |
 |------|-------------|
-| `XybridModelLoader` | Factory for loading models from registry or bundle |
-| `XybridModel` | Loaded model ready for inference |
-| `XybridEnvelope` | Input data (Audio, Text, Embedding, Image, or UserMessage) |
+| `XybridModel` | Loaded model ready for inference (construct/factory to load) |
+| `Envelope` | Factory for `XybridEnvelope` inputs (`text`, `audio`, `embedding`, `image`, `userMessage`) |
+| `XybridEnvelope` | Input data container |
 | `XybridResult` | Inference output with success/error and result data |
 | `XybridException` | Error types (ModelNotFound, InferenceFailed, etc.) |
 
-### XybridModelLoader
+### XybridModel (loading)
 
-| Method | Description |
+| Call | Description |
 |--------|-------------|
-| `fromRegistry(modelId: String)` | Load model from Xybrid registry |
-| `fromBundle(path: String)` | Load model from local bundle path |
-| `load(): XybridModel` | Fetch and load the model |
+| `XybridModel(id: String)` | Resolve and load a model from the Xybrid registry |
+| `XybridModel.fromBundle(path: String)` | Load a model from a local `.xyb` bundle |
+| `XybridModel.fromDirectory(path: String)` | Load a model from an extracted directory |
+| `XybridModel.fromHuggingface(repo: String)` | Resolve and load a HuggingFace repo |
+
+Each loads synchronously; use the `…Async` suspend variants
+(`XybridModel.fromRegistryAsync(id)`, etc.) to load off the calling thread.
 
 ### XybridEnvelope
 

--- a/docs/content/docs/guides/reasoning.mdx
+++ b/docs/content/docs/guides/reasoning.mdx
@@ -57,7 +57,7 @@ if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
 ### Kotlin
 
 ```kotlin
-val model = XybridModel.fromRegistry("lfm2.5-1.2b-thinking")
+val model = XybridModel("lfm2.5-1.2b-thinking")
 val result = model.run(Envelope.text("Is 97 a prime number? Reason, then answer."))
 
 result.text?.let { println("Answer: $it") }


### PR DESCRIPTION
## Summary

The Apple and Kotlin binding READMEs documented a `XybridModelLoader` type and an `XybridEnvelope.Text(...)` factory that no longer exist in the current bolt bindings, so their examples don't compile. Fixes them to the real APIs — Swift loads via `try XybridModel(fromRegistry:)` (plus `(fromBundle:)`/`(fromDirectory:)`/`(fromHuggingface:)`); Kotlin uses the `XybridModel(id)` constructor for the registry, `XybridModel.fromBundle/fromDirectory/fromHuggingface`, and `Envelope.text(...)` — and updates the type/API-reference tables accordingly. Also corrects the reasoning guide's Kotlin snippet, which used a non-existent `XybridModel.fromRegistry(...)` factory (a stale review suggestion) instead of `XybridModel(id)`. Verified against the binding source before editing; Dart and Rust snippets were already correct and untouched.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)