### PR TITLE
bazel(apple): the macOS GPU lane — Metal+CoreML CLI builds and runs (flip 2, M1-M3)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -44,6 +44,18 @@ build:windows --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-gnu
 # ort-sys annotation in MODULE.bazel) instead of ort's build-time download,
 # which is structurally incompatible with remote execution.
 build:macos --platforms=@rules_rs//rs/platforms:aarch64-apple-darwin
+
+# Desktop macOS GPU lane (Flip 2): Metal + Accelerate ON — REQUIRES a Mac with
+# Xcode (the metal shader compiler); never combine with linux remote EXECUTION.
+# Uses the host's preinstalled cmake/make/pkg-config for rfcc's exec tools
+# (macos-14 runners and dev Macs ship them; the from-source bootstrap is the
+# known mac-host wall). The Rust side is identical to the CPU lane by design —
+# same features, same rlibs — so a warm shared cache serves most of the graph.
+build:macos-metal --platforms=@rules_rs//rs/platforms:aarch64-apple-darwin
+build:macos-metal --//:metal=true
+build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain
+build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_make_toolchain
+build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain
 # (-fstack-protector, which needs a libssp hermetic-llvm's MinGW sysroot doesn't
 # ship, is disabled for windows at the toolchain level in hermetic_llvm.patch.)
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -168,11 +168,15 @@ cmake(
             "LLAMA_BUILD_COMMON": "ON",
             "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
         },
-        # darwin CPU lane (RBE): _DARWIN_LLAMA + the hermetic static C++
-        # runtime for the tool exes (linux-exec builds of libcxx work; mac-host
-        # ones don't — the Metal lane is a separate target, //:llama_metal).
+        # darwin CPU lane (RBE): _DARWIN_LLAMA + the SDK's -lc++ for the tool
+        # exes (resolves against the sysroot's libc++.tbd stubs; the tools are
+        # discarded). NOT the hermetic static libcxx: compiling hermetic-llvm's
+        # libcxx from source FOR A DARWIN TARGET breaks against the minimal
+        # SDK regardless of exec platform (_CTYPE_* undeclared in ___wctype.h,
+        # unresolved using declarations) — same reason //:llama_metal links
+        # -lc++. The static-archive approach remains linux-only.
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": _DARWIN_LLAMA | {
-            "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
+            "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
         },
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
     }),
@@ -189,16 +193,13 @@ cmake(
         ],
         "//conditions:default": [],
     }),
