### PR TITLE
bazel(windows): the .exe lands — dlltool staged at the toolchain layer, full CLI parity on RBE

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -68,10 +68,18 @@ jobs:
     timeout-minutes: 60
     env:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+    # Downstream jobs can't read secrets in a job-level `if`; export the
+    # fork-safety signal (RBE available or not) as a job output instead.
+    outputs:
+      rbe: ${{ steps.rbe-check.outputs.rbe }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
+
+      - name: Check RBE availability
+        id: rbe-check
+        run: echo "rbe=${{ env.BUILDBUDDY_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
 
       # Repo fetches (LLVM prebuilt, rustc, NDK symlink tree) + downloaded
       # toplevel outputs need headroom; reclaim toolchains this job never
@@ -124,10 +132,12 @@ jobs:
 
       # Desktop lanes on RBE: linux CLI (native) + the macOS-CPU cross
       # (hermetic clang + @macos_sdk + vendored ort; Metal/Swift stay Mac-bound
-      # and are NOT built here) + the windows-gnu llama core (PR #343). Keeps
-      # the shared cache warm so a future Mac lane PULLS the shared graph
-      # instead of recompiling it — the cache-fed-Mac model.
-      - name: Build desktop lanes on RBE (linux CLI, macOS-CPU cross, windows llama)
+      # and are NOT built here) + the full windows-gnu CLI (the .exe chapter —
+      # llama + the raw-dylib Rust crates via the dlltool toolchain fix + the
+      # final MinGW link). Keeps the shared cache warm so a future Mac lane
+      # PULLS the shared graph instead of recompiling it — the cache-fed-Mac
+      # model.
+      - name: Build desktop lanes on RBE (linux CLI, macOS-CPU cross, windows CLI)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk build --config=remote -c opt \
@@ -135,8 +145,8 @@ jobs:
           bazelisk build --config=remote --config=macos \
             //crates/xybrid-cli:xybrid \
             //crates/xybrid-bolt:xybrid_bolt_staticlib
-          bazelisk build --config=remote --config=windows \
-            //:llama
+          bazelisk build --config=remote --config=windows -c opt \
+            //crates/xybrid-cli:xybrid
 
       # Linux-CLI smoke + parity gate (Flip 1): this is the SHIPPED artifact
       # since the release-prep build-cli-linux cutover — run it, verify the
@@ -159,6 +169,31 @@ jobs:
           echo "glibc floor: $MAX_GLIBC"
           [ "$(printf '%s\n' "$MAX_GLIBC" GLIBC_2.31 | sort -V | tail -1)" = "GLIBC_2.31" ] || { echo "glibc floor regressed above 2.31: $MAX_GLIBC"; exit 1; }
           echo "linux CLI smoke: OK ✅"
+
+      # Windows .exe payload gate (static half): verify the artifact is a real
+      # PE32+ x86-64 binary carrying the desktop feature set, then hand it to
+      # the windows-latest job below for the run-it half (this linux runner
+      # can't execute a PE). cquery, not bazel-bin: the symlink tracks the
+      # LAST invocation above.
+      - name: Verify + stage the windows CLI (.exe)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          EXE=$(bazelisk cquery --config=remote --config=windows -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          echo "resolved windows CLI: $EXE"
+          file "$EXE"
+          file "$EXE" | grep -q 'PE32+.*x86-64' || { echo "NOT a PE32+ x86-64 binary"; exit 1; }
+          grep -aq 'mtmd_' "$EXE" || { echo "MISSING vision (mtmd) markers"; exit 1; }
+          grep -aq 'huggingface\.co' "$EXE" || { echo "MISSING huggingface support"; exit 1; }
+          mkdir -p /tmp/win-exe && cp "$EXE" /tmp/win-exe/xybrid.exe
+          echo "windows CLI payload: OK ✅"
+
+      - name: Upload windows CLI artifact
+        if: env.BUILDBUDDY_API_KEY != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bazel-xybrid-windows-exe
+          path: /tmp/win-exe/xybrid.exe
+          retention-days: 7
 
       # The RBE-proven Android row (PR #326 gates 6-10): NDK cross-compile +
       # one-link .so + complete AAR. ABI fan-out (arm64-v8a / armeabi-v7a /
@@ -267,3 +302,29 @@ jobs:
           test "$(nm "$BIN" | grep -c '_mtmd_')" -gt 0 || { echo "MISSING vision symbols"; exit 1; }
           strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface"; exit 1; }
           echo "Metal CLI smoke: OK"
+
+  # The run-it half of the windows .exe gate: the linux job can build and
+  # byte-inspect the PE but not execute it — a real Windows runner downloads
+  # the RBE-built artifact and runs it. This is the only Windows machine in
+  # the whole lane, and it compiles nothing (the build happened on Linux
+  # workers); a few windows-latest minutes per Bazel-touching PR.
+  bazel-windows-smoke:
+    name: Bazel windows .exe smoke (runs the RBE-built CLI)
+    needs: bazel
+    if: needs.bazel.outputs.rbe == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: bazel-xybrid-windows-exe
+
+      - name: Run the .exe + verify features
+        shell: bash
+        run: |
+          ls -la xybrid.exe
+          ./xybrid.exe --help
+          ./xybrid.exe --version || true
+          grep -aq 'mtmd_' xybrid.exe || { echo "MISSING vision (mtmd) markers"; exit 1; }
+          grep -aq 'huggingface\.co' xybrid.exe || { echo "MISSING huggingface support"; exit 1; }
+          echo "windows .exe smoke: OK"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -144,9 +144,26 @@ cmake(
         # Set the pair explicitly (rfcc only folds CMAKE_SYSTEM_PROCESSOR into the
         # crossfile when CMAKE_SYSTEM_NAME is user-set); AMD64 → ggml x86 arch.
         # Same shape as the armv7 seeding above.
+        # Windows vision (the .exe chapter): TOOLS+COMMON=ON unlock tools/ ->
+        # libmtmd, mirroring the linux arm — cargo ships the windows CLI with
+        # platform-desktop (vision + huggingface), so the Bazel artifact must
+        # match. The throwaway tool EXES need a C++ runtime exactly like linux
+        # (the hermetic toolchain links libc++ via staged inputs, which rfcc's
+        # cmake doesn't replicate) — hand them the same static archives, built
+        # for the windows target (hermetic-llvm builds its runtimes from source
+        # per target on windows; the darwin-only breakage doesn't apply).
         "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": _LLAMA_CACHE_ENTRIES | {
             "CMAKE_SYSTEM_NAME": "Windows",
             "CMAKE_SYSTEM_PROCESSOR": "AMD64",
+            "LLAMA_BUILD_TOOLS": "ON",
+            "LLAMA_BUILD_COMMON": "ON",
+            "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
+            # mtmd-audio uses M_PI, which MinGW's math.h hides under strict
+            # ANSI (glibc/bionic expose it by default — this bites only the
+            # windows cross). rfcc maps these to CMAKE_*_FLAGS_INIT with
+            # replace=False, so they APPEND to the toolchain-derived flags.
+            "CMAKE_C_FLAGS": "-D_USE_MATH_DEFINES",
+            "CMAKE_CXX_FLAGS": "-D_USE_MATH_DEFINES",
         },
         # macOS cross from Linux RBE (the macOS-CPU lane): same rfcc gap as
         # windows — no darwin entry in rfcc's _TARGET_OS_PARAMS, so without
@@ -193,13 +210,18 @@ cmake(
         ],
         "//conditions:default": [],
     }),
-    # linux vision: the static C++ runtime archives referenced by the linux
-    # arm's CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're linked into
+    # linux + windows vision: the static C++ runtime archives referenced by
+    # those arms' CMAKE_CXX_STANDARD_LIBRARIES. cfg=target (they're linked into
     # TARGET binaries), unlike build_data's exec-config host tools. darwin
     # deliberately absent: darwin-target libcxx-from-source is broken (see the
     # darwin arm comment) — both darwin lanes use the SDK's -lc++.
     data = select({
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
+            "@llvm//runtimes/libcxx:libcxx.static",
+            "@llvm//runtimes/libcxx:libcxxabi.static",
+            "@llvm//runtimes/libunwind:libunwind.static",
+        ],
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
             "@llvm//runtimes/libcxx:libcxx.static",
             "@llvm//runtimes/libcxx:libcxxabi.static",
             "@llvm//runtimes/libunwind:libunwind.static",
@@ -223,8 +245,10 @@ cmake(
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["libmtmd.a"] + _LLAMA_LIBS,
         # Windows/MinGW: ggml/CMakeLists.txt sets CMAKE_STATIC_LIBRARY_PREFIX=""
         # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
-        # libggml.a) — while llama (sibling scope) keeps it (libllama.a).
+        # libggml.a) — while llama (sibling scope) keeps it (libllama.a), and
+        # so does mtmd (tools/mtmd, also outside ggml's directory scope).
         "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
+            "libmtmd.a",
             "libllama.a",
             "ggml.a",
             "ggml-base.a",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -213,9 +213,13 @@ toolchains.toolchain(
         # unstageable build-script-link-search shape as winapi's). Its own
         # windows_raw_dylib cfg switches the link! macro to raw-dylib —
         # the path the 0.61 family already uses, served by the dlltool
-        # staging fix (hermetic_llvm.patch + rules_rs.patch). Emits benign
-        # unexpected_cfgs warnings in crates that don't declare the cfg.
-        "x86_64-pc-windows-gnu": ["--cfg=windows_raw_dylib"],
+        # staging fix (hermetic_llvm.patch + rules_rs.patch). check-cfg
+        # declares the custom cfg so crates that don't know it stay free
+        # of unexpected_cfgs warnings.
+        "x86_64-pc-windows-gnu": [
+            "--cfg=windows_raw_dylib",
+            "--check-cfg=cfg(windows_raw_dylib)",
+        ],
     },
     version = "1.92.0",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -208,6 +208,14 @@ toolchains.toolchain(
         "aarch64-apple-ios": ["-Ctarget-feature=+fp16"],
         "aarch64-apple-ios-sim": ["-Ctarget-feature=+fp16"],
         "aarch64-linux-android": ["-Ctarget-feature=+fp16"],
+        # windows-targets 0.52-family defaults to a BUNDLED import lib
+        # (libwindows.0.52.0.a inside the windows_x86_64_gnu crate — same
+        # unstageable build-script-link-search shape as winapi's). Its own
+        # windows_raw_dylib cfg switches the link! macro to raw-dylib —
+        # the path the 0.61 family already uses, served by the dlltool
+        # staging fix (hermetic_llvm.patch + rules_rs.patch). Emits benign
+        # unexpected_cfgs warnings in crates that don't declare the cfg.
+        "x86_64-pc-windows-gnu": ["--cfg=windows_raw_dylib"],
     },
     version = "1.92.0",
 )
@@ -277,19 +285,41 @@ crate.annotation(
     ],
 )
 
+# winapi 0.3 on windows-gnu links its own RENAMED copies of the system import
+# libs (-lwinapi_gdi32, ...) bundled in the winapi-x86_64-pc-windows-gnu
+# sidecar crate — a build-script link-search into crate SOURCE that Bazel
+# never stages into the final link. The crate's own escape hatch drops the
+# prefix so it links the standard names (-lgdi32, ...), which the hermetic
+# MinGW import libs already resolve (proven: the plain system -l's resolve in
+# the same link). This is winapi's documented cross-compilation knob.
+crate.annotation(
+    crate = "winapi",
+    build_script_env = {
+        "WINAPI_NO_BUNDLED_LIBRARIES": "1",
+    },
+)
+
+# ntapi mimics winapi's bundled-import-lib convention (-lwinapi_ntdll from its
+# own sidecar copy) and honors the same escape hatch → plain -lntdll.
+crate.annotation(
+    crate = "ntapi",
+    build_script_env = {
+        "WINAPI_NO_BUNDLED_LIBRARIES": "1",
+    },
+)
+
 crate.annotation(
     crate = "hmac-sha256",
     crate_features = ["default"],
 )
 
-# NOTE: Windows Rust CLI (raw-dylib -> dlltool) is a deliberate follow-up, not
-# wired here. The windows/windows-sys 0.61 family + ort-sys/getrandom/... emit
-# #[link(kind="raw-dylib")], so rustc needs `dlltool` at compile time. The tool
-# (hermetic-llvm's llvm-dlltool) is a symlink into the ~100MB multicall `llvm`
-# binary and can only be STAGED for the rustc compile by the toolchain machinery,
-# which is not reachable from crate.annotation / rules_rs (rules_rust is
-# extension-generated, so unpatchable; it doesn't consume llvm_tools for compile).
-# The C/C++ half (//:llama for windows-gnu) IS green. See
-# .context/bazel-windows-cli-progress.md for the full analysis + the proper fix
-# (patch hermetic-llvm's cc toolchain to ship dlltool).
+# NOTE: Windows Rust CLI (raw-dylib -> dlltool) is RESOLVED at the toolchain
+# layer, not here. The windows/windows-sys families emit #[link(kind =
+# "raw-dylib")] on windows-gnu, so rustc shells out to `dlltool` at compile
+# time — a tool that is a symlink into the ~100MB multicall `llvm` binary and
+# can only be staged by the toolchain machinery. hermetic_llvm.patch ships
+# dlltool (+ the multicall binary) in the windows tool_map's linker_files and
+# exposes llvm_tool_execroot_path(); rules_rs.patch injects the matching
+# -Cdlltool=<exec-correct path> into every windows-gnu rust toolchain. See
+# .context/bazel-windows-cli-progress.md for the full history.
 use_repo(crate, "crates")

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -19,6 +19,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2: macOS parity
+    "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
 ]
 
 # First-party C++ shim: defines the _c-suffixed symbols the Rust bindings call.

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -61,6 +61,11 @@ rust_library(
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
             "llm-llamacpp-vision",
         ],
