### PR TITLE
bazel(flutter): Bazel-build the FRB cdylib/staticlib (macOS/linux/iOS/android)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -161,7 +161,8 @@ jobs:
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk build --config=remote -c opt \
-            //crates/xybrid-cli:xybrid
+            //crates/xybrid-cli:xybrid \
+            //bindings/flutter/rust:xybrid_flutter_ffi_cdylib
           bazelisk build --config=remote --config=macos \
             //crates/xybrid-cli:xybrid \
             //crates/xybrid-bolt:xybrid_bolt_staticlib
@@ -309,7 +310,8 @@ jobs:
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk build --config=remote --config=macos-metal -c opt \
-            //crates/xybrid-cli:xybrid
+            //crates/xybrid-cli:xybrid \
+            //bindings/flutter/rust:xybrid_flutter_ffi_staticlib
 
       - name: Smoke the Metal CLI (run + Metal + features)
         if: env.BUILDBUDDY_API_KEY != ''

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -224,6 +224,12 @@ cmake(
             "LLAMA_BUILD_TOOLS": "ON",
             "LLAMA_BUILD_COMMON": "ON",
             "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
+            # PIC so these static libs also link into a -shared consumer (the
+            # Flutter cdylib, //bindings/flutter/rust): stb_image's __thread
+            # globals otherwise emit R_X86_64_TPOFF32, illegal in a shared lib.
+            # Harmless for the CLI exe (macOS/arm64 is PIC by default, Android via
+            # the NDK, so only the linux GNU arm needs this explicitly).
+            "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
         },
         # darwin CPU lane (RBE): _DARWIN_LLAMA + the SDK's -lc++ for the tool
         # exes (resolves against the sysroot's libc++.tbd stubs; the tools are

--- a/bindings/flutter/rust/BUILD.bazel
+++ b/bindings/flutter/rust/BUILD.bazel
@@ -1,12 +1,21 @@
 # GATE 5 — flutter_rust_bridge wrapper (Dart cdylib + staticlib).
 #
+# Platform support (the desktop-precompile provenance flip): the cdylib builds
+# green on macOS / linux / android and the staticlib on macOS / iOS (the shipped
+# desktop-precompile units). WINDOWS is intentionally NOT built via Bazel here:
+# the Bazel windows toolchain is MinGW/GNU, but the cargokit precompile asset is
+# `x86_64-pc-windows-msvc` — a MinGW `.dll` carries the wrong triple in its name
+# (the consumer would never download it) and needs the static libc++/unwind trio
+# a `-shared` DLL doesn't get for free. Windows stays on the cargo/MSVC precompile.
+#
 # Builds the Rust artifacts from @crates. Its build.rs is link-glue only —
 # `cargo:rustc-link-lib=c++` on macOS/iOS and the Android 16KB-page link-arg —
-# and a no-op on Linux, so the Linux/desktop cdylib compiles without it. On
-# Apple/Android those link directives must be ported to Bazel linkopts (the same
-# per-platform native glue as the other -sys/FFI crates); flagged below, not
-# wired (desktop-first spike). The frb Dart-bridge codegen is a separate
-# `flutter_rust_bridge_codegen` CLI step (not a build script) and stays in CI.
+# and a no-op on Linux, so the Linux/desktop cdylib compiles without it. Bazel
+# does NOT run this build.rs (no cargo_build_script target), so those link
+# directives are ported to the cdylib's rustc_flags below (+ the android
+# c++_shared that cargo picks up from .cargo/config.toml). The frb Dart-bridge
+# codegen is a separate `flutter_rust_bridge_codegen` CLI step (not a build
+# script) and stays in CI.
 load("@rules_rs//rs:rust_shared_library.bzl", "rust_shared_library")
 load("@rules_rs//rs:rust_static_library.bzl", "rust_static_library")
 load("@crates//:defs.bzl", "all_crate_deps")