-    # desktop vision: the static C++ runtime archives referenced by the linux
-    # and darwin arms' CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're
-    # linked into TARGET binaries), unlike build_data's exec-config host tools.
+    # linux vision: the static C++ runtime archives referenced by the linux
+    # arm's CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're linked into
+    # TARGET binaries), unlike build_data's exec-config host tools. darwin
+    # deliberately absent: darwin-target libcxx-from-source is broken (see the
+    # darwin arm comment) — both darwin lanes use the SDK's -lc++.
     data = select({
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
-            "@llvm//runtimes/libcxx:libcxx.static",
-            "@llvm//runtimes/libcxx:libcxxabi.static",
-            "@llvm//runtimes/libunwind:libunwind.static",
-        ],
-        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
             "@llvm//runtimes/libcxx:libcxx.static",
             "@llvm//runtimes/libcxx:libcxxabi.static",
             "@llvm//runtimes/libunwind:libunwind.static",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -285,7 +285,14 @@ cmake(
     # (like //:llama's), and an incompatibility marker on it poisons the whole
     # top target under --config=remote.
     exec_compatible_with = ["@platforms//os:macos"],
-    tags = ["no-remote-exec"],
+    # "manual": keep wildcard builds (bazel build //...) on non-mac machines
+    # from analyzing this target — with no macOS exec platform registered,
+    # exec_compatible_with would hard-fail resolution. Explicit requests and
+    # the transitive path (llama-cpp-sys' --//:metal select) still work.
+    tags = [
+        "manual",
+        "no-remote-exec",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,6 @@ exports_files([
     "Cargo.toml",
 ])
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 # The macOS GPU lane toggle (Flip 2). Both darwin lanes share the SAME Rust
@@ -23,24 +22,6 @@ config_setting(
     name = "metal_enabled",
     flag_values = {":metal": "true"},
     visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "metal_disabled",
-    flag_values = {":metal": "false"},
-)
-
-# darwin CPU lane (RBE): the only darwin config that builds the hermetic
-# libc++ archives — the Metal lane (mac-local exec) links the real SDK's
-# -lc++ instead, because compiling hermetic-llvm's libc++ FROM SOURCE on a
-# mac host is broken (unresolved-using-declaration in libcxx headers; the
-# linux-exec build of the same target is fine).
-selects.config_setting_group(
-    name = "darwin_cpu_lane",
-    match_all = [
-        "@rules_rs//rs/platforms/config:aarch64-apple-darwin",
-        ":metal_disabled",
-    ],
 )
 
 # Host platform for Linux hosts (CI runners): rules_rs' experimental toolchains
@@ -117,6 +98,24 @@ _LLAMA_LIBS = [
     "libggml-cpu.a",
 ]
 
+# Shared darwin cmake config (CPU lane //:llama darwin arm + //:llama_metal).
+# CMAKE_SYSTEM pair: same rfcc gap as windows — no darwin _TARGET_OS_PARAMS
+# entry, so without it cmake detects the Linux exec host and ggml defines
+# _GNU_SOURCE instead of _DARWIN_C_SOURCE. With SYSTEM_NAME=Darwin cmake also
+# requires Mach-O binutils (CMakeFindBinUtils) — pointed at the hermetic llvm
+# equivalents via $(execpath) (labels ride in via build_data, cfg=exec).
+# Vision (TOOLS/COMMON=ON -> libmtmd) for parity with the shipped
+# platform-macos CLI; the throwaway tool exes get a C++ runtime via
+# CMAKE_CXX_STANDARD_LIBRARIES (lands AFTER objects, unlike EXE_LINKER_FLAGS).
+_DARWIN_LLAMA = _LLAMA_CACHE_ENTRIES | {
+    "CMAKE_SYSTEM_NAME": "Darwin",
+    "CMAKE_SYSTEM_PROCESSOR": "arm64",
+    "CMAKE_INSTALL_NAME_TOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-install-name-tool)",
+    "CMAKE_OTOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-otool)",
+    "LLAMA_BUILD_TOOLS": "ON",
+    "LLAMA_BUILD_COMMON": "ON",
+}
+
 cmake(
     name = "llama",
     # armv7: rfcc's crosstool has no CMAKE_SYSTEM_PROCESSOR mapping for armv7,
@@ -169,40 +168,13 @@ cmake(
             "LLAMA_BUILD_COMMON": "ON",
             "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
         },
-        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": _LLAMA_CACHE_ENTRIES | {
-            "CMAKE_SYSTEM_NAME": "Darwin",
-            "CMAKE_SYSTEM_PROCESSOR": "arm64",
-            # With SYSTEM_NAME=Darwin cmake requires Mach-O binutils
-            # (CMakeFindBinUtils). Point cmake at the hermetic llvm equivalents
-            # via label expansion: rfcc expands $(execpath) in cache_entries,
-            # and the tools ride in via build_data (cfg=exec, so the alias
-            # resolves to the WORKER's binary — linux on RBE, darwin locally).
-            # $$EXT_BUILD_ROOT -> $EXT_BUILD_ROOT, shell-expanded on the worker
-            # (execpath is execroot-relative; cmake needs it absolute).
-            "CMAKE_INSTALL_NAME_TOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-install-name-tool)",
-            "CMAKE_OTOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-otool)",
-            # Vision (mtmd), same shape as the linux arm: parity with the
-            # shipped platform-macos CLI. Tool exes get the static C++ runtime
-            # handed explicitly (hermetic toolchain stages it as link inputs,
-            # which rfcc's cmake doesn't replicate); tools are discarded.
-            "LLAMA_BUILD_TOOLS": "ON",
-            "LLAMA_BUILD_COMMON": "ON",
+        # darwin CPU lane (RBE): _DARWIN_LLAMA + the hermetic static C++
+        # runtime for the tool exes (linux-exec builds of libcxx work; mac-host
+        # ones don't — the Metal lane is a separate target, //:llama_metal).
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": _DARWIN_LLAMA | {
             "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
         },
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
-    }) | select({
-        # The GPU lane (Flip 2): dict-union overrides the base Metal/Accelerate
-        # OFF entries. Requires a Mac (Xcode's metal compiler) — build with
-        # --config=macos-metal, never with linux RBE execution. The tool exes
-        # link the REAL SDK's libc++ (-lc++ resolves against the sysroot tbds):
-        # the hermetic libc++ archives can't be compiled on a mac host (see
-        # :darwin_cpu_lane) and the tools are discarded anyway.
-        ":metal_enabled": {
-            "GGML_METAL": "ON",
-            "GGML_ACCELERATE": "ON",
-            "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
-        },
-        "//conditions:default": {},
     }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
     # rfcc finds its own downloaded cmake; /opt/homebrew doesn't exist there.)
@@ -226,22 +198,12 @@ cmake(
             "@llvm//runtimes/libcxx:libcxxabi.static",
             "@llvm//runtimes/libunwind:libunwind.static",
         ],
-        ":darwin_cpu_lane": [
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
             "@llvm//runtimes/libcxx:libcxx.static",
             "@llvm//runtimes/libcxx:libcxxabi.static",
             "@llvm//runtimes/libunwind:libunwind.static",
         ],
         "//conditions:default": [],
-    }),
-    # Metal lane runs on a mac host with the PREINSTALLED cmake/make/pkg-config
-    # (see build:macos-metal), but rfcc sanitizes PATH to /bin:/usr/bin:
-    # /usr/local/bin — homebrew's /opt/homebrew/bin (Apple-silicon, incl. the
-    # macos-14 runners) is missing. User env overrides the framework's PATH.
-    env = select({
-        ":metal_enabled": {
-            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
-        },
-        "//conditions:default": {},
     }),
     lib_source = ":llama_src",
     # Build cmake's default `all` target — same as build.rs's vision path (it
