### PR TITLE
bazel(apple): iOS feature parity — vision + candle + coreml + iOS-16 floor

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,13 @@ build:macos-metal --config=local_tools
 build:ios --platforms=@rules_rs//rs/platforms:aarch64-apple-ios
 build:ios --config=local_tools
 build:ios --compilation_mode=opt
+# Min iOS floor, matching Package.swift .iOS(.v16) / boltffi
+# deployment_target=16.0 — otherwise apple clang defaults to the SDK's newest
+# min (an iOS-16 app then can't link the objects). --ios_minimum_os is the
+# apple_support-honored flag; the IPHONEOS_DEPLOYMENT_TARGET env is a belt-and-
+# suspenders for cc-rs/rustc which read it directly.
+build:ios --ios_minimum_os=16.0
+build:ios --action_env=IPHONEOS_DEPLOYMENT_TARGET=16.0
 
 # On Linux hosts, rules_rs' experimental toolchains need an explicit host platform
 # with libc constraints (//:host_linux_gnu, root BUILD.bazel). The enable flag

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -138,6 +138,12 @@ _IOS_LLAMA = _LLAMA_CACHE_ENTRIES | {
     "CMAKE_OSX_ARCHITECTURES": "arm64",
     "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
     "IOS": "ON",
+    # Vision (mtmd) parity: TOOLS/COMMON unlock tools/ -> libmtmd (the shipped
+    # platform-ios bolt has vision). The throwaway tool exes get the SDK's -lc++
+    # (resolves against iphoneos libc++.tbd), like the darwin/metal lanes.
+    "LLAMA_BUILD_TOOLS": "ON",
+    "LLAMA_BUILD_COMMON": "ON",
+    "CMAKE_CXX_STANDARD_LIBRARIES": "-lc++",
 } | _METAL_CMAKE_FLAGS
 
 cmake(
@@ -279,9 +285,8 @@ cmake(
         "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": ["libmtmd.a"] + _LLAMA_LIBS,
         # Darwin vision (Flip 2 parity — both CPU and Metal lanes).
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": ["libmtmd.a"] + _LLAMA_LIBS,
-        # iOS G2: Metal backend is its own archive (like //:llama_metal).
-        # Vision (libmtmd) is a later parity step — not collected yet.
-        "@rules_rs//rs/platforms/config:aarch64-apple-ios": ["libggml-metal.a"] + _LLAMA_LIBS,
+        # iOS parity: Metal backend archive + vision (libmtmd), like darwin.
+        "@rules_rs//rs/platforms/config:aarch64-apple-ios": ["libmtmd.a", "libggml-metal.a"] + _LLAMA_LIBS,
         # Windows/MinGW: ggml/CMakeLists.txt sets CMAKE_STATIC_LIBRARY_PREFIX=""
         # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
         # libggml.a) — while llama (sibling scope) keeps it (libllama.a), and

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -19,6 +19,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2: macOS parity
+    "@rules_rs//rs/platforms/config:aarch64-apple-ios",  # Apple parity: iOS vision
     "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
 ]
 

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -52,6 +52,17 @@ rust_library(
             # Flip 2: parity with the shipped platform-macos CLI (vision).
             "llm-llamacpp-vision",
         ],
+        # Apple G1-G2 parity: platform-ios expands to the SAME core backend set
+        # as platform-macos (candle-metal + coreml + vision), so mirror darwin.
+        "@rules_rs//rs/platforms/config:aarch64-apple-ios": [
+            "candle",
+            "candle-core",
+            "candle-hub",
+            "candle-metal",
+            "candle-nn",
+            "ort-coreml",
+            "llm-llamacpp-vision",
+        ],
         "@rules_rs//rs/platforms/config:aarch64-linux-android": _ANDROID_BACKENDS,
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": _ANDROID_BACKENDS,
         "@rules_rs//rs/platforms/config:x86_64-linux-android": _ANDROID_BACKENDS,

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -9,6 +9,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:x86_64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",  # Flip 2: macOS parity
+    "@rules_rs//rs/platforms/config:aarch64-apple-ios",  # Apple parity: iOS vision
     "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
 ]
 

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -10,6 +10,7 @@ load("@rules_rs//rs/private:all_crate_deps.bzl", _all_crate_deps = "all_crate_de
 
 PLATFORMS = [
     "@rules_rs//rs/platforms/config:aarch64-apple-darwin",
+    "@rules_rs//rs/platforms/config:aarch64-apple-ios",
     "@rules_rs//rs/platforms/config:aarch64-linux-android",
     "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu",
     "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",
@@ -71,6 +72,13 @@ rust_library(
             "platform-macos",
             "llm-llamacpp-vision",
             "huggingface",
+        ],
+        # Apple G1-G2 parity: cargo's platform-ios == platform-macos EXCEPT it
+        # does NOT pull the sdk-level `huggingface` (that was macOS-CLI-only), so
+        # no huggingface here and no hf-hub dep (iOS absent from _HF_PLATFORMS).
+        "@rules_rs//rs/platforms/config:aarch64-apple-ios": [
+            "platform-ios",
+            "llm-llamacpp-vision",
         ],
         # Windows .exe parity: cargo's windows leg builds platform-desktop,
         # same expansion as the linux arm above.


### PR DESCRIPTION
Brings the Bazel iOS build to full parity with cargo's `platform-ios`, before the xcframework gate.

**What changed**
- **core** iOS arm: candle + ort-coreml + vision (mirrors darwin — `platform-ios` == `platform-macos`).
- **sdk** iOS arm: `platform-ios` + vision. *No* `huggingface`/hf-hub — that was macOS-CLI-only, not in `platform-ios`.
- **vision**: iOS added to `_VISION_PLATFORMS` (llama-cpp-sys + xybrid-llama); `//:llama` iOS arm builds `libmtmd.a`.
- **iOS-16 floor**: `--ios_minimum_os=16.0` — objects were building at the SDK's newest min, which an iOS-16 app can't link.

**Verified** (`--config=ios` staticlib)
- 384 `ggml_metal` + 477 `mtmd_` (vision) + 12,753 `coreml` + 10,353 `candle` symbols.
- Every object now min-iOS ≤ 16.0 (was 26.5).

**Safe**
- All iOS-keyed additions; the four shipping lanes re-verified analyze-clean.

**Next**
- G3: assemble the xcframework via `rules_apple`/`rules_swift` (the multi-week gate).