### PR TITLE
ci(apple): Bazel-build the PR XCFramework check (retire boltffi)

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -66,6 +66,12 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Bazel's //:llama_src globs the vendored llama.cpp submodule
+          # (vendor/llama-cpp); without this the cmake source dir is empty and the
+          # build fails "does not contain CMakeLists.txt". The old cargo path
+          # didn't need it (build.rs cloned llama into OUT_DIR).
+          submodules: true
 
       # Apple CI is Bazel-built — the SAME //bindings/apple:XybridFFI target the
       # release ships (device + simulator slices, G4). No cargo/boltffi/sccache/

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -9,20 +9,26 @@ on:
       - 'crates/xybrid-ffi-facade/**'
       - 'crates/xybrid-core/**'
       - 'crates/xybrid-sdk/**'
-      - 'xtask/**'
+      - 'crates/xybrid-llama/**'
+      - 'crates/llama-cpp-sys/**'
+      # The Bazel graph that assembles the xcframework (G4): sim triple + ort-sys
+      # annotation, the llama iOS arms, --config=ios, the fetched sim-ORT rule,
+      # and the committed device ORT slice.
+      - 'MODULE.bazel'
+      - 'BUILD.bazel'
+      - '.bazelrc'
+      - 'bazel/**'
+      - 'vendor/ort-ios/**'
       - 'Cargo.lock'
       - 'Cargo.toml'
       - '.github/workflows/build-apple.yml'
       # Docs-only changes under the paths above (READMEs, examples) never
       # affect the native build — exclude markdown so they don't trigger it.
       - '!**.md'
-  # Run on master merges too, so each merge saves a default-branch-scoped
-  # cache (sccache + rust-cache). GitHub Actions caches are branch-scoped:
-  # a PR run can only restore caches from its own branch or the default
-  # branch. Without this trigger master never builds, so master has no
-  # cache, so every new PR branch's first run is cold (~30 min). Warming
-  # master here lets new branches start warm (~5 min). Keep these paths in
-  # sync with the pull_request trigger above.
+  # Run on master merges too, so the Bazel xcframework build stays green on the
+  # default branch (and warms any future Bazel remote/disk cache — the build is
+  # currently uncached, so a cold iOS build is ~15-20 min; caching is a follow-up).
+  # Keep these paths in sync with the pull_request trigger above.
   push:
     branches: [master]
     paths:
@@ -31,7 +37,13 @@ on:
       - 'crates/xybrid-ffi-facade/**'
       - 'crates/xybrid-core/**'
       - 'crates/xybrid-sdk/**'
-      - 'xtask/**'
+      - 'crates/xybrid-llama/**'
+      - 'crates/llama-cpp-sys/**'
+      - 'MODULE.bazel'
+      - 'BUILD.bazel'
+      - '.bazelrc'
+      - 'bazel/**'
+      - 'vendor/ort-ios/**'
       - 'Cargo.lock'
       - 'Cargo.toml'
       - '.github/workflows/build-apple.yml'
@@ -55,118 +67,51 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-          targets: >-
-            aarch64-apple-ios,
-            aarch64-apple-ios-sim,
-            aarch64-apple-darwin
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-      - name: Configure sccache environment
-        shell: bash
+      # Apple CI is Bazel-built — the SAME //bindings/apple:XybridFFI target the
+      # release ships (device + simulator slices, G4). No cargo/boltffi/sccache/
+      # oras scaffolding: Bazel uses rules_rs's own rust toolchain + cache, and the
+      # C header / Swift wrapper are committed (boltffi is codegen-only). bazelisk
+      # ships on macos runners and honors .bazelversion; --config=ios is Mac-LOCAL
+      # (xcodebuild -create-xcframework, iphoneos/iphonesimulator SDKs) — never RBE.
+      - name: Ensure Bazel host tools
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          which cmake >/dev/null || brew install cmake
+          which pkg-config >/dev/null || brew install pkg-config
+          which xz >/dev/null || brew install xz   # decodes the fetched sim ORT slice
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          prefix-key: "v1-rust"
-          shared-key: "apple-xcframework"
-          cache-all-crates: "true"
-          save-if: "true"
+      - name: Build XCFramework (Bazel)
+        run: bazelisk build --config=ios //bindings/apple:XybridFFI
 
-      # boltffi CLI provides the `boltffi pack apple` that
-      # `cargo xtask build-xcframework` shells out to. Cache the installed
-      # binary across runs.
-      - name: Cache boltffi CLI
-        id: cache-boltffi
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.cargo/bin/boltffi
-          key: boltffi-cli-${{ runner.os }}-0.25.3
-
-      - name: Install boltffi CLI
-        # `which || install` is idempotent whether or not the cache populated
-        # the binary. Pinned to 0.25.3 to MATCH the runtime `boltffi` crate
-        # (Cargo.lock): a CLI/runtime version skew mis-generates unit-ok
-        # `Result<(), E>` exports (model warmup/unload) as a `void` foreign
-        # function that drops the error and leaks the result buffer. `--locked`
-        # installs against the CLI's own bundled Cargo.lock for reproducibility.
-        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
-
-      # Prebuilt-natives fast path (iOS device + arm64 simulator — the two
-      # slices boltffi's xcframework builds). Best-effort: pull the prebuilt
-      # llama.cpp slices and point build.rs at them so the xcframework build
-      # skips the llama.cpp cmake compile per slice. On ANY miss/error this is a
-      # silent no-op (continue-on-error) and the slice compiles from source — it
-      # can never break the build. build.rs keys on
-      # XYBRID_NATIVES_PREBUILT_DIR/<target>, so each slice in the single
-      # `boltffi pack apple` invocation resolves its own (or falls through).
-      - name: Setup oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
-      # `oras login`, not docker/login-action: macOS runners have no docker.
-      # Best-effort + same-repo only (forks have no token → anonymous pull).
-      - name: Log in to ghcr (best-effort, same-repo)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-      - name: Pull prebuilt natives (iOS device + sim, best-effort)
-        continue-on-error: true
-        env:
-          XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+      - name: Stage XCFramework
+        # Unzip the Bazel output to the path Package.swift's local-natives mode +
+        # the artifact upload expect. apple_static_xcframework's zip root is
+        # already XybridFFI.xcframework/, so this lands
+        # bindings/apple/XCFrameworks/XybridFFI.xcframework/ (gitignored).
         run: |
-          # Use the Rust TARGET spelling aarch64-apple-ios-sim (with -sim);
-          # build.rs keys the slice dir on it.
-          DEST="$RUNNER_TEMP/natives"
-          got_any=0
-          for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
-            if tools/scripts/natives-pull.sh "$triple" vision "$DEST"; then
-              echo "prebuilt natives staged for $triple (will skip cmake)"
-              got_any=1
-            else
-              echo "no prebuilt natives for $triple — compiles from source"
-            fi
-          done
-          if [ "$got_any" = 1 ]; then
-            echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
-          else
-            echo "no prebuilt natives — compiles from source (unchanged)"
-          fi
-
-      - name: Build XCFramework
-        run: cargo xtask build-xcframework --release
+          set -euo pipefail
+          DEST="bindings/apple/XCFrameworks"
+          rm -rf "$DEST/XybridFFI.xcframework"
+          mkdir -p "$DEST"
+          unzip -q -o bazel-bin/bindings/apple/XybridFFI.xcframework.zip -d "$DEST"
 
       - name: Verify XCFramework
         run: |
-          XCFW_PATH="bindings/apple/XCFrameworks/XybridFFI.xcframework"
-          if [ ! -d "$XCFW_PATH" ]; then
-            echo "Error: XCFramework not found at $XCFW_PATH"
-            exit 1
-          fi
-          echo "XCFramework contents:"
-          ls -la "$XCFW_PATH"
-          echo ""
-          echo "Verifying architectures..."
-          # boltffi names the slice static lib libxybrid-bolt.a and lays
-          # out one dir per slice (ios-arm64, ios-arm64-simulator; macOS is
-          # excluded via boltffi.toml). Glob rather than hard-code so this
-          # survives naming/slice changes.
-          found=$(find "$XCFW_PATH" -name '*.a')
-          if [ -z "$found" ]; then
-            echo "Error: no static libraries found inside the XCFramework"
-            exit 1
-          fi
-          echo "$found" | while read -r lib; do file "$lib"; done
+          set -euo pipefail
+          XCFW="bindings/apple/XCFrameworks/XybridFFI.xcframework"
+          test -d "$XCFW" || { echo "Error: XCFramework not found at $XCFW"; exit 1; }
+          echo "XCFramework contents:"; ls -la "$XCFW"
+          # Bazel's apple_static_xcframework emits a static FRAMEWORK per slice
+          # (XybridFFI.framework/XybridFFI = an ar archive, no .a extension), one
+          # dir per slice. Assert BOTH the device and simulator slices (G4) are
+          # present, each a real Mach-O archive, and both are in the umbrella plist.
+          for slice in ios-arm64 ios-arm64-simulator; do
+            BIN="$XCFW/$slice/XybridFFI.framework/XybridFFI"
+            test -f "$BIN" || { echo "Error: missing slice binary $BIN"; exit 1; }
+            file "$BIN" | grep -qi 'archive' || { echo "Error: $BIN is not an ar archive"; exit 1; }
+            grep -q "<string>$slice</string>" "$XCFW/Info.plist" || { echo "Error: $slice not in Info.plist"; exit 1; }
+            echo "OK: $slice -> $(lipo -info "$BIN" | sed 's/.*: //')"
+          done
+          echo "XCFramework verify: device + simulator slices OK"
 
       - name: Compile Swift binding wrapper (iOS Simulator)
         # Compiles the hand-written Xybrid.swift + the bolt-generated