@@ -268,11 +230,6 @@ cmake(
             "ggml-cpu.a",
         ],
         "//conditions:default": _LLAMA_LIBS,
-    }) + select({
-        # Metal lane: ggml builds its Metal backend as a separate archive,
-        # linked unconditionally by cargo's apple path (build.rs:681).
-        ":metal_enabled": ["libggml-metal.a"],
-        "//conditions:default": [],
     }),
     # Windows: ggml/CMakeLists.txt installs the ggml umbrella/base libs with
     # `install(TARGETS ggml LIBRARY)` (no ARCHIVE). On Linux that still lands the
@@ -284,6 +241,51 @@ cmake(
         "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": "mkdir -p $$INSTALLDIR/lib && find $$BUILD_TMPDIR -name '*.a' -exec cp -f {} $$INSTALLDIR/lib/ \\;",
         "//conditions:default": "",
     }),
+    visibility = ["//visibility:public"],
+)
+
+# The macOS GPU lane (Flip 2): llama with Metal + Accelerate, a SEPARATE target
+# so (a) the proven //:llama keeps its action keys byte-stable on every lane,
+# and (b) this one can be pinned LOCAL (tags) while the rest of the same build
+# graph executes remotely — the mixed-exec model: a Mac drives the build, RBE
+# compiles the Rust, only this action needs the Mac (Xcode's metal compiler).
+# Selected into the graph by //crates/llama-cpp-sys when --//:metal=true
+# (build:macos-metal). Tool exes link the REAL SDK's -lc++ (hermetic libc++
+# cannot be compiled FROM SOURCE on a mac host — unresolved-using-declaration
+# in its own headers; linux-exec builds of the same target are fine).
+cmake(
+    name = "llama_metal",
+    # rfcc sanitizes PATH to /bin:/usr/bin:/usr/local/bin; the preinstalled
+    # cmake/make/pkg-config (build:macos-metal --extra_toolchains) live in
+    # /opt/homebrew/bin on Apple silicon (incl. macos-14 runners).
+    env = {"PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"},
+    build_data = [
+        "@llvm//tools:llvm-install-name-tool",
+        "@llvm//tools:llvm-otool",
+    ],
+    cache_entries = _DARWIN_LLAMA | {
+        "GGML_METAL": "ON",
+        "GGML_ACCELERATE": "ON",
+        "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
+    },
+    lib_source = ":llama_src",
+    out_static_libs = [
+        "libmtmd.a",
+        # ggml's Metal backend is its own archive, linked unconditionally by
+        # cargo's apple path (build.rs:681).
+        "libggml-metal.a",
+    ] + _LLAMA_LIBS,
+    # Never on a remote (Linux) worker: needs Xcode's metal compiler.
+    # exec_compatible_with pins the EXEC PLATFORM (toolchain resolution) to a
+    # Mac — the no-remote-exec tag alone only pins the spawn strategy, and
+    # under --config=remote toolchain resolution would still pick the
+    # prioritized rbe_linux exec platform, handing this local action LINUX
+    # clang binaries (exec format error 126). NOTE: no target_compatible_with
+    # — the graph carries an analysis-only exec-config copy of this chain
+    # (like //:llama's), and an incompatibility marker on it poisons the whole
+    # top target under --config=remote.
+    exec_compatible_with = ["@platforms//os:macos"],
+    tags = ["no-remote-exec"],
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,44 @@ exports_files([
     "Cargo.toml",
 ])
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+# The macOS GPU lane toggle (Flip 2). Both darwin lanes share the SAME Rust
+# feature set (candle-metal/CoreML/vision are bindings — pure Rust, cross-
+# compilable, so keeping features identical maximizes rlib cache overlap
+# between the RBE CPU lane and the Mac Metal lane). The flag flips only what
+# physically differs: llama.cpp's GGML_METAL/ACCELERATE, which need Xcode —
+# so --//:metal=true builds must run ON a Mac (see build:macos-metal).
+bool_flag(
+    name = "metal",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "metal_enabled",
+    flag_values = {":metal": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "metal_disabled",
+    flag_values = {":metal": "false"},
+)
+
+# darwin CPU lane (RBE): the only darwin config that builds the hermetic
+# libc++ archives — the Metal lane (mac-local exec) links the real SDK's
+# -lc++ instead, because compiling hermetic-llvm's libc++ FROM SOURCE on a
+# mac host is broken (unresolved-using-declaration in libcxx headers; the
+# linux-exec build of the same target is fine).
+selects.config_setting_group(
+    name = "darwin_cpu_lane",
+    match_all = [
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin",
+        ":metal_disabled",
+    ],
+)
+
 # Host platform for Linux hosts (CI runners): rules_rs' experimental toolchains
 # need an explicit host platform carrying a libc constraint on Linux. Activated
 # by `common:linux` in .bazelrc (auto-applied via --enable_platform_specific_config).
@@ -143,8 +181,28 @@ cmake(
             # (execpath is execroot-relative; cmake needs it absolute).
             "CMAKE_INSTALL_NAME_TOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-install-name-tool)",
             "CMAKE_OTOOL": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-otool)",
+            # Vision (mtmd), same shape as the linux arm: parity with the
+            # shipped platform-macos CLI. Tool exes get the static C++ runtime
+            # handed explicitly (hermetic toolchain stages it as link inputs,
+            # which rfcc's cmake doesn't replicate); tools are discarded.
+            "LLAMA_BUILD_TOOLS": "ON",
+            "LLAMA_BUILD_COMMON": "ON",
+            "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
         },
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
+    }) | select({
+        # The GPU lane (Flip 2): dict-union overrides the base Metal/Accelerate
+        # OFF entries. Requires a Mac (Xcode's metal compiler) — build with
+        # --config=macos-metal, never with linux RBE execution. The tool exes
+        # link the REAL SDK's libc++ (-lc++ resolves against the sysroot tbds):
+        # the hermetic libc++ archives can't be compiled on a mac host (see
+        # :darwin_cpu_lane) and the tools are discarded anyway.
+        ":metal_enabled": {
+            "GGML_METAL": "ON",
+            "GGML_ACCELERATE": "ON",
+            "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
+        },
+        "//conditions:default": {},
     }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
     # rfcc finds its own downloaded cmake; /opt/homebrew doesn't exist there.)
@@ -159,16 +217,31 @@ cmake(
         ],
         "//conditions:default": [],
     }),
