### PR TITLE
bazel(apple): fix the xcframework Info.plist + iOS consumer smoke passes

### DIFF
--- a/bindings/apple/BUILD.bazel
+++ b/bindings/apple/BUILD.bazel
@@ -16,6 +16,14 @@ load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_xcframework")
 apple_static_xcframework(
     name = "XybridFFI",
     bundle_name = "XybridFFI",
+    # bundle_id gives the EMBEDDED framework its Info.plist (nested_bundle_id in
+    # rules_apple) — without it the .framework has no Info.plist and Xcode
+    # rejects it ("did not contain an Info.plist") when a consumer app processes
+    # the binaryTarget. Internal to the static framework; not user-facing.
+    bundle_id = "ai.xybrid.XybridFFI",
+    # The framework Info.plist needs version keys (CFBundleVersion); the rest is
+    # generated. Merged into the embedded XybridFFI.framework/Info.plist.
+    infoplists = ["XybridFFI-Info.plist"],
     minimum_os_versions = {"ios": "16.0"},  # matches Package.swift .iOS(.v16)
     ios = {"device": ["arm64"]},
     public_hdrs = ["include/xybrid-bolt.h"],

--- a/bindings/apple/XybridFFI-Info.plist
+++ b/bindings/apple/XybridFFI-Info.plist
@@ -7,8 +7,8 @@
 	     CFBundlePackageType) on top of these; only the version keys must be
 	     supplied. This is the embedded static framework's Info.plist. -->
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0.3.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.3.0</string>
 </dict>
 </plist>

--- a/bindings/apple/XybridFFI-Info.plist
+++ b/bindings/apple/XybridFFI-Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- rules_apple merges the generated keys (CFBundleIdentifier from
+	     bundle_id, CFBundleName/Executable from bundle_name, MinimumOSVersion,
+	     CFBundlePackageType) on top of these; only the version keys must be
+	     supplied. This is the embedded static framework's Info.plist. -->
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/tools/scripts/version-sync.sh
+++ b/tools/scripts/version-sync.sh
@@ -25,6 +25,10 @@ FLUTTER_RUST_CARGO="$REPO_ROOT/bindings/flutter/rust/Cargo.toml"
 # URL for SPM consumers in remote mode and MUST match the cargo workspace
 # version.
 SWIFT_PACKAGE="$REPO_ROOT/Package.swift"
+# The XybridFFI.xcframework's embedded framework Info.plist (Bazel-built via
+# apple_static_xcframework). Its CFBundleVersion/ShortVersionString bake into the
+# shipped xcframework, so they must track the SDK version too.
+SWIFT_FFI_PLIST="$REPO_ROOT/bindings/apple/XybridFFI-Info.plist"
 # React Native npm package. RN is hand-translated (not generated), so it was
 # absent from this sync and its package.json drifted. Two versions must equal
 # the workspace version: the npm package version, and the `ai.xybrid:xybrid-kotlin`
@@ -67,6 +71,13 @@ get_flutter_rust_version() {
 # Extract sdkVersion from root Package.swift
 get_swift_version() {
     grep '^let sdkVersion = ' "$SWIFT_PACKAGE" | sed 's/let sdkVersion = "\(.*\)"/\1/'
+}
+
+# Extract CFBundleShortVersionString from the xcframework framework Info.plist
+# (the value on the line after the key). Portable (no plutil, so CI --check
+# works on Linux).
+get_swift_ffi_version() {
+    grep -A1 'CFBundleShortVersionString' "$SWIFT_FFI_PLIST" | grep '<string>' | head -1 | sed 's|.*<string>\(.*\)</string>.*|\1|'
 }
 
 # Extract version from React Native package.json (parsed, like Unity's).
@@ -140,6 +151,18 @@ set_swift_version() {
     rm -f "$SWIFT_PACKAGE.bak"
 }
 
+# Set both version keys in the xcframework framework Info.plist. Each <string>
+# value sits on the line AFTER its key, so match the key then replace the next
+# line (`n`). Both track the SDK version (fine for a static-lib framework).
+set_swift_ffi_version() {
+    local version="$1"
+    sed -i.bak \
+        -e "/CFBundleVersion/{n;s|<string>.*</string>|<string>$version</string>|;}" \
+        -e "/CFBundleShortVersionString/{n;s|<string>.*</string>|<string>$version</string>|;}" \
+        "$SWIFT_FFI_PLIST"
+    rm -f "$SWIFT_FFI_PLIST.bak"
+}
+
 # Set version in React Native package.json (parsed + rewritten, like Unity's —
 # robust against reformatting; preserves the file's standard 2-space layout).
 set_rn_version() {
@@ -179,7 +202,7 @@ check_versions() {
     echo "Cargo workspace version: $cargo_version"
     echo ""
 
-    for name_func in "Flutter:get_flutter_version" "Flutter rust crate:get_flutter_rust_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version" "React Native:get_rn_version" "React Native AAR:get_rn_aar_version" "Python:get_python_version"; do
+    for name_func in "Flutter:get_flutter_version" "Flutter rust crate:get_flutter_rust_version" "Unity:get_unity_version" "Kotlin:get_kotlin_version" "Swift:get_swift_version" "Swift FFI plist:get_swift_ffi_version" "React Native:get_rn_version" "React Native AAR:get_rn_aar_version" "Python:get_python_version"; do
         local name="${name_func%%:*}"
         local func="${name_func##*:}"
         local version
@@ -216,6 +239,7 @@ case "${1:-}" in
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
         set_swift_version "$VERSION"
+        set_swift_ffi_version "$VERSION"
         set_rn_version "$VERSION"
         set_rn_aar_version "$VERSION"
         set_python_version "$VERSION"
@@ -239,6 +263,7 @@ case "${1:-}" in
         set_unity_version "$VERSION"
         set_kotlin_version "$VERSION"
         set_swift_version "$VERSION"
+        set_swift_ffi_version "$VERSION"
         set_rn_version "$VERSION"
         set_rn_aar_version "$VERSION"
         set_python_version "$VERSION"


### PR DESCRIPTION
Fixes the G3 xcframework so real consumers can use it, and validates it end-to-end in an app.

**The bug**
- The embedded `XybridFFI.framework` had no `Info.plist` → a consumer app rejected it ("did not contain an Info.plist"). `apple_static_xcframework` only generates the framework Info.plist when given `bundle_id` + version keys.

**The fix**
- Added `bundle_id` + a minimal `infoplists` (CFBundleVersion). The framework now carries a complete Info.plist (identifier, version, MinimumOSVersion 16.0); the binary is still the arm64/iOS static lib.

**Verified — the iOS consumer smoke** ✅
- `examples/ios/XybridExample` compiles, links, and **runs on device** against the Bazel-built xcframework (`useLocalNatives`). That's the real 'does it work in an app' proof for the whole iOS Bazel chain (G1→G3).

**Note**
- Device slice only (simulator deferred — no vendored ONNX sim slice).