### PR TITLE
bazel(android): 3-ABI AAR via in-graph fan-out + opt/strip sizing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,11 +21,15 @@ common --repo_env=XYBRID_NDK_HOST_TAG=linux-x86_64
 # instead of the default /usr/bin/env python3 launcher.
 common --@rules_python//python/config_settings:bootstrap_impl=script
 
-# Android arm64 target config. The rustflag mirrors .cargo/config.toml's
-# [target.aarch64-linux-android] +fp16 (gemm-f16 FP16 SIMD asm; runtime-detected,
-# scalar fallback). extra_rustc_flags is target-config-only (exec tools unaffected).
+# Android per-ABI target configs (shipping semantics: opt + the toolchain's
+# per-triple flags — +fp16 lives on the rust toolchain in MODULE.bazel now, so
+# it also applies under build-graph transitions, not just these configs).
 build:android-arm64 --platforms=@rules_rs//rs/platforms:aarch64-linux-android
-build:android-arm64 --@rules_rust//rust/settings:extra_rustc_flags=-Ctarget-feature=+fp16
+build:android-arm64 --compilation_mode=opt
+build:android-armv7 --platforms=@rules_rs//rs/platforms:armv7-linux-androideabi
+build:android-armv7 --compilation_mode=opt
+build:android-x86_64 --platforms=@rules_rs//rs/platforms:x86_64-linux-android
+build:android-x86_64 --compilation_mode=opt
 
 # On Linux hosts, rules_rs' experimental toolchains need an explicit host platform
 # with libc constraints (//:host_linux_gnu, root BUILD.bazel). The enable flag

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -133,3 +133,35 @@ jobs:
           name: bazel-xybrid-kotlin-aar
           path: bazel-bin/bindings/kotlin/xybrid-kotlin.aar
           retention-days: 7
+
+      # Gradle-consumer smoke: a real AGP app consumes the Bazel AAR the way a
+      # Maven consumer would — manifest parses, classes.jar dexes, and all three
+      # ABIs' native libs land in the APK. Runner ships the Android SDK.
+      - name: Set up JDK 17 (consumer smoke)
+        if: env.BUILDBUDDY_API_KEY != ''
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Gradle-consumer smoke of the Bazel AAR
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          mkdir -p bindings/kotlin/consumer-smoke/app/libs
+          cp bazel-bin/bindings/kotlin/xybrid-kotlin.aar bindings/kotlin/consumer-smoke/app/libs/
+          bindings/kotlin/gradlew -p bindings/kotlin/consumer-smoke :app:assembleDebug --no-daemon
+
+      - name: Verify APK payload (classes + 3-ABI jniLibs)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          APK=bindings/kotlin/consumer-smoke/app/build/outputs/apk/debug/app-debug.apk
+          unzip -l "$APK"
+          for f in \
+            lib/arm64-v8a/libxybrid-bolt.so lib/arm64-v8a/libc++_shared.so lib/arm64-v8a/libonnxruntime.so \
+            lib/armeabi-v7a/libxybrid-bolt.so lib/armeabi-v7a/libc++_shared.so \
+            lib/x86_64/libxybrid-bolt.so lib/x86_64/libc++_shared.so lib/x86_64/libonnxruntime.so \
+            classes.dex; do
+            unzip -l "$APK" | grep -q " $f\$" || { echo "MISSING: $f"; exit 1; }
+          done
+          echo "APK payload complete: 3-ABI jniLibs + classes.dex ✅"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -117,11 +117,13 @@ jobs:
             //crates/xybrid-llama:xybrid_llama
 
       # The RBE-proven Android row (PR #326 gates 6-10): NDK cross-compile +
-      # one-link .so + complete AAR.
+      # one-link .so + complete AAR. ABI fan-out (arm64-v8a / armeabi-v7a /
+      # x86_64) happens via transitions inside the graph — one invocation,
+      # shipping mode (-c opt + link-time strip).
       - name: Build Android AAR on RBE
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          bazelisk build --config=remote --config=android-arm64 \
+          bazelisk build --config=remote -c opt \
             //bindings/kotlin:xybrid_kotlin_aar
 
       - name: Upload AAR artifact

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,9 @@ claudedocs/
 # Cargo.lock is authoritative. A lockfile here is spurious (cargo ignores it)
 # but vuln scanners would read its stale contents — keep it out of the repo.
 /bindings/flutter/rust/Cargo.lock