-    # linux-vision: the static C++ runtime archives referenced by the linux
-    # arm's CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're linked into
-    # TARGET binaries), unlike build_data's exec-config host tools.
+    # desktop vision: the static C++ runtime archives referenced by the linux
+    # and darwin arms' CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're
+    # linked into TARGET binaries), unlike build_data's exec-config host tools.
     data = select({
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
             "@llvm//runtimes/libcxx:libcxx.static",
             "@llvm//runtimes/libcxx:libcxxabi.static",
             "@llvm//runtimes/libunwind:libunwind.static",
         ],
+        ":darwin_cpu_lane": [
+            "@llvm//runtimes/libcxx:libcxx.static",
+            "@llvm//runtimes/libcxx:libcxxabi.static",
+            "@llvm//runtimes/libunwind:libunwind.static",
+        ],
         "//conditions:default": [],
+    }),
+    # Metal lane runs on a mac host with the PREINSTALLED cmake/make/pkg-config
+    # (see build:macos-metal), but rfcc sanitizes PATH to /bin:/usr/bin:
+    # /usr/local/bin — homebrew's /opt/homebrew/bin (Apple-silicon, incl. the
+    # macos-14 runners) is missing. User env overrides the framework's PATH.
+    env = select({
+        ":metal_enabled": {
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+        },
+        "//conditions:default": {},
     }),
     lib_source = ":llama_src",
     # Build cmake's default `all` target — same as build.rs's vision path (it
