### PR TITLE
bazel(windows): cross-compile llama.cpp for x86_64-pc-windows-gnu on RBE

### DIFF
--- a/.agents/skills/test-model/SKILL.md
+++ b/.agents/skills/test-model/SKILL.md
@@ -1,0 +1,133 @@
+Test a model end-to-end using the xybrid execution system.
+
+The user should specify which model to test (e.g., "test kokoro-82m" or "test the TTS model").
+
+**Input**: $ARGUMENTS (optional — model name or path to model directory)
+
+---
+
+## Step 1: Locate the Model
+
+If `$ARGUMENTS` is provided, use it to find the model. Otherwise ask which model to test.
+
+Search for the model in these locations (in order):
+1. Direct path if `$ARGUMENTS` is a directory path
+2. `integration-tests/fixtures/models/{name}/`
+3. `~/.xybrid/cache/{name}/`
+4. Current directory
+
+Verify that `model_metadata.json` exists in the model directory.
+
+---
+
+## Step 2: Validate model_metadata.json
+
+Read `model_metadata.json` and check:
+
+1. **All files listed in `files` array exist** in the model directory
+2. **`model_file` in `execution_template`** points to an actual file
+3. **JSON is valid** and has required fields (`model_id`, `version`, `execution_template`, `files`)
+4. **Preprocessing/postprocessing types are valid** enum values
+
+If any check fails, report the specific issue and suggest how to fix it.
+
+---
+
+## Step 3: Determine Test Strategy
+
+Based on the `execution_template.type` and `metadata.task`:
+
+| Task | Input | Expected Output | Feature Flags |
+|------|-------|-----------------|---------------|
+| `text-to-speech` | `Envelope::Text("Hello world")` | Audio bytes (length > 0) | default |
+| `speech-recognition` (Onnx) | `Envelope::Audio(wav_bytes)` | Text transcription | default |
+| `speech-recognition` (SafeTensors) | `Envelope::Audio(wav_bytes)` | Text transcription | `candle,candle-metal` |
+| `text-generation` (Gguf) | `Envelope::Text("Hello")` | Text response | `llm-llamacpp` |
+| `text-embedding` | `Envelope::Text("test sentence")` | Embedding vector (f32) | default |
+| `image_classification` | Raw image bytes | Class probabilities | default |
+
+---
+
+## Step 4: Find or Create Test Example
+
+Check for an existing example in `crates/xybrid-core/examples/` that matches the model.
+
+If no example exists, create a minimal one at `crates/xybrid-core/examples/{model_id}_test.rs`:
+
+```rust
+//! Test example for {model_id}
+use std::collections::HashMap;
+use std::path::PathBuf;
+use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+use xybrid_core::ir::{Envelope, EnvelopeKind};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let model_dir = PathBuf::from("integration-tests/fixtures/models/{model_id}");
+    let metadata_path = model_dir.join("model_metadata.json");
+    let metadata: ModelMetadata = serde_json::from_str(&std::fs::read_to_string(&metadata_path)?)?;
+
+    let mut executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap());
+
+    // Create appropriate input based on model task
+    let input = Envelope {
+        kind: EnvelopeKind::Text("Hello world".into()), // adjust per task
+        metadata: HashMap::new(),
+    };
+
+    let output = executor.execute(&metadata, &input)?;
+    println!("Output: {:?}", output.kind);
+    println!("Test passed!");
+    Ok(())
+}
+```
+
+Adjust the input type based on the model task (Text for TTS/LLM/embedding, Audio for ASR).
+
+---
+
+## Step 5: Run the Test
+
+Run from the `repos/xybrid/` directory (or the repo root if that's where Cargo.toml is):
+
+```bash
+cargo run --example {example_name} -p xybrid-core --features {features}
+```
+
+Add feature flags based on the model type (see table in Step 3).
+
+---
+
+## Step 6: Validate Output
+
+Check the output based on model type:
+
+- **TTS**: Output should be `EnvelopeKind::Audio(bytes)` with `bytes.len() > 0`. Optionally save to `output.wav` for manual listening.
+- **ASR**: Output should be `EnvelopeKind::Text(transcription)` with non-empty text.
+- **LLM**: Output should be `EnvelopeKind::Text(response)` with non-empty text.
+- **Embedding**: Output should be `EnvelopeKind::Embedding(vec)` with expected dimensionality.
+- **Classification**: Output should contain class probabilities or indices.
+
+---
+
+## Step 7: Report Results
+
+Print a summary:
+
+```
+Model: {model_id}
+Task:  {task}
+Input: {input_type}
+Output: {output_summary}
+Status: PASS / FAIL
+
+{If FAIL: specific error message and suggestion}
+```
+
+## Common Issues
+
+- **"model_metadata.json not found"**: Check the model directory path
+- **"file not found"**: A file listed in `files` array doesn't exist — download it or fix the path
+- **"preprocessing failed"**: Wrong preprocessing step for the model type
+- **"ONNX error"**: Model file may be corrupted or wrong format
+- **"feature not enabled"**: Add the required feature flag (e.g., `--features candle` for SafeTensors models)
+- **"llm backend not available"**: Add `--features llm-llamacpp` for GGUF models

--- a/.agents/skills/xybrid-init/SKILL.md
+++ b/.agents/skills/xybrid-init/SKILL.md
@@ -1,0 +1,330 @@
+Generate a `model_metadata.json` for any ML model so it works with xybrid.
+
+The user may provide a HuggingFace repo, a local directory, or nothing (in which case ask).
+
+**Input**: $ARGUMENTS (optional — HuggingFace repo ID, URL, or local path)
+
+---
+
+## Step 1: Determine Source
+
+If `$ARGUMENTS` is provided, use it. Otherwise ask:
+
+> What model do you want to set up?
+> - Paste a HuggingFace repo (e.g. `hexgrad/Kokoro-82M-v1.0-ONNX`)
+> - Or a local directory path (e.g. `./my-model/`)
+
+Detect the source type:
+- Contains `huggingface.co/` or matches `org/repo` pattern → **HuggingFace**
+- Is a local path that exists → **Local directory**
+- Otherwise → ask the user to clarify
+
+---
+
+## Step 2: Gather Context
+
+### If HuggingFace:
+
+Fetch these three resources (use WebFetch for each):
+
+1. **Model card**: `https://huggingface.co/{repo}/raw/main/README.md`
+2. **File listing**: `https://huggingface.co/api/models/{repo}` (look at the `siblings` array for file names and sizes)
+3. **Config file** (if exists): `https://huggingface.co/{repo}/raw/main/config.json`
+
+Also check for these files (fetch if they exist in the file listing):
+- `tokenizer_config.json`
+- `tokenizer.json`
+- `generation_config.json`
+
+### If Local directory:
+
+1. List all files in the directory
+2. Read any `README.md`, `config.json`, `tokenizer_config.json` if present
+3. If Python is available and there's an `.onnx` file, inspect it:
+   ```bash
+   python3 -c "import onnx; m = onnx.load('MODEL.onnx'); print('Inputs:', [(i.name, [d.dim_value for d in i.type.tensor_type.shape.dim]) for i in m.graph.input]); print('Outputs:', [(o.name, [d.dim_value for d in o.type.tensor_type.shape.dim]) for o in m.graph.output])"
+   ```
+
+---
+
+## Step 3: Analyze and Generate
+
+Using ALL the gathered context (model card, file list, config, ONNX inputs/outputs), generate a valid `model_metadata.json`.
+
+### Decision Tree
+
+Use the model card description, file extensions, and config to determine the model type:
+
+**File-based detection:**
+- `.gguf` file → **LLM** (Gguf template)
+- `.safetensors` + whisper/candle architecture → **ASR** (SafeTensors template)
+- `.onnx` file → continue to task detection below
+- `.mlmodel` / `.mlpackage` → **CoreML** template
+- `.tflite` → **TfLite** template
+
+**Task detection (from model card + config):**
+- Model card mentions "text-to-speech", "TTS", "speech synthesis" → **TTS**
+- Model card mentions "speech recognition", "ASR", "transcription" → **ASR**
+- Model card mentions "embedding", "sentence transformer", "similarity" → **Embedding**
+- Model card mentions "classification", "image", "vision", "ImageNet" → **Vision**
+- Model card mentions "language model", "text generation", "chat", "instruct" → **LLM**
+- Model card mentions "object detection", "YOLO", "segmentation" → **Vision**
+
+### Schema Reference
+
+The `model_metadata.json` must conform to this exact schema:
+
+```json
+{
+  "model_id": "string (required) — kebab-case identifier",
+  "version": "string (required) — model version",
+  "description": "string (optional) — human-readable description",
+  "execution_template": { "type": "...", ... },
+  "preprocessing": [ ... ],
+  "postprocessing": [ ... ],
+  "files": [ "list of all required files" ],
+  "metadata": { "task": "...", ... },
+  "voices": { "... (TTS only)" }
+}
+```
+
+Common optional `metadata` fields:
+- `tool_calling` (boolean, LLMs only): advisory declaration that xybrid's local tool calling works end-to-end for this model — the template accepts a `tools` context AND the model emits a call format xybrid parses (currently LFM2-family pythonic and gemma-4-family `call:` notation). Declare `true` only for those verified families; omit when unknown (never infer from architecture); a model whose template renders tools but whose emissions xybrid cannot parse must NOT declare `true` — it would produce silent no-call responses.
+
+### Execution Templates
+
+Choose ONE:
+
+```json
+// ONNX model
+{ "type": "Onnx", "model_file": "model.onnx" }
+
+// SafeTensors (Candle runtime — currently only Whisper)
+{ "type": "SafeTensors", "model_file": "model.safetensors", "architecture": "whisper", "config_file": "config.json", "tokenizer_file": "tokenizer.json" }
+
+// GGUF (local LLMs via llama.cpp)
+{ "type": "Gguf", "model_file": "model.gguf", "context_length": 4096 }
+
+// CoreML (Apple platforms)
+{ "type": "CoreMl", "model_file": "model.mlpackage" }
+
+// TFLite (mobile)
+{ "type": "TfLite", "model_file": "model.tflite" }
+```
+
+### Preprocessing Steps
+
+Choose the appropriate chain based on task:
+
+**TTS (text-to-speech):**
+```json
+[{ "type": "Phonemize", "tokens_file": "tokens.txt", "backend": "MisakiDictionary", "add_padding": true, "normalize_text": true }]
+```
+Backends: `MisakiDictionary` (default, pure Rust), `EspeakNG` (multi-language, needs system install), `CmuDictionary` (legacy), `OpenPhonemizer` (hybrid dictionary + neural)
+
+**ASR (speech recognition) with ONNX:**
+```json
+[{ "type": "AudioDecode", "sample_rate": 16000, "channels": 1 }]
+```
+
+**ASR with Whisper SafeTensors:** empty `[]` (Candle handles internally)
+
+**Text embedding / NLP:**
+```json
+[{ "type": "Tokenize", "vocab_file": "tokenizer.json", "tokenizer_type": "WordPiece", "max_length": 512 }]
+```
+Tokenizer types: `WordPiece` (BERT), `BPE` (GPT), `SentencePiece` (T5)
+
+**Image classification / vision:**
+```json
+[
+  { "type": "Resize", "width": 224, "height": 224 },
+  { "type": "Normalize", "mean": [0.485, 0.456, 0.406], "std": [0.229, 0.224, 0.225] }
+]
+```
+Use ImageNet normalization values unless model card specifies otherwise.
+
+**LLM (GGUF):** empty `[]` (llama.cpp handles internally)
+
+### Postprocessing Steps
+
+**TTS:**
+```json
+[{ "type": "TTSAudioEncode", "sample_rate": 24000, "apply_postprocessing": true }]
+```
+
+**ASR (CTC-based, e.g. Wav2Vec2):**
+```json
+[{ "type": "CTCDecode", "vocab_file": "vocab.json", "blank_index": 0 }]
+```
+
+**ASR (Whisper SafeTensors):** empty `[]`
+
+**Text embedding:**
+```json
+[{ "type": "MeanPool", "dim": 1 }]
+```
+
+**Image classification:**
+```json
+[{ "type": "Softmax", "dim": 1 }]
+```
+Or `{ "type": "Argmax" }` if you just need the class index.
+
+**LLM:** empty `[]`
+
+### Voice Config (TTS only)
+
+If the model has voice embeddings (e.g. `voices.bin`):
+```json
+{
+  "voices": {
+    "format": "embedded",
+    "file": "voices.bin",
+    "loader": "binary_f32_256",
+    "default": "voice_id",
+    "selection_strategy": "TokenLength",
+    "catalog": [
+      { "id": "voice_id", "name": "Display Name", "index": 0, "gender": "female", "language": "en-US", "style": "neutral" }
+    ]
+  }
+}
+```
+
+---
+
+## Step 4: Validate
+
+Before presenting the result, verify:
+
+1. **All files in `files` array exist** (in the HF repo or local directory)
+2. **`model_file` matches** an actual file name
+3. **Preprocessing/postprocessing steps match** the model task
+4. **Step types are valid** — only use the types listed above
+5. **The JSON is valid** — parseable, no trailing commas
+
+---
+
+## Step 5: Real Examples for Reference
+
+### TTS (Kokoro 82M)
+```json
+{
+  "model_id": "kokoro-82m",
+  "version": "1.0",
+  "description": "Kokoro 82M - High-quality TTS with 24 voices",
+  "execution_template": { "type": "Onnx", "model_file": "model.onnx" },
+  "preprocessing": [{ "type": "Phonemize", "tokens_file": "tokens.txt", "backend": "MisakiDictionary", "add_padding": true, "normalize_text": true }],
+  "postprocessing": [{ "type": "TTSAudioEncode", "sample_rate": 24000, "apply_postprocessing": true }],
+  "files": ["model.onnx", "voices.bin", "tokens.txt", "misaki/us_gold.json"],
+  "metadata": { "task": "text-to-speech", "sample_rate": 24000, "parameters": 82000000, "family": "hexgrad", "license": "Apache-2.0" }
+}
+```
+
+### LLM (Qwen 3.5 0.8B)
+```json
+{
+  "model_id": "qwen3.5-0.8b",
+  "version": "1.0",
+  "description": "Qwen 3.5 0.8B - Lightweight multilingual LLM",
+  "execution_template": { "type": "Gguf", "model_file": "Qwen3.5-0.8B-Q4_K_M.gguf", "context_length": 4096 },
+  "preprocessing": [],
+  "postprocessing": [],
+  "files": ["Qwen3.5-0.8B-Q4_K_M.gguf"],
+  "metadata": { "task": "text-generation", "architecture": "qwen35", "backend": "llamacpp", "parameters": 800000000, "license": "Apache-2.0" }
+}
+```
+
+### Text Embedding (all-MiniLM)
+```json
+{
+  "model_id": "all-minilm",
+  "version": "L6-v2",
+  "execution_template": { "type": "Onnx", "model_file": "model.onnx" },
+  "preprocessing": [{ "type": "Tokenize", "vocab_file": "tokenizer.json", "tokenizer_type": "WordPiece", "max_length": 512 }],
+  "postprocessing": [{ "type": "MeanPool", "dim": 1 }],
+  "files": ["model.onnx", "vocab.txt", "tokenizer.json", "config.json"],
+  "metadata": { "task": "text-embedding", "embedding_dim": 384 }
+}
+```
+
+### ASR (Whisper Tiny — SafeTensors)
+```json
+{
+  "model_id": "whisper-tiny",
+  "version": "1.0",
+  "description": "Whisper Tiny - Fast multilingual ASR (Candle runtime)",
+  "execution_template": { "type": "SafeTensors", "model_file": "model.safetensors", "config_file": "config.json", "tokenizer_file": "tokenizer.json" },
+  "preprocessing": [],
+  "postprocessing": [],
+  "files": ["model.safetensors", "config.json", "tokenizer.json", "melfilters.bytes"],
+  "metadata": { "task": "speech-recognition", "runtime": "candle", "sample_rate": 16000, "parameters": 39000000 }
+}
+```
+
+### Image Classification (MNIST)
+```json
+{
+  "model_id": "mnist-digit-recognition",
+  "version": "12",
+  "description": "MNIST handwritten digit recognition",
+  "execution_template": { "type": "Onnx", "model_file": "model.onnx" },
+  "preprocessing": [
+    { "type": "Reshape", "shape": [1, 1, 28, 28] },
+    { "type": "Normalize", "mean": [0.0], "std": [255.0] }
+  ],
+  "postprocessing": [{ "type": "Softmax", "dim": 1 }],
+  "files": ["model.onnx"],
+  "metadata": { "task": "image_classification", "input_shape": [1, 1, 28, 28], "num_classes": 10 }
+}
+```
+
+---
+
+## Step 6: Present and Save
+
+Show the generated `model_metadata.json` to the user with a brief explanation of the key decisions made (e.g., "Using MisakiDictionary phonemizer because the model card says it's a Kokoro-based TTS model").
+
+Then ask:
+
+> Save to `{directory}/model_metadata.json`?
+
+If the user confirms, write the file.
+
+---
+
+## Step 7: Download Model Files (if HuggingFace)
+
+If the source is HuggingFace and the model files aren't local yet, offer to download:
+
+> Download model files (~{size})? This will fetch:
+> - `model.onnx` (150 MB)
+> - `voices.bin` (24 KB)
+> - ...
+
+If the user confirms, download each file listed in the `files` array:
+```bash
+curl -L "https://huggingface.co/{repo}/resolve/main/{file}" -o "{directory}/{file}"
+```
+
+For files in subdirectories (e.g. `misaki/us_gold.json`), create the subdirectory first.
+
+---
+
+## Step 8: Next Steps
+
+After saving, print:
+
+```
+Your model is ready. Next steps:
+
+# Test it works (use --input-audio <file>.wav for ASR models)
+xybrid run --model {model_id} --input-text "test input"
+
+# Or from Rust
+cargo run --example your_test -p xybrid-core
+
+# Or use /test-model to validate end-to-end
+```
+
+If `/test-model` is available (the user has xybrid cloned), suggest running it.

--- a/.bazelrc
+++ b/.bazelrc
@@ -36,13 +36,8 @@ build:android-x86_64 --compilation_mode=opt
 # x86_64-pc-windows-gnu PE — NOT the MSVC binary today's cargo windows-latest
 # build ships. Combine with --config=remote so exec=Linux RBE.
 build:windows --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-gnu
-# hermetic-llvm defaults -fstack-protector, but its MinGW sysroot ships no libssp
-# (-lssp/-lssp_nonshared), so any windows-gnu link fails. Append -fno-stack-protector
-# (wins over the default) for C/C++ compiles+links; rustc compiles are unaffected
-# (--copt is C-only). llama builds static libs, so this only needs the compile side,
-# but the linkopt keeps cmake's compiler-probe link and the final exe link clean.
-build:windows --copt=-fno-stack-protector
-build:windows --linkopt=-fno-stack-protector
+# (-fstack-protector, which needs a libssp hermetic-llvm's MinGW sysroot doesn't
+# ship, is disabled for windows at the toolchain level in hermetic_llvm.patch.)
 
 # On Linux hosts, rules_rs' experimental toolchains need an explicit host platform
 # with libc constraints (//:host_linux_gnu, root BUILD.bazel). The enable flag

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,19 @@ build:android-armv7 --compilation_mode=opt
 build:android-x86_64 --platforms=@rules_rs//rs/platforms:x86_64-linux-android
 build:android-x86_64 --compilation_mode=opt
 
+# Desktop Windows, cross-compiled from Linux RBE (no Windows runner needed).
+# hermetic-llvm ships a MinGW (GNU-ABI) sysroot only, so this produces an
+# x86_64-pc-windows-gnu PE — NOT the MSVC binary today's cargo windows-latest
+# build ships. Combine with --config=remote so exec=Linux RBE.
+build:windows --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-gnu
+# hermetic-llvm defaults -fstack-protector, but its MinGW sysroot ships no libssp
+# (-lssp/-lssp_nonshared), so any windows-gnu link fails. Append -fno-stack-protector
+# (wins over the default) for C/C++ compiles+links; rustc compiles are unaffected
+# (--copt is C-only). llama builds static libs, so this only needs the compile side,
+# but the linkopt keeps cmake's compiler-probe link and the final exe link clean.
+build:windows --copt=-fno-stack-protector
+build:windows --linkopt=-fno-stack-protector
+
 # On Linux hosts, rules_rs' experimental toolchains need an explicit host platform
 # with libc constraints (//:host_linux_gnu, root BUILD.bazel). The enable flag
 # makes `common:linux` auto-apply on Linux hosts (no-op on macOS: no macos config).

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -101,6 +101,16 @@ cmake(
         },
         "@rules_rs//rs/platforms/config:aarch64-linux-android": _LLAMA_CACHE_ENTRIES | _ANDROID_LLAMA,
         "@rules_rs//rs/platforms/config:x86_64-linux-android": _LLAMA_CACHE_ENTRIES | _ANDROID_LLAMA,
+        # Desktop Windows cross (GNU/MinGW). rfcc has NO windows entry in its
+        # _TARGET_OS_PARAMS, so CMAKE_SYSTEM_NAME is not auto-set — without it
+        # cmake detects the Linux exec host and ggml takes its non-Windows path.
+        # Set the pair explicitly (rfcc only folds CMAKE_SYSTEM_PROCESSOR into the
+        # crossfile when CMAKE_SYSTEM_NAME is user-set); AMD64 → ggml x86 arch.
+        # Same shape as the armv7 seeding above.
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": _LLAMA_CACHE_ENTRIES | {
+            "CMAKE_SYSTEM_NAME": "Windows",
+            "CMAKE_SYSTEM_PROCESSOR": "AMD64",
+        },
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
     }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
