### PR TITLE
feat(unity): hand-port the bolt C# run/envelope path (A2 unblock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           fi
           echo "relevant=$RELEVANT" >> "$GITHUB_OUTPUT"
           echo "Tooling-relevant changes: $RELEVANT"
-          if printf '%s\n' "$FILES" | grep -qE '^(bindings/unity/Runtime/Bolt/|tools/unity-bolt-compile-check/|tools/scripts/gen_unity_bolt_csharp\.py$|crates/xybrid-bolt/boltffi\.toml$|\.github/workflows/ci\.yml$)'; then
+          if printf '%s\n' "$FILES" | grep -qE '^(bindings/unity/Runtime/Bolt/|bindings/unity/Runtime/BoltSupplement/|tools/unity-bolt-compile-check/|tools/scripts/gen_unity_bolt_csharp\.py$|crates/xybrid-bolt/boltffi\.toml$|\.github/workflows/ci\.yml$)'; then
             UNITY_BOLT=true
           else
             UNITY_BOLT=false

--- a/bindings/unity/Runtime/Bolt/XybridModel.cs
+++ b/bindings/unity/Runtime/Bolt/XybridModel.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace XybridBolt
 {
-    public sealed class XybridModel : IDisposable
+    public sealed partial class XybridModel : IDisposable
     {
         private IntPtr _handle;
 

--- a/bindings/unity/Runtime/BoltSupplement.meta
+++ b/bindings/unity/Runtime/BoltSupplement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32cafdd79d2593838a13a50b0aba7a80
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/bindings/unity/Runtime/BoltSupplement/XybridInference.cs
+++ b/bindings/unity/Runtime/BoltSupplement/XybridInference.cs
@@ -248,6 +248,12 @@ namespace XybridBolt
             finally
             {
                 NativeMethods.FreeBuf(buf);
+                // Run blocks for the whole inference. Once _handle is read into
+                // the native call above, the JIT may treat `this` as dead; if it
+                // is otherwise unreferenced, a GC here could run ~XybridModel and
+                // free the handle while Rust is still using it (use-after-free).
+                // Keep the wrapper alive across the call.
+                GC.KeepAlive(this);
             }
         }
     }

