### PR TITLE
ci(vercel): only build docs site when docs/ changes

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- ':/docs'"
+}

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- ':/docs'"
+  "ignoreCommand": "git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- ."
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/docs'"
-}


### PR DESCRIPTION
## Summary

This pull request fixes the Vercel "xybrid" docs project so it only builds when the documentation site actually changes, instead of on every push to the repo. The `ignoreCommand` previously lived in the repo-root `vercel.json`, but the docs project's Root Directory is `docs/` — and Vercel reads `vercel.json` from the Root Directory, not the git root — so the ignore step was never applied and every commit triggered a docs deploy.

**Vercel Configuration Changes:**

* Added `docs/vercel.json` — where Vercel actually reads project config for a `docs/` Root Directory — carrying the `ignoreCommand` that skips the build unless files under `docs/` changed. The command runs with the working directory set to the Root Directory (`docs/`), and the `:/docs` pathspec is repo-root-anchored so it still resolves correctly.
* Hardened the diff to compare across the full pushed range using `VERCEL_GIT_PREVIOUS_SHA`, falling back to `HEAD^`, so multi-commit pushes that touch docs aren't missed and non-docs pushes are correctly skipped.
* Removed the now-dead repo-root `vercel.json`, which was never read under the `docs/` Root Directory and gave the false impression the ignore step was active.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — n/a, CI/config-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable) — n/a
- [x] No breaking changes

> Note: this only takes effect if the Vercel project's **Ignored Build Step** (Settings → Git) is set to **Automatic** — a non-Automatic dashboard value overrides `vercel.json`.
