### PR TITLE
ci: retire the redundant cargo/MSVC windows-CLI job (+ cargo-vs-Bazel audit)

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -13,7 +13,6 @@ on:
           - darwin-precompile
           - linux-precompile
           - windows-precompile
-          - windows-cli
 
 env:
   CARGO_TERM_COLOR: always
@@ -276,48 +275,6 @@ jobs:
         run: |
           ARGS="--repository ${{ github.repository }} --manifest-dir ${{ github.workspace }}/bindings/flutter/rust --verbose"
           dart run bin/build_tool.dart precompile-binaries $ARGS
-
-  #
-  # CLI (windows)
-  #
-  build-cli-windows:
-    name: Build CLI (windows)
-    if: inputs.platform == 'windows-cli'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
-
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-          targets: x86_64-pc-windows-msvc
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-      - name: Configure sccache environment
-        shell: bash
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: test-cli-windows
-
-      - name: Install LLVM and NASM
-        run: choco install llvm nasm
-
-      - name: Add NASM to PATH
-        shell: bash
-        run: echo "C:\\Program Files\\NASM" >> $GITHUB_PATH
-
-      - name: Build CLI
-        run: cargo build --release -p xybrid-cli --target x86_64-pc-windows-msvc --features platform-desktop
 
   #
   # Publish Kotlin SDK (dry-run: build Android + assemble AAR, no actual publish)


### PR DESCRIPTION
## Summary

Retires **`test-ci.yml:build-cli-windows`** — a `workflow_dispatch`-only cargo build of the CLI for `x86_64-pc-windows-msvc`. It's now redundant:

- **Ships via Bazel:** `release-prep.yml:build-cli-windows` (Bazel/MinGW, PE32+ gate).
- **Per-PR coverage:** `bazel.yml` builds + byte-inspects the `.exe` and `bazel-windows-smoke` runs it on `windows-latest`.
- **Break-glass retained:** the MSVC fallback still lives in the legacy `release.yml`.

Its only distinct value was an on-demand MSVC compile-check, and **MSVC is no longer a shipping toolchain for the CLI** (the shipped windows binary is MinGW/GNU-ABI). Also drops the now-dead `windows-cli` dispatch option. Verified: valid YAML, actionlint clean, no leftover references.

## Why only this one

A full cargo-vs-Bazel audit of every CI build/test job found this is the **only cargo CLI job cleanly retireable today**. The rest are blocked or premature:

- **`ci.yml:build-cli` (linux)** — the sole *guaranteed per-PR* cargo link-check of the CLI. `bazel.yml` builds the same CLI but is **advisory + fork-gated** (skips without the RBE secret), and cargo is still the build-of-record. Retire only after `bazel.yml`'s CLI lane is promoted to a **required + fork-safe** check.
- **`release.yml` cargo CLI jobs** — documented break-glass; delete `release.yml` **wholesale** after a release ships cleanly through the new Bazel flow, not piecemeal.
- **`release-dryrun.yml:build-validate-windows`** — *not* a CLI job despite the MSVC name; it validates the **Flutter Windows cdylib**. Left untouched.

## The bigger picture (from the audit)

"Closing the loop" is bigger than the CLI swaps — the still-off-Bazel surface is **the bindings** (Apple xcframework = the one un-flipped *ship* artifact; Flutter cargokit; Unity, still on the pre-bolt C ABI), **the entire test/lint gate** (no `bazel test`/`rust_test` target exists anywhere), and **the natives producer** (`build-natives.yml`, a cargo/cmake ghcr cache whose Bazel twin `//:llama` already exists). Full inventory posted separately.

## Type of Change

- [x] Other — CI cleanup (dead-job removal)

## Checklist

- [x] Tests pass — YAML validation + actionlint clean; the removed job is dispatch-only and depended on by nothing
- [x] No breaking changes (removes a redundant on-demand job; shipping + PR coverage of the windows CLI is unaffected)