### PR TITLE
ci(rn): stage the iOS head from the Bazel xcframework (retire boltffi here)

### DIFF
--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -50,38 +50,29 @@ jobs:
   # binding from the `ai.xybrid:xybrid-kotlin` Maven AAR (declared in
   # android/build.gradle), so there is nothing to stage or cross-build here.
 
+  # RN's iOS piece IS the Apple xcframework — since the Apple G4 flip it is
+  # Bazel-built (the same //bindings/apple:XybridFFI the release and
+  # build-apple.yml use), so this job now stages that instead of running its
+  # own boltffi pack. The cargo-era helpers (iOS rust targets, boltffi CLI,
+  # the ghcr llama-natives pull) are dead on this path and gone.
   stage-ios:
     name: Stage iOS artifacts
     runs-on: macos-14
+    env:
+      # Enables the remote-cache fast path below. Absent on fork PRs → the
+      # config step skips → a plain local Bazel build (slow but correct).
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true  # Bazel //:llama_src = vendor/llama-cpp
 
+      # Host-only toolchain: it compiles xtask. Bazel brings its own Rust
+      # (and its own iOS cross-targets).
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
-          targets: >-
-            aarch64-apple-ios,
-            aarch64-apple-ios-sim,
-            aarch64-apple-darwin
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-      - name: Configure sccache environment
-        shell: bash
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          # The GHA-backed sccache server occasionally needs more than the
-          # default 10s to complete its first handshake with the cache
-          # service, which surfaces as "Timed out waiting for server startup"
-          # and aborts the build. There is no env var for this, so write a
-          # minimal config file (it coexists with the env-based GHA settings
-          # above) bumping the startup timeout. https://github.com/mozilla/sccache
-          SCCACHE_CONF="$RUNNER_TEMP/sccache-config.toml"
-          echo "server_startup_timeout_ms = 60000" > "$SCCACHE_CONF"
-          echo "SCCACHE_CONF=$SCCACHE_CONF" >> $GITHUB_ENV
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -91,55 +82,31 @@ jobs:
           cache-all-crates: "true"
           save-if: "true"
 
-      # boltffi CLI provides the `boltffi pack apple` that build-xcframework
-      # (invoked by stage-react-native) shells out to. Pinned to 0.25.3 to
-      # match the runtime `boltffi` crate (see build-apple.yml for why the
-      # CLI/runtime versions must match).
-      - name: Cache boltffi CLI
-        id: cache-boltffi
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.cargo/bin/boltffi
-          key: boltffi-cli-${{ runner.os }}-0.25.3
-
-      - name: Install boltffi CLI
-        run: which boltffi || cargo install boltffi_cli --version 0.25.3 --locked
-
-      # Prebuilt-natives fast path (iOS device + arm64 simulator). stage-ios
-      # routes through the same `boltffi pack apple` as build-apple, so it
-      # consumes the identical two slices. Best-effort: a miss/error is a silent
-      # no-op (continue-on-error) and the slice compiles from source — it can
-      # never break the build.
-      - name: Setup oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
-      # `oras login`, not docker/login-action: macOS runners have no docker.
-      # Best-effort + same-repo only (forks have no token → anonymous pull).
-      - name: Log in to ghcr (best-effort, same-repo)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-      - name: Pull prebuilt natives (iOS device + sim, best-effort)
-        continue-on-error: true
-        env:
-          XYBRID_NATIVES_PKG: ghcr.io/xybrid-ai/llama-natives
+      # build:ios uses the host's preinstalled cmake/make/pkg-config for
+      # rfcc's exec tools; xz decodes the fetched ort iOS-sim slice.
+      - name: Ensure rfcc host tools
         run: |