@@ -183,6 +256,8 @@ cmake(
         "@rules_rs//rs/platforms/config:x86_64-linux-android": ["libmtmd.a"] + _LLAMA_LIBS,
         # Desktop-linux vision (Flip 1) also collects libmtmd.
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": ["libmtmd.a"] + _LLAMA_LIBS,
+        # Darwin vision (Flip 2 parity — both CPU and Metal lanes).
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["libmtmd.a"] + _LLAMA_LIBS,
         # Windows/MinGW: ggml/CMakeLists.txt sets CMAKE_STATIC_LIBRARY_PREFIX=""
         # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
         # libggml.a) — while llama (sibling scope) keeps it (libllama.a).
@@ -193,6 +268,11 @@ cmake(
             "ggml-cpu.a",
         ],
         "//conditions:default": _LLAMA_LIBS,
+    }) + select({
+        # Metal lane: ggml builds its Metal backend as a separate archive,
+        # linked unconditionally by cargo's apple path (build.rs:681).
+        ":metal_enabled": ["libggml-metal.a"],
+        "//conditions:default": [],
     }),
     # Windows: ggml/CMakeLists.txt installs the ggml umbrella/base libs with
     # `install(TARGETS ggml LIBRARY)` (no ARCHIVE). On Linux that still lands the

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,8 @@ bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
 # rules_cc must be a direct dep so the `@rules_cc//...` flag in .bazelrc resolves.
 bazel_dep(name = "rules_cc", version = "0.2.20")
