### PR TITLE
docs(readme): restructure badges into a tiered hierarchy + DeepWiki

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -17,19 +17,11 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.xybrid.dev">ドキュメント</a> ·
-  <a href="#sdk">SDK</a> ·
-  <a href="https://www.xybrid.ai/models">モデル</a> ·
-  <a href="https://discord.gg/YhFHHkhbad">Discordに参加</a> ·
-  <a href="https://x.com/xybrid_ai">Xでフォロー</a> ·
-  <a href="https://github.com/xybrid-ai/xybrid/issues">Issues</a>
-</p>
-
-<p align="center">
 
 [![Documentation][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
 [![Discord][discord-shield]][discord-url]
+[![Follow on X][twitter-shield]][twitter-url]
 
 </p>
 
@@ -48,7 +40,6 @@
 <br>
 [![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Stars][stars-shield]][stars-url]
-[![Follow on X][twitter-shield]][twitter-url]
 [![Visitors][visitors-shield]][visitors-url]
 
 </p>
@@ -58,7 +49,7 @@
 [docs-url]: https://docs.xybrid.dev/
 [website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
 [website-url]: https://www.xybrid.ai/
-[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members&style=for-the-badge
+[discord-shield]: https://img.shields.io/badge/Join_Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white
 [discord-url]: https://discord.gg/YhFHHkhbad
 
 <!-- Project health — flat-square -->
@@ -88,7 +79,7 @@
 [deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
 [stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
-[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai?style=flat-square
+[twitter-shield]: https://img.shields.io/badge/Follow-%40xybrid__ai-000000?style=for-the-badge&logo=x&logoColor=white
 [twitter-url]: https://x.com/xybrid_ai
 [visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
 [visitors-url]: https://github.com/xybrid-ai/xybrid

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -27,56 +27,71 @@
 
 <p align="center">
 
+[![Documentation][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
-[![Docs][docs-shield]][docs-url]
-[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Discord][discord-shield]][discord-url]
-[![Twitter][twitter-shield]][twitter-url]
-<br>
-[![License][license-shield]][license-url]
-[![Build][build-shield]][build-url]
-[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
-[![Stars][stars-shield]][stars-url]
-[![Release][release-shield]][release-url]
-[![Release Date][release-date-shield]][release-url]
-<br>
-[![pub.dev][pubdev-shield]][pubdev-url]
-[![Maven Central][maven-shield]][maven-url]
-[![Swift Package Manager][spm-shield]][spm-url]
-[![crates.io][crates-shield]][crates-url]
-[![Visitors](https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid)](https://github.com/xybrid-ai/xybrid)
 
 </p>
 
-[website-shield]: https://img.shields.io/badge/xybrid.ai-4285F4?style=flat
-[website-url]: https://www.xybrid.ai/
-[docs-shield]: https://img.shields.io/badge/docs-xybrid.dev-1F6FEB?style=flat&logo=readthedocs&logoColor=white
+<p align="center">
+
+[![Build][build-shield]][build-url]
+[![Release][release-shield]][release-url]
+[![License][license-shield]][license-url]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
+[![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
+<br>
+[![crates.io][crates-shield]][crates-url]
+[![pub.dev][pubdev-shield]][pubdev-url]
+[![Maven Central][maven-shield]][maven-url]
+[![Swift Package Manager][spm-shield]][spm-url]
+<br>
+[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
+[![Stars][stars-shield]][stars-url]
+[![Follow on X][twitter-shield]][twitter-url]
+[![Visitors][visitors-shield]][visitors-url]
+
+</p>
+
+<!-- Primary — for-the-badge -->
+[docs-shield]: https://img.shields.io/badge/Documentation-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
-[deepwiki-shield]: https://deepwiki.com/badge.svg
-[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
-[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members
+[website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
+[website-url]: https://www.xybrid.ai/
+[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members&style=for-the-badge
 [discord-url]: https://discord.gg/YhFHHkhbad
-[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai
-[twitter-url]: https://x.com/xybrid_ai
-[license-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat
-[license-url]: https://opensource.org/licenses/Apache-2.0
-[build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat
+
+<!-- Project health — flat-square -->
+[build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat-square
 [build-url]: https://github.com/xybrid-ai/xybrid/actions
+[release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat-square&sort=semver
+[release-url]: https://github.com/xybrid-ai/xybrid/releases
+[license-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square
+[license-url]: https://opensource.org/licenses/Apache-2.0
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/xybrid-ai/xybrid/badge
 [scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/xybrid-ai/xybrid
-[stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat
-[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
-[release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat&sort=semver
-[release-url]: https://github.com/xybrid-ai/xybrid/releases
-[release-date-shield]: https://img.shields.io/github/release-date/xybrid-ai/xybrid?style=flat
-[pubdev-shield]: https://img.shields.io/pub/v/xybrid_flutter?style=flat&label=pub.dev
-[pubdev-url]: https://pub.dev/packages/xybrid_flutter
-[maven-shield]: https://img.shields.io/maven-central/v/ai.xybrid/xybrid-kotlin?style=flat&label=Maven%20Central
-[maven-url]: https://central.sonatype.com/artifact/ai.xybrid/xybrid-kotlin
-[spm-shield]: https://img.shields.io/badge/Swift_Package_Manager-compatible-F05138?style=flat&logo=swift&logoColor=white
-[spm-url]: https://github.com/xybrid-ai/xybrid
-[crates-shield]: https://img.shields.io/crates/v/xybrid?style=flat&label=crates.io&logo=rust
+[bestpractices-shield]: https://www.bestpractices.dev/projects/13041/badge
+[bestpractices-url]: https://www.bestpractices.dev/projects/13041
+
+<!-- Packages — flat-square -->
+[crates-shield]: https://img.shields.io/crates/v/xybrid?style=flat-square&label=crates.io&logo=rust
 [crates-url]: https://crates.io/crates/xybrid
+[pubdev-shield]: https://img.shields.io/pub/v/xybrid_flutter?style=flat-square&label=pub.dev
+[pubdev-url]: https://pub.dev/packages/xybrid_flutter
+[maven-shield]: https://img.shields.io/maven-central/v/ai.xybrid/xybrid-kotlin?style=flat-square&label=Maven%20Central
+[maven-url]: https://central.sonatype.com/artifact/ai.xybrid/xybrid-kotlin
+[spm-shield]: https://img.shields.io/badge/Swift_Package_Manager-compatible-F05138?style=flat-square&logo=swift&logoColor=white
+[spm-url]: https://github.com/xybrid-ai/xybrid
+
+<!-- Community — flat-square -->
+[deepwiki-shield]: https://deepwiki.com/badge.svg
+[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
+[stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
+[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
+[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai?style=flat-square
+[twitter-url]: https://x.com/xybrid_ai
+[visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
+[visitors-url]: https://github.com/xybrid-ai/xybrid
 </div>
 
 <p align="center">

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -18,10 +18,10 @@
 
 <p align="center">
 
-[![Documentation][docs-shield]][docs-url]
+[![Docs][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
-[![Discord][discord-shield]][discord-url]
 [![Follow on X][twitter-shield]][twitter-url]
+[![Discord][discord-shield]][discord-url]
 
 </p>
 
@@ -45,7 +45,7 @@
 </p>
 
 <!-- Primary — for-the-badge -->
-[docs-shield]: https://img.shields.io/badge/Documentation-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
+[docs-shield]: https://img.shields.io/badge/Docs-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
 [website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
 [website-url]: https://www.xybrid.ai/

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -29,6 +29,7 @@
 
 [![Website][website-shield]][website-url]
 [![Docs][docs-shield]][docs-url]
+[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Discord][discord-shield]][discord-url]
 [![Twitter][twitter-shield]][twitter-url]
 <br>
@@ -51,6 +52,8 @@
 [website-url]: https://www.xybrid.ai/
 [docs-shield]: https://img.shields.io/badge/docs-xybrid.dev-1F6FEB?style=flat&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
+[deepwiki-shield]: https://deepwiki.com/badge.svg
+[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members
 [discord-url]: https://discord.gg/YhFHHkhbad
 [twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai

--- a/README.md
+++ b/README.md
@@ -17,19 +17,11 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.xybrid.dev">Documentation</a> ·
-  <a href="#sdks">SDKs</a> ·
-  <a href="https://www.xybrid.ai/models">Models</a> ·
-  <a href="https://discord.gg/YhFHHkhbad">Join Discord</a> ·
-  <a href="https://x.com/xybrid_ai">Follow on X</a> ·
-  <a href="https://github.com/xybrid-ai/xybrid/issues">Issues</a>
-</p>
-
-<p align="center">
 
 [![Documentation][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
 [![Discord][discord-shield]][discord-url]
+[![Follow on X][twitter-shield]][twitter-url]
 
 </p>
 
@@ -48,7 +40,6 @@
 <br>
 [![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Stars][stars-shield]][stars-url]
-[![Follow on X][twitter-shield]][twitter-url]
 [![Visitors][visitors-shield]][visitors-url]
 
 </p>
@@ -58,7 +49,7 @@
 [docs-url]: https://docs.xybrid.dev/
 [website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
 [website-url]: https://www.xybrid.ai/
-[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members&style=for-the-badge
+[discord-shield]: https://img.shields.io/badge/Join_Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white
 [discord-url]: https://discord.gg/YhFHHkhbad
 
 <!-- Project health — flat-square -->
@@ -88,7 +79,7 @@
 [deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
 [stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
-[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai?style=flat-square
+[twitter-shield]: https://img.shields.io/badge/Follow-%40xybrid__ai-000000?style=for-the-badge&logo=x&logoColor=white
 [twitter-url]: https://x.com/xybrid_ai
 [visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
 [visitors-url]: https://github.com/xybrid-ai/xybrid

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 
 <p align="center">
 
-[![Documentation][docs-shield]][docs-url]
+[![Docs][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
-[![Discord][discord-shield]][discord-url]
 [![Follow on X][twitter-shield]][twitter-url]
+[![Discord][discord-shield]][discord-url]
 
 </p>
 
@@ -45,7 +45,7 @@
 </p>
 
 <!-- Primary — for-the-badge -->
-[docs-shield]: https://img.shields.io/badge/Documentation-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
+[docs-shield]: https://img.shields.io/badge/Docs-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
 [website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
 [website-url]: https://www.xybrid.ai/

--- a/README.md
+++ b/README.md
@@ -27,59 +27,71 @@
 
 <p align="center">
 
+[![Documentation][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
-[![Docs][docs-shield]][docs-url]
-[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Discord][discord-shield]][discord-url]
-[![Twitter][twitter-shield]][twitter-url]
-<br>
-[![License][license-shield]][license-url]
-[![Build][build-shield]][build-url]
-[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
-[![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
-[![Stars][stars-shield]][stars-url]
-[![Release][release-shield]][release-url]
-[![Release Date][release-date-shield]][release-url]
-<br>
-[![pub.dev][pubdev-shield]][pubdev-url]
-[![Maven Central][maven-shield]][maven-url]
-[![Swift Package Manager][spm-shield]][spm-url]
-[![crates.io][crates-shield]][crates-url]
-[![Visitors](https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid)](https://github.com/xybrid-ai/xybrid)
 
 </p>
 
-[website-shield]: https://img.shields.io/badge/xybrid.ai-4285F4?style=flat
-[website-url]: https://www.xybrid.ai/
-[docs-shield]: https://img.shields.io/badge/docs-xybrid.dev-1F6FEB?style=flat&logo=readthedocs&logoColor=white
+<p align="center">
+
+[![Build][build-shield]][build-url]
+[![Release][release-shield]][release-url]
+[![License][license-shield]][license-url]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
+[![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
+<br>
+[![crates.io][crates-shield]][crates-url]
+[![pub.dev][pubdev-shield]][pubdev-url]
+[![Maven Central][maven-shield]][maven-url]
+[![Swift Package Manager][spm-shield]][spm-url]
+<br>
+[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
+[![Stars][stars-shield]][stars-url]
+[![Follow on X][twitter-shield]][twitter-url]
+[![Visitors][visitors-shield]][visitors-url]
+
+</p>
+
+<!-- Primary — for-the-badge -->
+[docs-shield]: https://img.shields.io/badge/Documentation-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
-[deepwiki-shield]: https://deepwiki.com/badge.svg
-[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
-[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members
+[website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
+[website-url]: https://www.xybrid.ai/
+[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members&style=for-the-badge
 [discord-url]: https://discord.gg/YhFHHkhbad
-[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai
-[twitter-url]: https://x.com/xybrid_ai
-[license-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat
-[license-url]: https://opensource.org/licenses/Apache-2.0
-[build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat
+
+<!-- Project health — flat-square -->
+[build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat-square
 [build-url]: https://github.com/xybrid-ai/xybrid/actions
+[release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat-square&sort=semver
+[release-url]: https://github.com/xybrid-ai/xybrid/releases
+[license-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square
+[license-url]: https://opensource.org/licenses/Apache-2.0
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/xybrid-ai/xybrid/badge
 [scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/xybrid-ai/xybrid
 [bestpractices-shield]: https://www.bestpractices.dev/projects/13041/badge
 [bestpractices-url]: https://www.bestpractices.dev/projects/13041
-[stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat
-[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
-[release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat&sort=semver
-[release-url]: https://github.com/xybrid-ai/xybrid/releases
-[release-date-shield]: https://img.shields.io/github/release-date/xybrid-ai/xybrid?style=flat
-[pubdev-shield]: https://img.shields.io/pub/v/xybrid_flutter?style=flat&label=pub.dev
-[pubdev-url]: https://pub.dev/packages/xybrid_flutter
-[maven-shield]: https://img.shields.io/maven-central/v/ai.xybrid/xybrid-kotlin?style=flat&label=Maven%20Central
-[maven-url]: https://central.sonatype.com/artifact/ai.xybrid/xybrid-kotlin
-[spm-shield]: https://img.shields.io/badge/Swift_Package_Manager-compatible-F05138?style=flat&logo=swift&logoColor=white
-[spm-url]: https://github.com/xybrid-ai/xybrid
-[crates-shield]: https://img.shields.io/crates/v/xybrid?style=flat&label=crates.io&logo=rust
+
+<!-- Packages — flat-square -->
+[crates-shield]: https://img.shields.io/crates/v/xybrid?style=flat-square&label=crates.io&logo=rust
 [crates-url]: https://crates.io/crates/xybrid
+[pubdev-shield]: https://img.shields.io/pub/v/xybrid_flutter?style=flat-square&label=pub.dev
+[pubdev-url]: https://pub.dev/packages/xybrid_flutter
+[maven-shield]: https://img.shields.io/maven-central/v/ai.xybrid/xybrid-kotlin?style=flat-square&label=Maven%20Central
+[maven-url]: https://central.sonatype.com/artifact/ai.xybrid/xybrid-kotlin
+[spm-shield]: https://img.shields.io/badge/Swift_Package_Manager-compatible-F05138?style=flat-square&logo=swift&logoColor=white
+[spm-url]: https://github.com/xybrid-ai/xybrid
+
+<!-- Community — flat-square -->
+[deepwiki-shield]: https://deepwiki.com/badge.svg
+[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
+[stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
+[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
+[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai?style=flat-square
+[twitter-url]: https://x.com/xybrid_ai
+[visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
+[visitors-url]: https://github.com/xybrid-ai/xybrid
 </div>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 [![Website][website-shield]][website-url]
 [![Docs][docs-shield]][docs-url]
+[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Discord][discord-shield]][discord-url]
 [![Twitter][twitter-shield]][twitter-url]
 <br>
@@ -52,6 +53,8 @@
 [website-url]: https://www.xybrid.ai/
 [docs-shield]: https://img.shields.io/badge/docs-xybrid.dev-1F6FEB?style=flat&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
+[deepwiki-shield]: https://deepwiki.com/badge.svg
+[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members
 [discord-url]: https://discord.gg/YhFHHkhbad
 [twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,56 +27,71 @@
 
 <p align="center">
 
+[![Documentation][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
-[![Docs][docs-shield]][docs-url]
-[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Discord][discord-shield]][discord-url]
-[![Twitter][twitter-shield]][twitter-url]
-<br>
-[![License][license-shield]][license-url]
-[![Build][build-shield]][build-url]
-[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
-[![Stars][stars-shield]][stars-url]
-[![Release][release-shield]][release-url]
-[![Release Date][release-date-shield]][release-url]
-<br>
-[![pub.dev][pubdev-shield]][pubdev-url]
-[![Maven Central][maven-shield]][maven-url]
-[![Swift Package Manager][spm-shield]][spm-url]
-[![crates.io][crates-shield]][crates-url]
-[![Visitors](https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid)](https://github.com/xybrid-ai/xybrid)
 
 </p>
 
-[website-shield]: https://img.shields.io/badge/xybrid.ai-4285F4?style=flat
-[website-url]: https://www.xybrid.ai/
-[docs-shield]: https://img.shields.io/badge/docs-xybrid.dev-1F6FEB?style=flat&logo=readthedocs&logoColor=white
+<p align="center">
+
+[![Build][build-shield]][build-url]
+[![Release][release-shield]][release-url]
+[![License][license-shield]][license-url]
+[![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
+[![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
+<br>
+[![crates.io][crates-shield]][crates-url]
+[![pub.dev][pubdev-shield]][pubdev-url]
+[![Maven Central][maven-shield]][maven-url]
+[![Swift Package Manager][spm-shield]][spm-url]
+<br>
+[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
+[![Stars][stars-shield]][stars-url]
+[![Follow on X][twitter-shield]][twitter-url]
+[![Visitors][visitors-shield]][visitors-url]
+
+</p>
+
+<!-- Primary — for-the-badge -->
+[docs-shield]: https://img.shields.io/badge/Documentation-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
-[deepwiki-shield]: https://deepwiki.com/badge.svg
-[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
-[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members
+[website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
+[website-url]: https://www.xybrid.ai/
+[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members&style=for-the-badge
 [discord-url]: https://discord.gg/YhFHHkhbad
-[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai
-[twitter-url]: https://x.com/xybrid_ai
-[license-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat
-[license-url]: https://opensource.org/licenses/Apache-2.0
-[build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat
+
+<!-- Project health — flat-square -->
+[build-shield]: https://img.shields.io/github/actions/workflow/status/xybrid-ai/xybrid/ci.yml?branch=master&style=flat-square
 [build-url]: https://github.com/xybrid-ai/xybrid/actions
+[release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat-square&sort=semver
+[release-url]: https://github.com/xybrid-ai/xybrid/releases
+[license-shield]: https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square
+[license-url]: https://opensource.org/licenses/Apache-2.0
 [scorecard-shield]: https://api.scorecard.dev/projects/github.com/xybrid-ai/xybrid/badge
 [scorecard-url]: https://scorecard.dev/viewer/?uri=github.com/xybrid-ai/xybrid
-[stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat
-[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
-[release-shield]: https://img.shields.io/github/v/release/xybrid-ai/xybrid?style=flat&sort=semver
-[release-url]: https://github.com/xybrid-ai/xybrid/releases
-[release-date-shield]: https://img.shields.io/github/release-date/xybrid-ai/xybrid?style=flat
-[pubdev-shield]: https://img.shields.io/pub/v/xybrid_flutter?style=flat&label=pub.dev
-[pubdev-url]: https://pub.dev/packages/xybrid_flutter
-[maven-shield]: https://img.shields.io/maven-central/v/ai.xybrid/xybrid-kotlin?style=flat&label=Maven%20Central
-[maven-url]: https://central.sonatype.com/artifact/ai.xybrid/xybrid-kotlin
-[spm-shield]: https://img.shields.io/badge/Swift_Package_Manager-compatible-F05138?style=flat&logo=swift&logoColor=white
-[spm-url]: https://github.com/xybrid-ai/xybrid
-[crates-shield]: https://img.shields.io/crates/v/xybrid?style=flat&label=crates.io&logo=rust
+[bestpractices-shield]: https://www.bestpractices.dev/projects/13041/badge
+[bestpractices-url]: https://www.bestpractices.dev/projects/13041
+
+<!-- Packages — flat-square -->
+[crates-shield]: https://img.shields.io/crates/v/xybrid?style=flat-square&label=crates.io&logo=rust
 [crates-url]: https://crates.io/crates/xybrid
+[pubdev-shield]: https://img.shields.io/pub/v/xybrid_flutter?style=flat-square&label=pub.dev
+[pubdev-url]: https://pub.dev/packages/xybrid_flutter
+[maven-shield]: https://img.shields.io/maven-central/v/ai.xybrid/xybrid-kotlin?style=flat-square&label=Maven%20Central
+[maven-url]: https://central.sonatype.com/artifact/ai.xybrid/xybrid-kotlin
+[spm-shield]: https://img.shields.io/badge/Swift_Package_Manager-compatible-F05138?style=flat-square&logo=swift&logoColor=white
+[spm-url]: https://github.com/xybrid-ai/xybrid
+
+<!-- Community — flat-square -->
+[deepwiki-shield]: https://deepwiki.com/badge.svg
+[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
+[stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
+[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
+[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai?style=flat-square
+[twitter-url]: https://x.com/xybrid_ai
+[visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
+[visitors-url]: https://github.com/xybrid-ai/xybrid
 </div>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,10 +18,10 @@
 
 <p align="center">
 
-[![Documentation][docs-shield]][docs-url]
+[![Docs][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
-[![Discord][discord-shield]][discord-url]
 [![Follow on X][twitter-shield]][twitter-url]
+[![Discord][discord-shield]][discord-url]
 
 </p>
 
@@ -45,7 +45,7 @@
 </p>
 
 <!-- Primary — for-the-badge -->
-[docs-shield]: https://img.shields.io/badge/Documentation-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
+[docs-shield]: https://img.shields.io/badge/Docs-docs.xybrid.dev-1F6FEB?style=for-the-badge&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
 [website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
 [website-url]: https://www.xybrid.ai/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,7 @@
 
 [![Website][website-shield]][website-url]
 [![Docs][docs-shield]][docs-url]
+[![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Discord][discord-shield]][discord-url]
 [![Twitter][twitter-shield]][twitter-url]
 <br>
@@ -51,6 +52,8 @@
 [website-url]: https://www.xybrid.ai/
 [docs-shield]: https://img.shields.io/badge/docs-xybrid.dev-1F6FEB?style=flat&logo=readthedocs&logoColor=white
 [docs-url]: https://docs.xybrid.dev/
+[deepwiki-shield]: https://deepwiki.com/badge.svg
+[deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members
 [discord-url]: https://discord.gg/YhFHHkhbad
 [twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,19 +17,11 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.xybrid.dev">文档</a> ·
-  <a href="#sdk">SDK</a> ·
-  <a href="https://www.xybrid.ai/models">模型</a> ·
-  <a href="https://discord.gg/YhFHHkhbad">加入 Discord</a> ·
-  <a href="https://x.com/xybrid_ai">关注 X</a> ·
-  <a href="https://github.com/xybrid-ai/xybrid/issues">问题反馈</a>
-</p>
-
-<p align="center">
 
 [![Documentation][docs-shield]][docs-url]
 [![Website][website-shield]][website-url]
 [![Discord][discord-shield]][discord-url]
+[![Follow on X][twitter-shield]][twitter-url]
 
 </p>
 
@@ -48,7 +40,6 @@
 <br>
 [![Ask DeepWiki][deepwiki-shield]][deepwiki-url]
 [![Stars][stars-shield]][stars-url]
-[![Follow on X][twitter-shield]][twitter-url]
 [![Visitors][visitors-shield]][visitors-url]
 
 </p>
@@ -58,7 +49,7 @@
 [docs-url]: https://docs.xybrid.dev/
 [website-shield]: https://img.shields.io/badge/Website-xybrid.ai-4285F4?style=for-the-badge
 [website-url]: https://www.xybrid.ai/
-[discord-shield]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2FYhFHHkhbad%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&label=Discord&color=5865F2&suffix=%20members&style=for-the-badge
+[discord-shield]: https://img.shields.io/badge/Join_Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white
 [discord-url]: https://discord.gg/YhFHHkhbad
 
 <!-- Project health — flat-square -->
@@ -88,7 +79,7 @@
 [deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
 [stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
-[twitter-shield]: https://img.shields.io/twitter/follow/xybrid_ai?style=flat-square
+[twitter-shield]: https://img.shields.io/badge/Follow-%40xybrid__ai-000000?style=for-the-badge&logo=x&logoColor=white
 [twitter-url]: https://x.com/xybrid_ai
 [visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
 [visitors-url]: https://github.com/xybrid-ai/xybrid


### PR DESCRIPTION
## Summary

This pull request restructures the README badge block into a clear visual hierarchy — inspired by the [strix](https://github.com/usestrix/strix) README — so the most important links stand out and the rest are grouped by purpose, and adds an "Ask DeepWiki" badge. Previously ~18 identical `style=flat` badges sat in one undifferentiated wall; now hierarchy is expressed through badge style and grouping. All three locales (`README.md`, `README.zh-CN.md`, `README.ja-JP.md`) are kept in sync.

**Badge Hierarchy:**

* **Primary calls-to-action** rendered large with `style=for-the-badge`: Documentation, Website, Discord.
* **Project health** as a `style=flat-square` row: Build, Release, License, OpenSSF Scorecard, OpenSSF Best Practices.
* **Packages** as a `style=flat-square` row: crates.io, pub.dev, Maven Central, Swift Package Manager.
* **Community** as a `style=flat-square` row: Ask DeepWiki (official `deepwiki.com/badge.svg` → https://deepwiki.com/xybrid-ai/xybrid), Stars, Follow on X, Visitors.

**Cleanup & parity:**

* Dropped the redundant Release Date badge (Release already shows the version), and added OpenSSF Best Practices to the zh/ja READMEs so all three locales carry the same badges.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`) — n/a, README-only change
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes
