### PR TITLE
bazel(apple): G1 — build the iOS Rust staticlib on a Mac

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,30 +45,31 @@ build:windows --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-gnu
 # which is structurally incompatible with remote execution.
 build:macos --platforms=@rules_rs//rs/platforms:aarch64-apple-darwin
 
+# Preinstalled host cmake/make/pkg-config for rfcc's exec tools — shared by the
+# local-only Mac lanes (macos-metal, ios). rfcc's from-source bootstrap is the
+# known mac-host wall, so both use the host's tools (macos-14 runners + dev Macs
+# ship them).
+build:local_tools --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain
+build:local_tools --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_make_toolchain
+build:local_tools --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain
+
 # Desktop macOS GPU lane (Flip 2): Metal + Accelerate ON — REQUIRES a Mac with
 # Xcode (the metal shader compiler); never combine with linux remote EXECUTION.
-# Uses the host's preinstalled cmake/make/pkg-config for rfcc's exec tools
-# (macos-14 runners and dev Macs ship them; the from-source bootstrap is the
-# known mac-host wall). The Rust side is identical to the CPU lane by design —
-# same features, same rlibs — so a warm shared cache serves most of the graph.
+# The Rust side is identical to the CPU lane by design — same features, same
+# rlibs — so a warm shared cache serves most of the graph.
 build:macos-metal --platforms=@rules_rs//rs/platforms:aarch64-apple-darwin
 build:macos-metal --//:metal=true
-build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain
-build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_make_toolchain
-build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain
+build:macos-metal --config=local_tools
 # (-fstack-protector, which needs a libssp hermetic-llvm's MinGW sysroot doesn't
 # ship, is disabled for windows at the toolchain level in hermetic_llvm.patch.)
 
 # --- Apple Gate 1: iOS device staticlib, built LOCALLY on a Mac (Xcode iphoneos
 # SDK via apple_support). CPU-only, Metal OFF. Mac-bound end-to-end — NEVER
 # combine with --config=remote (no Mac RBE; the iOS closure needs an iphoneos
-# sysroot Linux can't provide). rfcc's exec tools come from the host's
-# preinstalled cmake/make/pkg-config (the from-source bootstrap is the mac-host
-# wall); //:llama's iOS arm sets PATH so rfcc's sanitized PATH finds them.
+# sysroot Linux can't provide). //:llama's iOS arm sets PATH so rfcc's sanitized
+# PATH finds the host tools.
 build:ios --platforms=@rules_rs//rs/platforms:aarch64-apple-ios
-build:ios --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain
-build:ios --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_make_toolchain
-build:ios --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain
+build:ios --config=local_tools
 build:ios --compilation_mode=opt
 
 # On Linux hosts, rules_rs' experimental toolchains need an explicit host platform

--- a/.bazelrc
+++ b/.bazelrc
@@ -59,6 +59,18 @@ build:macos-metal --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_
 # (-fstack-protector, which needs a libssp hermetic-llvm's MinGW sysroot doesn't
 # ship, is disabled for windows at the toolchain level in hermetic_llvm.patch.)
 
+# --- Apple Gate 1: iOS device staticlib, built LOCALLY on a Mac (Xcode iphoneos
+# SDK via apple_support). CPU-only, Metal OFF. Mac-bound end-to-end — NEVER
+# combine with --config=remote (no Mac RBE; the iOS closure needs an iphoneos
+# sysroot Linux can't provide). rfcc's exec tools come from the host's
+# preinstalled cmake/make/pkg-config (the from-source bootstrap is the mac-host
+# wall); //:llama's iOS arm sets PATH so rfcc's sanitized PATH finds them.
+build:ios --platforms=@rules_rs//rs/platforms:aarch64-apple-ios
+build:ios --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain
+build:ios --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_make_toolchain
+build:ios --extra_toolchains=@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain
+build:ios --compilation_mode=opt
+
 # On Linux hosts, rules_rs' experimental toolchains need an explicit host platform
 # with libc constraints (//:host_linux_gnu, root BUILD.bazel). The enable flag
 # makes `common:linux` auto-apply on Linux hosts (no-op on macOS: no macos config).

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -116,6 +116,24 @@ _DARWIN_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "LLAMA_BUILD_COMMON": "ON",
 }
 