+        # Desktop-windows (the .exe chapter): cargo's windows leg also builds
+        # platform-desktop — same expansion as linux.
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
+            "llm-llamacpp-vision",
+        ],
         "//conditions:default": [],
     }),
     deps = all_crate_deps(normal = True),

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -9,6 +9,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2: macOS parity
+    "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
 ]
 
 rust_library(

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -12,6 +12,7 @@ PLATFORMS = [
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",
     "@rules_rs//rs/platforms/config:aarch64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
+    "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",
 ]
 
 # Android's `platform-android` preset expansion, set directly (Bazel doesn't
@@ -38,6 +39,7 @@ filtered_sdk_deps["deps"] = [d for d in original_sdk_deps.get("deps", []) if d !
 _HF_PLATFORMS = [
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2
+    "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
 ]
 
 _ORIG_DBP = original_sdk_deps.get("deps_by_platform", {})
@@ -67,6 +69,13 @@ rust_library(
         # (Bazel doesn't expand presets across crates — name them).
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
             "platform-macos",
+            "llm-llamacpp-vision",
+            "huggingface",
+        ],
+        # Windows .exe parity: cargo's windows leg builds platform-desktop,
+        # same expansion as the linux arm above.
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
+            "platform-desktop",
             "llm-llamacpp-vision",
             "huggingface",
         ],

--- a/hermetic_llvm.patch
+++ b/hermetic_llvm.patch
@@ -163,8 +163,8 @@ index 0000000..0000000 100644
 diff --git a/toolchain/selects.bzl b/toolchain/selects.bzl
 index 0000000..0000000 100644
 --- a/toolchain/selects.bzl	2026-07-14 19:03:24
-+++ b/toolchain/selects.bzl	2026-07-14 19:04:36
-@@ -56,5 +56,25 @@
++++ b/toolchain/selects.bzl	2026-07-15 09:09:42
+@@ -56,5 +56,29 @@
          "@llvm//toolchain:macos_complete_with_libtool": Label(tool_repo + ":tools_with_dsym_and_libtool"),
          "@llvm//toolchain:macos_complete": Label(tool_repo + ":tools_with_dsym"),
          "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": Label(tool_repo + ":tools_with_libtool_for_runtime"),
@@ -184,10 +184,14 @@ index 0000000..0000000 100644
 +# Only valid while the tool is also STAGED for the consuming action (the
 +# windows tool_map above stages dlltool for windows-target actions).
 +def llvm_tool_execroot_path(exec_os, exec_cpu, binary):
++    # Accept both this module's exec-OS vocabulary ("macos") and rustc triple
++    # spellings ("darwin") without relying on _tool_repo's pass-through of
++    # unknown names (the release repos are darwin-flavored).
++    os_part = "macos" if exec_os == "darwin" else exec_os
 +    label = Label("%s:bin/%s%s" % (
-+        _tool_repo(exec_os, exec_cpu),
++        _tool_repo(os_part, exec_cpu),
 +        binary,
-+        ".exe" if exec_os == "windows" else "",
++        ".exe" if os_part == "windows" else "",
 +    ))
 +    return "external/%s/%s" % (label.repo_name, label.name)
 diff --git a/runtimes/libunwind/BUILD.bazel b/runtimes/libunwind/BUILD.bazel

--- a/hermetic_llvm.patch
+++ b/hermetic_llvm.patch
@@ -93,3 +93,144 @@ index 065900f..ca85123 100644
      char *strip_args[] = {
          (char *)strip,
          "-S",
+diff --git a/toolchain/llvm/llvm.bzl b/toolchain/llvm/llvm.bzl
+index 0000000..0000000 100644
+--- a/toolchain/llvm/llvm.bzl	2026-07-14 19:03:24
++++ b/toolchain/llvm/llvm.bzl	2026-07-14 19:04:12
+@@ -209,8 +209,62 @@
+             "bin/lld" + suffix,
+             "bin/wasm-ld" + suffix,
+         ],
++    )
++
++    # xybrid: windows-gnu raw-dylib support. rustc shells out to `dlltool` at
++    # COMPILE time for crates using #[link(kind = "raw-dylib")] (the modern
++    # windows/windows-sys family), so the tool must reach every windows-target
++    # rustc action. rules_rust stages the cc toolchain's linker_files into its
++    # compile actions, so the link tool's data is the staging vehicle. Both the
++    # `llvm-dlltool` symlink AND the multicall `llvm` binary it points at must
++    # ship (a lone symlink dangles on a remote worker). Windows-only tool_map
++    # variants (selected in //toolchain/selects.bzl) keep every other
++    # platform's action keys byte-identical.
++    cc_tool(
++        name = "lld_with_dlltool",
++        src = "bin/clang++" + suffix,
++        data = [
++            "bin/ld.lld" + suffix,
++            "bin/ld64.lld" + suffix,
++            "bin/lld" + suffix,
++            "bin/wasm-ld" + suffix,
++            "bin/llvm-dlltool" + suffix,
++        ] + native.glob(
++            # The multicall binary: `llvm` in the unix releases; globbed so a
++            # release that ships real per-tool binaries (no multicall) still
++            # analyzes.
++            ["bin/llvm", "bin/llvm.exe"],
++            allow_empty = True,
++        ),
++    )
++
++    cc_tool_map(
++        name = "default_tools_windows",
++        tools = BASE_TOOLS | COMPLETE_ONLY_TOOLS | {
++            "@rules_cc//cc/toolchains/actions:link_actions": ":lld_with_dlltool",
++            "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
++        },
++        visibility = ["//visibility:public"],
+     )
+ 
++    cc_tool_map(
++        name = "staged_default_tools_windows",
++        tools = BASE_TOOLS | {
++            "@rules_cc//cc/toolchains/actions:link_actions": ":lld_with_dlltool",
++            "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
++        },
++        visibility = ["//visibility:public"],
++    )
++
++    native.alias(
++        name = "default_tools_for_runtime_windows",
++        actual = select({
++            "@llvm//toolchain:runtimes_all": ":default_tools_windows",
++            "//conditions:default": ":staged_default_tools_windows",
++        }),
++        visibility = ["//visibility:public"],
++    )
++
+     cc_tool(
+         name = "link-wrapper",
+         src = "@llvm//tools/internal:link-wrapper",
+diff --git a/toolchain/selects.bzl b/toolchain/selects.bzl
+index 0000000..0000000 100644
+--- a/toolchain/selects.bzl	2026-07-14 19:03:24
++++ b/toolchain/selects.bzl	2026-07-14 19:04:36
+@@ -56,5 +56,25 @@
+         "@llvm//toolchain:macos_complete_with_libtool": Label(tool_repo + ":tools_with_dsym_and_libtool"),
+         "@llvm//toolchain:macos_complete": Label(tool_repo + ":tools_with_dsym"),
+         "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": Label(tool_repo + ":tools_with_libtool_for_runtime"),
++        # xybrid: windows targets get the dlltool-carrying link tool so rustc's
++        # raw-dylib compiles find it staged (see toolchain/llvm/llvm.bzl).
++        # Resolved under the TARGET configuration (see comment above), so this
++        # keys on the target OS while the tool binaries stay exec-correct.
++        "@platforms//os:windows": Label(tool_repo + ":default_tools_for_runtime_windows"),
+         "//conditions:default": Label(tool_repo + ":default_tools_for_runtime"),
+     })
++
++# xybrid: execroot-relative path of a prebuilt LLVM tool for a given EXEC
++# platform, computed from this module's own version pin so it survives LLVM
++# bumps (no hardcoded canonical repo names in consumers). Needed by consumers
++# that must pass a tool PATH on a command line where label expansion does not
++# exist (e.g. rustc's -Cdlltool via a rust_toolchain's extra_rustc_flags).
++# Only valid while the tool is also STAGED for the consuming action (the
++# windows tool_map above stages dlltool for windows-target actions).
++def llvm_tool_execroot_path(exec_os, exec_cpu, binary):
++    label = Label("%s:bin/%s%s" % (
++        _tool_repo(exec_os, exec_cpu),
++        binary,
++        ".exe" if exec_os == "windows" else "",
++    ))
++    return "external/%s/%s" % (label.repo_name, label.name)
+diff --git a/runtimes/libunwind/BUILD.bazel b/runtimes/libunwind/BUILD.bazel
+index 0000000..0000000 100644
+--- a/runtimes/libunwind/BUILD.bazel	2026-07-14 23:14:14
++++ b/runtimes/libunwind/BUILD.bazel	2026-07-14 23:26:03
+@@ -23,6 +23,24 @@
+     visibility = ["//visibility:public"],
+ )
+ 
++# xybrid: rustc's windows-gnu target spec hardcodes -lgcc_eh (GCC's unwinder
++# library, which an LLVM/compiler-rt toolchain does not ship). Same problem
++# class as gcc_s above, same treatment: an empty stub satisfies the -l while
++# the real unwinding comes from the toolchain's explicitly-staged runtimes.
++stub_library(
++    name = "gcc_eh",
++    visibility = ["//visibility:public"],
++)
++
++# xybrid: -lgcc is likewise hardcoded by rustc's windows-gnu spec (compiler
++# builtins live in libgcc on a GCC toolchain). Here the clang driver already
++# links compiler-rt builtins (-rtlib=compiler-rt), so an empty stub is the
++# correct resolution.
++stub_library(
++    name = "gcc",
++    visibility = ["//visibility:public"],
++)
++
+ config_setting(
+     name = "stub_libgcc_s",
+     flag_values = {
+@@ -37,6 +55,14 @@
+     ] + select({
+         ":stub_libgcc_s": [":gcc_s"],
+         "//conditions:default": [],
++    }) + select({
++        # xybrid: windows-scoped so every other platform's link action keys
++        # stay byte-identical.
++        "@platforms//os:windows": [
++            ":gcc",
++            ":gcc_eh",
++        ],
++        "//conditions:default": [],
+     }),
+     visibility = ["//visibility:public"],
+ )

