### PR TITLE
docs: fix stale loader/exception APIs in Android example README

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -137,7 +137,7 @@ import ai.xybrid.XybridException
 import ai.xybrid.displayMessage
 
 try {
-    val model = XybridModel.fromBundle("/path/to/model/directory")
+    val model = XybridModel.fromBundle("/path/to/model.xyb")
     // Model ready for inference
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.displayMessage}")

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -5,9 +5,9 @@ This is a native Android example app demonstrating how to integrate the Xybrid S
 ## Features
 
 - **SDK Initialization**: Shows proper SDK startup flow with loading and error states
-- **Model Loading**: Loads models from a local bundle path using `XybridModelLoader.fromBundle()`
+- **Model Loading**: Loads models from a local bundle path using `XybridModel.fromBundle()`
 - **TTS Inference**: Runs text-to-speech inference with result display and latency metrics from `XybridResult.latencyMs`
-- **Error Handling**: Displays `XybridException` messages (ModelNotFound, InferenceFailed, InvalidInput, IoException)
+- **Error Handling**: Displays `XybridException` messages (ModelNotFound, InferenceError, IoError, etc.)
 - **Jetpack Compose UI**: Modern declarative UI with Material 3 design
 - **Proper Async Handling**: Uses Kotlin coroutines for all SDK operations on `Dispatchers.IO`
 
@@ -132,17 +132,16 @@ The app defaults to `<app-files-dir>/models/kokoro-82m` — you can edit the pat
 ### Model Loading (from bundle)
 
 ```kotlin
-import ai.xybrid.XybridModelLoader
+import ai.xybrid.XybridModel
 import ai.xybrid.XybridException
 import ai.xybrid.displayMessage
 
 try {
-    val loader = XybridModelLoader.fromBundle("/path/to/model/directory")
-    val model = loader.load()
+    val model = XybridModel.fromBundle("/path/to/model/directory")
     // Model ready for inference
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.displayMessage}")
-} catch (e: XybridException.IoException) {
+} catch (e: XybridException.IoError) {
     println("I/O error: ${e.displayMessage}")
 }
 ```
@@ -199,8 +198,7 @@ import ai.xybrid.displayMessage
 suspend fun loadAndRun(path: String, text: String) {
     withContext(Dispatchers.IO) {
         try {
-            val loader = XybridModelLoader.fromBundle(path)
-            val model = loader.load()
+            val model = XybridModel.fromBundle(path)
             val result = model.run(Envelope.text(text))
             // Handle result...
         } catch (e: XybridException) {


### PR DESCRIPTION
## Summary

The Android example README documented APIs that no longer exist in the current bolt bindings, so its Kotlin snippets don't compile — the same class of bug #333 fixed in the Apple/Kotlin binding READMEs, still present here. Replaces `XybridModelLoader.fromBundle(...).load()` with `XybridModel.fromBundle(...)` (there is no `XybridModelLoader`), and corrects the exception variants (`InferenceFailed` → `InferenceError`, `IoException` → `IoError`, dropping the non-existent `InvalidInput`) in both the code examples and the Features list. Verified against `XybridBolt.kt`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)