### PR TITLE
ci: retire the cargo linux-CLI build (covered by required Bazel check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,26 +202,9 @@ jobs:
       - name: Run doc tests
         run: cargo test --workspace --features ort-download --doc
 
-  # Linux-only on push/PR. Per-platform CLI builds run in release.yml.
-  build-cli:
-    name: Build CLI (ubuntu-latest)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
-
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-          targets: x86_64-unknown-linux-gnu
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: ubuntu-latest-cli
-
-      - name: Build CLI
-        run: cargo build --release -p xybrid-cli --target x86_64-unknown-linux-gnu --features platform-desktop
+  # (Retired) The cargo linux-CLI build lived here. The required Bazel check
+  # ("Bazel graph + RBE targets", bazel.yml) now builds + smokes the linux CLI
+  # on every Bazel-relevant PR, so this cargo build was redundant.
 
   # API contract validation (soft warning — does not block CI)
   api-contract:
@@ -240,6 +223,6 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check-no-default-features, check-platform-macos, check-platform-desktop, check-vision-platforms, clippy-llm, test-llm, test, build-cli, api-contract]
+    needs: [fmt, clippy, check-no-default-features, check-platform-macos, check-platform-desktop, check-vision-platforms, clippy-llm, test-llm, test, api-contract]
     steps:
       - run: echo "All CI checks passed!"


### PR DESCRIPTION
Retires the last redundant cargo CLI build now that Bazel is the required gate.

**What changed**
- Removed `ci.yml:build-cli` (the cargo linux `xybrid-cli --features platform-desktop` build).
- Dropped it from the `ci-success` aggregator's `needs`.

**Why it's safe**
- The required **"Bazel graph + RBE targets"** check now builds + smokes the linux CLI on every Bazel-relevant PR — the cargo build was doing the same thing.

**One trade-off (documented)**
- Fork PRs can't use RBE, so they lose the pre-merge `platform-desktop` CLI link. Still caught by `clippy`/`test` + the master-push Bazel build. Easy to restore as a fork-only job if we want parity.