--- a/rules_rs.patch
+++ b/rules_rs.patch
@@ -1,6 +1,6 @@
-diff --color -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
---- a/rs/private/cfg_parser.bzl	2026-07-08 13:05:37
-+++ b/rs/private/cfg_parser.bzl	2026-07-08 13:05:37
+diff -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
+--- a/rs/private/cfg_parser.bzl	2026-07-14 19:13:22
++++ b/rs/private/cfg_parser.bzl	2026-07-14 19:13:22
 @@ -148,6 +148,13 @@
  def _normalize_os(os_raw):
      if os_raw == "darwin":
@@ -33,9 +33,9 @@ diff --color -ru a/rs/private/cfg_parser.bzl b/rs/private/cfg_parser.bzl
      vendor_part = _get(parts, 1, "unknown")
      os_raw_part = _get(parts, 2, "none")
      env_part = "-".join(parts[3:])
-diff --color -ru a/rs/private/repository_utils.bzl b/rs/private/repository_utils.bzl
---- a/rs/private/repository_utils.bzl	2026-07-11 11:00:00
-+++ b/rs/private/repository_utils.bzl	2026-07-11 11:00:00
+diff -ru a/rs/private/repository_utils.bzl b/rs/private/repository_utils.bzl
+--- a/rs/private/repository_utils.bzl	2026-07-14 19:13:22
++++ b/rs/private/repository_utils.bzl	2026-07-14 19:13:22
 @@ -191,7 +191,8 @@
  {indent}    build_script_data = {build_script_data}{conditional_build_script_data},
  {indent}    build_deps = [
@@ -70,12 +70,10 @@ diff --color -ru a/rs/private/repository_utils.bzl b/rs/private/repository_utils
          build_script_env = repr(attr.build_script_env),
          conditional_build_script_env = " | " + conditional_build_script_env if conditional_build_script_env else "",
          allow_build_script_to_detect_nonhermetic_paths = repr(attr.allow_build_script_to_detect_nonhermetic_paths),
-diff --color -ru a/rs/rust_crate.bzl b/rs/rust_crate.bzl
---- a/rs/rust_crate.bzl	2026-07-11 11:00:00
-+++ b/rs/rust_crate.bzl	2026-07-11 11:00:00
-@@ -43,9 +43,10 @@
-         has_lib,
-         binaries,
+diff -ru a/rs/rust_crate.bzl b/rs/rust_crate.bzl
+--- a/rs/rust_crate.bzl	2026-07-14 19:13:22
++++ b/rs/rust_crate.bzl	2026-07-14 19:13:22
+@@ -45,7 +45,8 @@
          use_legacy_rules_rust_platforms,
          extra_compile_data = [],
          rustc_env = {},
@@ -124,3 +122,45 @@ diff --color -ru a/rs/rust_crate.bzl b/rs/rust_crate.bzl
                  build_script_kwargs_for_triple["rustc_flags"] = build_script_kwargs["rustc_flags"] + [
                      # Avoid metadata generation to clash under the same directory when cross-compiling to multiple targets
                      # concurrently, see https://github.com/hermeticbuild/rules_rs/issues/161
+diff -ru a/rs/toolchains/declare_rustc_toolchains.bzl b/rs/toolchains/declare_rustc_toolchains.bzl
+--- a/rs/toolchains/declare_rustc_toolchains.bzl	2026-07-14 19:13:22
++++ b/rs/toolchains/declare_rustc_toolchains.bzl	2026-07-14 19:13:22
+@@ -1,3 +1,4 @@
++load("@llvm//toolchain:selects.bzl", "llvm_tool_execroot_path")
+ load("@rules_rust//rust:toolchain.bzl", "rust_toolchain")
+ load("@rules_rust//rust/platform:triple.bzl", _parse_triple = "triple")
+ load("//rs/platforms:triples.bzl", "ALL_TARGET_TRIPLES", "SUPPORTED_EXEC_TRIPLES", "SUPPORTED_TIER_3_TRIPLES", "triple_to_rust_constraint_set")
+@@ -50,6 +51,24 @@
+         exec_triple = _parse_triple(triple)
+         triple_suffix = exec_triple.system + "_" + exec_triple.arch
+ 
++        # xybrid patch: windows-gnu targets make rustc shell out to `dlltool`
++        # at COMPILE time (#[link(kind = "raw-dylib")] in the modern windows/
++        # windows-sys family). rustc's default lookup (x86_64-w64-mingw32-
++        # dlltool on PATH) cannot resolve in the hermetic stack, so point it at
++        # hermetic-llvm's llvm-dlltool for THIS toolchain's exec platform —
++        # correct on remote Linux workers and local machines alike, with no
++        # per-crate annotation lists. The tool is staged into windows-target
++        # rustc actions by hermetic-llvm's cc toolchain (its windows tool_map
++        # carries dlltool in linker_files, which ride along with every
++        # rules_rust compile).
++        dlltool_path = llvm_tool_execroot_path(exec_triple.system, exec_triple.arch, "llvm-dlltool")
++        extra_rustc_flags_for_exec = dict(extra_rustc_flags)
++        for target_triple in targets:
++            if target_triple.endswith("-windows-gnu"):
++                extra_rustc_flags_for_exec[target_triple] = list(extra_rustc_flags.get(target_triple, [])) + [
++                    "-Cdlltool=" + dlltool_path,
++                ]
++
+         rustc_repo_label = "@rustc_{}_{}//:".format(triple_suffix, version_key)
+         cargo_repo_label = "@cargo_{}_{}//:".format(triple_suffix, version_key)
+         clippy_repo_label = "@clippy_{}_{}//:".format(triple_suffix, version_key)
+@@ -151,7 +170,7 @@
+             }),
+             default_edition = edition,
+             extra_exec_rustc_flags = _rustc_flags_to_select(extra_exec_rustc_flags),
+-            extra_rustc_flags = _rustc_flags_to_select(extra_rustc_flags),
++            extra_rustc_flags = _rustc_flags_to_select(extra_rustc_flags_for_exec),
+             exec_triple = triple,
+             target_triple = select(target_triple_select),
+             visibility = ["//visibility:public"],