+# bool_flag for the //:metal build setting (the macOS GPU lane toggle).
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 # platforms must be a direct dep so the `@platforms//...` constraints in //:android_arm64 resolve.
 bazel_dep(name = "platforms", version = "1.0.0")
 
@@ -175,8 +177,18 @@ osx.frameworks(names = [
     "IOKit",
     "IOSurface",
     "Metal",
+    "MetalKit",
     "MetalPerformanceShaders",
     "MetalPerformanceShadersGraph",
+    # header-graph deps of the Metal lane's ObjC compile (ggml-metal.m):
+    # Foundation's headers include CoreServices; MetalKit's include ModelIO
+    # and QuartzCore (CAMetalLayer) / CoreImage (MTKTextureLoader).
+    "CFNetwork",
+    "CoreImage",
+    "CoreServices",
+    "DiskArbitration",  # CoreServices/CarbonCore/Files.h includes DADisk.h
+    "ModelIO",
+    "QuartzCore",
 ])
 use_repo(osx, "macos_sdk")
 

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -18,6 +18,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:armv7-linux-androideabi",
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
+    "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2: macOS parity
 ]
 
 # First-party C++ shim: defines the _c-suffixed symbols the Rust bindings call.
@@ -32,6 +33,18 @@ cc_library(
         cfg: ["XYBRID_LLAMA_VISION"]
         for cfg in _VISION_PLATFORMS
     } | {"//conditions:default": []}),
+    # Metal lane: the frameworks cargo's build.rs emits on apple (build.rs:
+    # 675-680). The Rust crates' #[link] attrs already pull Metal/Foundation/
+    # Accelerate; MetalKit exists ONLY here — ggml-metal.m needs it.
+    linkopts = select({
+        "//:metal_enabled": [
+            "-framework Accelerate",
+            "-framework Metal",
+            "-framework MetalKit",
+            "-framework Foundation",
+        ],
+        "//conditions:default": [],
+    }),
     deps = ["//:llama"],
 )
 

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -45,7 +45,13 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    deps = ["//:llama"],
+    deps = select({
+        # --//:metal=true swaps in the Metal llama (a separate, local-pinned
+        # target — see //:llama_metal). Everything above this select is
+        # identical between the lanes by design.
+        "//:metal_enabled": ["//:llama_metal"],
+        "//conditions:default": ["//:llama"],
+    }),
 )
 
 # The crate. `committed-bindings` makes lib.rs include! the committed
@@ -63,10 +69,10 @@ rust_library(
         for cfg in _VISION_PLATFORMS
     } | {"//conditions:default": []}),
     edition = "2021",