+
+# Bazel-AAR consumer smoke (bindings/kotlin/consumer-smoke): transient build
+# state + the AAR copied in by the smoke step. Sources are committed.
+bindings/kotlin/consumer-smoke/.gradle/
+bindings/kotlin/consumer-smoke/app/build/
+bindings/kotlin/consumer-smoke/app/libs/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,25 +37,54 @@ filegroup(
 # "graph node" llama target the evaluation's Option B describes.
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
+# Base llama cmake configuration (CPU-only, hermetic on desktop: Metal OFF).
+_LLAMA_CACHE_ENTRIES = {
+    "CMAKE_BUILD_TYPE": "Release",
+    "BUILD_SHARED_LIBS": "OFF",
+    "LLAMA_BUILD_EXAMPLES": "OFF",
+    "LLAMA_BUILD_TESTS": "OFF",
+    "LLAMA_BUILD_TOOLS": "OFF",
+    "LLAMA_BUILD_SERVER": "OFF",
+    "LLAMA_BUILD_COMMON": "OFF",
+    "LLAMA_CURL": "OFF",
+    "GGML_OPENMP": "OFF",
+    "GGML_NATIVE": "OFF",  # reproducible: no -march=native
+    "GGML_METAL": "OFF",  # <-- the key: no Apple GPU => no Xcode => hermetic
+    "GGML_ACCELERATE": "OFF",
+    "GGML_BLAS": "OFF",
+    "GGML_CUDA": "OFF",
+    "GGML_VULKAN": "OFF",
+}
+
 cmake(
     name = "llama",
-    cache_entries = {
-        "CMAKE_BUILD_TYPE": "Release",
-        "BUILD_SHARED_LIBS": "OFF",
-        "LLAMA_BUILD_EXAMPLES": "OFF",
-        "LLAMA_BUILD_TESTS": "OFF",
-        "LLAMA_BUILD_TOOLS": "OFF",
-        "LLAMA_BUILD_SERVER": "OFF",
-        "LLAMA_BUILD_COMMON": "OFF",
-        "LLAMA_CURL": "OFF",
-        "GGML_OPENMP": "OFF",
-        "GGML_NATIVE": "OFF",  # reproducible: no -march=native
-        "GGML_METAL": "OFF",  # <-- the key: no Apple GPU => no Xcode => hermetic
-        "GGML_ACCELERATE": "OFF",
-        "GGML_BLAS": "OFF",
-        "GGML_CUDA": "OFF",
-        "GGML_VULKAN": "OFF",
-    },
+    # armv7: rfcc's crosstool has no CMAKE_SYSTEM_PROCESSOR mapping for armv7,
+    # so cmake falls back to the EXEC machine's uname (x86_64 RBE worker) and
+    # ggml's arch detection applies x86 SIMD flags (-mavx/-mf16c/…) to the arm
+    # compile. CMAKE_SYSTEM_* set via cache_entries are absorbed into the
+    # generated toolchain file (a plain -D is overridden by it), steering ggml
+    # onto its ARM path. (aarch64/x86_64 map correctly on their own.)
+    # Android mirrors build.rs's mobile cmake block: GGML_LLAMAFILE=OFF
+    # (llamafile's sgemm uses NEON fp16 intrinsics armv7 doesn't have; today's
+    # pipeline disables it on android across the board). armv7 additionally
+    # needs the CMAKE_SYSTEM pair: rfcc only honors CMAKE_SYSTEM_PROCESSOR
+    # (moving it into the generated crossfile) when CMAKE_SYSTEM_NAME is
+    # user-set — without them ggml detects the EXEC worker's x86_64 and applies
+    # x86 SIMD flags to the arm compile (verified in the configure log).
+    cache_entries = select({
+        "@rules_rs//rs/platforms/config:armv7-linux-androideabi": _LLAMA_CACHE_ENTRIES | {
+            "CMAKE_SYSTEM_NAME": "Linux",
+            "CMAKE_SYSTEM_PROCESSOR": "arm",
+            "GGML_LLAMAFILE": "OFF",
+        },
+        "@rules_rs//rs/platforms/config:aarch64-linux-android": _LLAMA_CACHE_ENTRIES | {
+            "GGML_LLAMAFILE": "OFF",
+        },
+        "@rules_rs//rs/platforms/config:x86_64-linux-android": _LLAMA_CACHE_ENTRIES | {
+            "GGML_LLAMAFILE": "OFF",
+        },
+        "//conditions:default": _LLAMA_CACHE_ENTRIES,
+    }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
     # rfcc finds its own downloaded cmake; /opt/homebrew doesn't exist there.)
     lib_source = ":llama_src",
@@ -85,12 +114,18 @@ cc_library(
     srcs = ["ndk_smoke.c"],
 )
 
-# Vendored Android runtime libs (dlopened at runtime): libonnxruntime.so +
-# libc++_shared.so per ABI. Explicit graph nodes for the AAR jni payload.
-# NOTE: c++_shared should track the link NDK (r27) — follow-up: source it from
-# @androidndk's sysroot instead of the vendored copy.
+# Vendored ONNX Runtime (dlopened at runtime), per ABI that ships it — armv7
+# has no vendored ORT (matches today's AAR). libc++_shared.so is NOT taken from
+# vendor anymore: it comes from @androidndk's sysroot, version-matched to the
+# NDK that linked the .so (see bindings/kotlin/BUILD.bazel).
 filegroup(
-    name = "ort_android_arm64_libs",
-    srcs = glob(["vendor/ort-android/arm64-v8a/*.so"]),
+    name = "ort_android_arm64",
+    srcs = ["vendor/ort-android/arm64-v8a/libonnxruntime.so"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "ort_android_x86_64",
+    srcs = ["vendor/ort-android/x86_64/libonnxruntime.so"],
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,6 +72,12 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 # same move as the NDK). kotlinx-coroutines is the one real compile dep (JNA is
 # gradle-declared but unreferenced) -> a single pinned http_jar, no rules_jvm_external.
 bazel_dep(name = "rules_kotlin", version = "2.4.0")  # >=2.2 needed for Bazel 9 (JavaPluginInfo removal)
+
+# Kotlin-1.9-consumer-compatible metadata for the AAR's classes.jar (language
+# mode 2.0 = the modern compiler's floor, readable by 1.9 consumers; see the
+# toolchain comment in bindings/kotlin/BUILD.bazel — caught by the consumer
+# smoke). Root registrations take precedence over rules_kotlin's default.
+register_toolchains("//bindings/kotlin:kotlin_toolchain_consumer_compat")
 # Direct dep so http_jar's generated repo (loads @rules_java//java:java_import.bzl)
 # resolves; Bazel 9 removed native java_import. MVS bumps to whatever kotlin needs.
 bazel_dep(name = "rules_java", version = "8.11.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,18 @@ module(name = "xybrid_bazel_spike", version = "0.0.0")
 # --- hermeticbuild stack, pinned from the Bazel Central Registry (replaces the
 # earlier git_override commit pins; re-validated on RBE at these versions).
 bazel_dep(name = "rules_rs", version = "0.0.95")
+
+# rules_rs resolver fix (report upstream): 3-part android triples fold the abi
+# into the os token (armv7-linux-androideabi), so _normalize_os must map
+# "androideabi" -> "android" — otherwise the triple is not unix and every
+# cfg(unix) / cfg(target_os="android") dep is silently dropped for armv7
+# (libloading lost cfg-if, dirs-sys lost libc, ...).
+single_version_override(
+    module_name = "rules_rs",
+    patch_strip = 1,
+    patches = ["//:rules_rs.patch"],
+    version = "0.0.95",
+)
 bazel_dep(name = "llvm", version = "0.8.11")
 bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
@@ -51,6 +63,9 @@ single_version_override(
 # workers as an action input (same mechanism as the bazelified NDK).
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_python", version = "1.7.0")
+# platform_transition_filegroup: build the SAME cdylib target for each Android
+# ABI inside one graph (the AAR packages all ABIs in a single zip).
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 # --- Gate 10: classes.jar. Kotlin sources import android.* -> compile against a
 # BAZELIFIED android.jar (platforms;android-34, pinned zip from dl.google.com —
@@ -131,6 +146,16 @@ use_repo(rules_rust, "rules_rust")
 toolchains = use_extension("@rules_rs//rs/toolchains:module_extension.bzl", "toolchains")
 toolchains.toolchain(
     edition = "2021",
+    # Per-triple rustc flags travel WITH the toolchain (the Bazel analog of
+    # .cargo/config's [target.<triple>] rustflags), so they apply under both
+    # --platforms and build-graph transitions. +fp16: gemm-f16's FP16 SIMD asm
+    # needs the assembler to accept the instructions (runtime-detected, scalar
+    # fallback) — mirrors .cargo/config.toml exactly.
+    extra_rustc_flags = {
+        "aarch64-apple-ios": ["-Ctarget-feature=+fp16"],
+        "aarch64-apple-ios-sim": ["-Ctarget-feature=+fp16"],
+        "aarch64-linux-android": ["-Ctarget-feature=+fp16"],
+    },
     version = "1.92.0",
 )
 use_repo(toolchains, "default_rust_toolchains")
@@ -148,6 +173,8 @@ crate.from_cargo(
         "x86_64-unknown-linux-gnu",
         "aarch64-apple-darwin",
         "aarch64-linux-android",
+        "armv7-linux-androideabi",
+        "x86_64-linux-android",
     ],
 )
 crate.annotation(

--- a/bindings/kotlin/BUILD.bazel
+++ b/bindings/kotlin/BUILD.bazel
@@ -1,20 +1,77 @@
-# GATE 9 — the Android AAR payload, assembled by Bazel (replaces the
-# build-android-bolt.sh copy loop + the .so→zip→Gradle hand-off).
+# The Android AAR, assembled by Bazel (replaces the build-android-bolt.sh copy
+# loop + the .so→zip→Gradle hand-off).
 #
-# What's here: the per-ABI jni tree with the ONE-LINK .so from Gate 8 (renamed
-# to the name the Kotlin loader expects) + the vendored dlopen runtime libs,
-# zipped into an .aar skeleton with the manifest.
-# NOT here yet (next gate): classes.jar — compiling Xybrid.kt/XybridBolt.kt
-# needs android.jar (sources import android.content/os); that's a bazelified
-# platforms;android-34 jar + rules_kotlin. Gradle remains the classes/publish
-# owner until then.
+# ABI fan-out happens INSIDE the graph: platform_transition_filegroup builds the
+# same cdylib target once per Android platform, so ONE plain invocation
+# (`bazel build [-c opt] //bindings/kotlin:xybrid_kotlin_aar`) produces the
+# 3-ABI AAR — no per-ABI --config needed. Per-triple rustc flags (+fp16 on
+# arm64) live on the rust toolchain (MODULE.bazel), so they apply under
+# transitions too.
+#
+# jni payload per ABI:
+#   libxybrid-bolt.so   — the one-link cdylib (renamed: rustc emits underscore,
+#                         Kotlin's System.loadLibrary("xybrid-bolt") wants hyphen)
+#   libc++_shared.so    — from @androidndk's sysroot (version-matched to the
+#                         NDK that linked the .so; no vendored drift)
+#   libonnxruntime.so   — vendored, arm64-v8a + x86_64 only (armv7 ships no ORT,
+#                         matching today's AAR)
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 
-# GATE 10 — classes.jar: the committed Kotlin sources (hand Xybrid.kt +
-# bolt-generated XybridBolt.kt) compiled by hermetic kotlinc against the
-# bazelified android.jar (neverlink) + the pinned coroutines jar.
+# (abi dir, rules_rs platform, NDK target_system_name, ships vendored ORT)
+ANDROID_ABIS = [
+    ("arm64-v8a", "@rules_rs//rs/platforms:aarch64-linux-android", "aarch64-linux-android", True),
+    ("armeabi-v7a", "@rules_rs//rs/platforms:armv7-linux-androideabi", "arm-linux-androideabi", False),
+    ("x86_64", "@rules_rs//rs/platforms:x86_64-linux-android", "x86_64-linux-android", True),
+]
+
+# The NDK repo's clang dir is pinned to linux-x86_64 binaries by
+# XYBRID_NDK_HOST_TAG in the committed .bazelrc (RBE workers run them).
+NDK_SYSROOT = "@androidndk//toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+
+[
+    platform_transition_filegroup(
+        name = "bolt_so_" + abi,
+        srcs = ["//crates/xybrid-bolt:xybrid_bolt_cdylib"],
+        target_platform = platform,
+    )
+    for abi, platform, _, _ in ANDROID_ABIS
+]
+
+[
+    pkg_files(
+        name = "jni_bolt_" + abi,
+        srcs = [":bolt_so_" + abi],
+        prefix = "jni/" + abi,
+        renames = {":bolt_so_" + abi: "libxybrid-bolt.so"},
+    )
+    for abi, _, _, _ in ANDROID_ABIS
+]
+
+[
+    pkg_files(
+        name = "jni_cxx_" + abi,
+        srcs = ["%s:libcxx_shared_%s" % (NDK_SYSROOT, tsn)],
+        prefix = "jni/" + abi,
+    )
+    for abi, _, tsn, _ in ANDROID_ABIS
+]
+
+[
+    pkg_files(
+        name = "jni_ort_" + abi,
+        srcs = ["//:ort_android_" + abi.replace("-v8a", "")],
+        prefix = "jni/" + abi,
+    )
+    for abi, _, _, has_ort in ANDROID_ABIS
+    if has_ort
+]
+
+# classes.jar: the committed Kotlin sources (hand Xybrid.kt + bolt-generated
+# XybridBolt.kt) compiled by hermetic kotlinc against the bazelified android.jar
+# (neverlink) + the pinned coroutines jar.
 kt_jvm_library(
     name = "xybrid_kotlin_classes",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
@@ -24,31 +81,6 @@ kt_jvm_library(
     ],
 )
 
-# Gate-8 .so, renamed at package time: rustc emits libxybrid_bolt.so (underscore);
-# Kotlin's System.loadLibrary("xybrid-bolt") expects libxybrid-bolt.so (hyphen).
-pkg_files(
-    name = "jni_bolt_arm64",
-    srcs = ["//crates/xybrid-bolt:xybrid_bolt_cdylib"],
-    prefix = "jni/arm64-v8a",
-    renames = {
-        "//crates/xybrid-bolt:xybrid_bolt_cdylib": "libxybrid-bolt.so",
-    },
-)
-
-# dlopened runtime libs (libonnxruntime.so + libc++_shared.so), vendored.
-pkg_files(
-    name = "jni_runtime_arm64",
-    srcs = ["//:ort_android_arm64_libs"],
-    prefix = "jni/arm64-v8a",
-)
-
-pkg_files(
-    name = "aar_manifest",
-    srcs = ["bazel/AndroidManifest.xml"],
-    renames = {"bazel/AndroidManifest.xml": "AndroidManifest.xml"},
-)
-
-# classes.jar + (empty) R.txt — the pieces AGP consumers require of an AAR.
 pkg_files(
     name = "aar_classes",
     # The predeclared jar output (the bare target also carries the srcjar,
@@ -58,21 +90,26 @@ pkg_files(
 )
 
 pkg_files(
+    name = "aar_manifest",
+    srcs = ["bazel/AndroidManifest.xml"],
+    renames = {"bazel/AndroidManifest.xml": "AndroidManifest.xml"},
+)
+
+pkg_files(
     name = "aar_rtxt",
     srcs = ["bazel/R.txt"],
     renames = {"bazel/R.txt": "R.txt"},
 )
 
-# The AAR: manifest + classes.jar + R.txt + jni.
 pkg_zip(
     name = "xybrid_kotlin_aar",
     srcs = [
         ":aar_classes",
         ":aar_manifest",
         ":aar_rtxt",
-        ":jni_bolt_arm64",
-        ":jni_runtime_arm64",
-    ],
+    ] + [":jni_bolt_" + abi for abi, _, _, _ in ANDROID_ABIS] +
+        [":jni_cxx_" + abi for abi, _, _, _ in ANDROID_ABIS] +
+        [":jni_ort_" + abi for abi, _, _, has_ort in ANDROID_ABIS if has_ort],
     out = "xybrid-kotlin.aar",
     visibility = ["//visibility:public"],
 )

--- a/bindings/kotlin/BUILD.bazel
+++ b/bindings/kotlin/BUILD.bazel
@@ -16,9 +16,22 @@
 #   libonnxruntime.so   — vendored, arm64-v8a + x86_64 only (armv7 ships no ORT,
 #                         matching today's AAR)
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+
+# Consumer-compatibility toolchain (registered in MODULE.bazel): rules_kotlin
+# 2.4's bundled kotlinc emits Kotlin 2.1 METADATA by default, which the shipped
+# ecosystem pin (Kotlin 1.9.22, settings.gradle.kts) cannot read — caught by
+# the consumer smoke ("metadata version 2.1.0, expected 1.9.0; can read up to
+# 2.0.0"). kotlinc 2.x no longer supports language mode 1.9, so 2.0 is the
+# floor — and its metadata (2.0.x) is within the 1.9 compiler's read range.
+define_kt_toolchain(
+    name = "kotlin_toolchain_consumer_compat",
+    api_version = "2.0",
+    language_version = "2.0",
+)
 
 # (abi dir, rules_rs platform, NDK target_system_name, ships vendored ORT)
 ANDROID_ABIS = [

--- a/bindings/kotlin/BUILD.bazel
+++ b/bindings/kotlin/BUILD.bazel
@@ -33,11 +33,11 @@ define_kt_toolchain(
     language_version = "2.0",
 )
 
-# (abi dir, rules_rs platform, NDK target_system_name, ships vendored ORT)
+# (abi dir, rules_rs platform, NDK target_system_name, vendored-ORT label or None)
 ANDROID_ABIS = [
-    ("arm64-v8a", "@rules_rs//rs/platforms:aarch64-linux-android", "aarch64-linux-android", True),
-    ("armeabi-v7a", "@rules_rs//rs/platforms:armv7-linux-androideabi", "arm-linux-androideabi", False),
-    ("x86_64", "@rules_rs//rs/platforms:x86_64-linux-android", "x86_64-linux-android", True),
+    ("arm64-v8a", "@rules_rs//rs/platforms:aarch64-linux-android", "aarch64-linux-android", "//:ort_android_arm64"),
+    ("armeabi-v7a", "@rules_rs//rs/platforms:armv7-linux-androideabi", "arm-linux-androideabi", None),
+    ("x86_64", "@rules_rs//rs/platforms:x86_64-linux-android", "x86_64-linux-android", "//:ort_android_x86_64"),
 ]
 
 # The NDK repo's clang dir is pinned to linux-x86_64 binaries by
@@ -75,11 +75,11 @@ NDK_SYSROOT = "@androidndk//toolchains/llvm/prebuilt/linux-x86_64/sysroot"
 [
     pkg_files(
         name = "jni_ort_" + abi,
-        srcs = ["//:ort_android_" + abi.replace("-v8a", "")],
+        srcs = [ort_target],
         prefix = "jni/" + abi,
     )
-    for abi, _, _, has_ort in ANDROID_ABIS
-    if has_ort
+    for abi, _, _, ort_target in ANDROID_ABIS
+    if ort_target
 ]
 
 # classes.jar: the committed Kotlin sources (hand Xybrid.kt + bolt-generated
@@ -122,7 +122,7 @@ pkg_zip(
         ":aar_rtxt",
     ] + [":jni_bolt_" + abi for abi, _, _, _ in ANDROID_ABIS] +
         [":jni_cxx_" + abi for abi, _, _, _ in ANDROID_ABIS] +
-        [":jni_ort_" + abi for abi, _, _, has_ort in ANDROID_ABIS if has_ort],
+        [":jni_ort_" + abi for abi, _, _, ort_target in ANDROID_ABIS if ort_target],
     out = "xybrid-kotlin.aar",
     visibility = ["//visibility:public"],
 )

--- a/bindings/kotlin/consumer-smoke/app/build.gradle.kts
+++ b/bindings/kotlin/consumer-smoke/app/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "ai.xybrid.smoke"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "ai.xybrid.smoke"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.0.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    // The Bazel-built AAR, copied here by the smoke step (gitignored).
+    implementation(files("libs/xybrid-kotlin.aar"))
+    // The AAR's transitive runtime dep. A Maven consumer gets this from the
+    // POM; a local-file AAR carries no metadata, so declare it explicitly.
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+}

--- a/bindings/kotlin/consumer-smoke/app/src/main/AndroidManifest.xml
+++ b/bindings/kotlin/consumer-smoke/app/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/bindings/kotlin/consumer-smoke/app/src/main/kotlin/ai/xybrid/smoke/Smoke.kt
+++ b/bindings/kotlin/consumer-smoke/app/src/main/kotlin/ai/xybrid/smoke/Smoke.kt
@@ -1,0 +1,13 @@
+package ai.xybrid.smoke
+
+/**
+ * Compile-time proof the AAR's classes resolve from a consumer: references to
+ * the public surface force kotlinc + d8 to load them from classes.jar.
+ */
+object Smoke {
+    val entrypoints = listOf(
+        ai.xybrid.Xybrid::class,
+        ai.xybrid.Envelope::class,
+        ai.xybrid.XybridEnvelope::class,
+    )
+}

--- a/bindings/kotlin/consumer-smoke/gradle.properties
+++ b/bindings/kotlin/consumer-smoke/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g

--- a/bindings/kotlin/consumer-smoke/settings.gradle.kts
+++ b/bindings/kotlin/consumer-smoke/settings.gradle.kts
@@ -1,0 +1,26 @@
+// Consumer smoke for the BAZEL-built AAR: a minimal real AGP app that consumes
+// bindings/kotlin's Bazel output (copied into app/libs/ by the CI step) the way
+// a Maven consumer would — proves the manifest parses, classes.jar dexes, and
+// all three ABIs' jniLibs land in the APK. Versions mirror ../settings.gradle.kts.
+pluginManagement {
+    plugins {
+        id("com.android.application") version "8.2.2"
+        kotlin("android") version "1.9.22"
+    }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "xybrid-aar-consumer-smoke"
+include(":app")

--- a/crates/xybrid-bolt/BUILD.bazel
+++ b/crates/xybrid-bolt/BUILD.bazel
@@ -33,6 +33,9 @@ rust_shared_library(
             "-Clink-arg=-lc++_shared",
             "-Clink-arg=-llog",
             "-Clink-arg=-Wl,-z,max-page-size=16384",
+            # Strip the symtab at link time (keeps dynsym — the JNI/dlopen
+            # exports). Replaces the pipeline's post-hoc llvm-strip.
+            "-Cstrip=symbols",
         ],
         "//conditions:default": [],
     }),

--- a/rules_android_ndk.patch
+++ b/rules_android_ndk.patch
@@ -1,5 +1,26 @@
---- a/rules.bzl	2026-07-08 10:46:44
-+++ b/rules.bzl	2026-07-08 10:46:44
+diff --color -ru a/BUILD.ndk_sysroot.tpl b/BUILD.ndk_sysroot.tpl
+--- a/BUILD.ndk_sysroot.tpl	2026-07-08 11:15:00
++++ b/BUILD.ndk_sysroot.tpl	2026-07-08 11:15:00
+@@ -19,6 +19,16 @@
+     ], allow_empty = True),
+ ) for target_system_name in TARGET_SYSTEM_NAMES]
+ 
++# xybrid spike patch: the exact libc++_shared.so per ABI, for bundling into
++# the AAR jni dirs (version-matched to the NDK that linked the .so).
++[filegroup(
++    name = "libcxx_shared_%s" % target_system_name,
++    srcs = glob(
++        ["usr/lib/%s/libc++_shared.so" % target_system_name],
++        allow_empty = True,
++    ),
++) for target_system_name in TARGET_SYSTEM_NAMES]
++
+ [filegroup(
+     name = "dynamic_runtime_lib_%s" % target_system_name,
+     srcs = glob([
+diff --color -ru a/rules.bzl b/rules.bzl
+--- a/rules.bzl	2026-07-08 11:15:00
++++ b/rules.bzl	2026-07-08 11:15:00
 @@ -23,16 +23,41 @@
      Returns:
          A final dict of configuration attributes and values.

--- a/rules_rs.patch
+++ b/rules_rs.patch
@@ -1,0 +1,32 @@
+diff --color -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
+--- a/rs/private/cfg_parser.bzl	2026-07-08 11:24:16
++++ b/rs/private/cfg_parser.bzl	2026-07-08 11:26:23
+@@ -148,6 +148,13 @@
+ def _normalize_os(os_raw):
+     if os_raw == "darwin":
+         return "macos"
++    # xybrid patch: 3-part android triples fold the abi into the os token
++    # (armv7-linux-androideabi, arm-linux-androideabi). Without this, target_os
++    # != "android" and the triple is not unix, so every cfg(unix)/
++    # cfg(target_os = "android") dependency is silently dropped for armv7
++    # (observed: libloading losing cfg-if, dirs-sys losing libc).
++    if os_raw == "androideabi":
++        return "android"
+     return os_raw
+ 
+ def _family_for_os(os_name):
+@@ -212,6 +219,14 @@
+ def triple_to_cfg_attrs(triple):
+     parts = triple.split("-")
+     arch_part = _get(parts, 0, "")
++
++    # xybrid patch: rustc normalizes 32-bit arm arch variants to
++    # target_arch = "arm" (armv7-linux-androideabi has target_arch "arm", not
++    # "armv7"). Without this, cfg(target_arch = "arm") deps are silently
++    # dropped (observed: zip 1.x losing crossbeam-utils, its 32-bit-arm
++    # atomics polyfill). aarch64 does not start with "arm" so it is unaffected.
++    if arch_part.startswith("arm"):
++        arch_part = "arm"
+     vendor_part = _get(parts, 1, "unknown")
+     os_raw_part = _get(parts, 2, "none")
+     env_part = "-".join(parts[3:])

--- a/rules_rs.patch
+++ b/rules_rs.patch
@@ -1,6 +1,6 @@
 diff --color -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
---- a/rs/private/cfg_parser.bzl	2026-07-08 11:24:16
-+++ b/rs/private/cfg_parser.bzl	2026-07-08 11:26:23
+--- a/rs/private/cfg_parser.bzl	2026-07-08 13:05:37
++++ b/rs/private/cfg_parser.bzl	2026-07-08 13:05:37
 @@ -148,6 +148,13 @@
  def _normalize_os(os_raw):
      if os_raw == "darwin":
@@ -15,17 +15,20 @@ diff --color -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
      return os_raw
  
  def _family_for_os(os_name):
-@@ -212,6 +219,14 @@
+@@ -212,6 +219,17 @@
  def triple_to_cfg_attrs(triple):
      parts = triple.split("-")
      arch_part = _get(parts, 0, "")
 +
-+    # xybrid patch: rustc normalizes 32-bit arm arch variants to
-+    # target_arch = "arm" (armv7-linux-androideabi has target_arch "arm", not
-+    # "armv7"). Without this, cfg(target_arch = "arm") deps are silently
-+    # dropped (observed: zip 1.x losing crossbeam-utils, its 32-bit-arm
-+    # atomics polyfill). aarch64 does not start with "arm" so it is unaffected.
-+    if arch_part.startswith("arm"):
++    # xybrid patch: mirror rustc's arch normalization. arm64/arm64e/arm64_32
++    # (Apple spellings) have target_arch = "aarch64"; every other arm* variant
++    # (armv7, armv5te, ...) has target_arch = "arm". Without this,
++    # cfg(target_arch = "arm") deps are silently dropped for armv7 (observed:
++    # zip 1.x losing crossbeam-utils, its 32-bit-arm atomics polyfill) — and a
++    # bare startswith("arm") would misclassify arm64* as 32-bit.
++    if arch_part.startswith("arm64"):
++        arch_part = "aarch64"
++    elif arch_part.startswith("arm"):
 +        arch_part = "arm"
      vendor_part = _get(parts, 1, "unknown")
      os_raw_part = _get(parts, 2, "none")


### PR DESCRIPTION
## Summary

Phase-2 step 1: one plain \`bazel build -c opt //bindings/kotlin:xybrid_kotlin_aar\` now assembles the complete 3-ABI AAR (arm64-v8a / armeabi-v7a / x86_64) — fan-out happens inside the graph via \`platform_transition_filegroup\`, \`+fp16\` moves onto the rust toolchain's per-triple flags so it survives transitions, and \`-Cstrip=symbols\` + \`-c opt\` take the arm64 \`.so\` from 100.4MB to **15.4MB** (ELF machine + 16KB alignment verified on all three ABIs). \`libc++_shared.so\` is now per-ABI from \`@androidndk\`'s sysroot (NDK-version-matched); armv7 ships no ORT, matching today's AAR. Includes a two-line-root-cause \`rules_rs.patch\` for two resolver bugs worth upstreaming (the \`androideabi\` os token and \`armv7\` arch token are never normalized, silently dropping \`cfg(unix)\`/\`cfg(target_arch="arm")\` deps), plus llama's android cmake config mirroring \`build.rs\`'s mobile block (\`GGML_LLAMAFILE=OFF\`, armv7 \`CMAKE_SYSTEM\` pair). Validated end-to-end on BuildBuddy RBE; the advisory bazel.yml re-validates on this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below)

Bazel Phase-2: Android ABI fan-out + artifact sizing (advisory pipeline only; cargo untouched).

## Checklist

- [ ] Tests pass (\`cargo test\`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)