### PR TITLE
bazel(linux): ship the desktop CLI via Bazel — full parity + release cutover

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -130,13 +130,30 @@ jobs:
       - name: Build desktop lanes on RBE (linux CLI, macOS-CPU cross, windows llama)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          bazelisk build --config=remote \
+          bazelisk build --config=remote -c opt \
             //crates/xybrid-cli:xybrid
           bazelisk build --config=remote --config=macos \
             //crates/xybrid-cli:xybrid \
             //crates/xybrid-bolt:xybrid_bolt_staticlib
           bazelisk build --config=remote --config=windows \
             //:llama
+
+      # Linux-CLI smoke + parity gate (Flip 1): this is the SHIPPED artifact
+      # since the release-prep build-cli-linux cutover — run it, verify the
+      # desktop feature set (vision/mtmd + huggingface; parity with cargo's
+      # platform-desktop), and hold the hermetic glibc floor (2.28 — the old
+      # cargo/ubuntu-24.04 build required 2.39 and couldn't run on 22.04).
+      - name: Smoke the linux CLI (run + features + glibc floor)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          BIN=bazel-bin/crates/xybrid-cli/xybrid
+          "$BIN" --help >/dev/null
+          test "$(nm "$BIN" | grep -c ' mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
+          strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface support"; exit 1; }
+          MAX_GLIBC=$(strings "$BIN" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu | tail -1)
+          echo "glibc floor: $MAX_GLIBC"
+          [ "$(printf '%s\n' "$MAX_GLIBC" GLIBC_2.31 | sort -V | tail -1)" = "GLIBC_2.31" ] || { echo "glibc floor regressed above 2.31: $MAX_GLIBC"; exit 1; }
+          echo "linux CLI smoke: OK ✅"
 
       # The RBE-proven Android row (PR #326 gates 6-10): NDK cross-compile +
       # one-link .so + complete AAR. ABI fan-out (arm64-v8a / armeabi-v7a /

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -143,10 +143,15 @@ jobs:
       # desktop feature set (vision/mtmd + huggingface; parity with cargo's
       # platform-desktop), and hold the hermetic glibc floor (2.28 — the old
       # cargo/ubuntu-24.04 build required 2.39 and couldn't run on 22.04).
+      # NOTE: resolve the binary via cquery, NOT the bazel-bin symlink — the
+      # symlink tracks the LAST invocation above (windows), whose output is a
+      # different platform's binary ("Exec format error").
       - name: Smoke the linux CLI (run + features + glibc floor)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          BIN=bazel-bin/crates/xybrid-cli/xybrid
