### PR TITLE
bazel(apple): G2 — Metal on the iOS llama build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -107,6 +107,12 @@ _LLAMA_LIBS = [
 # Vision (TOOLS/COMMON=ON -> libmtmd) for parity with the shipped
 # platform-macos CLI; the throwaway tool exes get a C++ runtime via
 # CMAKE_CXX_STANDARD_LIBRARIES (lands AFTER objects, unlike EXE_LINKER_FLAGS).
+# Metal GPU backend, shared by the Apple Metal lanes (macOS //:llama_metal + iOS).
+_METAL_CMAKE_FLAGS = {
+    "GGML_METAL": "ON",
+    "GGML_ACCELERATE": "ON",
+}
+
 _DARWIN_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "CMAKE_SYSTEM_NAME": "Darwin",
     "CMAKE_SYSTEM_PROCESSOR": "arm64",
@@ -132,9 +138,7 @@ _IOS_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "CMAKE_OSX_ARCHITECTURES": "arm64",
     "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
     "IOS": "ON",
-    "GGML_METAL": "ON",
-    "GGML_ACCELERATE": "ON",
-}
+} | _METAL_CMAKE_FLAGS
 
 cmake(
     name = "llama",
@@ -323,9 +327,7 @@ cmake(
         "@llvm//tools:llvm-install-name-tool",
         "@llvm//tools:llvm-otool",
     ],
-    cache_entries = _DARWIN_LLAMA | {
-        "GGML_METAL": "ON",
-        "GGML_ACCELERATE": "ON",
+    cache_entries = _DARWIN_LLAMA | _METAL_CMAKE_FLAGS | {
         "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
     },
     lib_source = ":llama_src",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -116,15 +116,15 @@ _DARWIN_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "LLAMA_BUILD_COMMON": "ON",
 }
 
-# iOS device (Apple G1), built LOCALLY on a Mac via Xcode's iphoneos SDK
+# iOS device (Apple G1+G2), built LOCALLY on a Mac via Xcode's iphoneos SDK
 # (apple_support toolchain). Same rfcc gap as darwin/windows — no iOS entry in
 # rfcc's _TARGET_OS_PARAMS, so set CMAKE_SYSTEM_NAME=iOS explicitly, else cmake
 # detects the macOS EXEC host and builds llama as macOS. OSX_SYSROOT=iphoneos +
 # ARCHITECTURES=arm64 pick the iOS SDK via xcrun; deployment 16.0 matches
-# Package.swift / boltffi.toml. Metal stays OFF (base): GGML_METAL_DEFAULT is ON
-# on APPLE, so the base GGML_METAL=OFF is load-bearing (Metal is a later gate).
-# CPU-only, no vision/tools — the leanest iOS build. No Mach-O binutils overrides
-# (unlike the darwin CROSS): iOS builds ON the Mac, where /usr/bin/otool exists.
+# Package.swift / boltffi.toml. G2: Metal GPU + Accelerate ON (Xcode's metal
+# compiler, Mac-bound) — iOS always ships with Metal, so unlike desktop it needs
+# no --//:metal flag; just turn it on for the iOS arm. No Mach-O binutils
+# overrides (unlike the darwin CROSS): iOS builds ON the Mac (/usr/bin/otool).
 _IOS_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "CMAKE_SYSTEM_NAME": "iOS",
     "CMAKE_SYSTEM_PROCESSOR": "arm64",
@@ -132,6 +132,8 @@ _IOS_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "CMAKE_OSX_ARCHITECTURES": "arm64",
     "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
     "IOS": "ON",
+    "GGML_METAL": "ON",
+    "GGML_ACCELERATE": "ON",
 }
 
 cmake(
@@ -273,6 +275,9 @@ cmake(
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": ["libmtmd.a"] + _LLAMA_LIBS,
         # Darwin vision (Flip 2 parity — both CPU and Metal lanes).
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["libmtmd.a"] + _LLAMA_LIBS,
+        # iOS G2: Metal backend is its own archive (like //:llama_metal).
+        # Vision (libmtmd) is a later parity step — not collected yet.
+        "@rules_rs//rs/platforms/config:aarch64-apple-ios": ["libggml-metal.a"] + _LLAMA_LIBS,
         # Windows/MinGW: ggml/CMakeLists.txt sets CMAKE_STATIC_LIBRARY_PREFIX=""
         # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
         # libggml.a) — while llama (sibling scope) keeps it (libllama.a), and


### PR DESCRIPTION
Second gate of the Apple chapter: turn on the Metal GPU backend for the iOS build.

**What changed**
- iOS llama arm now builds with `GGML_METAL=ON + GGML_ACCELERATE=ON` (Xcode's metal compiler, on the Mac).
- Collects `libggml-metal.a` into the iOS staticlib.
- No flag needed — iOS always ships with Metal (unlike desktop's `--//:metal` toggle).

**Result**
- `bazel build --config=ios //crates/xybrid-bolt:xybrid_bolt_staticlib` → iOS arm64 `.a` with the Metal backend (384 `ggml_metal` symbols).

**Safe**
- Both edits are iOS-keyed selects; other platforms' llama arms untouched.

**Still to come (parity, before the xcframework gate)**
- Vision (mtmd) + candle-metal + coreml features to match cargo's platform-ios.
- Align the min-iOS deployment target (objects still build at the SDK default).