### PR TITLE
bazel(apple): macOS-CPU lane on Linux RBE — CLI builds, links, and runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,14 @@ build:android-x86_64 --compilation_mode=opt
 # x86_64-pc-windows-gnu PE — NOT the MSVC binary today's cargo windows-latest
 # build ships. Combine with --config=remote so exec=Linux RBE.
 build:windows --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-gnu
+
+# Desktop macOS (CPU lane), cross-compiled from Linux RBE via hermetic clang +
+# @macos_sdk. Metal/Accelerate stay OFF (//:llama default arm): CPU-only is
+# the lane that can leave the Mac — Metal/Swift/xcframework need Xcode.
+# ort is satisfied by the vendored static lib (vendor/ort-macos, see the
+# ort-sys annotation in MODULE.bazel) instead of ort's build-time download,
+# which is structurally incompatible with remote execution.
+build:macos --platforms=@rules_rs//rs/platforms:aarch64-apple-darwin
 # (-fstack-protector, which needs a libssp hermetic-llvm's MinGW sysroot doesn't
 # ship, is disabled for windows at the toolchain level in hermetic_llvm.patch.)
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -19,10 +19,13 @@ on:
       - "**/BUILD.bazel"
       - "rules_android_ndk.patch"
       - "rules_foreign_cc.patch"
+      - "rules_rs.patch"
+      - "hermetic_llvm.patch"
       - "crates/**"
       - "bindings/kotlin/**"
       - "macros/**"
       - "vendor/llama-cpp"
+      - "vendor/ort-macos/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/bazel.yml"
@@ -39,10 +42,13 @@ on:
       - "**/BUILD.bazel"
       - "rules_android_ndk.patch"
       - "rules_foreign_cc.patch"
+      - "rules_rs.patch"
+      - "hermetic_llvm.patch"
       - "crates/**"
       - "bindings/kotlin/**"
       - "macros/**"
       - "vendor/llama-cpp"
+      - "vendor/ort-macos/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/bazel.yml"
@@ -115,6 +121,22 @@ jobs:
             //:llama \
             //crates/llama-cpp-sys:llama_cpp_sys \
             //crates/xybrid-llama:xybrid_llama
+
+      # Desktop lanes on RBE: linux CLI (native) + the macOS-CPU cross
+      # (hermetic clang + @macos_sdk + vendored ort; Metal/Swift stay Mac-bound
+      # and are NOT built here) + the windows-gnu llama core (PR #343). Keeps
+      # the shared cache warm so a future Mac lane PULLS the shared graph
+      # instead of recompiling it — the cache-fed-Mac model.
+      - name: Build desktop lanes on RBE (linux CLI, macOS-CPU cross, windows llama)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote \
+            //crates/xybrid-cli:xybrid
+          bazelisk build --config=remote --config=macos \
+            //crates/xybrid-cli:xybrid \
+            //crates/xybrid-bolt:xybrid_bolt_staticlib
+          bazelisk build --config=remote --config=windows \
+            //:llama
 
       # The RBE-proven Android row (PR #326 gates 6-10): NDK cross-compile +
       # one-link .so + complete AAR. ABI fan-out (arm64-v8a / armeabi-v7a /

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -121,17 +121,30 @@ cmake(
             "CMAKE_SYSTEM_NAME": "Darwin",
             "CMAKE_SYSTEM_PROCESSOR": "arm64",
             # With SYSTEM_NAME=Darwin cmake requires Mach-O binutils
-            # (CMakeFindBinUtils). The hermetic LINUX toolchain ships the llvm-
-            # equivalents; point cmake at them ($$VAR -> $VAR, shell-expanded on
-            # the worker). Path pins the llvm-toolchain version — revisit on
-            # `llvm` module bumps (breaks loudly, not silently).
-            "CMAKE_INSTALL_NAME_TOOL": "$$EXT_BUILD_ROOT/external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64/bin/llvm-install-name-tool",
-            "CMAKE_OTOOL": "$$EXT_BUILD_ROOT/external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64/bin/llvm-otool",
+            # (CMakeFindBinUtils). Point cmake at the hermetic llvm equivalents
+            # via label expansion: rfcc expands $(execpath) in cache_entries,
+            # and the tools ride in via build_data (cfg=exec, so the alias
+            # resolves to the WORKER's binary — linux on RBE, darwin locally).
+            # $$EXT_BUILD_ROOT -> $EXT_BUILD_ROOT, shell-expanded on the worker
+            # (execpath is execroot-relative; cmake needs it absolute).
+            "CMAKE_INSTALL_NAME_TOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-install-name-tool)",
+            "CMAKE_OTOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-otool)",
         },
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
     }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
     # rfcc finds its own downloaded cmake; /opt/homebrew doesn't exist there.)
