### PR TITLE
bazel(apple): G3 — assemble the iOS XybridFFI.xcframework via rules_apple

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,7 +46,19 @@ bazel_dep(name = "rules_cc", version = "0.2.20")
 # self-registers; os:ios is a UNIQUE match, so it resolves for aarch64-apple-ios
 # while hermetic-llvm keeps every desktop target (no conflict with the macOS
 # lanes). Pinned here for explicitness/stability.
-bazel_dep(name = "apple_support", version = "1.24.2", repo_name = "build_bazel_apple_support")
+# apple_support: the iOS cc toolchain (G1). Bumped 1.24.2 -> 2.2.0 by
+# rules_apple 4.5.x below — the older rules_apple that kept 1.24.2 (4.0/4.1) uses
+# apple fragment APIs Bazel 9 removed (multi_arch_platform / apple_crosstool_top),
+# so the Bazel-9-compatible rules_apple forces this bump. Re-validated: the iOS
+# staticlib (G1/G2) still builds under 2.2.0.
+bazel_dep(name = "apple_support", version = "2.2.0", repo_name = "build_bazel_apple_support")
+
+# Apple Gate 3: rules_apple's apple_static_xcframework assembles the iOS
+# XybridFFI.xcframework from the G1/G2 rust staticlib + the committed C header
+# (FFI-only — no rules_swift rules used; the Swift wrapper is committed SPM
+# source compiled by the consumer). 4.5.3 is the Bazel-9-compatible line
+# (4.0/4.1 use removed apple fragment APIs); it floors apple_support at 2.2.0.
+bazel_dep(name = "rules_apple", version = "4.5.3", repo_name = "build_bazel_rules_apple")
 # bool_flag for the //:metal build setting (the macOS GPU lane toggle).
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 # platforms must be a direct dep so the `@platforms//...` constraints in //:android_arm64 resolve.