@@ -17,16 +26,32 @@ rust_shared_library(
     srcs = glob(["src/**/*.rs"]),
     crate_name = "xybrid_flutter_ffi",
     edition = "2021",
+    # ["default"] matches the cargokit ship (it passes no --features); the real
+    # candle/vision/coreml feature set flows transitively from the //crates/
+    # xybrid-sdk target this links (verified: the darwin staticlib carries
+    # ggml_metal/mtmd/candle/CoreML symbols with default features only).
     crate_features = ["default"],
     deps = all_crate_deps(normal = True),
-    # APPLE/ANDROID TODO (not wired, desktop-first): the build.rs link directives
-    # become linkopts here, e.g.
-    #   select({
-    #       "@platforms//os:macos": ["-lc++"],
-    #       "@platforms//os:ios":   ["-lc++"],
-    #       "@platforms//os:android": ["-Wl,-z,max-page-size=16384"],
-    #       "//conditions:default": [],
-    #   })
+    # build.rs is NOT run under Bazel (no cargo_build_script target here), so its
+    # link directives are ported to rustc_flags — the proven xybrid-bolt form
+    # (-Clink-arg=, not bare linkopts). cdylib ONLY: the staticlib is an unlinked
+    # archive, so link args are inert there.
+    rustc_flags = select({
+        # ort/llama.cpp/candle are C++ — the C++ runtime must be linked
+        # (build.rs: cargo:rustc-link-lib=c++ on macos/ios).
+        "@platforms//os:macos": ["-Clink-arg=-lc++"],
+        "@platforms//os:ios": ["-Clink-arg=-lc++"],  # covers ios-sim
+        "@platforms//os:android": [
+            # candle/llama.cpp built -DANDROID_STL=c++_shared leave undefined C++
+            # ABI symbols needing a DT_NEEDED. cargo gets this from
+            # .cargo/config.toml (which Bazel doesn't read); build.rs emits only
+            # the 16KB arg — so both are needed here.
+            "-Clink-arg=-lc++_shared",
+            # Android 15+ (API 35) 16KB page alignment; last -z wins with lld.
+            "-Clink-arg=-Wl,-z,max-page-size=16384",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
First gate of the **Flutter** row — make the flutter_rust_bridge cdylib/staticlib build via Bazel with feature + link parity, so a follow-up can swap the desktop precompile *producer* off cargo/cargokit.

## Framing (important)
Flutter's shipped unit on pub.dev is **source + cargokit** — consumers compile the cdylib at `flutter build` time (mobile via cargokit gradle/podspec). The precompiled desktop binaries are a **rustless-consumer fallback, off by default**. So this is a desktop-precompile **provenance** flip (parity with the CLI + xcframework Bazel lanes), not a ship-path flip like Apple. Scoped accordingly.

## What changed (`BUILD.bazel` only — no cargokit-hashed input touched)
- **flutter cdylib** `rustc_flags` link glue (Bazel doesn't run its `build.rs`): `-lc++` on macOS/iOS; `-lc++_shared` + 16KB page-align on android (the proven xybrid-bolt form). `crate_features` stays `["default"]` to **match the ship** (cargokit passes no `--features`); the candle/vision/coreml set flows via the `//crates/xybrid-sdk` target it links.
- **`//:llama` linux arm** `CMAKE_POSITION_INDEPENDENT_CODE=ON` — the static libs must be PIC to link into a `-shared` cdylib (stb_image `__thread` globals otherwise emit `R_X86_64_TPOFF32`, illegal in a shared lib). Harmless for the linux CLI exe (relinks; verified it still builds green).
- **`bazel.yml`** gates the linux cdylib (RBE, per-PR) + the darwin staticlib (macos-metal, post-merge) so the targets don't rot.

## Windows declined
Bazel is MinGW/GNU but the cargokit asset is `x86_64-pc-windows-**msvc**` — a MinGW `.dll` has the wrong triple in its name (never downloaded) and needs the static libc++/unwind trio. No consumer benefit; stays on cargo/MSVC. Documented in the BUILD file.

## Verified locally (Mac + RBE)
- macOS `.a`: candle/mtmd/coreml/frb symbols
- iOS `.a`: green
- android cdylib: `libc++_shared.so` DT_NEEDED + 16KB LOAD align
- linux `.so`: vision + 14 `frb_*` dynsym exports, correctly **no** candle/metal (matches `platform-desktop`)

## Follow-up (G2)
Swap `precompile-flutter-{darwin,linux}` to consume these Bazel outputs, keeping cargokit's ed25519 sign + upload (the cargokit seam is `RustBuilder.build()` in the vendored Dart).