+    # Mach-O binutils for the darwin cross, referenced by the darwin
+    # cache_entries via $(execpath). build_data is cfg=exec: the platform-
+    # selected alias resolves to the binary that runs on the BUILD worker.
+    # Darwin-scoped so other platforms' action keys stay byte-stable.
+    build_data = select({
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
+            "@llvm//tools:llvm-install-name-tool",
+            "@llvm//tools:llvm-otool",
+        ],
+        "//conditions:default": [],
+    }),
     lib_source = ":llama_src",
     # Build cmake's default `all` target — same as build.rs's vision path (it
     # sets TOOLS=ON and builds everything). Building only `mtmd` breaks cmake's

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -111,6 +111,23 @@ cmake(
             "CMAKE_SYSTEM_NAME": "Windows",
             "CMAKE_SYSTEM_PROCESSOR": "AMD64",
         },
+        # macOS cross from Linux RBE (the macOS-CPU lane): same rfcc gap as
+        # windows — no darwin entry in rfcc's _TARGET_OS_PARAMS, so without
+        # CMAKE_SYSTEM_NAME cmake detects the Linux exec host and ggml defines
+        # _GNU_SOURCE instead of _DARWIN_C_SOURCE (u_int/u_char vanish from the
+        # SDK headers). Metal stays OFF (base entries): CPU-only is the lane
+        # that can leave the Mac; Metal needs Xcode.
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": _LLAMA_CACHE_ENTRIES | {
+            "CMAKE_SYSTEM_NAME": "Darwin",
+            "CMAKE_SYSTEM_PROCESSOR": "arm64",
+            # With SYSTEM_NAME=Darwin cmake requires Mach-O binutils
+            # (CMakeFindBinUtils). The hermetic LINUX toolchain ships the llvm-
+            # equivalents; point cmake at them ($$VAR -> $VAR, shell-expanded on
+            # the worker). Path pins the llvm-toolchain version — revisit on
+            # `llvm` module bumps (breaks loudly, not silently).
+            "CMAKE_INSTALL_NAME_TOOL": "$$EXT_BUILD_ROOT/external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64/bin/llvm-install-name-tool",
+            "CMAKE_OTOOL": "$$EXT_BUILD_ROOT/external/llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64/bin/llvm-otool",
+        },
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
     }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