-    deps = [
-        ":wrapper_cc",
-        "//:llama",
-    ],
+    deps = [":wrapper_cc"] + select({
+        "//:metal_enabled": ["//:llama_metal"],
+        "//conditions:default": ["//:llama"],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -49,6 +49,8 @@ rust_library(
             "candle-metal",
             "candle-nn",
             "ort-coreml",
+            # Flip 2: parity with the shipped platform-macos CLI (vision).
+            "llm-llamacpp-vision",
         ],
         "@rules_rs//rs/platforms/config:aarch64-linux-android": _ANDROID_BACKENDS,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": _ANDROID_BACKENDS,

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -8,6 +8,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:armv7-linux-androideabi",
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
+    "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2: macOS parity
 ]
 
 rust_library(

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -32,14 +32,20 @@ filtered_sdk_deps["deps"] = [d for d in original_sdk_deps.get("deps", []) if d !
 # (it records the preset name, not its optional-dep expansion). Same surgery
 # precedent as the //macros filter above. hf-hub 0.5 resolves in the hub with
 # exactly [rustls-tls, ureq] — no new inputs.
-_SDK_LINUX_CFG = "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu"
-filtered_sdk_deps["deps_by_platform"] = dict(original_sdk_deps.get("deps_by_platform", {}))
-filtered_sdk_deps["deps_by_platform"][_SDK_LINUX_CFG] = filtered_sdk_deps["deps_by_platform"].get(_SDK_LINUX_CFG, []) + [
-    # Unversioned alias: this reference is hand-written (unlike the generated
-    # DEP_DATA's versioned labels, which re-render on bumps), so it must not
-    # pin a version the lockfile will outgrow.
-    "@crates//:hf-hub",
+# Unversioned alias: this reference is hand-written (unlike the generated
+# DEP_DATA's versioned labels, which re-render on bumps), so it must not
+# pin a version the lockfile will outgrow.
+_HF_PLATFORMS = [
+    "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
+    "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2
 ]
+
+_ORIG_DBP = original_sdk_deps.get("deps_by_platform", {})
+
+filtered_sdk_deps["deps_by_platform"] = _ORIG_DBP | {
+    _cfg: _ORIG_DBP.get(_cfg, []) + ["@crates//:hf-hub"]
+    for _cfg in _HF_PLATFORMS
+}
 
 rust_library(
     name = "xybrid-sdk",
@@ -57,7 +63,13 @@ rust_library(
             "llm-llamacpp-vision",
             "huggingface",
         ],
-        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["platform-macos"],
+        # Flip 2: cargo's platform-macos preset also implies vision + hf
+        # (Bazel doesn't expand presets across crates — name them).
+        "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
+            "platform-macos",
+            "llm-llamacpp-vision",
+            "huggingface",
+        ],
         "@rules_rs//rs/platforms/config:aarch64-linux-android": _SDK_ANDROID,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": _SDK_ANDROID,
         "@rules_rs//rs/platforms/config:x86_64-linux-android": _SDK_ANDROID,


### PR DESCRIPTION
## Summary

Adds the macOS GPU lane to the Bazel migration: a new `--//:metal` flag (config `build:macos-metal`) selects a standalone `//:llama_metal` target that compiles llama.cpp with `GGML_METAL=ON + GGML_ACCELERATE=ON` on a Mac (Xcode's metal compiler + the host's preinstalled cmake/make/pkg-config), while **both darwin lanes share one Rust feature set at full `platform-macos` parity** (candle-metal/CoreML/vision/huggingface — pure-Rust bindings, so identical rlibs maximize cache overlap; core/sdk darwin arms updated, darwin joins `_VISION_PLATFORMS`, hf-hub wired). The headline result is **mixed execution, measured**: one `bazel build --config=remote --config=macos-metal` from a Mac ran **818 actions = 644 remote (BuildBuddy Linux) + 1889 cache hits + exactly 1 local darwin action** (the Metal compile), producing a Mach-O arm64 CLI that runs with the full Metal surface (199 `ggml_metal` symbols + vision + candle + hf — matching the shipped v0.3.0 macOS binary's feature markers). Two routing lessons are encoded in comments: `tags=["no-remote-exec"]` pins only the spawn strategy while `exec_compatible_with=["@platforms//os:macos"]` is what pins toolchain resolution (the local action otherwise receives Linux clang, exec error 126), and no `target_compatible_with` on such targets (the analysis-only exec-config copy of the chain would poison the top target under `--config=remote`). Also closed: hermetic-llvm's libc++ cannot be compiled from source on a mac host (Metal lane's throwaway tool exes link the real SDK's `-lc++`; the hermetic archives stay on the RBE CPU lane), and the hermetic macOS SDK stub list grows by the Metal header graph (MetalKit, CoreServices, DiskArbitration, ModelIO, QuartzCore, CoreImage, CFNetwork). Additive and flag-gated: the flag defaults to false, `//:llama`'s action keys are byte-stable, and all five existing lanes re-analyze clean — the advisory-CI macos-14 job and the `build-cli-macos` release swap are deliberately follow-ups (M4).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A: Bazel-only additive change; cargo untouched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (in-file comments; lane docs in workspace .context)
- [x] No breaking changes (flag-gated, default off; proven lanes' action keys byte-stable)