+# iOS device (Apple G1), built LOCALLY on a Mac via Xcode's iphoneos SDK
+# (apple_support toolchain). Same rfcc gap as darwin/windows — no iOS entry in
+# rfcc's _TARGET_OS_PARAMS, so set CMAKE_SYSTEM_NAME=iOS explicitly, else cmake
+# detects the macOS EXEC host and builds llama as macOS. OSX_SYSROOT=iphoneos +
+# ARCHITECTURES=arm64 pick the iOS SDK via xcrun; deployment 16.0 matches
+# Package.swift / boltffi.toml. Metal stays OFF (base): GGML_METAL_DEFAULT is ON
+# on APPLE, so the base GGML_METAL=OFF is load-bearing (Metal is a later gate).
+# CPU-only, no vision/tools — the leanest iOS build. No Mach-O binutils overrides
+# (unlike the darwin CROSS): iOS builds ON the Mac, where /usr/bin/otool exists.
+_IOS_LLAMA = _LLAMA_CACHE_ENTRIES | {
+    "CMAKE_SYSTEM_NAME": "iOS",
+    "CMAKE_SYSTEM_PROCESSOR": "arm64",
+    "CMAKE_OSX_SYSROOT": "iphoneos",
+    "CMAKE_OSX_ARCHITECTURES": "arm64",
+    "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
+    "IOS": "ON",
+}
+
 cmake(
     name = "llama",
     # armv7: rfcc's crosstool has no CMAKE_SYSTEM_PROCESSOR mapping for armv7,
@@ -195,7 +213,19 @@ cmake(
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": _DARWIN_LLAMA | {
             "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
         },
+        # iOS device (Apple G1) — Mac-local build via the iphoneos SDK.
+        "@rules_rs//rs/platforms/config:aarch64-apple-ios": _IOS_LLAMA,
         "//conditions:default": _LLAMA_CACHE_ENTRIES,
+    }),
+    # iOS builds LOCALLY (--config=ios never uses --config=remote), so the exec
+    # platform is already this Mac — no exec_compatible_with pin needed (unlike
+    # //:llama_metal, which runs under remote exec and must be forced local).
+    # rfcc's PATH is sanitized, so hand the iOS arm the Apple-Silicon Homebrew
+    # path so it finds the preinstalled cmake/make (--config=ios registers them);
+    # /usr/bin keeps xcrun reachable. Default {} keeps other arms' keys stable.
+    env = select({
+        "@rules_rs//rs/platforms/config:aarch64-apple-ios": {"PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"},
+        "//conditions:default": {},
     }),
     # (macOS-host PATH hack removed for the RBE/Linux test — on Linux workers
     # rfcc finds its own downloaded cmake; /opt/homebrew doesn't exist there.)