--- a/bindings/unity/Runtime/BoltSupplement/XybridInference.cs
+++ b/bindings/unity/Runtime/BoltSupplement/XybridInference.cs
@@ -1,0 +1,254 @@
+// Hand-written supplement to the generated BoltFFI C# bindings.
+//
+// boltffi 0.25.3's C# generator silently drops the entire inference path: no
+// `run` method, and none of the types it needs -- XybridEnvelope,
+// XybridEnvelopeKind (a data-carrying enum used as a function INPUT, which the
+// 0.25.3 C# lowering can't express), or XybridResult. Swift/Kotlin generate
+// them fine; C# does not. Rather than block Unity on inference, this file
+// hand-ports that path, exactly as bindings/python/xybrid/_bolt.py does for the
+// Python SDK. It is pinned to the boltffi 0.25.3 wire ABI.
+//
+// The wire format mirrors the generated Swift (bindings/apple/.../xybrid_bolt.swift,
+// which is device-validated) and reuses the generated C# WireReader/WireWriter
+// primitives in Runtime/Bolt/XybridBolt.cs. This layer is NOT emitted by
+// tools/scripts/gen_unity_bolt_csharp.py; that script only marks XybridModel
+// `partial` so the Run() method below can extend it. When boltffi >= 0.26 lands
+// (which is expected to express this path), delete this file and let the
+// generator emit run() natively.
+
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace XybridBolt
+{
+    /// <summary>
+    /// A unit of input or output crossing the FFI boundary: a payload
+    /// (<see cref="XybridEnvelopeKind"/>) plus free-form metadata.
+    /// </summary>
+    public sealed class XybridEnvelope
+    {
+        public XybridEnvelopeKind Kind { get; }
+        public XybridMetadataEntry[] Metadata { get; }
+
+        public XybridEnvelope(XybridEnvelopeKind kind, XybridMetadataEntry[]? metadata = null)
+        {
+            Kind = kind ?? throw new ArgumentNullException(nameof(kind));
+            Metadata = metadata ?? Array.Empty<XybridMetadataEntry>();
+        }
+
+        internal void WireEncodeTo(WireWriter wire)
+        {
+            Kind.WireEncodeTo(wire);
+            wire.WriteI32(Metadata.Length);
+            foreach (XybridMetadataEntry entry in Metadata)
+            {
+                entry.WireEncodeTo(wire);
+            }
+        }
+
+        internal static XybridEnvelope Decode(WireReader reader) =>
+            new XybridEnvelope(
+                XybridEnvelopeKind.Decode(reader),
+                reader.ReadEncodedArray<XybridMetadataEntry>(r => XybridMetadataEntry.Decode(r)));
+    }
+
+    /// <summary>
+    /// The payload variants an <see cref="XybridEnvelope"/> can carry. The wire
+    /// tags (0..4) and field order are part of the contract and must stay in
+    /// lockstep with <c>XybridEnvelopeKind</c> in crates/xybrid-bolt/src/lib.rs.
+    /// </summary>
+    public abstract class XybridEnvelopeKind
+    {
+        // Private ctor seals the hierarchy to the nested variants below (nested
+        // types can reach the enclosing type's private members).
+        private XybridEnvelopeKind() { }
+
+        internal abstract void WireEncodeTo(WireWriter wire);
+
+        public sealed class Text : XybridEnvelopeKind
+        {
+            public string Value { get; }
+            public Text(string value) { Value = value ?? throw new ArgumentNullException(nameof(value)); }
+            internal override void WireEncodeTo(WireWriter wire)
+            {
+                wire.WriteI32(0);
+                wire.WriteString(Value);
+            }
+        }
+
+        public sealed class Audio : XybridEnvelopeKind
+        {
+            public byte[] Bytes { get; }
+            public Audio(byte[] bytes) { Bytes = bytes ?? throw new ArgumentNullException(nameof(bytes)); }
+            internal override void WireEncodeTo(WireWriter wire)
+            {
+                wire.WriteI32(1);
+                wire.WriteBytes(Bytes);
+            }
+        }
+
+        public sealed class Embedding : XybridEnvelopeKind
+        {
+            public float[] Values { get; }
+            public Embedding(float[] values) { Values = values ?? throw new ArgumentNullException(nameof(values)); }
+            internal override void WireEncodeTo(WireWriter wire)
+            {
+                wire.WriteI32(2);
+                wire.WriteBlittableArray(Values);
+            }
+        }
+
+        public sealed class Image : XybridEnvelopeKind
+        {
+            public byte[] Bytes { get; }
+            public string Format { get; }
+            public Image(byte[] bytes, string format)
+            {
+                Bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+                Format = format ?? throw new ArgumentNullException(nameof(format));
+            }
+            internal override void WireEncodeTo(WireWriter wire)
+            {
+                wire.WriteI32(3);
+                wire.WriteBytes(Bytes);
+                wire.WriteString(Format);
+            }
+        }
+
+        public sealed class MultiPart : XybridEnvelopeKind
+        {
+            public XybridEnvelope[] Parts { get; }
+            public MultiPart(XybridEnvelope[] parts) { Parts = parts ?? throw new ArgumentNullException(nameof(parts)); }
+            internal override void WireEncodeTo(WireWriter wire)
+            {
+                wire.WriteI32(4);
+                wire.WriteI32(Parts.Length);
+                foreach (XybridEnvelope part in Parts)
+                {
+                    part.WireEncodeTo(wire);
+                }
+            }
+        }
+
+        internal static XybridEnvelopeKind Decode(WireReader reader)
+        {
+            int tag = reader.ReadI32();
+            switch (tag)
+            {
+                case 0:
+                    return new Text(reader.ReadString());
+                case 1:
+                    return new Audio(reader.ReadBytes());
+                case 2:
+                    return new Embedding(reader.ReadLengthPrefixedBlittableArray<float>());
+                case 3:
+                    return new Image(reader.ReadBytes(), reader.ReadString());
+                case 4:
+                    return new MultiPart(
+                        reader.ReadEncodedArray<XybridEnvelope>(r => XybridEnvelope.Decode(r)));
+                default:
+                    throw new InvalidOperationException($"Unknown XybridEnvelopeKind wire tag: {tag}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The output of <see cref="XybridModel.Run"/>: the result envelope plus
+    /// the model id, output type, latency, and inference metrics.
+    /// </summary>
+    public sealed class XybridResult
+    {
+        public XybridEnvelope Envelope { get; }
+        public XybridOutputType OutputType { get; }
+        public string ModelId { get; }
+        public uint LatencyMs { get; }
+        public XybridInferenceMetrics Metrics { get; }
+
+        internal XybridResult(
+            XybridEnvelope envelope,
+            XybridOutputType outputType,
+            string modelId,
+            uint latencyMs,
+            XybridInferenceMetrics metrics)
+        {
+            Envelope = envelope;
+            OutputType = outputType;
+            ModelId = modelId;
+            LatencyMs = latencyMs;
+            Metrics = metrics;
+        }
+
+        internal static XybridResult Decode(WireReader reader) =>
+            new XybridResult(
+                XybridEnvelope.Decode(reader),
+                XybridOutputTypeWire.Decode(reader),
+                reader.ReadString(),
+                reader.ReadU32(),
+                XybridInferenceMetrics.Decode(reader));
+    }
+
+    internal static class BoltRunNative
+    {
+        [DllImport(NativeMethods.LibName, EntryPoint = "boltffi_xybrid_model_run")]
+        internal static extern FfiBuf XybridModelRun(
+            IntPtr self,
+            byte[] envelope,
+            UIntPtr envelopeLen,
+            byte[] options,
+            UIntPtr optionsLen);
+    }
+
+    public sealed partial class XybridModel
+    {
+        /// <summary>
+        /// Run inference on <paramref name="envelope"/>, optionally overriding
+        /// defaults with <paramref name="options"/>. Blocks until complete.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="envelope"/> is null.</exception>
+        /// <exception cref="XybridErrorException">If the model returns a typed error.</exception>
+        /// <exception cref="ObjectDisposedException">If the model has been disposed.</exception>
+        public XybridResult Run(XybridEnvelope envelope, XybridRunOptions? options = null)
+        {
+            if (envelope is null) throw new ArgumentNullException(nameof(envelope));
+            ThrowIfDisposed();
+
+            using var envelopeWire = new WireWriter(64);
+            envelope.WireEncodeTo(envelopeWire);
+            byte[] envelopeBytes = envelopeWire.ToArray();
+
+            // Options cross as an Optional<XybridRunOptions>: a u8 presence tag
+            // followed by the encoded options when present (matching the Swift
+            // `writer.writeOptional(options)`).
+            using var optionsWire = new WireWriter(16);
+            if (options is { } opts)
+            {
+                optionsWire.WriteU8(1);
+                opts.WireEncodeTo(optionsWire);
+            }
+            else
+            {
+                optionsWire.WriteU8(0);
+            }
+            byte[] optionsBytes = optionsWire.ToArray();
+
+            FfiBuf buf = BoltRunNative.XybridModelRun(
+                _handle,
+                envelopeBytes,
+                (UIntPtr)envelopeBytes.Length,
+                optionsBytes,
+                (UIntPtr)optionsBytes.Length);
+            try
+            {
+                var reader = new WireReader(buf);
+                if (reader.ReadU8() != 0) throw new XybridErrorException(XybridError.Decode(reader));
+                return XybridResult.Decode(reader);
+            }
+            finally
+            {
+                NativeMethods.FreeBuf(buf);
+            }
+        }
+    }
+}

--- a/bindings/unity/Runtime/BoltSupplement/XybridInference.cs.meta
+++ b/bindings/unity/Runtime/BoltSupplement/XybridInference.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 162e639a44c5160724508e352658dbd4

--- a/tools/scripts/gen_unity_bolt_csharp.py
+++ b/tools/scripts/gen_unity_bolt_csharp.py
@@ -32,6 +32,10 @@ What it does:
         IsExternalInit, a .NET 5 type Unity lacks -> a one-file internal
         polyfill is emitted (needed by the C# 9 record hierarchy in
         XybridError, whose positional records still synthesize `init`).
+     e. `class XybridModel` -> `partial class XybridModel`, so the hand-ported
+        inference path in bindings/unity/Runtime/BoltSupplement (which boltffi
+        0.25.3 drops entirely -- run(), XybridEnvelope/EnvelopeKind/Result) can
+        extend it. That folder is hand-written and NOT touched by this script.
      d. `NativeMemory.Alloc` (.NET 6) in FfiBuf.FromBytes -> fail closed. That
         method hands an owned buffer to Rust, which frees it with its global
         allocator in boltffi_free_buf (std::alloc::dealloc) — a free no C#
@@ -133,6 +137,18 @@ LE_FLOAT_REWRITES = (
         "BitConverter.DoubleToInt64Bits(v))",
     ),
 )
+
+# --- Transform (e): make XybridModel partial. boltffi 0.25.3's C# generator
+# drops the entire inference path -- no `run`, and no XybridEnvelope /
+# XybridEnvelopeKind / XybridResult (a data-carrying enum used as a function
+# INPUT, which the 0.25.3 C# lowering can't express; same class the Python
+# generator drops). bindings/unity/Runtime/BoltSupplement/ hand-ports that path
+# (wire codecs + a `partial class XybridModel` adding Run()), mirroring
+# bindings/python/xybrid/_bolt.py. Marking the generated class partial lets the
+# supplement extend it and reach its private _handle.
+MODEL_FILE = "XybridModel.cs"
+MODEL_PARTIAL_TARGET = "public sealed class XybridModel : IDisposable"
+MODEL_PARTIAL_REPLACEMENT = "public sealed partial class XybridModel : IDisposable"
 
 # --- Transform (c): IsExternalInit polyfill (a Unity-only supplement) ---
 POLYFILL_FILE = "IsExternalInit.cs"
@@ -249,6 +265,7 @@ def generate() -> dict[str, str]:
     record_structs = 0
     le_floats = 0
     native_memory_shimmed = False
+    model_made_partial = False
     for src in sources:
         content = src.read_text(encoding="utf-8")
         content, n = _downlevel_record_structs(content)
@@ -262,6 +279,15 @@ def generate() -> dict[str, str]:
             )
             content = content.replace(SHIM_TARGET, SHIM_REPLACEMENT, 1)
             native_memory_shimmed = True
+        if src.name == MODEL_FILE:
+            _drift(
+                MODEL_PARTIAL_TARGET in content,
+                f"expected XybridModel class declaration not found in {src.name}",
+            )
+            content = content.replace(
+                MODEL_PARTIAL_TARGET, MODEL_PARTIAL_REPLACEMENT, 1
+            )
+            model_made_partial = True
         tree[src.name] = content
         tree[src.name + ".meta"] = script_meta(f"{DEST_REL}/{src.name}")
 
@@ -279,6 +305,7 @@ def generate() -> dict[str, str]:
         f"rewrote {le_floats} float LE writers, expected {len(LE_FLOAT_REWRITES)}",
     )
     _drift(native_memory_shimmed, f"{SHIM_FILE} not found in boltffi output")
+    _drift(model_made_partial, f"{MODEL_FILE} not found in boltffi output")
     return tree
 
 

--- a/tools/unity-bolt-compile-check/UnityBoltCompileCheck.csproj
+++ b/tools/unity-bolt-compile-check/UnityBoltCompileCheck.csproj
@@ -23,6 +23,8 @@
 
   <ItemGroup>
     <Compile Include="../../bindings/unity/Runtime/Bolt/*.cs" />
+    <!-- Hand-ported inference path (run/envelope) that boltffi 0.25.3 drops. -->
+    <Compile Include="../../bindings/unity/Runtime/BoltSupplement/*.cs" />
     <!-- Unity bundles System.Runtime.CompilerServices.Unsafe; supply it here so
          the standalone compile resolves Unsafe.SizeOf the same way Unity does. -->
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />


### PR DESCRIPTION
Unblocks A2. While starting the managed-API rewrite I found that **boltffi 0.25.3's C# generator silently drops the entire inference path** — no `run()`, and none of `XybridEnvelope` / `XybridEnvelopeKind` / `XybridResult`. It's a data-carrying enum used as a function *input* the 0.25.3 C# lowering can't express (the same class the Python generator drops, per `boltffi.toml`). Swift/Kotlin generate it fine — so the generated C# could **load + introspect** a model but not **run** it.

Per your "hand-port it": port that path, mirroring `bindings/python/xybrid/_bolt.py`, pinned to the 0.25.3 wire ABI.

**What's here**
- **`bindings/unity/Runtime/BoltSupplement/XybridInference.cs`** (hand-written, *not* generator-managed): `XybridEnvelope` / `XybridEnvelopeKind` (Text/Audio/Embedding/Image/MultiPart, recursive) / `XybridResult` wire codecs + a `partial class XybridModel` adding `Run(envelope, options)` that P/Invokes `boltffi_xybrid_model_run`. Reuses the generated `WireReader`/`WireWriter` primitives; the wire format mirrors the **device-validated Swift**.
- **`gen_unity_bolt_csharp.py`**: one new guarded transform marks the generated `XybridModel` `partial` so the supplement can extend it and reach `_handle`. (The supplement dir is never touched by the generator.)
- **Compile gate + CI**: `UnityBoltCompileCheck.csproj` and the `unity_bolt` path filter extended to cover `BoltSupplement`.

**Verified**
- **Golden bytes**: `Text("hi")` encodes to exactly `00-00-00-00 02-00-00-00 68-69 00-00-00-00` (hand-computed from the wire spec → matches Rust).
- **Round-trip**: all 5 envelope kinds + metadata + recursive `MultiPart` — decode consumes *exactly* what encode produces.
- **Compiles** clean at **netstandard2.1 / C# 9** (generated + hand-port together).

**Scope / honesty**
- End-to-end inference still needs an on-device run (the wire correctness is proven by golden+round-trip + mirroring device-validated Swift, but the actual native call is exercised only on device).
- This is a hand-maintained layer pinned to the 0.25.3 ABI. **When boltffi ≥ 0.26 lands** (expected to express this path natively), delete the supplement and let the generator emit `run()`.