+          BIN=$(bazelisk cquery --config=remote -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          echo "resolved linux CLI: $BIN"
+          file "$BIN"
           "$BIN" --help >/dev/null
           test "$(nm "$BIN" | grep -c ' mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
           strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface support"; exit 1; }

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -642,7 +642,8 @@ jobs:
       # glibc floor — strictly better than the old cargo/ubuntu-24.04 build.
       - name: Verify CLI payload (run + features + glibc floor)
         run: |
-          BIN=bazel-bin/crates/xybrid-cli/xybrid
+          BIN=$(bazelisk cquery --config=remote -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          echo "resolved CLI: $BIN"
           "$BIN" --help >/dev/null
           test "$(nm "$BIN" | grep -c ' mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
           strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface support"; exit 1; }
@@ -657,7 +658,8 @@ jobs:
         run: |
           mkdir -p dist
           ARTIFACT="dist/xybrid-${TAG}-linux-x86_64"
-          cp bazel-bin/crates/xybrid-cli/xybrid "$ARTIFACT"
+          BIN=$(bazelisk cquery --config=remote -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          cp "$BIN" "$ARTIFACT"
           chmod +w "$ARTIFACT"   # bazel-bin outputs are read-only
           strip "$ARTIFACT"
           chmod +x "$ARTIFACT"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -59,7 +59,7 @@ env:
 #     precompile-binaries creates/uploads release assets)
 #   - contents + pull-requests: write -> open-release-pr
 #   - id-token + attestations: write  -> build-xcframework, build-cli-macos,
-#     build-android, build-cli (the jobs that call `attest-build-provenance`)
+#     build-android, build-cli, build-cli-linux (the jobs that call `attest-build-provenance`)
 # Keeping these off the workflow level means the remaining jobs don't get
 # unnecessary OIDC-issuance, release-write, or attestation-write privileges.
 permissions: read-all
@@ -587,6 +587,93 @@ jobs:
   # =========================================================================
   # CLI builds (Linux + Windows; macOS is built in build-apple-all).
   # =========================================================================
+  # ==========================================================================
+  # Linux CLI via Bazel on RBE (Flip 1 — mirrors the build-android cutover):
+  # Bazel produces the binary on the shared BuildBuddy cache with the hermetic
+  # toolchain; everything downstream (artifact name, provenance attestation,
+  # draft release, install.sh) is unchanged. Parity vs the cargo build was
+  # verified feature-by-feature (vision/mtmd + huggingface, no candle), and
+  # the hermetic build LOWERS the glibc floor from the runner's 2.39 to 2.28
+  # (the cargo binary built on ubuntu-24.04 could not run on Ubuntu 22.04).
+  # ==========================================================================
+  build-cli-linux:
+    name: Build CLI (linux-x86_64, Bazel)
+    needs: [check-release-branch]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # actions/checkout
+      id-token: write      # Sigstore OIDC for attest-build-provenance
+      attestations: write  # GitHub attestations API
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+
+      - name: Configure BuildBuddy remote config
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote --remote_executor=grpcs://remote.buildbuddy.io
+          common:remote --remote_cache_compression
+          common:remote --remote_download_toplevel
+          common:remote --remote_timeout=600
+          common:remote --jobs=200
+          common:remote --extra_execution_platforms=@llvm//:rbe_linux_x86_64
+          EOF
+
+      - name: Build CLI (Bazel on RBE, shipping mode)
+        run: |
+          bazelisk build --config=remote -c opt //crates/xybrid-cli:xybrid
+
+      # The payload gate (mirrors the Android APK-payload verify): the binary
+      # must run, carry vision (mtmd) + huggingface, and keep the hermetic
+      # glibc floor — strictly better than the old cargo/ubuntu-24.04 build.
+      - name: Verify CLI payload (run + features + glibc floor)
+        run: |
+          BIN=bazel-bin/crates/xybrid-cli/xybrid
+          "$BIN" --help >/dev/null
+          test "$(nm "$BIN" | grep -c ' mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
+          strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface support"; exit 1; }
+          MAX_GLIBC=$(strings "$BIN" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu | tail -1)
+          echo "glibc floor: $MAX_GLIBC"
+          [ "$(printf '%s\n' "$MAX_GLIBC" GLIBC_2.31 | sort -V | tail -1)" = "GLIBC_2.31" ] || { echo "glibc floor regressed above 2.31: $MAX_GLIBC"; exit 1; }
+
+      - name: Prepare artifact
+        id: prepare
+        env:
+          TAG: ${{ needs.check-release-branch.outputs.tag }}
+        run: |
+          mkdir -p dist
+          ARTIFACT="dist/xybrid-${TAG}-linux-x86_64"
+          cp bazel-bin/crates/xybrid-cli/xybrid "$ARTIFACT"
+          chmod +w "$ARTIFACT"   # bazel-bin outputs are read-only
+          strip "$ARTIFACT"
+          chmod +x "$ARTIFACT"
+          echo "artifact_path=$ARTIFACT" >> "$GITHUB_OUTPUT"
+
+      - name: Attest CLI provenance (linux-x86_64)
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: ${{ steps.prepare.outputs.artifact_path }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cli-linux-x86_64
+          path: dist/*
+
   build-cli:
     name: Build CLI (${{ matrix.name }})
     needs: [check-release-branch]
@@ -599,12 +686,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: linux-x86_64
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            artifact: xybrid
-            features: platform-desktop
-
+          # linux-x86_64 moved to the Bazel-built `build-cli-linux` job below
+          # (Flip 1 of the Bazel rollout — mirrors the Android AAR cutover).
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -736,6 +819,7 @@ jobs:
       - precompile-flutter-darwin
       - build-android
       - build-cli
+      - build-cli-linux
       - precompile-flutter-linux
       - precompile-flutter-windows
     runs-on: ubuntu-latest

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -117,6 +117,20 @@ cmake(
         # _GNU_SOURCE instead of _DARWIN_C_SOURCE (u_int/u_char vanish from the
         # SDK headers). Metal stays OFF (base entries): CPU-only is the lane
         # that can leave the Mac; Metal needs Xcode.
+        # Desktop-linux VISION (Flip 1): TOOLS+COMMON=ON unlock tools/ -> libmtmd,
+        # mirroring the android arms — the shipped cargo CLI is built with
+        # platform-desktop = vision+huggingface, so the Bazel artifact must match.
+        # The tool EXECUTABLES need a C++ runtime: the hermetic toolchain links
+        # C++ via staged inputs (-nostdlib++), which rfcc's cmake doesn't
+        # replicate — hand the static libc++/abi/unwind archives to the exe
+        # links via CMAKE_CXX_STANDARD_LIBRARIES (lands AFTER objects, unlike
+        # EXE_LINKER_FLAGS). The tools themselves are discarded; only the
+        # static libs ship. GGML_LLAMAFILE stays default-ON (android-only off).
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": _LLAMA_CACHE_ENTRIES | {
+            "LLAMA_BUILD_TOOLS": "ON",
+            "LLAMA_BUILD_COMMON": "ON",
+            "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
+        },
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": _LLAMA_CACHE_ENTRIES | {
             "CMAKE_SYSTEM_NAME": "Darwin",
             "CMAKE_SYSTEM_PROCESSOR": "arm64",
@@ -145,6 +159,17 @@ cmake(
         ],
         "//conditions:default": [],
     }),
+    # linux-vision: the static C++ runtime archives referenced by the linux
+    # arm's CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're linked into
+    # TARGET binaries), unlike build_data's exec-config host tools.
+    data = select({
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
+            "@llvm//runtimes/libcxx:libcxx.static",
+            "@llvm//runtimes/libcxx:libcxxabi.static",
+            "@llvm//runtimes/libunwind:libunwind.static",
+        ],
+        "//conditions:default": [],
+    }),
     lib_source = ":llama_src",
     # Build cmake's default `all` target — same as build.rs's vision path (it
     # sets TOOLS=ON and builds everything). Building only `mtmd` breaks cmake's
@@ -156,6 +181,8 @@ cmake(
         "@rules_rs//rs/platforms/config:aarch64-linux-android": ["libmtmd.a"] + _LLAMA_LIBS,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": ["libmtmd.a"] + _LLAMA_LIBS,
         "@rules_rs//rs/platforms/config:x86_64-linux-android": ["libmtmd.a"] + _LLAMA_LIBS,
+        # Desktop-linux vision (Flip 1) also collects libmtmd.
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": ["libmtmd.a"] + _LLAMA_LIBS,
         # Windows/MinGW: ggml/CMakeLists.txt sets CMAKE_STATIC_LIBRARY_PREFIX=""
         # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
         # libggml.a) — while llama (sibling scope) keeps it (libllama.a).

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -7,14 +7,17 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 
-# Android configs share the vision wiring. Vision (mtmd) is a mobile backend, so
-# the wrapper compiles its mtmd functions + the crate enables `vision` on Android
-# only; desktop's committed bindings carry the mtmd declarations but never call
-# them (no libmtmd link), keeping the proven desktop chain untouched.
-_ANDROID = [
+# Platforms with the vision (mtmd) backend: the wrapper compiles its mtmd
+# functions + the crate enables `vision`, and //:llama builds/installs libmtmd
+# for the same configs. Android (since #341) + desktop-linux (Flip 1 — the
+# shipped cargo CLI is platform-desktop = vision+huggingface, so the Bazel
+# artifact matches). Other platforms' committed bindings carry the mtmd
+# declarations but never call them (no libmtmd link).
+_VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:aarch64-linux-android",
     "@rules_rs//rs/platforms/config:armv7-linux-androideabi",
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
+    "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
 ]
 
 # First-party C++ shim: defines the _c-suffixed symbols the Rust bindings call.
@@ -27,7 +30,7 @@ cc_library(
     hdrs = ["wrapper.h"],
     defines = select({
         cfg: ["XYBRID_LLAMA_VISION"]
-        for cfg in _ANDROID
+        for cfg in _VISION_PLATFORMS
     } | {"//conditions:default": []}),
     deps = ["//:llama"],
 )
@@ -43,8 +46,8 @@ rust_library(
         "bindings",
         "committed-bindings",
     ] + select({
-        cfg: ["vision"]  # mtmd re-exports; matches the Android wrapper + libmtmd
-        for cfg in _ANDROID
+        cfg: ["vision"]  # mtmd re-exports; matches the wrapper define + libmtmd
+        for cfg in _VISION_PLATFORMS
     } | {"//conditions:default": []}),
     edition = "2021",
     deps = [

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -53,6 +53,12 @@ rust_library(
         "@rules_rs//rs/platforms/config:aarch64-linux-android": _ANDROID_BACKENDS,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": _ANDROID_BACKENDS,
         "@rules_rs//rs/platforms/config:x86_64-linux-android": _ANDROID_BACKENDS,
+        # Desktop-linux (Flip 1): the shipped cargo CLI is platform-desktop =
+        # vision + huggingface — NO candle (desktop voice runs on ORT). Parity
+        # means vision only here; hf rides on the sdk's features/deps.
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
+            "llm-llamacpp-vision",
+        ],
         "//conditions:default": [],
     }),
     deps = all_crate_deps(normal = True),

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -1,12 +1,13 @@
 # GATE 3: safe Rust wrapper over llama-cpp-sys. Builds once llama_cpp_sys links.
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
 
-# Vision (mtmd safe wrappers) is Android-only — a mobile backend (see
-# llama-cpp-sys/BUILD.bazel). Desktop builds the base llama wrapper only.
-_ANDROID = [
+# Vision (mtmd safe wrappers): Android + desktop-linux (Flip 1) — must match
+# llama-cpp-sys/BUILD.bazel's _VISION_PLATFORMS and //:llama's libmtmd arms.
+_VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:aarch64-linux-android",
     "@rules_rs//rs/platforms/config:armv7-linux-androideabi",
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
+    "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
 ]
 
 rust_library(
@@ -15,7 +16,7 @@ rust_library(
     edition = "2021",
     crate_features = ["bindings"] + select({
         cfg: ["vision"]
-        for cfg in _ANDROID
+        for cfg in _VISION_PLATFORMS
     } | {"//conditions:default": []}),
     deps = [
         "//crates/llama-cpp-sys:llama_cpp_sys",

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -27,6 +27,17 @@ original_sdk_deps = DEP_DATA.get("crates/xybrid-sdk", {})
 filtered_sdk_deps = dict(original_sdk_deps)
 filtered_sdk_deps["deps"] = [d for d in original_sdk_deps.get("deps", []) if d != "//macros"]
 
+# Flip 1 (desktop-linux parity): the `huggingface` feature needs the optional
+# hf-hub dep, which the hub's per-platform resolution doesn't wire for linux
+# (it records the preset name, not its optional-dep expansion). Same surgery
+# precedent as the //macros filter above. hf-hub 0.5 resolves in the hub with
+# exactly [rustls-tls, ureq] — no new inputs.
+_SDK_LINUX_CFG = "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu"
+filtered_sdk_deps["deps_by_platform"] = dict(original_sdk_deps.get("deps_by_platform", {}))
+filtered_sdk_deps["deps_by_platform"][_SDK_LINUX_CFG] = filtered_sdk_deps["deps_by_platform"].get(_SDK_LINUX_CFG, []) + [
+    "@crates//:hf-hub-0.5.0",
+]
+
 rust_library(
     name = "xybrid-sdk",
     srcs = glob(["src/**/*.rs"]),
@@ -35,7 +46,14 @@ rust_library(
         "default",
         "llm-llamacpp",
     ] + select({
-        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": ["platform-desktop"],
+        # Flip 1: the shipped cargo CLI uses platform-desktop = ort-download
+        # (no-op marker) + llm-llamacpp-vision + huggingface. Bazel doesn't
+        # expand presets across crates, so name the expansion explicitly.
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
+            "platform-desktop",
+            "llm-llamacpp-vision",
+            "huggingface",
+        ],
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["platform-macos"],
         "@rules_rs//rs/platforms/config:aarch64-linux-android": _SDK_ANDROID,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": _SDK_ANDROID,

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -35,7 +35,10 @@ filtered_sdk_deps["deps"] = [d for d in original_sdk_deps.get("deps", []) if d !
 _SDK_LINUX_CFG = "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu"
 filtered_sdk_deps["deps_by_platform"] = dict(original_sdk_deps.get("deps_by_platform", {}))
 filtered_sdk_deps["deps_by_platform"][_SDK_LINUX_CFG] = filtered_sdk_deps["deps_by_platform"].get(_SDK_LINUX_CFG, []) + [
-    "@crates//:hf-hub-0.5.0",
+    # Unversioned alias: this reference is hand-written (unlike the generated
+    # DEP_DATA's versioned labels, which re-render on bumps), so it must not
+    # pin a version the lockfile will outgrow.
+    "@crates//:hf-hub",
 ]
 
 rust_library(


### PR DESCRIPTION
## Summary

Flip 1 of the Bazel rollout: the `linux-x86_64` CLI release artifact is now produced by Bazel on BuildBuddy RBE, mirroring the Android AAR cutover — parity first, verification gates, then the pipeline swap with the artifact name, provenance attestation, and every downstream consumer (`create-draft-release`, `install.sh`, docs) unchanged. Parity was verified against the actual shipped v0.3.0 release asset: vision (54 `mtmd_` symbols, unlocked by handing the hermetic static libc++/abi/unwind archives to llama's tool links — retiring the libc++ wall that kept desktop vision off since July) and HuggingFace (optional `hf-hub` dep wired via DEP_DATA surgery), with candle deliberately absent (desktop voice runs on ORT, matching cargo's `platform-desktop`). Two shipping improvements ride along: the hermetic build lowers the glibc floor from **2.39 → 2.28** (the current cargo binary, built on ubuntu-24.04, cannot run on Ubuntu 22.04 or older), and it replaces cargo's `-march=native`-on-whatever-runner ggml build with a generic, reproducible one. The advisory `bazel.yml` now builds the linux CLI at `-c opt` and smokes it (runs + feature markers + a `glibc ≤ 2.31` gate) on every Bazel-touching PR, and the swap itself only takes effect on the next `release/v*` branch — rollback is a one-commit revert. Windows stays on cargo (its Bazel `.exe` remains parked); Android AAR + macOS lanes re-verified cache-stable on RBE.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A: no Rust source changes; cargo untouched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (in-file comments; plan in workspace .context)
- [x] No breaking changes (shipped artifact name/attestation unchanged; parity verified vs the v0.3.0 asset; swap activates only on the next release branch)