### PR TITLE
fix(unity): bundle desktop ONNX Runtime

### DIFF
--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -191,6 +191,11 @@ jobs:
       - name: Build for x86_64-pc-windows-msvc
         run: cargo xtask build-ffi --target x86_64-pc-windows-msvc --deploy-unity
 
+      - name: Stage ONNX Runtime (Windows)
+        run: >-
+          python tools/scripts/stage_unity_desktop_ort.py windows
+          bindings/unity/Runtime/Plugins/Windows
+
       - name: Strip debug symbols (Windows)
         shell: bash
         run: llvm-strip bindings/unity/Runtime/Plugins/Windows/xybrid_ffi.dll
@@ -199,7 +204,13 @@ jobs:
         shell: bash
         run: |
           echo "Windows plugin directory:"
-          ls -la bindings/unity/Runtime/Plugins/Windows/ || echo "WARNING: Windows plugin directory not found"
+          PLUGINS=bindings/unity/Runtime/Plugins/Windows
+          ls -la "$PLUGINS"
+          test -f "$PLUGINS/xybrid_ffi.dll"
+          test -f "$PLUGINS/onnxruntime.dll"
+          test -f "$PLUGINS/onnxruntime.dll.meta"
+          python -c "import ctypes; ctypes.CDLL(r'$PLUGINS/onnxruntime.dll')"
+          echo "Windows ORT runtime loads successfully."
 
       - name: Upload Windows plugins
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -249,13 +260,24 @@ jobs:
       - name: Build for x86_64-unknown-linux-gnu
         run: cargo xtask build-ffi --target x86_64-unknown-linux-gnu --deploy-unity
 
+      - name: Stage ONNX Runtime (Linux)
+        run: >-
+          python3 tools/scripts/stage_unity_desktop_ort.py linux
+          bindings/unity/Runtime/Plugins/Linux
+
       - name: Strip debug symbols (Linux)
         run: strip --strip-unneeded bindings/unity/Runtime/Plugins/Linux/libxybrid_ffi.so
 
       - name: Verify deployed libraries
         run: |
           echo "Linux plugin directory:"
-          ls -la bindings/unity/Runtime/Plugins/Linux/ || echo "WARNING: Linux plugin directory not found"
+          PLUGINS=bindings/unity/Runtime/Plugins/Linux
+          ls -la "$PLUGINS"
+          test -f "$PLUGINS/libxybrid_ffi.so"
+          test -f "$PLUGINS/libonnxruntime.so"
+          test -f "$PLUGINS/libonnxruntime.so.meta"
+          python3 -c "import ctypes; ctypes.CDLL('$PLUGINS/libonnxruntime.so')"
+          echo "Linux ORT runtime loads successfully."
 
       - name: Upload Linux plugins
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -491,6 +513,21 @@ jobs:
           echo ""
           echo "Final plugin directory structure:"
           find bindings/unity/Runtime/Plugins -type f | sort
+
+      - name: Verify desktop runtime dependencies
+        run: |
+          set -euo pipefail
+          PLUGINS=bindings/unity/Runtime/Plugins
+          for path in \
+            Windows/xybrid_ffi.dll \
+            Windows/onnxruntime.dll \
+            Windows/onnxruntime.dll.meta \
+            Linux/libxybrid_ffi.so \
+            Linux/libonnxruntime.so \
+            Linux/libonnxruntime.so.meta; do
+            test -f "$PLUGINS/$path" || { echo "Missing Unity runtime: $path"; exit 1; }
+          done
+          echo "Unity desktop bundles contain xybrid_ffi + ONNX Runtime."
 
       - name: Extract version
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,29 @@ env:
 
 jobs:
   tooling-tests:
-    name: Tooling tests
-    runs-on: ubuntu-latest
+    name: Tooling tests (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            python: python3
+            runtime: libonnxruntime.so
+          - os: windows-latest
+            platform: windows
+            python: python
+            runtime: onnxruntime.dll
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Test native staging tools
+        if: matrix.platform == 'linux'
         run: python3 -m unittest discover -s tools/scripts/tests -p 'test_*.py'
+      - name: Stage and load the real ONNX Runtime
+        run: |
+          ${{ matrix.python }} tools/scripts/stage_unity_desktop_ort.py ${{ matrix.platform }} "${{ runner.temp }}/unity-ort"
+          ${{ matrix.python }} -c "import ctypes, sys; ctypes.CDLL(sys.argv[1])" "${{ runner.temp }}/unity-ort/${{ matrix.runtime }}"
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  tooling-tests:
+    name: Tooling tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Test native staging tools
+        run: python3 -m unittest discover -s tools/scripts/tests -p 'test_*.py'
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,43 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  tooling-changes:
+    name: Detect tooling-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Check changed paths
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            FILES=$(gh api --paginate \
+              "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
+              --jq '.[].filename')
+          else
+            FILES=$(gh api \
+              "repos/$REPOSITORY/compare/$BEFORE_SHA...$CURRENT_SHA" \
+              --jq '.files[].filename')
+          fi
+          if printf '%s\n' "$FILES" | grep -qE '^(tools/scripts/|\.github/workflows/ci\.yml$)'; then
+            RELEVANT=true
+          else
+            RELEVANT=false
+          fi
+          echo "relevant=$RELEVANT" >> "$GITHUB_OUTPUT"
+          echo "Tooling-relevant changes: $RELEVANT"
+
   tooling-tests:
     name: Tooling tests (${{ matrix.platform }})
+    needs: tooling-changes
+    if: needs.tooling-changes.outputs.relevant == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -302,6 +337,24 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check-no-default-features, check-platform-macos, check-platform-desktop, check-vision-platforms, clippy-llm, test-llm, test, api-contract, web]
+    # Inspect dependency results even when the tooling path gate skips its matrix.
+    if: ${{ !cancelled() }}
+    needs: [tooling-changes, tooling-tests, fmt, clippy, check-no-default-features, check-platform-macos, check-platform-desktop, check-vision-platforms, clippy-llm, test-llm, test, api-contract, web]
     steps:
-      - run: echo "All CI checks passed!"
+      - name: Verify required job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          jq --exit-status '
+            . as $needs
+            |
+            to_entries
+            | all(
+                .value.result == "success"
+                or (
+                  .key == "tooling-tests"
+                  and .value.result == "skipped"
+                  and $needs["tooling-changes"].outputs.relevant == "false"
+                )
+              )
+          ' <<<"$NEEDS_JSON"

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -85,6 +85,8 @@ version from the [GitHub Release](https://github.com/xybrid-ai/xybrid/releases),
 verifies their SHA-256, and installs them into `Assets/Xybrid/Plugins/`. This
 keeps the package small and sidesteps Git/registry size limits — **including the
 ~326 MB iOS static library, which now installs automatically** (no manual step).
+The Windows and Linux bundles include the matching ONNX Runtime shared library,
+so desktop users do not need a system-wide ONNX Runtime installation.
 
 To (re)download on demand, use the editor menu:
 

--- a/tools/scripts/stage_unity_desktop_ort.py
+++ b/tools/scripts/stage_unity_desktop_ort.py
@@ -11,6 +11,7 @@ import tarfile
 import tempfile
 import urllib.request
 import zipfile
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -179,8 +180,12 @@ def stage_from_archive(
     output_dir.mkdir(parents=True, exist_ok=True)
     destination = output_dir / spec.runtime_name
     temporary = output_dir / f".{spec.runtime_name}.tmp"
-    temporary.write_bytes(runtime)
-    temporary.replace(destination)
+    try:
+        temporary.write_bytes(runtime)
+        temporary.replace(destination)
+    finally:
+        with suppress(OSError):
+            temporary.unlink()
     destination.with_name(f"{destination.name}.meta").write_text(
         unity_meta(spec), encoding="utf-8"
     )

--- a/tools/scripts/stage_unity_desktop_ort.py
+++ b/tools/scripts/stage_unity_desktop_ort.py
@@ -108,6 +108,7 @@ def unity_meta(spec: RuntimeSpec) -> str:
         target_data = """\
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
+        Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
     Editor:
@@ -128,6 +129,7 @@ def unity_meta(spec: RuntimeSpec) -> str:
         target_data = """\
         Exclude Linux64: 0
         Exclude OSXUniversal: 1
+        Exclude WebGL: 1
         Exclude Win: 1
         Exclude Win64: 1
     Editor:

--- a/tools/scripts/stage_unity_desktop_ort.py
+++ b/tools/scripts/stage_unity_desktop_ort.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Stage the pinned ONNX Runtime shared library into a Unity plugin tree."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ORT_VERSION = "1.23.2"
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    platform: str
+    url: str
+    sha256: str
+    archive_member: str
+    runtime_name: str
+
+
+# These are Microsoft's CPU release archives. The digests are published by the
+# GitHub release API for v1.23.2 and deliberately match ort-sys 2.0.0-rc.11's
+# ONNX Runtime version.
+RUNTIMES = {
+    "linux": RuntimeSpec(
+        platform="linux",
+        url=(
+            "https://github.com/microsoft/onnxruntime/releases/download/"
+            f"v{ORT_VERSION}/onnxruntime-linux-x64-{ORT_VERSION}.tgz"
+        ),
+        sha256="1fa4dcaef22f6f7d5cd81b28c2800414350c10116f5fdd46a2160082551c5f9b",
+        # Extract the real ELF payload, not the archive's libonnxruntime.so
+        # symlink, then install it under the name ort/load-dynamic opens.
+        archive_member=(
+            f"onnxruntime-linux-x64-{ORT_VERSION}/lib/"
+            f"libonnxruntime.so.{ORT_VERSION}"
+        ),
+        runtime_name="libonnxruntime.so",
+    ),
+    "windows": RuntimeSpec(
+        platform="windows",
+        url=(
+            "https://github.com/microsoft/onnxruntime/releases/download/"
+            f"v{ORT_VERSION}/onnxruntime-win-x64-{ORT_VERSION}.zip"
+        ),
+        sha256="0b38df9af21834e41e73d602d90db5cb06dbd1ca618948b8f1d66d607ac9f3cd",
+        archive_member=(
+            f"onnxruntime-win-x64-{ORT_VERSION}/lib/onnxruntime.dll"
+        ),
+        runtime_name="onnxruntime.dll",
+    ),
+}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download(spec: RuntimeSpec, destination: Path) -> None:
+    request = urllib.request.Request(
+        spec.url,
+        headers={"User-Agent": "xybrid-unity-ort-stager/1"},
+    )
+    with urllib.request.urlopen(request, timeout=300) as response:
+        with destination.open("wb") as output:
+            shutil.copyfileobj(response, output, length=1024 * 1024)
+
+
+def read_runtime(spec: RuntimeSpec, archive: Path) -> bytes:
+    try:
+        if spec.platform == "linux":
+            with tarfile.open(archive, "r:gz") as tar:
+                member = tar.extractfile(spec.archive_member)
+                if member is None:
+                    raise KeyError(spec.archive_member)
+                return member.read()
+
+        with zipfile.ZipFile(archive) as zip_file:
+            return zip_file.read(spec.archive_member)
+    except (KeyError, tarfile.TarError, zipfile.BadZipFile) as error:
+        raise ValueError(
+            f"ONNX Runtime archive does not contain {spec.archive_member}"
+        ) from error
+
+
+def unity_guid(spec: RuntimeSpec) -> str:
+    logical_name = f"xybrid-unity:{spec.platform}:{spec.runtime_name}"
+    return hashlib.sha256(logical_name.encode()).hexdigest()[:32]
+
+
+def unity_meta(spec: RuntimeSpec) -> str:
+    guid = unity_guid(spec)
+    if spec.platform == "windows":
+        target_data = """\
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+    Editor:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: Windows
+    Win:
+      enabled: 1
+      settings:
+        CPU: x86
+    Win64:
+      enabled: 1
+      settings:
+        CPU: x86_64"""
+    else:
+        target_data = """\
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+    Editor:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+    Linux64:
+      enabled: 1
+      settings:
+        CPU: x86_64"""
+
+    return f"""\
+fileFormatVersion: 2
+guid: {guid}
+PluginImporter:
+  externalObjects: {{}}
+  serializedVersion: 3
+  iconMap: {{}}
+  executionOrder: {{}}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+    Any:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+{target_data}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+"""
+
+
+def stage_from_archive(
+    spec: RuntimeSpec, archive: Path, output_dir: Path
+) -> Path:
+    actual_sha = sha256(archive)
+    if actual_sha != spec.sha256:
+        raise ValueError(
+            "ONNX Runtime archive SHA-256 mismatch: "
+            f"expected {spec.sha256}, got {actual_sha}"
+        )
+
+    runtime = read_runtime(spec, archive)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    destination = output_dir / spec.runtime_name
+    temporary = output_dir / f".{spec.runtime_name}.tmp"
+    temporary.write_bytes(runtime)
+    temporary.replace(destination)
+    destination.with_name(f"{destination.name}.meta").write_text(
+        unity_meta(spec), encoding="utf-8"
+    )
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download, verify, and stage desktop ONNX Runtime for Unity."
+    )
+    parser.add_argument("platform", choices=sorted(RUNTIMES))
+    parser.add_argument(
+        "output_dir",
+        type=Path,
+        help="Unity platform plugin directory (for example Runtime/Plugins/Linux)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    spec = RUNTIMES[args.platform]
+    suffix = ".tgz" if spec.platform == "linux" else ".zip"
+    try:
+        with tempfile.TemporaryDirectory(prefix="xybrid-unity-ort-") as temp:
+            archive = Path(temp) / f"onnxruntime-{spec.platform}{suffix}"
+            print(f"Downloading ONNX Runtime {ORT_VERSION} for {spec.platform}...")
+            download(spec, archive)
+            destination = stage_from_archive(spec, archive, args.output_dir)
+            print(f"Staged {destination}")
+        return 0
+    except Exception as error:
+        print(f"stage-unity-desktop-ort: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/tests/test_stage_unity_desktop_ort.py
+++ b/tools/scripts/tests/test_stage_unity_desktop_ort.py
@@ -1,0 +1,110 @@
+import hashlib
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from stage_unity_desktop_ort import RuntimeSpec, stage_from_archive
+
+
+class StageUnityDesktopOrtTests(unittest.TestCase):
+    def test_linux_archive_stages_runtime_under_the_load_name(self):
+        payload = b"linux-onnxruntime"
+        member = "onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so.1.23.2"
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "ort.tgz"
+            with tarfile.open(archive, "w:gz") as tar:
+                info = tarfile.TarInfo(member)
+                info.size = len(payload)
+                tar.addfile(info, io.BytesIO(payload))
+
+            spec = self.spec("linux", member, "libonnxruntime.so", archive)
+            output = root / "Linux"
+            stage_from_archive(spec, archive, output)
+
+            self.assertEqual(payload, (output / "libonnxruntime.so").read_bytes())
+            meta = (output / "libonnxruntime.so.meta").read_text()
+            self.assertIn("Linux64:", meta)
+            self.assertIn("CPU: x86_64", meta)
+
+    def test_windows_archive_stages_runtime_and_windows_metadata(self):
+        payload = b"windows-onnxruntime"
+        member = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "ort.zip"
+            with zipfile.ZipFile(archive, "w") as zip_file:
+                zip_file.writestr(member, payload)
+
+            spec = self.spec("windows", member, "onnxruntime.dll", archive)
+            output = root / "Windows"
+            stage_from_archive(spec, archive, output)
+
+            self.assertEqual(payload, (output / "onnxruntime.dll").read_bytes())
+            meta = (output / "onnxruntime.dll.meta").read_text()
+            self.assertIn("OS: Windows", meta)
+            self.assertIn("Win64:", meta)
+
+    def test_hash_mismatch_fails_without_staging_a_runtime(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "ort.zip"
+            archive.write_bytes(b"not-the-pinned-archive")
+            spec = RuntimeSpec(
+                platform="windows",
+                url="https://example.invalid/ort.zip",
+                sha256="0" * 64,
+                archive_member="onnxruntime.dll",
+                runtime_name="onnxruntime.dll",
+            )
+            output = root / "Windows"
+
+            with self.assertRaisesRegex(ValueError, "SHA-256 mismatch"):
+                stage_from_archive(spec, archive, output)
+
+            self.assertFalse((output / "onnxruntime.dll").exists())
+
+    def test_missing_runtime_member_fails_without_partial_output(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "ort.zip"
+            with zipfile.ZipFile(archive, "w") as zip_file:
+                zip_file.writestr("README.md", "no runtime here")
+            spec = self.spec(
+                "windows",
+                "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll",
+                "onnxruntime.dll",
+                archive,
+            )
+            output = root / "Windows"
+
+            with self.assertRaisesRegex(ValueError, "does not contain"):
+                stage_from_archive(spec, archive, output)
+
+            self.assertFalse((output / "onnxruntime.dll").exists())
+
+    @staticmethod
+    def spec(
+        platform: str, member: str, runtime_name: str, archive: Path
+    ) -> RuntimeSpec:
+        return RuntimeSpec(
+            platform=platform,
+            url="https://example.invalid/ort",
+            sha256=hashlib.sha256(archive.read_bytes()).hexdigest(),
+            archive_member=member,
+            runtime_name=runtime_name,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/tests/test_stage_unity_desktop_ort.py
+++ b/tools/scripts/tests/test_stage_unity_desktop_ort.py
@@ -36,6 +36,7 @@ class StageUnityDesktopOrtTests(unittest.TestCase):
             meta = (output / "libonnxruntime.so.meta").read_text()
             self.assertIn("Linux64:", meta)
             self.assertIn("CPU: x86_64", meta)
+            self.assertIn("Exclude WebGL: 1", meta)
 
     def test_windows_archive_stages_runtime_and_windows_metadata(self):
         payload = b"windows-onnxruntime"
@@ -55,6 +56,7 @@ class StageUnityDesktopOrtTests(unittest.TestCase):
             meta = (output / "onnxruntime.dll.meta").read_text()
             self.assertIn("OS: Windows", meta)
             self.assertIn("Win64:", meta)
+            self.assertIn("Exclude WebGL: 1", meta)
 
     def test_hash_mismatch_fails_without_staging_a_runtime(self):
         with tempfile.TemporaryDirectory() as temp:

--- a/tools/scripts/tests/test_stage_unity_desktop_ort.py
+++ b/tools/scripts/tests/test_stage_unity_desktop_ort.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
@@ -92,6 +93,28 @@ class StageUnityDesktopOrtTests(unittest.TestCase):
                 stage_from_archive(spec, archive, output)
 
             self.assertFalse((output / "onnxruntime.dll").exists())
+
+    def test_replace_failure_removes_temporary_runtime(self):
+        payload = b"windows-onnxruntime"
+        member = "onnxruntime-win-x64-1.23.2/lib/onnxruntime.dll"
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "ort.zip"
+            with zipfile.ZipFile(archive, "w") as zip_file:
+                zip_file.writestr(member, payload)
+
+            spec = self.spec("windows", member, "onnxruntime.dll", archive)
+            output = root / "Windows"
+
+            with mock.patch.object(
+                Path, "replace", side_effect=OSError("rename failed")
+            ):
+                with self.assertRaisesRegex(OSError, "rename failed"):
+                    stage_from_archive(spec, archive, output)
+
+            self.assertFalse((output / "onnxruntime.dll").exists())
+            self.assertFalse((output / ".onnxruntime.dll.tmp").exists())
 
     @staticmethod
     def spec(


### PR DESCRIPTION
## Summary

- stage pinned ONNX Runtime 1.23.2 shared libraries in the Unity Linux and Windows plugin artifacts
- verify archive SHA-256, native loadability, Unity metadata, and final resolver bundle contents
- add focused tooling tests and document that desktop consumers need no system-wide ORT install

## Verification

- python3 -m unittest discover -s tools/scripts/tests -p test_*.py
- actionlint workflow syntax validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --features ort-download
- real Microsoft Linux and Windows archive download/checksum/extraction/architecture checks