-          DEST="$RUNNER_TEMP/natives"
-          got_any=0
-          for triple in aarch64-apple-ios aarch64-apple-ios-sim; do
-            if tools/scripts/natives-pull.sh "$triple" vision "$DEST"; then
-              echo "prebuilt natives staged for $triple (will skip cmake)"
-              got_any=1
-            else
-              echo "no prebuilt natives for $triple — compiles from source"
-            fi
-          done
-          if [ "$got_any" = 1 ]; then
-            echo "XYBRID_NATIVES_PREBUILT_DIR=$DEST" >> "$GITHUB_ENV"
-          else
-            echo "no prebuilt natives — compiles from source (unchanged)"
-          fi
+          which cmake >/dev/null || brew install cmake
+          which pkg-config >/dev/null || brew install pkg-config
+          which xz >/dev/null || brew install xz
+
+      # Remote CACHE only — never remote execution: iOS actions must run on
+      # this Mac (Apple policy), but their results can still up/download from
+      # BuildBuddy so identical macos-14 runners share work across jobs and
+      # runs. xtask adds --config=remote-cache when this file defines it.
+      - name: Configure BuildBuddy remote-cache config
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote-cache --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote-cache --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote-cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote-cache --remote_cache_compression
+          common:remote-cache --remote_timeout=600
+          common:remote-cache --remote_upload_local_results
+          EOF
 
       - name: Stage iOS artifacts
         run: cargo xtask stage-react-native --release

--- a/bindings/react-native/react-native-xybrid.podspec
+++ b/bindings/react-native/react-native-xybrid.podspec
@@ -24,10 +24,10 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.swift_version = "5.0"
 
