### PR TITLE
bazel(apple): ship the macOS CLI via Bazel mixed execution — flip 2 cutover (M4)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -209,3 +209,61 @@ jobs:
             unzip -l "$APK" | grep -q " $f\$" || { echo "MISSING: $f"; exit 1; }
           done
           echo "APK payload complete: 3-ABI jniLibs + classes.dex ✅"
+
+  # The macOS Metal lane (Flip 2), on a real Mac. NOT on pull_request: macOS
+  # minutes bill at 10x linux and PR-level coverage of the shared Rust graph
+  # already comes from the desktop-lanes step above (the macOS-CPU cross
+  # compiles the identical rlib set on linux workers). This job validates the
+  # Mac-only remainder — the Metal llama compile + final link — on every
+  # master merge and keeps its action cached for the release job.
+  bazel-macos-metal:
+    name: Bazel macOS Metal lane (mixed execution)
+    if: github.event_name != 'pull_request'
+    runs-on: macos-14
+    timeout-minutes: 45
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Ensure rfcc host tools
+        run: |
+          which cmake >/dev/null || brew install cmake
+          which pkg-config >/dev/null || brew install pkg-config
+
+      - name: Configure BuildBuddy remote config
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote --remote_executor=grpcs://remote.buildbuddy.io
+          common:remote --remote_cache_compression
+          common:remote --remote_download_toplevel
+          common:remote --remote_timeout=600
+          common:remote --jobs=200
+          common:remote --extra_execution_platforms=@llvm//:rbe_linux_x86_64
+          EOF
+
+      - name: Build Metal CLI (mixed execution)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote --config=macos-metal -c opt \
+            //crates/xybrid-cli:xybrid
+
+      - name: Smoke the Metal CLI (run + Metal + features)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          BIN=$(bazelisk cquery --config=remote --config=macos-metal -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          echo "resolved CLI: $BIN"
+          file "$BIN"
+          "$BIN" --help >/dev/null
+          test "$(nm "$BIN" | grep -c '_ggml_metal')" -gt 0 || { echo "MISSING Metal symbols"; exit 1; }
+          test "$(nm "$BIN" | grep -c '_mtmd_')" -gt 0 || { echo "MISSING vision symbols"; exit 1; }
+          strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface"; exit 1; }
+          echo "Metal CLI smoke: OK"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -284,7 +284,13 @@ jobs:
 
   # ----- Apple job 3/3: CLI macos-arm64 (parallel)
   build-cli-macos:
-    name: Build CLI (macos-arm64)
+    # Flip 2 (macOS): Bazel mixed execution — the Mac runner drives the build,
+    # the Rust graph executes on BuildBuddy's Linux workers (or comes from the
+    # shared cache the advisory CI keeps warm), and only the Metal llama
+    # compile runs on this Mac (Xcode's metal compiler). Same parity-first
+    # ritual as the Android AAR and linux CLI cutovers: payload gate before
+    # anything ships; artifact name, attestation, and downstream unchanged.
+    name: Build CLI (macos-arm64, Bazel)
     needs: [check-release-branch]
     runs-on: macos-14
     permissions:
@@ -296,36 +302,49 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-          targets: aarch64-apple-darwin
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-      - name: Configure sccache environment
-        shell: bash
+      # build:macos-metal uses the host's preinstalled cmake/make/pkg-config
+      # for rfcc's exec tools (macos-14 images ship them; guard just in case).
+      - name: Ensure rfcc host tools
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          which cmake >/dev/null || brew install cmake
+          which pkg-config >/dev/null || brew install pkg-config
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          prefix-key: "v1-rust"
-          shared-key: "cli-macos-arm64"
-          cache-all-crates: "true"
-          save-if: "true"
+      - name: Configure BuildBuddy remote config
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote --remote_executor=grpcs://remote.buildbuddy.io
+          common:remote --remote_cache_compression
+          common:remote --remote_download_toplevel
+          common:remote --remote_timeout=600
+          common:remote --jobs=200
+          common:remote --extra_execution_platforms=@llvm//:rbe_linux_x86_64
+          EOF
 
-      - name: Build CLI (macos-arm64)
-        run: cargo build --release -p xybrid-cli --target aarch64-apple-darwin --features platform-macos
+      - name: Build CLI (Bazel mixed execution, shipping mode)
+        run: |
+          bazelisk build --config=remote --config=macos-metal -c opt \
+            //crates/xybrid-cli:xybrid
 
-      - name: Strip CLI binary
-        run: strip target/aarch64-apple-darwin/release/xybrid
+      # The payload gate: must run, and carry the full platform-macos surface —
+      # Metal GPU (ggml_metal), vision (mtmd), candle voice, huggingface.
+      # (Mach-O symbols carry a leading underscore.)
+      - name: Verify CLI payload (run + Metal + features)
+        run: |
+          BIN=$(bazelisk cquery --config=remote --config=macos-metal -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          echo "resolved CLI: $BIN"
+          file "$BIN"
+          "$BIN" --help >/dev/null
+          test "$(nm "$BIN" | grep -c '_ggml_metal')" -gt 0 || { echo "MISSING Metal (ggml_metal) symbols"; exit 1; }
+          test "$(nm "$BIN" | grep -c '_mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
+          strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface support"; exit 1; }
+          strings "$BIN" | grep -qi 'candle' || { echo "MISSING candle (voice) support"; exit 1; }
 
       - name: Prepare CLI artifact
         shell: bash
@@ -333,7 +352,10 @@ jobs:
           TAG: ${{ needs.check-release-branch.outputs.tag }}
         run: |
           mkdir -p dist-cli
-          cp target/aarch64-apple-darwin/release/xybrid dist-cli/xybrid-${TAG}-macos-arm64
+          BIN=$(bazelisk cquery --config=remote --config=macos-metal -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          cp "$BIN" dist-cli/xybrid-${TAG}-macos-arm64
+          chmod +w dist-cli/xybrid-${TAG}-macos-arm64   # bazel outputs are read-only
+          strip dist-cli/xybrid-${TAG}-macos-arm64
           chmod +x dist-cli/xybrid-${TAG}-macos-arm64
 
       - name: Attest macOS CLI provenance


### PR DESCRIPTION

This pull request updates the macOS build and release workflows to switch the macOS CLI build from a direct Cargo build to a Bazel-based, mixed-execution approach using BuildBuddy remote caching and execution. This aligns the macOS build process with the Linux and Android workflows, improves build parity, and ensures all required features are present in the shipped binary. Additionally, a new CI job is introduced to validate the Mac-only Metal build path on every master merge.

**CI/CD Workflow Improvements:**

* Added a new `bazel-macos-metal` job in `.github/workflows/bazel.yml` to validate the Mac-only Metal build and linking process on every master merge, ensuring the Metal-specific code path is tested on real Mac hardware.

**Release Build Process Changes:**

* Switched the `build-cli-macos` job in `.github/workflows/release-prep.yml` from a Cargo-based build to a Bazel-based, mixed-execution build using BuildBuddy remote workers, with the Metal compile step running on the Mac host. [[1]](diffhunk://#diff-0722b1375f2b82d0814d6acab64efbb06c23a87477d8cdcbe015dcbb11323050L287-R293) [[2]](diffhunk://#diff-0722b1375f2b82d0814d6acab64efbb06c23a87477d8cdcbe015dcbb11323050L299-R358)
* Removed Rust toolchain, sccache, and Rust dependency caching steps from the macOS CLI build job, as these are no longer needed with the Bazel build system.
* Added steps to ensure host tools (`cmake`, `pkg-config`) are installed for Bazel builds, and to configure BuildBuddy remote caching in the build environment.

**Artifact Verification and Packaging:**

* Enhanced the CLI binary verification step to check for the presence of Metal, vision, candle (voice), and huggingface features in the built binary using symbol and string checks, ensuring the artifact is fully featured before release.
* Updated the artifact packaging step to handle Bazel output files, adjust permissions, and strip the binary as needed for release.