--- a/bindings/apple/BUILD.bazel
+++ b/bindings/apple/BUILD.bazel
@@ -18,10 +18,6 @@ apple_static_xcframework(
     bundle_name = "XybridFFI",
     minimum_os_versions = {"ios": "16.0"},  # matches Package.swift .iOS(.v16)
     ios = {"device": ["arm64"]},
-    families_required = {"ios": [
-        "iphone",
-        "ipad",
-    ]},
     public_hdrs = ["include/xybrid-bolt.h"],
     umbrella_header = "include/xybrid-bolt.h",
     # The full-feature iOS staticlib (Metal + vision + candle + coreml, min-iOS

--- a/bindings/apple/BUILD.bazel
+++ b/bindings/apple/BUILD.bazel
@@ -23,5 +23,10 @@ apple_static_xcframework(
     # The full-feature iOS staticlib (Metal + vision + candle + coreml, min-iOS
     # 16.0). Provides CcInfo, so it feeds apple_static_xcframework directly.
     deps = ["//crates/xybrid-bolt:xybrid_bolt_staticlib"],
+    # Mac-only (xcodebuild -create-xcframework, iphoneos SDK): keep it OUT of
+    # wildcard builds like the advisory CI's `//bindings/...` analyze, which
+    # runs on a LINUX runner where no macOS exec platform exists (same reason
+    # //:llama_metal is `manual`). Explicit `--config=ios` builds still work.
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )

--- a/bindings/apple/BUILD.bazel
+++ b/bindings/apple/BUILD.bazel
@@ -1,0 +1,31 @@
+# Apple Gate 3 — assemble XybridFFI.xcframework via rules_apple, replacing
+# `boltffi pack apple` / `cargo xtask build-xcframework`. FFI-only: the C static
+# lib (the G1/G2 rust staticlib) + the committed boltffi-generated C header. The
+# Swift wrappers (Sources/Xybrid/*.swift) are committed SPM source compiled by
+# the CONSUMER, so no rules_swift here. Mac-bound (xcodebuild -create-xcframework).
+#
+# The C header is boltffi-generated (regenerate: `cd crates/xybrid-bolt &&
+# boltffi generate`, then copy dist/apple/include/xybrid-bolt.h here). Committed
+# like the Swift wrapper; a CI drift check keeps it fresh.
+load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_xcframework")
+
+# Device-only for now (G3b). The simulator slice is a follow-up — blocked on a
+# vendored ort-ios SIMULATOR onnxruntime slice (only ios-arm64 device ships today).
+# bundle_name "XybridFFI" -> the xcframework dir AND the clang module name, which
+# must match `import XybridFFI` in the committed xybrid_bolt.swift + Package.swift.
+apple_static_xcframework(
+    name = "XybridFFI",
+    bundle_name = "XybridFFI",
+    minimum_os_versions = {"ios": "16.0"},  # matches Package.swift .iOS(.v16)
+    ios = {"device": ["arm64"]},
+    families_required = {"ios": [
+        "iphone",
+        "ipad",
+    ]},
+    public_hdrs = ["include/xybrid-bolt.h"],
+    umbrella_header = "include/xybrid-bolt.h",
+    # The full-feature iOS staticlib (Metal + vision + candle + coreml, min-iOS
+    # 16.0). Provides CcInfo, so it feeds apple_static_xcframework directly.
+    deps = ["//crates/xybrid-bolt:xybrid_bolt_staticlib"],
+    visibility = ["//visibility:public"],
+)

--- a/bindings/apple/include/xybrid-bolt.h
+++ b/bindings/apple/include/xybrid-bolt.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdatomic.h>
+
+typedef struct FfiStatus { int32_t code; } FfiStatus;
+typedef struct FfiString { uint8_t* ptr; size_t len; size_t cap; } FfiString;
+typedef struct FfiBuf_u8 { uint8_t* ptr; size_t len; size_t cap; size_t align; } FfiBuf_u8;
+typedef struct FfiError { FfiString message; } FfiError;
+typedef struct BoltFFICallbackHandle { uint64_t handle; const void* vtable; } BoltFFICallbackHandle;
+
+static inline bool boltffi_atomic_u8_cas(volatile uint8_t* target, uint8_t expected, uint8_t desired) {
+    return atomic_compare_exchange_strong((_Atomic uint8_t*)target, &expected, desired);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(volatile uint64_t* target, uint64_t value) {
+    return atomic_exchange((_Atomic uint64_t*)target, value);
+}
+
+static inline bool boltffi_atomic_u64_cas(volatile uint64_t* target, uint64_t expected, uint64_t desired) {
+    return atomic_compare_exchange_strong((_Atomic uint64_t*)target, &expected, desired);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(const volatile uint64_t* target) {
+    return atomic_load_explicit((const _Atomic uint64_t*)target, memory_order_acquire);
+}
+
+
+
+struct XybridModel;
+
+typedef int32_t ___XybridMessageRole;
+#define ___XybridMessageRole_System 0
+#define ___XybridMessageRole_User 1
+#define ___XybridMessageRole_Assistant 2
+typedef int32_t ___XybridAbortSignal;
+#define ___XybridAbortSignal_MemoryPressureWarn 0
+#define ___XybridAbortSignal_MemoryPressureCritical 1
+#define ___XybridAbortSignal_ThermalHot 2
+#define ___XybridAbortSignal_ThermalCritical 3
+typedef int32_t ___XybridOutputType;
+#define ___XybridOutputType_Text 0
+#define ___XybridOutputType_Audio 1
+#define ___XybridOutputType_Embedding 2
+#define ___XybridOutputType_Unknown 3
+typedef int32_t ___XybridThermalState;
+#define ___XybridThermalState_Normal 0
+#define ___XybridThermalState_Warm 1
+#define ___XybridThermalState_Hot 2
+#define ___XybridThermalState_Critical 3
+FfiBuf_u8 boltffi_json_schema_to_gbnf(const uint8_t* schema_json, uintptr_t schema_json_len);void boltffi_set_thermal_state(int32_t state);void boltffi_clear_thermal_state(void);void boltffi_set_battery_level(uint8_t percent);void boltffi_clear_battery_level(void);void boltffi_configure_runtime(const uint8_t* api_key, uintptr_t api_key_len, const uint8_t* gateway_url, uintptr_t gateway_url_len, const uint8_t* ingest_url, uintptr_t ingest_url_len);void boltffi_init_sdk_cache_dir(const uint8_t* cache_dir, uintptr_t cache_dir_len);void boltffi_set_binding(const uint8_t* binding, uintptr_t binding_len);void boltffi_set_api_key(const uint8_t* api_key, uintptr_t api_key_len);void boltffi_set_provider_api_key(const uint8_t* provider, uintptr_t provider_len, const uint8_t* api_key, uintptr_t api_key_len);struct XybridModel * boltffi_xybrid_model_from_registry(const uint8_t* id, uintptr_t id_len);struct XybridModel * boltffi_xybrid_model_from_directory(const uint8_t* path, uintptr_t path_len);struct XybridModel * boltffi_xybrid_model_from_bundle(const uint8_t* path, uintptr_t path_len);struct XybridModel * boltffi_xybrid_model_from_huggingface(const uint8_t* repo, uintptr_t repo_len);void boltffi_xybrid_model_free(struct XybridModel * handle);FfiBuf_u8 boltffi_xybrid_model_model_id(const struct XybridModel * self);FfiBuf_u8 boltffi_xybrid_model_version(const struct XybridModel * self);int32_t boltffi_xybrid_model_output_type(const struct XybridModel * self);bool boltffi_xybrid_model_is_loaded(const struct XybridModel * self);bool boltffi_xybrid_model_supports_streaming(const struct XybridModel * self);bool boltffi_xybrid_model_is_llm(const struct XybridModel * self);bool boltffi_xybrid_model_has_voices(const struct XybridModel * self);FfiBuf_u8 boltffi_xybrid_model_voices(const struct XybridModel * self);FfiBuf_u8 boltffi_xybrid_model_default_voice(const struct XybridModel * self);FfiBuf_u8 boltffi_xybrid_model_voice(const struct XybridModel * self, const uint8_t* voice_id, uintptr_t voice_id_len);FfiBuf_u8 boltffi_xybrid_model_run(const struct XybridModel * self, const uint8_t* envelope, uintptr_t envelope_len, const uint8_t* options, uintptr_t options_len);FfiBuf_u8 boltffi_xybrid_model_warmup(const struct XybridModel * self);FfiBuf_u8 boltffi_xybrid_model_unload(const struct XybridModel * self);
+
+void boltffi_free_string(FfiString s);
+void boltffi_free_buf(FfiBuf_u8 buf);
+FfiStatus boltffi_last_error_message(FfiString *out);
+void boltffi_clear_last_error(void);


### PR DESCRIPTION
Assembles the iOS `XybridFFI.xcframework` via Bazel/`rules_apple`, replacing `boltffi pack apple` / `cargo xtask build-xcframework`.

**What changed**
- Added `rules_apple` 4.5.3 (the Bazel-9-compatible line — 4.0/4.1 use removed apple fragment APIs). It bumps `apple_support` 1.24.2 → 2.2.0; the G1/G2 iOS staticlib rebuilt clean under it.
- New `bindings/apple/BUILD.bazel`: `apple_static_xcframework` wraps the iOS `.a` + the C header into `XybridFFI.xcframework`.
- Committed the boltffi-generated C header (`bindings/apple/include/xybrid-bolt.h`).

**Result** (`bazel build --config=ios //bindings/apple:XybridFFI`)
- Real `XybridFFI.xcframework` — `ios-arm64/XybridFFI.framework`, module `XybridFFI` (matches the committed Swift's `import XybridFFI`), min-iOS 16.0, full feature surface (Metal/vision/candle/coreml/ort).

**Not changed**
- Downstream (`Package.swift` binaryTarget, release zip, checksum) — G3 swaps only the xcframework *producer*.

**Scope / next**
- Device slice only; the simulator slice is a follow-up (no vendored ONNX sim slice yet).
- Next: consumer smoke (`swift build` against the Bazel xcframework), then the release-job swap (G4).
- All 4 shipping lanes re-verified analyze-clean under `apple_support` 2.2.0.