@@ -116,7 +126,26 @@ cmake(
         "@rules_rs//rs/platforms/config:aarch64-linux-android": ["libmtmd.a"] + _LLAMA_LIBS,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": ["libmtmd.a"] + _LLAMA_LIBS,
         "@rules_rs//rs/platforms/config:x86_64-linux-android": ["libmtmd.a"] + _LLAMA_LIBS,
+        # Windows/MinGW: ggml/CMakeLists.txt sets CMAKE_STATIC_LIBRARY_PREFIX=""
+        # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
+        # libggml.a) — while llama (sibling scope) keeps it (libllama.a).
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
+            "libllama.a",
+            "ggml.a",
+            "ggml-base.a",
+            "ggml-cpu.a",
+        ],
         "//conditions:default": _LLAMA_LIBS,
+    }),
+    # Windows: ggml/CMakeLists.txt installs the ggml umbrella/base libs with
+    # `install(TARGETS ggml LIBRARY)` (no ARCHIVE). On Linux that still lands the
+    # static .a, but on Windows CMake treats a static lib strictly as an ARCHIVE
+    # artifact, so libggml*.a never reaches the install lib/ (only libllama.a,
+    # which has its own rule, does). Copy the built ggml archives into lib/ so
+    # rfcc can collect them. No-op on other platforms (proven install works there).
+    postfix_script = select({
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": "find $$BUILD_TMPDIR -name '*.a' -exec cp -f {} $$INSTALLDIR/lib/ \\;",
+        "//conditions:default": "",
     }),
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -144,7 +144,7 @@ cmake(
     # which has its own rule, does). Copy the built ggml archives into lib/ so
     # rfcc can collect them. No-op on other platforms (proven install works there).
     postfix_script = select({
-        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": "find $$BUILD_TMPDIR -name '*.a' -exec cp -f {} $$INSTALLDIR/lib/ \\;",
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": "mkdir -p $$INSTALLDIR/lib && find $$BUILD_TMPDIR -name '*.a' -exec cp -f {} $$INSTALLDIR/lib/ \\;",
         "//conditions:default": "",
     }),
     visibility = ["//visibility:public"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,16 @@ single_version_override(
     version = "0.0.95",
 )
 bazel_dep(name = "llvm", version = "0.8.11")
+
+# hermetic-llvm fix (report upstream): toolchain/features/legacy adds
+# -fstack-protector unconditionally, but the module ships NO libssp — so clang's
+# MinGW driver pulls -lssp/-lssp_nonshared at link time and every windows-gnu
+# link fails with "unable to find library -lssp". Gate it off for windows.
+single_version_override(
+    module_name = "llvm",
+    patch_strip = 1,
+    patches = ["//:hermetic_llvm.patch"],
+)
 bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
 # rules_cc must be a direct dep so the `@rules_cc//...` flag in .bazelrc resolves.
@@ -177,6 +187,8 @@ crate.from_cargo(
     cargo_toml = "//:Cargo.toml",
     platform_triples = [
         "x86_64-unknown-linux-gnu",
+        # Desktop Windows cross (GNU/MinGW ABI — hermetic-llvm ships no MSVC CRT).
+        "x86_64-pc-windows-gnu",
         "aarch64-apple-darwin",
         "aarch64-linux-android",
         "armv7-linux-androideabi",
@@ -190,4 +202,15 @@ crate.annotation(
     },
     allow_build_script_to_detect_nonhermetic_paths = True,
 )
+
+# NOTE: Windows Rust CLI (raw-dylib -> dlltool) is a deliberate follow-up, not
+# wired here. The windows/windows-sys 0.61 family + ort-sys/getrandom/... emit
+# #[link(kind="raw-dylib")], so rustc needs `dlltool` at compile time. The tool
+# (hermetic-llvm's llvm-dlltool) is a symlink into the ~100MB multicall `llvm`
+# binary and can only be STAGED for the rustc compile by the toolchain machinery,
+# which is not reachable from crate.annotation / rules_rs (rules_rust is
+# extension-generated, so unpatchable; it doesn't consume llvm_tools for compile).
+# The C/C++ half (//:llama for windows-gnu) IS green. See
+# .context/bazel-windows-cli-progress.md for the full analysis + the proper fix
+# (patch hermetic-llvm's cc toolchain to ship dlltool).
 use_repo(crate, "crates")

--- a/hermetic_llvm.patch
+++ b/hermetic_llvm.patch
@@ -1,0 +1,12 @@
+diff --git a/toolchain/features/legacy/BUILD.bazel b/toolchain/features/legacy/BUILD.bazel
+index 0000000..0000000 100644
+--- a/toolchain/features/legacy/BUILD.bazel
++++ b/toolchain/features/legacy/BUILD.bazel
+@@ -21,4 +21,7 @@
+     args = select({
+         "@platforms//os:none": [],
++        # xybrid: hermetic-llvm's MinGW sysroot ships no libssp, so -fstack-protector
++        # makes clang's MinGW driver pull -lssp/-lssp_nonshared at link (undefined ref).
++        "@platforms//os:windows": [],
+         "//conditions:default": ["-fstack-protector"],
+     }) + [

--- a/rules_foreign_cc.patch
+++ b/rules_foreign_cc.patch
@@ -205,3 +205,46 @@ index d96af9e..b50b16a 100644
  
  def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic, additional_tools = None):
      """Framework function for bootstrapping C/C++ build tools.
+diff --git a/toolchains/private/BUILD.bazel b/toolchains/private/BUILD.bazel
+index 0000000..0000000 100644
+--- a/toolchains/private/BUILD.bazel
++++ b/toolchains/private/BUILD.bazel
+@@ -29,12 +29,12 @@
+ native_tool_toolchain(
+     name = "built_make",
+     env = select({
+-        "@platforms//os:windows": {"MAKE": "$(execpath :make_tool)/bin/make.exe"},
++        "@platforms//os:windows": {"MAKE": "$(execpath :make_tool)/bin/make"},
+         "//conditions:default": {"MAKE": "$(execpath :make_tool)/bin/make"},
+     }),
+     path = select({
+-        "@platforms//os:windows": "$(execpath :make_tool)/bin/make.exe",
++        "@platforms//os:windows": "$(execpath :make_tool)/bin/make",
+         "//conditions:default": "$(execpath :make_tool)/bin/make",
+     }),
+     target = ":make_tool",
+ )
+@@ -142,7 +142,7 @@
+ native_tool_toolchain(
+     name = "preinstalled_m4",
+     path = select({
+-        "@platforms//os:windows": "m4.exe",
++        "@platforms//os:windows": "m4",
+         "//conditions:default": "m4",
+     }),
+ )
+@@ -164,12 +164,12 @@
+ native_tool_toolchain(
+     name = "built_pkgconfig",
+     env = select({
+-        "@platforms//os:windows": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)"},
++        "@platforms//os:windows": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)/bin/pkg-config"},
+         "//conditions:default": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)/bin/pkg-config"},
+     }),
+     path = select({
+-        "@platforms//os:windows": "$(execpath :pkgconfig_tool)",
++        "@platforms//os:windows": "$(execpath :pkgconfig_tool)/bin/pkg-config",
+         "//conditions:default": "$(execpath :pkgconfig_tool)/bin/pkg-config",
+     }),
+     target = ":pkgconfig_tool",
+ )

--- a/rules_foreign_cc.patch
+++ b/rules_foreign_cc.patch
@@ -214,12 +214,12 @@ index 0000000..0000000 100644
      name = "built_make",
      env = select({
 -        "@platforms//os:windows": {"MAKE": "$(execpath :make_tool)/bin/make.exe"},
-+        "@platforms//os:windows": {"MAKE": "$(execpath :make_tool)/bin/make"},
++        "@bazel_tools//src/conditions:host_windows": {"MAKE": "$(execpath :make_tool)/bin/make.exe"},
          "//conditions:default": {"MAKE": "$(execpath :make_tool)/bin/make"},
      }),
      path = select({
 -        "@platforms//os:windows": "$(execpath :make_tool)/bin/make.exe",
-+        "@platforms//os:windows": "$(execpath :make_tool)/bin/make",
++        "@bazel_tools//src/conditions:host_windows": "$(execpath :make_tool)/bin/make.exe",
          "//conditions:default": "$(execpath :make_tool)/bin/make",
      }),
      target = ":make_tool",
@@ -229,7 +229,7 @@ index 0000000..0000000 100644
      name = "preinstalled_m4",
      path = select({
 -        "@platforms//os:windows": "m4.exe",
-+        "@platforms//os:windows": "m4",
++        "@bazel_tools//src/conditions:host_windows": "m4.exe",
          "//conditions:default": "m4",
      }),
  )
@@ -238,12 +238,12 @@ index 0000000..0000000 100644
      name = "built_pkgconfig",
      env = select({
 -        "@platforms//os:windows": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)"},
-+        "@platforms//os:windows": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)/bin/pkg-config"},
++        "@bazel_tools//src/conditions:host_windows": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)"},
          "//conditions:default": {"PKG_CONFIG": "$(execpath :pkgconfig_tool)/bin/pkg-config"},
      }),
      path = select({
 -        "@platforms//os:windows": "$(execpath :pkgconfig_tool)",
-+        "@platforms//os:windows": "$(execpath :pkgconfig_tool)/bin/pkg-config",
++        "@bazel_tools//src/conditions:host_windows": "$(execpath :pkgconfig_tool)",
          "//conditions:default": "$(execpath :pkgconfig_tool)/bin/pkg-config",
      }),
      target = ":pkgconfig_tool",


### PR DESCRIPTION
## Summary

Registers the `x86_64-pc-windows-gnu` triple and gets the C/C++ half of the desktop-Windows build (llama.cpp + ggml) cross-compiling from Linux RBE with the hermetic MinGW toolchain — no Windows runner. Six windows-scoped toolchain fixes land here: `rules_foreign_cc.patch` stops `.exe`-suffixing rfcc's exec-side tools (make/m4/pkg-config) for a windows target; a new `hermetic_llvm.patch` gates `-fstack-protector` off for windows (no libssp shipped → undefined `-lssp` at link); the `//:llama` windows arm sets `CMAKE_SYSTEM_NAME=Windows` + collects/renames ggml's static libs; `.bazelrc` adds `build:windows`. This is the **GNU/MinGW ABI** (hermetic-llvm ships no MSVC CRT), a different artifact than the cargo `windows-latest` build, and is **additive/dormant** — cargo and the advisory CI are untouched. The desktop Linux CLI builds green on RBE unchanged; the Windows *Rust* CLI (`raw-dylib` → `dlltool`) is a documented follow-up (`dlltool` is a symlink into the multicall `llvm` binary that only the toolchain layer can stage, which is unreachable via rules_rs — see the `MODULE.bazel` note). Verified: `//:llama` for windows-gnu and `//crates/xybrid-cli:xybrid` for linux both green on BuildBuddy RBE.

> Also vendors two project skill definitions (`test-model`, `xybrid-init`) under `.agents/skills/` in a separate `chore:` commit (content matches the local `.claude/skills/` copies) — unrelated to the Bazel change.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A: Bazel-only additive change; cargo build of record untouched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (MODULE.bazel note + `.context/bazel-windows-cli-progress.md`)
- [x] No breaking changes (additive/dormant; cargo + advisory CI untouched)