### PR DESCRIPTION
## Summary

Finishes the parked Windows chapter: **`xybrid.exe` now builds entirely on Linux RBE** — `bazel build --config=remote --config=windows -c opt //crates/xybrid-cli:xybrid` produces a verified **PE32+ x86-64 Windows console binary (43MB)** carrying the full desktop feature payload (vision/mtmd + huggingface, no candle — parity with cargo's `platform-desktop` windows leg). The dlltool blocker fell exactly where the parked analysis said it had to: **the toolchain machinery**. `hermetic_llvm.patch` adds a windows-target-only tool_map whose link tool carries `bin/llvm-dlltool` + the ~100MB multicall `llvm` binary it symlinks into — landing them in `linker_files`, which rules_rust stages into every rustc action — selected via a `@platforms//os:windows` arm in `platform_cc_tool_map` (resolved under the *target* configuration, tool binaries stay exec-correct, every other platform's action keys stay byte-identical). A new `llvm_tool_execroot_path()` helper computes the tool's execroot path from the module's own version pin (`Label().repo_name` — no hardcoded canonical repo names), and `rules_rs.patch` injects the matching `-Cdlltool=<per-exec path>` into every `*-windows-gnu` rust toolchain: host-independent, no per-crate annotation lists.

With staging solved, the final link surfaced the remaining windows-gnu ecosystem gaps, each fixed at its layer:

| Gap | Fix | Layer |
|---|---|---|
| `-lwinapi_*` ×14 (winapi 0.3 bundled import libs — build-script link-search into crate *source*, unstageable in Bazel) | `WINAPI_NO_BUNDLED_LIBRARIES=1` → plain system `-l`'s, resolved by the hermetic MinGW import libs | MODULE annotation |
| `-lwinapi_ntdll` (ntapi copies winapi's convention) | same env, same escape hatch | MODULE annotation |
| `-lwindows.0.52.0` ×5 (windows-targets 0.52 bundled lib) | `--cfg=windows_raw_dylib` — flips the 0.52/0.59 family onto the raw-dylib path the dlltool fix serves | MODULE toolchain flags |
| `-lgcc_eh`, `-lgcc` (hardcoded by rustc's windows-gnu spec; GCC-only libs) | empty `stub_library`'s in the libunwind search dir — upstream's own `gcc_s` stub pattern, windows-scoped (builtins come from `-rtlib=compiler-rt`, unwinding from the staged runtimes) | hermetic_llvm.patch |
| `M_PI` undeclared in mtmd-audio (MinGW hides it under strict ANSI) | `-D_USE_MATH_DEFINES` via rfcc's *appending* `CMAKE_*_FLAGS` (replace=False) | `//:llama` windows arm |

**Vision parity**: the windows llama arm gains `TOOLS/COMMON=ON` → `libmtmd.a` (lib-prefixed — mtmd sits outside ggml's prefix-stripping scope), tool exes link the hermetic static libc++ trio (the linux recipe; windows-target libcxx-from-source works — darwin remains the only broken case), and the feature arms mirror Flip 1 across llama-cpp-sys / xybrid-llama / core / sdk.

**CI**: the advisory desktop lane now builds the full .exe (was `//:llama` only), gates the payload (PE32+ + feature markers), uploads it, and a new `bazel-windows-smoke` job on windows-latest **downloads and runs it** — the only Windows machine in the lane, and it compiles nothing (fork-safety via a job output, since job-level `if:` can't read secrets).

**Deliberately NOT in this PR — the release swap.** Today's shipped Windows CLI is MSVC-built by cargo on windows-latest; this artifact is MinGW. Swapping the release job is a product decision to be made separately, with this PR's standing smoke evidence in hand. Cargo and every shipping path are untouched; all proven lanes re-verified green on RBE after the change (workspace analyze, linux CLI, macOS-CPU cross, Android AAR).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — N/A: Bazel-only additive change; cargo untouched
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (in-file comments; chapter log in workspace .context)
- [x] No breaking changes (advisory lane only; release swap explicitly deferred; other platforms' action keys byte-stable)