### PR TITLE
ci(unity): drop the obsolete xybrid-unity-sdk tarball

### DIFF
--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -587,39 +587,3 @@ jobs:
           name: unity-native-bundles
           path: dist/xybrid-unity-native*
           if-no-files-found: error
-
-      - name: Create SDK archive
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          tar -czf "xybrid-unity-sdk-${VERSION}.tar.gz" -C bindings unity
-          echo "Created xybrid-unity-sdk-${VERSION}.tar.gz"
-          ls -lh "xybrid-unity-sdk-${VERSION}.tar.gz"
-
-      - name: Upload Unity SDK package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: unity-sdk-package
-          path: xybrid-unity-sdk-*.tar.gz
-          if-no-files-found: error
-
-      - name: Upload to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          # The release is created by release.yml which runs in parallel.
-          # Wait up to 10 minutes for it to appear, checking every 30 seconds.
-          for i in $(seq 1 20); do
-            if gh release view "v${VERSION}" > /dev/null 2>&1; then
-              echo "Release v${VERSION} found — uploading Unity SDK..."
-              gh release upload "v${VERSION}" "xybrid-unity-sdk-${VERSION}.tar.gz" --clobber
-              echo "Upload complete."
-              exit 0
-            fi
-            echo "Waiting for release v${VERSION} to be created by release.yml... (attempt $i/20)"
-            sleep 30
-          done
-          echo "WARNING: Release v${VERSION} was not created within 10 minutes."
-          echo "Unity SDK is available as a CI artifact — upload manually with:"
-          echo "  gh release upload v${VERSION} xybrid-unity-sdk-${VERSION}.tar.gz --clobber"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -778,7 +778,7 @@ jobs:
             echo "- Precompiled native libraries auto-downloaded by cargokit"
             echo
             echo "**Unity**"
-            echo "- \`xybrid-unity-sdk-${TAG}.tar.gz\` — Native plugins (uploaded by Build Unity workflow)"
+            echo "- Install via OpenUPM (\`openupm add ai.xybrid.sdk\`); native libraries are published as \`xybrid-unity-native-<platform>-${TAG}.zip\` bundles + manifest (uploaded post-release by Build Unity) and fetched at import by the SDK"
             echo
             echo "**Swift (iOS/macOS)**"
             echo "- SPM: \`.package(url: \"https://github.com/${{ github.repository }}\", from: \"${TAG#v}\")\`"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -775,7 +775,7 @@ jobs:
           echo "- Precompiled native libraries auto-downloaded by cargokit (no Rust toolchain required)" >> CHANGELOG_RELEASE.md
           echo "" >> CHANGELOG_RELEASE.md
           echo "**Unity**" >> CHANGELOG_RELEASE.md
-          echo "- \`xybrid-unity-sdk-${CURRENT_TAG}.tar.gz\` - Native plugins for all platforms (uploaded by Build Unity workflow)" >> CHANGELOG_RELEASE.md
+          echo "- Install via OpenUPM (\`openupm add ai.xybrid.sdk\`); native libraries are published as \`xybrid-unity-native-<platform>-${CURRENT_TAG}.zip\` bundles + manifest (uploaded post-release by Build Unity) and fetched at import by the SDK" >> CHANGELOG_RELEASE.md
           echo "" >> CHANGELOG_RELEASE.md
           echo "**Swift (iOS/macOS)**" >> CHANGELOG_RELEASE.md
           echo "- SPM (recommended): \`.package(url: \"https://github.com/${{ github.repository }}\", exact: \"${CURRENT_TAG#v}\")\`" >> CHANGELOG_RELEASE.md


### PR DESCRIPTION
## Summary

Post-OpenUPM cleanup (follows #319/#321/#324). `build-unity.yml` still built and uploaded the monolithic `xybrid-unity-sdk-<ver>.tar.gz` — the old tarball-install artifact that nothing references anymore: the Unity SDK now installs managed-only via OpenUPM, and the resolver fetches natives from the per-platform `xybrid-unity-native-*` release bundles.

- **`build-unity.yml`** — remove the `Create SDK archive`, `Upload Unity SDK package` (artifact), and tar-`Upload to GitHub Release` steps. The `unity-native-bundles` artifact + release upload (the real delivery) are untouched.
- **`release-prep.yml` + `release.yml`** (legacy) — the release-notes generators listed the tarball as the Unity artifact; repoint them to the OpenUPM install + the native bundles.

No functional delivery change — the tarball had no consumers. The historical `[0.2.0]` CHANGELOG mention is left as-is (it's a record).

## Type of Change
- [x] Other (CI cleanup)