-  # Pre-built bolt static lib bundled as an XCFramework. Copied in from
-  # `bindings/apple/XCFrameworks/XybridFFI.xcframework` by
-  # `cargo xtask stage-react-native`. (Android pulls its natives from the
-  # Maven AAR instead — see android/build.gradle.)
+  # Pre-built bolt static framework bundled as an XCFramework — the same
+  # Bazel-built `//bindings/apple:XybridFFI` the Apple release ships, staged
+  # here by `cargo xtask stage-react-native`. (Android pulls its natives
+  # from the Maven AAR instead — see android/build.gradle.)
   s.vendored_frameworks = "ios/Frameworks/XybridFFI.xcframework"
 
   # System frameworks the Rust core links against (mirrors Package.swift).

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1203,32 +1203,72 @@ fn stage_react_native_ios(release: bool, version: &str) -> Result<()> {
     if !cfg!(target_os = "macos") {
         anyhow::bail!("React Native iOS staging is only supported on macOS");
     }
+    if !release {
+        eprintln!("warning: --release ignored; the Bazel iOS config always builds opt");
+    }
 
-    // 1. Build the XCFramework (also refreshes bindings/apple's Swift wrapper).
-    build_xcframework(release, version)?;
+    // 1. Build the XCFramework via Bazel — the same producer the Apple
+    //    release (release-prep) and PR CI (build-apple.yml) use. --config=ios
+    //    is Mac-local by design (Apple locks iOS builds to Xcode); when a
+    //    remote-cache-only config is staged (CI writes it from a secret),
+    //    add it so darwin-local action results up/download from BuildBuddy —
+    //    pure cache, never remote execution. Gated on the config actually
+    //    being defined in the rc, so a dev rc without it keeps working.
+    let mut args: Vec<String> = vec!["build".into()];
+    let rc = PathBuf::from(".context/buildbuddy.bazelrc");
+    if rc.is_file()
+        && std::fs::read_to_string(&rc)
+            .map(|s| s.contains(":remote-cache"))
+            .unwrap_or(false)
+    {
+        args.push("--config=remote-cache".into());
+    }
+    args.push("--config=ios".into());
+    args.push("//bindings/apple:XybridFFI".into());
+    let status = Command::new("bazelisk")
+        .args(&args)
+        .status()
+        .or_else(|_| Command::new("bazel").args(&args).status())
+        .context("Failed to run bazelisk/bazel — is Bazel installed?")?;
+    if !status.success() {
+        anyhow::bail!("bazel build --config=ios //bindings/apple:XybridFFI failed");
+    }
 
     let rn_ios = PathBuf::from("bindings/react-native/ios");
 
-    // 2. Stage the XCFramework (unversioned copy) into ios/Frameworks/.
-    let src_xcfw = PathBuf::from("bindings/apple/XCFrameworks/XybridFFI.xcframework");
-    if !src_xcfw.is_dir() {
-        anyhow::bail!(
-            "Expected XCFramework at {} after build — build_xcframework failed silently?",
-            src_xcfw.display()
-        );
+    // 2. Unzip the built xcframework into ios/Frameworks/. Single-config
+    //    invocation, so referencing bazel-bin right after the build is safe.
+    let zip = "bazel-bin/bindings/apple/XybridFFI.xcframework.zip";
+    if !PathBuf::from(zip).is_file() {
+        anyhow::bail!("Expected {} after the Bazel build", zip);
     }
-    let dst_xcfw = rn_ios.join("Frameworks/XybridFFI.xcframework");
+    let fw_dir = rn_ios.join("Frameworks");
+    let dst_xcfw = fw_dir.join("XybridFFI.xcframework");
     if dst_xcfw.exists() {
         std::fs::remove_dir_all(&dst_xcfw)
             .with_context(|| format!("Failed to remove existing {}", dst_xcfw.display()))?;
     }
-    std::fs::create_dir_all(rn_ios.join("Frameworks"))?;
-    copy_dir_recursive(&src_xcfw, &dst_xcfw)
-        .context("Failed to copy XCFramework into RN module")?;
+    std::fs::create_dir_all(&fw_dir)?;
+    if !Command::new("unzip")
+        .args(["-o", "-q", zip, "-d", fw_dir.to_str().unwrap()])
+        .status()
+        .context("unzip the xcframework")?
+        .success()
+    {
+        anyhow::bail!("Failed to unzip {} into {}", zip, fw_dir.display());
+    }
+    if !dst_xcfw.is_dir() {
+        anyhow::bail!(
+            "Zip did not contain XybridFFI.xcframework/ at its root — got {}",
+            fw_dir.display()
+        );
+    }
     println!("  ✓ XCFramework -> {}", dst_xcfw.display());
 
     // 3. Stage the bolt Swift wrapper sources into ios/XybridSwift/. The RN
-    //    Swift glue (XybridModuleImpl.swift) calls into these directly.
+    //    Swift glue (XybridModuleImpl.swift) calls into these directly. They
+    //    are committed sources (byte-identical to boltffi 0.25.3 output) —
+    //    no generator run needed.
     let dst_swift = rn_ios.join("XybridSwift");
     if dst_swift.exists() {
         std::fs::remove_dir_all(&dst_swift)
@@ -1239,7 +1279,7 @@ fn stage_react_native_ios(release: bool, version: &str) -> Result<()> {
         let src = PathBuf::from("bindings/apple/Sources/Xybrid").join(fname);
         if !src.is_file() {
             anyhow::bail!(
-                "Expected {} — run `cargo xtask build-xcframework` first",
+                "Expected committed Swift wrapper at {} — was it moved?",
                 src.display()
             );
         }


### PR DESCRIPTION
Finishes RN's move onto the shared build graph: the iOS piece now comes from the same Bazel-built `//bindings/apple:XybridFFI` the Apple release ships — `stage-ios` no longer runs its own `boltffi pack apple`.

## What

- `cargo xtask stage-react-native`: builds the xcframework via Bazel (`--config=ios`), unzips into `ios/Frameworks/`, stages the committed Swift wrappers — no generator run
- `stage-ios` job: `submodules: true` (Bazel needs `vendor/llama-cpp`), host-only Rust toolchain, cmake/pkg-config/xz guard; boltffi CLI + iOS rust targets + the ghcr llama-natives pull removed
- New **remote-cache-only** BuildBuddy config — never remote execution (iOS actions stay on the Mac by Apple policy), but action results up/download so identical `macos-14` runners share work across jobs and runs. Fork-safe: no secret → plain local build. xtask only adds the config when the staged rc defines it, so dev rcs keep working
- Podspec comment updated (framework-form xcframework — same artifact the SPM consumer smoke proved on-device in #366)

## Verified locally

- Staging runs fully cache-hot (1 Bazel action) and lands device + sim slices + wrappers in the exact layout the podspec references
- `pod lib lint --quick` path checks are covered by the existing smoke job on this PR

## Notes

- First CI run warms the iOS remote cache (cold ~20 min); subsequent runs on identical runner images should drop sharply
- Full pod-level compile proof still wants an iOS example app (`pod install`) — pre-existing gap, unchanged