@@ -181,8 +126,10 @@ jobs:
         # v<version> release is still a draft. The flip is CI-only, never committed.
         #
         # Targets the iOS Simulator for two reasons: (1) the xcframework ships
-        # only ios-arm64 + ios-arm64-simulator (boltffi.toml include_macos=false),
-        # so a host/macOS build has no slice to link; (2) Xybrid.swift gates
+        # only ios-arm64 + ios-arm64-simulator (bindings/apple/BUILD.bazel: ios =
+        # device + simulator, no macOS), so a host/macOS build has no slice to
+        # link — and this now links the G4 SIMULATOR slice end-to-end through the
+        # Swift wrapper, the coverage that was previously local-only; (2) Xybrid.swift gates
         # `import UIKit` behind `#if os(iOS)`, so only an iOS build type-checks
         # the UIKit-conditional code — the code most likely to break. Compiles
         # the wrapper library ONLY (the example .xcodeproj has no shared scheme;
@@ -198,24 +145,6 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO
-
-      - name: Check iOS vision build (fast early-fail smoke)
-        # Fast `cargo check` smoke for the native llama.cpp vision backend
-        # (mtmd). As of 0.2.1 `platform-ios` ships this backend, so the
-        # XCFramework above already compiles it — this step is a redundant but
-        # cheap early-fail signal that surfaces an mtmd cross-compile break in
-        # ~1-2 min instead of waiting on the full xcframework cycle. The chain:
-        # xybrid-sdk -> xybrid-core/llm-llamacpp-vision -> xybrid-llama-sys/vision
-        # (the -sys crate lives at crates/llama-cpp-sys/, package `xybrid-llama-sys`).
-        #
-        # `check` (not `build`) is sufficient and matches the old gate: the
-        # crates/llama-cpp-sys/build.rs runs on `check` and is what compiles
-        # llama.cpp + the mtmd C++ via cmake and bindgens the mtmd FFI (gated
-        # on CARGO_FEATURE_VISION). Like the shipped llm-llamacpp build above,
-        # it sources llama.cpp through build.rs's pinned-commit OUT_DIR clone
-        # (vendor/llama-cpp is an un-checked-out submodule), so no extra
-        # checkout is needed.
-        run: cargo check -p xybrid-sdk --features platform-ios,llm-llamacpp-vision --target aarch64-apple-ios
 
       - name: Upload XCFramework artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
Swaps the PR-time Apple check (`build-apple.yml`) from `cargo xtask build-xcframework` / `boltffi pack apple` to the **same Bazel target the release now ships** (`//bindings/apple:XybridFFI`, G4). Retires the last cargo/boltffi xcframework build from CI.

## Why this is more than cleanup
There was **no per-PR CI building the Bazel iOS xcframework** — the macOS Bazel lane is push-only, so the device + simulator slices (G4) were only ever verified locally. This check builds them on every Apple PR, and its **Swift-wrapper compile targets the iOS Simulator**, so it now **links the G4 simulator slice end-to-end** through the wrapper — exactly the coverage that was missing. It also de-risks the G4b release job (this is the first time the Bazel iOS build runs on a `macos-14` runner).

## What changed
- **Build** → `bazelisk build --config=ios //bindings/apple:XybridFFI`, unzip to `bindings/apple/XCFrameworks/`.
- **Dropped** the cargo/boltffi/sccache/oras scaffolding and the redundant `cargo check` iOS-vision smoke (the Bazel build compiles the full iOS closure — a stronger check — and needs no rust toolchain).
- **Verify** made framework-aware (`apple_static_xcframework` emits a static *framework* per slice, not a bare `.a`) and now asserts **both** slices are present.
- **Trigger paths** extended to the Bazel graph (`MODULE.bazel`, `BUILD.bazel`, `.bazelrc`, `bazel/**`, `llama-cpp-sys`/`xybrid-llama`, `vendor/ort-ios`) so a Bazel-only change to the iOS build still runs this check.

## Validated locally (Mac)
Build + stage + verify + `xcodebuild build -scheme Xybrid -destination "generic/platform=iOS Simulator"` → **BUILD SUCCEEDED** (links the sim slice).

## Tradeoff
Cold Bazel iOS build is ~15–20 min (vs ~5 min warm with sccache + prebuilt natives). A Bazel remote/disk cache is the natural follow-up; flagged in the workflow comment. No secrets needed (`--config=ios` is Mac-local), so forks run it fine.