@@ -180,5 +197,17 @@ filegroup(
 filegroup(
     name = "ort_android_x86_64",
     srcs = ["vendor/ort-android/x86_64/libonnxruntime.so"],
+    visibility = ["//visibility:public"],
+)
+
+# Vendored STATIC onnxruntime for the macOS lane (see vendor/ort-macos/README):
+# ort-sys on Apple uses download-binaries, but a build-time download is
+# incompatible with remote execution (the fetched file is not a tracked action
+# output, so it never reaches the rlib-compile action on another worker).
+# Fed to ort-sys via ORT_LIB_LOCATION (MODULE.bazel annotation) — the same
+# provide-the-artifact pattern as vendor/ort-ios in xtask.
+filegroup(
+    name = "ort_macos_arm64",
+    srcs = ["vendor/ort-macos/aarch64-apple-darwin/libonnxruntime.a"],
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -200,7 +200,42 @@ crate.annotation(
     build_script_env = {
         "ORT_CACHE_DIR": "/tmp",
     },
+    # darwin: hand ort-sys the vendored static onnxruntime instead of letting
+    # its build script download one — a build-time download is incompatible
+    # with RBE (the file isn't a tracked output, so it never reaches the
+    # rlib-compile action). ${pwd} = the action's execroot at runtime.
+    # `data` stages the .a for the rlib compile itself (rustc bundles static
+    # libs into the rlib); no per-triple data attr exists, so it's staged for
+    # all platforms — input-only, outputs unchanged.
+    build_script_data_select = {
+        "aarch64-apple-darwin": ["@@//:ort_macos_arm64"],
+    },
+    build_script_env_select = {
+        "aarch64-apple-darwin": "{\"ORT_LIB_LOCATION\": \"$${pwd}/vendor/ort-macos/aarch64-apple-darwin\"}",
+    },
+    data = ["@@//:ort_macos_arm64"],
     allow_build_script_to_detect_nonhermetic_paths = True,
+)
+
+# ort-sys's darwin build script pulls these two helper crates, whose features
+# the hub keys on aarch64-apple-darwin (conditional_crate_features). Build-
+# script deps compile in the EXEC config, where that config_setting doesn't
+# match (linux RBE worker) -> the crates lose std/default and the bs fails
+# trait resolution. Features are ADD-ONLY here, and neither crate has any
+# other consumer in the lock, so hoisting the darwin features to the base is
+# a no-op everywhere else. (Same exec-vs-target class as the bs-deps fix in
+# rules_rs.patch, one level down the dep tree.)
+crate.annotation(
+    crate = "lzma-rust2",
+    crate_features = [
+        "optimization",
+        "std",
+    ],
+)
+
+crate.annotation(
+    crate = "hmac-sha256",
+    crate_features = ["default"],
 )
 
 # NOTE: Windows Rust CLI (raw-dylib -> dlltool) is a deliberate follow-up, not

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -153,6 +153,31 @@ register_toolchains("@llvm//toolchain:all")
 
 # Hermetic macOS SDK (replaces xcrun) — needed on darwin host/target.
 osx = use_extension("@llvm//extensions:osx.bzl", "osx")
+
+# The macOS-CPU CLI links frameworks pulled in by the darwin dep graph
+# (objc2-metal/-io-kit/-core-ml, sysinfo, candle-metal — link directives fire
+# even though the GPU code paths are cfg'd off). The extension's default
+# framework set is minimal, and the tag REPLACES the defaults, so list them
+# too. Stub-only (.tbd) — cheap to include.
+osx.frameworks(names = [
+    # extension defaults
+    "CoreFoundation",
+    "Foundation",
+    "Kernel",
+    "OSLog",
+    "Security",
+    "SystemConfiguration",
+    # linked by the darwin closure
+    "Accelerate",
+    "CoreGraphics",
+    "CoreML",
+    "CoreVideo",
+    "IOKit",
+    "IOSurface",
+    "Metal",
+    "MetalPerformanceShaders",
+    "MetalPerformanceShadersGraph",
+])
 use_repo(osx, "macos_sdk")
 
 # --- Rust toolchain: rules_rs (facade over rules_rust) ------------------------
@@ -210,8 +235,15 @@ crate.annotation(
     build_script_data_select = {
         "aarch64-apple-darwin": ["@@//:ort_macos_arm64"],
     },
+    # CC=/usr/bin/false: ort-sys's bs probes `$CC --print-search-dirs` to find
+    # Xcode's clang_rt dir and, on success, emits -lclang_rt.osx — which only
+    # Xcode's clang ships (under the hermetic toolchain the probe "succeeds"
+    # with a mangled linux path and the link dies on the missing lib). A failed
+    # probe takes the graceful None branch: no bogus -L, no -lclang_rt.osx.
+    # Correct here: hermetic-llvm links its own compiler-rt builtins explicitly.
+    # CC is otherwise unused by this bs (no C compiled on the LIB_LOCATION path).
     build_script_env_select = {
-        "aarch64-apple-darwin": "{\"ORT_LIB_LOCATION\": \"$${pwd}/vendor/ort-macos/aarch64-apple-darwin\"}",
+        "aarch64-apple-darwin": "{\"ORT_LIB_LOCATION\": \"$${pwd}/vendor/ort-macos/aarch64-apple-darwin\", \"CC\": \"/usr/bin/false\"}",
     },
     data = ["@@//:ort_macos_arm64"],
     allow_build_script_to_detect_nonhermetic_paths = True,

--- a/hermetic_llvm.patch
+++ b/hermetic_llvm.patch
@@ -22,7 +22,7 @@ index 065900f..ca85123 100644
  
  #ifdef _WIN32
  #include <process.h>
-@@ -63,8 +64,49 @@ static const char *required_env(const char *name) {
+@@ -63,8 +64,51 @@ static const char *required_env(const char *name) {
      return value;
  }
  
@@ -45,6 +45,8 @@ index 065900f..ca85123 100644
 + * directories (e.g. cmake's try-compile scratch dirs) but export the
 + * execroot as EXT_BUILD_ROOT; fall back to resolving against it when the
 + * relative path does not exist from the current working directory.
++ * The resolved allocation is intentionally not freed: the wrapper either
++ * exec()s (never returns) or exits within milliseconds of its subprocesses.
 + */
 +static const char *resolve_tool(const char *path) {
 +    if (is_absolute(path) || path_exists(path)) {

--- a/hermetic_llvm.patch
+++ b/hermetic_llvm.patch
@@ -10,3 +10,84 @@ index 0000000..0000000 100644
 +        "@platforms//os:windows": [],
          "//conditions:default": ["-fstack-protector"],
      }) + [
+diff --git a/tools/internal/link_wrapper.c b/tools/internal/link_wrapper.c
+index 065900f..ca85123 100644
+--- a/tools/internal/link_wrapper.c
++++ b/tools/internal/link_wrapper.c
+@@ -2,6 +2,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/stat.h>
+ 
+ #ifdef _WIN32
+ #include <process.h>
+@@ -63,8 +64,49 @@ static const char *required_env(const char *name) {
+     return value;
+ }
+ 
++static int path_exists(const char *path) {
++    struct stat st;
++    return stat(path, &st) == 0;
++}
++
++static int is_absolute(const char *path) {
++    if (path[0] == '/' || path[0] == '\\') {
++        return 1;
++    }
++    return path[0] != '\0' && path[1] == ':';
++}
++
++/*
++ * Bazel passes tool paths relative to the execution root and runs actions
++ * with cwd == execroot, so relative paths normally resolve as-is. Consumers
++ * like rules_foreign_cc re-invoke the toolchain from other working
++ * directories (e.g. cmake's try-compile scratch dirs) but export the
++ * execroot as EXT_BUILD_ROOT; fall back to resolving against it when the
++ * relative path does not exist from the current working directory.
++ */
++static const char *resolve_tool(const char *path) {
++    if (is_absolute(path) || path_exists(path)) {
++        return path;
++    }
++    const char *root = getenv("EXT_BUILD_ROOT");
++    if (root == NULL || root[0] == '\0') {
++        return path;
++    }
++    size_t len = strlen(root) + 1 + strlen(path) + 1;
++    char *resolved = malloc(len);
++    if (resolved == NULL) {
++        return path;
++    }
++    snprintf(resolved, len, "%s/%s", root, path);
++    if (path_exists(resolved)) {
++        return resolved;
++    }
++    free(resolved);
++    return path;
++}
++
+ int main(int argc, char **argv) {
+-    const char *clangxx = required_env("LLVM_CLANGXX");
++    const char *clangxx = resolve_tool(required_env("LLVM_CLANGXX"));
+     const char *strip_debug_symbols = getenv("LLVM_STRIP_DEBUG_SYMBOLS");
+     int should_strip_debug_symbols = strip_debug_symbols != NULL && strip_debug_symbols[0] != '\0';
+ 
+@@ -80,7 +122,7 @@ int main(int argc, char **argv) {
+     }
+ 
+     const char *link_output = required_env("LLVM_LINK_OUTPUT");
+-    const char *dsymutil = required_env("LLVM_DSYMUTIL");
++    const char *dsymutil = resolve_tool(required_env("LLVM_DSYMUTIL"));
+ 
+     char *dsym_args[] = {
+         (char *)dsymutil,
+@@ -95,7 +137,7 @@ int main(int argc, char **argv) {
+         return status;
+     }
+ 
+-    const char *strip = required_env("LLVM_STRIP");
++    const char *strip = resolve_tool(required_env("LLVM_STRIP"));
+     char *strip_args[] = {
+         (char *)strip,
+         "-S",

--- a/rules_rs.patch
+++ b/rules_rs.patch
@@ -33,3 +33,94 @@ diff --color -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
      vendor_part = _get(parts, 1, "unknown")
      os_raw_part = _get(parts, 2, "none")
      env_part = "-".join(parts[3:])
+diff --color -ru a/rs/private/repository_utils.bzl b/rs/private/repository_utils.bzl
+--- a/rs/private/repository_utils.bzl	2026-07-11 11:00:00
++++ b/rs/private/repository_utils.bzl	2026-07-11 11:00:00
+@@ -191,7 +191,8 @@
+ {indent}    build_script_data = {build_script_data}{conditional_build_script_data},
+ {indent}    build_deps = [
+ {indent}        {build_deps}
+-{indent}    ]{conditional_build_deps},
++{indent}    ],
++{indent}    conditional_build_deps = {conditional_build_deps},
+ {indent}    build_script_env = {build_script_env}{conditional_build_script_env},
+ {indent}    allow_build_script_to_detect_nonhermetic_paths = {allow_build_script_to_detect_nonhermetic_paths},
+ {indent}    build_script_toolchains = {build_script_toolchains},
+@@ -212,7 +213,13 @@
+         {platform: _exclude_deps_from_features(features) for platform, features in attr.crate_features_select.items()},
+     )
+     use_legacy_rules_rust_platforms = attr.use_legacy_rules_rust_platforms
+-    build_deps, conditional_build_deps = render_select(attr.build_script_deps, attr.build_script_deps_select, use_legacy_rules_rust_platforms)
++    # xybrid patch: keep conditional build deps unrendered (a triple-keyed
++    # dict, like conditional_crate_features) so rust_crate can bake the right
++    # arm into each exec-configured per-triple `_bs_<triple>` build script.
++    build_deps, conditional_build_deps = compute_select(
++        [str(d) for d in attr.build_script_deps],
++        {platform: [str(d) for d in items] for platform, items in attr.build_script_deps_select.items()},
++    )
+     build_script_data, conditional_build_script_data = render_select(attr.build_script_data, attr.build_script_data_select, use_legacy_rules_rust_platforms)
+     build_script_tools, conditional_build_script_tools = render_select(attr.build_script_tools, attr.build_script_tools_select, use_legacy_rules_rust_platforms)
+     rustc_flags, conditional_rustc_flags = render_select(attr.rustc_flags, attr.rustc_flags_select, use_legacy_rules_rust_platforms)
+@@ -262,7 +269,7 @@
+         build_script_data = repr(build_script_data),
+         conditional_build_script_data = " + " + conditional_build_script_data if conditional_build_script_data else "",
+         build_deps = list_indent.join(['"%s"' % d for d in sorted(build_deps)]),
+-        conditional_build_deps = " + " + conditional_build_deps if conditional_build_deps else "",
++        conditional_build_deps = repr(conditional_build_deps),
+         build_script_env = repr(attr.build_script_env),
+         conditional_build_script_env = " | " + conditional_build_script_env if conditional_build_script_env else "",
+         allow_build_script_to_detect_nonhermetic_paths = repr(attr.allow_build_script_to_detect_nonhermetic_paths),
+diff --color -ru a/rs/rust_crate.bzl b/rs/rust_crate.bzl
+--- a/rs/rust_crate.bzl	2026-07-11 11:00:00
++++ b/rs/rust_crate.bzl	2026-07-11 11:00:00
+@@ -43,9 +43,10 @@
+         has_lib,
+         binaries,
+         use_legacy_rules_rust_platforms,
+         extra_compile_data = [],
+         rustc_env = {},
+-        skip_deps_verification = False):
++        skip_deps_verification = False,
++        conditional_build_deps = {}):
+     package_metadata(
+         name = name + "_package_metadata",
+         purl = purl,
+@@ -83,8 +84,20 @@
+     build_script_target_tags = crate_tags + build_script_tags
+ 
+     if build_script:
++        # xybrid patch: conditional build deps arrive as a triple-keyed dict
++        # (mirroring conditional_crate_features) instead of a pre-rendered
++        # select(). The default `_bs` reconstructs the target-platform select
++        # (unchanged behavior); the per-triple `_bs_<triple>` variants bake
++        # their own arm below.
++        bs_deps = build_deps
++        if conditional_build_deps:
++            bs_deps = bs_deps + select(
++                {_platform(k, use_legacy_rules_rust_platforms): v for k, v in conditional_build_deps.items()} |
++                {"//conditions:default": []},
++            )
++
+         build_script_kwargs = dict(
+-            deps = build_deps,
++            deps = bs_deps,
+             aliases = aliases,
+             compile_data = compile_data,
+             crate_name = "build_script_build",
+@@ -118,6 +131,16 @@
+                 branches[_platform(triple, use_legacy_rules_rust_platforms)] = build_script_name
+ 
+                 build_script_kwargs_for_triple = dict(build_script_kwargs)
++                # xybrid patch: this build script compiles in the EXEC
++                # configuration ("[for tool]"), where the target-platform
++                # config_setting for `triple` need not match (cross-compile:
++                # exec != target). A select() there falls to its default arm
++                # while the triple's crate_features are baked below — features
++                # can enable code paths whose build-deps the select dropped
++                # (ort-sys darwin "download-binaries" losing ureq/hmac-sha256/
++                # lzma-rust2 on a linux executor). Bake the matching triple's
++                # deps so deps and features agree.
++                build_script_kwargs_for_triple["deps"] = build_deps + conditional_build_deps.get(triple, [])
+                 build_script_kwargs_for_triple["rustc_flags"] = build_script_kwargs["rustc_flags"] + [
+                     # Avoid metadata generation to clash under the same directory when cross-compiling to multiple targets
+                     # concurrently, see https://github.com/hermeticbuild/rules_rs/issues/161

--- a/vendor/ort-macos/README.md
+++ b/vendor/ort-macos/README.md
@@ -1,0 +1,12 @@
+# Vendored ONNX Runtime — macOS (static)
+
+`aarch64-apple-darwin/libonnxruntime.a` is the exact artifact `ort-sys` 2.0.0-rc.11
+would download at build time (pyke CDN, `ms@1.23.2`, flavor `none`/CPU+CoreML):
+
+  https://cdn.pyke.io/0/pyke:ort-rs/ms@1.23.2/aarch64-apple-darwin.tar.lzma2
+  sha256: 0897a0e1b840566a97e5a49497b02cbc204be2d006815174b639bc99731840f9
+
+Vendored because a build-time download is incompatible with remote execution
+(the fetched file is not a tracked action output, so it does not propagate to
+the next action). Fed to ort-sys via ORT_LIB_LOCATION — the same mechanism as
+`vendor/ort-ios` (see MODULE.bazel ort-sys annotation + //:ort_macos_arm64).


### PR DESCRIPTION
## Summary

Opens the Apple chapter of the Bazel migration with its two scoped gates: the full `xybrid-bolt` staticlib closure and then the complete `xybrid` CLI now cross-compile for `aarch64-apple-darwin` **entirely on BuildBuddy Linux workers** — Mach-O-verified, and the CLI was smoke-run natively on an arm64 Mac (`--help` renders the full command surface). Nine darwin-specific fixes land at their proper layers: a new `hermetic_llvm.patch` hunk making the darwin link-wrapper resolve its tools via `EXT_BUILD_ROOT` when cwd ≠ execroot (the root cause of the original spike's macOS rfcc wall, upstream-worthy), a `rules_rs.patch` hunk baking per-triple build-script deps so they agree with the triple's baked features (exec-config select mismatch that broke ort-sys's darwin build script, upstream-worthy), the `//:llama` darwin cmake arm (`CMAKE_SYSTEM_NAME` + Mach-O binutils), extended `osx.frameworks` for the hermetic macOS SDK, feature hoists for `lzma-rust2`/`hmac-sha256`, and a vendored pinned `libonnxruntime.a` (71MB — the exact sha256-matched artifact ort-sys would download; build-time downloads are structurally incompatible with remote execution since the fetched file is never a tracked action output; same committed-vendor precedent as `ort-android`/`ort-ios`). The advisory `bazel.yml` gains a desktop-lanes step (linux CLI, macOS-CPU CLI + staticlib, windows llama) so every touching PR keeps the shared cache warm — a future Mac lane pulls the shared graph instead of recompiling it. Metal/Swift/xcframework remain Mac-bound by design (Apple ships no iOS SDK/Metal compiler off-Xcode); the iOS decompose is deliberately deferred per the scoped plan. Additive/dormant as always: cargo stays the build of record and no shipping workflow changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A: Bazel-only additive change; cargo untouched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (vendor/ort-macos/README + in-file comments)
- [x] No breaking changes (additive/dormant; linux/android/windows targets re-verified)