@@ -363,5 +393,15 @@ filegroup(
 filegroup(
     name = "ort_macos_arm64",
     srcs = ["vendor/ort-macos/aarch64-apple-darwin/libonnxruntime.a"],
+    visibility = ["//visibility:public"],
+)
+
+# Vendored STATIC onnxruntime for the iOS device slice (Apple G1). Same
+# provide-the-artifact pattern as macOS above; the .a lives inside the
+# committed xcframework at the ios-arm64 slice. Fed to ort-sys via
+# ORT_LIB_LOCATION (MODULE.bazel annotation).
+filegroup(
+    name = "ort_ios_arm64",
+    srcs = ["vendor/ort-ios/onnxruntime.xcframework/ios-arm64/libonnxruntime.a"],
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,16 @@ bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
 # rules_cc must be a direct dep so the `@rules_cc//...` flag in .bazelrc resolves.
 bazel_dep(name = "rules_cc", version = "0.2.20")
+
+# Apple cc toolchain for iOS (Apple G1). hermetic-llvm has NO iOS target and
+# @macos_sdk is macOS-only/link-only, so the iOS cc toolchain — used for the
+# C-sys build-script compiles (ring, zstd-sys, ...), the wrapper cc_library, and
+# //:llama's cmake — comes from apple_support, which resolves the host Xcode's
+# iphoneos SDK. Already in the graph transitively (rules_rs -> apple_support) and
+# self-registers; os:ios is a UNIQUE match, so it resolves for aarch64-apple-ios
+# while hermetic-llvm keeps every desktop target (no conflict with the macOS
+# lanes). Pinned here for explicitness/stability.
+bazel_dep(name = "apple_support", version = "1.24.2", repo_name = "build_bazel_apple_support")
 # bool_flag for the //:metal build setting (the macOS GPU lane toggle).
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 # platforms must be a direct dep so the `@platforms//...` constraints in //:android_arm64 resolve.
@@ -239,6 +249,9 @@ crate.from_cargo(
         # Desktop Windows cross (GNU/MinGW ABI — hermetic-llvm ships no MSVC CRT).
         "x86_64-pc-windows-gnu",
         "aarch64-apple-darwin",
+        # iOS device (Apple G1). Mac-bound — builds locally via Xcode's iOS SDK
+        # (apple_support toolchain), never on Linux RBE.
+        "aarch64-apple-ios",
         "aarch64-linux-android",
         "armv7-linux-androideabi",
         "x86_64-linux-android",
@@ -258,6 +271,7 @@ crate.annotation(
     # all platforms — input-only, outputs unchanged.
     build_script_data_select = {
         "aarch64-apple-darwin": ["@@//:ort_macos_arm64"],
+        "aarch64-apple-ios": ["@@//:ort_ios_arm64"],
     },
     # CC=/usr/bin/false: ort-sys's bs probes `$CC --print-search-dirs` to find
     # Xcode's clang_rt dir and, on success, emits -lclang_rt.osx — which only
@@ -268,8 +282,14 @@ crate.annotation(
     # CC is otherwise unused by this bs (no C compiled on the LIB_LOCATION path).
     build_script_env_select = {
         "aarch64-apple-darwin": "{\"ORT_LIB_LOCATION\": \"$${pwd}/vendor/ort-macos/aarch64-apple-darwin\", \"CC\": \"/usr/bin/false\"}",
+        # iOS: the vendored slice lives inside the committed xcframework
+        # (vendor/ort-ios/onnxruntime.xcframework/ios-arm64/libonnxruntime.a).
+        "aarch64-apple-ios": "{\"ORT_LIB_LOCATION\": \"$${pwd}/vendor/ort-ios/onnxruntime.xcframework/ios-arm64\", \"CC\": \"/usr/bin/false\"}",
     },
-    data = ["@@//:ort_macos_arm64"],
+    data = [
+        "@@//:ort_macos_arm64",
+        "@@//:ort_ios_arm64",
+    ],
     allow_build_script_to_detect_nonhermetic_paths = True,
 )
 


### PR DESCRIPTION
First gate of the Apple chapter: get Bazel building the iOS Rust library on a Mac.

**What changed**
- Added `aarch64-apple-ios` to the crate build set + `apple_support` (the Xcode iOS toolchain).
- Wired the vendored ort-ios slice to ort-sys.
- Gave `//:llama` an iOS cmake arm (iphoneos SDK, arm64, Metal OFF — CPU-first).
- New `--config=ios` (local-only; iOS is Mac-bound).

**Result**
- `bazel build --config=ios //crates/xybrid-bolt:xybrid_bolt_staticlib` → real **iOS arm64 Mach-O** `.a`, built entirely on this Mac (verified `platform IPHONEOS`).

**Safe**
- iOS is a *unique* toolchain match, so no conflict with the desktop lanes — all four shipping lanes (linux/macOS/windows/android) re-verified analyze-clean. Additive; no `--config=remote`.

**Known follow-up (not blocking)**
- Rust/cc objects use the SDK's default min-iOS; align to the 16.0 deployment target before the xcframework gate.