### PR TITLE
feat(unity): re-plumb the managed API onto bolt (A2.1)

### DIFF
--- a/bindings/unity/Runtime/Api/ConversationContext.cs
+++ b/bindings/unity/Runtime/Api/ConversationContext.cs
@@ -112,7 +112,7 @@ namespace Xybrid
 
             try
             {
-                _bolt.SetSystem(Envelope.Text(systemPrompt).Bolt);
+                _bolt.SetSystem(Envelope.Text(systemPrompt, MessageRole.System).Bolt);
             }
             catch (Exception ex) when (IsBoltError(ex))
             {

--- a/bindings/unity/Runtime/Api/ConversationContext.cs
+++ b/bindings/unity/Runtime/Api/ConversationContext.cs
@@ -2,7 +2,6 @@
 // Manages multi-turn conversation history for LLM interactions.
 
 using System;
-using Xybrid.Native;
 
 namespace Xybrid
 {
@@ -25,139 +24,99 @@ namespace Xybrid
     /// using var context = new ConversationContext();
     /// context.SetSystem("You are a helpful assistant.");
     ///
-    /// var input = Envelope.Text("Hello!", MessageRole.User);
-    /// context.Push(input);
-    ///
-    /// using var result = model.Run(input, context);
-    /// context.Push(Envelope.Text(result.Text, MessageRole.Assistant));
+    /// context.Push("Hello!", MessageRole.User);
+    /// using var result = model.Run(Envelope.Text("Hello!"), context);
+    /// context.Push(result.Text, MessageRole.Assistant);
     /// </code>
     /// </example>
     public sealed class ConversationContext : IDisposable
     {
-        private unsafe XybridContextHandle* _handle;
+        private readonly XybridBolt.XybridConversationContext _bolt;
         private bool _disposed;
 
-        /// <summary>
-        /// Gets whether this context has been disposed.
-        /// </summary>
+        /// <summary>The bolt handle backing this context. For internal use.</summary>
+        internal XybridBolt.XybridConversationContext Bolt
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _bolt;
+            }
+        }
+
+        /// <summary>Gets whether this context has been disposed.</summary>
         public bool IsDisposed => _disposed;
 
-        /// <summary>
-        /// Gets the conversation context ID.
-        /// </summary>
-        public unsafe string Id
+        /// <summary>Gets the conversation context ID.</summary>
+        public string Id
         {
             get
             {
                 ThrowIfDisposed();
-                byte* idPtr = NativeMethods.xybrid_context_id(_handle);
-                if (idPtr == null)
-                    return string.Empty;
-                return NativeHelpers.FromUtf8Ptr(idPtr);
+                return _bolt.Id();
             }
         }
 
-        /// <summary>
-        /// Gets the current history length (excluding system prompt).
-        /// </summary>
-        public unsafe uint HistoryLength
+        /// <summary>Gets the current history length (excluding system prompt).</summary>
+        public uint HistoryLength
         {
             get
             {
                 ThrowIfDisposed();
-                return NativeMethods.xybrid_context_history_len(_handle);
+                return _bolt.HistoryLen();
             }
         }
 
-        /// <summary>
-        /// Gets whether a system prompt is set.
-        /// </summary>
-        public unsafe bool HasSystem
+        /// <summary>Gets whether a system prompt is set.</summary>
+        public bool HasSystem
         {
             get
             {
                 ThrowIfDisposed();
-                return NativeMethods.xybrid_context_has_system(_handle) != 0;
+                return _bolt.HasSystem();
             }
         }
 
-        /// <summary>
-        /// Gets the internal native handle. For internal use only.
-        /// </summary>
-        internal unsafe XybridContextHandle* Handle
+        /// <summary>Creates a new conversation context with a generated UUID.</summary>
+        public ConversationContext()
         {
-            get
-            {
-                ThrowIfDisposed();
-                return _handle;
-            }
+            _bolt = new XybridBolt.XybridConversationContext();
         }
 
-        /// <summary>
-        /// Creates a new conversation context with a generated UUID.
-        /// </summary>
-        /// <exception cref="XybridException">Thrown if context creation fails.</exception>
-        public unsafe ConversationContext()
-        {
-            _handle = NativeMethods.xybrid_context_new();
-            if (_handle == null)
-            {
-                NativeHelpers.ThrowLastError("Failed to create conversation context");
-            }
-        }
-
-        /// <summary>
-        /// Creates a new conversation context with a specific ID.
-        /// </summary>
+        /// <summary>Creates a new conversation context with a specific ID.</summary>
         /// <param name="id">The context identifier.</param>
         /// <exception cref="ArgumentNullException">Thrown if id is null.</exception>
-        /// <exception cref="XybridException">Thrown if context creation fails.</exception>
-        public unsafe ConversationContext(string id)
+        public ConversationContext(string id)
         {
             if (id == null)
             {
                 throw new ArgumentNullException(nameof(id));
             }
-
-            byte[] idBytes = NativeHelpers.ToUtf8Bytes(id);
-            fixed (byte* idPtr = idBytes)
-            {
-                _handle = NativeMethods.xybrid_context_with_id(idPtr);
-                if (_handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create conversation context with ID");
-                }
-            }
+            _bolt = XybridBolt.XybridConversationContext.WithId(id);
         }
 
         /// <summary>
-        /// Sets the system prompt for this conversation.
+        /// Sets the system prompt for this conversation. Persists across Clear().
         /// </summary>
         /// <param name="systemPrompt">The system prompt text.</param>
-        /// <remarks>
-        /// The system prompt defines the assistant's behavior and persists
-        /// across Clear() calls.
-        /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if systemPrompt is null.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this context is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if setting system prompt fails.</exception>
-        public unsafe void SetSystem(string systemPrompt)
+        /// <exception cref="XybridException">Thrown if setting the system prompt fails.</exception>
+        public void SetSystem(string systemPrompt)
         {
             ThrowIfDisposed();
-
             if (systemPrompt == null)
             {
                 throw new ArgumentNullException(nameof(systemPrompt));
             }
 
-            byte[] textBytes = NativeHelpers.ToUtf8Bytes(systemPrompt);
-            fixed (byte* textPtr = textBytes)
+            try
             {
-                int result = NativeMethods.xybrid_context_set_system(_handle, textPtr);
-                if (result != 0)
-                {
-                    NativeHelpers.ThrowLastError("Failed to set system prompt");
-                }
+                _bolt.SetSystem(Envelope.Text(systemPrompt).Bolt);
+            }
+            catch (Exception ex) when (IsBoltError(ex))
+            {
+                throw BoltErrors.Translate(ex);
             }
         }
 
@@ -165,20 +124,11 @@ namespace Xybrid
         /// Sets the maximum history length before FIFO pruning.
         /// </summary>
         /// <param name="maxLength">Maximum number of history entries (default is 50).</param>
-        /// <remarks>
-        /// When the history exceeds this limit, the oldest messages are dropped.
-        /// </remarks>
         /// <exception cref="ObjectDisposedException">Thrown if this context is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if setting max length fails.</exception>
-        public unsafe void SetMaxHistoryLength(uint maxLength)
+        public void SetMaxHistoryLength(uint maxLength)
         {
             ThrowIfDisposed();
-
-            int result = NativeMethods.xybrid_context_set_max_history_len(_handle, maxLength);
-            if (result != 0)
-            {
-                NativeHelpers.ThrowLastError("Failed to set max history length");
-            }
+            _bolt.SetMaxHistoryLen(maxLength);
         }
 
         /// <summary>
@@ -189,36 +139,21 @@ namespace Xybrid
         /// <exception cref="ArgumentNullException">Thrown if text is null.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this context is disposed.</exception>
         /// <exception cref="XybridException">Thrown if pushing the message fails.</exception>
-        public unsafe void Push(string text, MessageRole role)
+        public void Push(string text, MessageRole role)
         {
             ThrowIfDisposed();
-
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
-            byte[] textBytes = NativeHelpers.ToUtf8Bytes(text);
-            fixed (byte* textPtr = textBytes)
+            try
             {
-                XybridEnvelopeHandle* envelope = NativeMethods.xybrid_envelope_text_with_role(textPtr, (int)role);
-                if (envelope == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create envelope for context push");
-                }
-
-                try
-                {
-                    int result = NativeMethods.xybrid_context_push(_handle, envelope);
-                    if (result != 0)
-                    {
-                        NativeHelpers.ThrowLastError("Failed to push message to context");
-                    }
-                }
-                finally
-                {
-                    NativeMethods.xybrid_envelope_free(envelope);
-                }
+                _bolt.Push(Envelope.Text(text, role).Bolt);
+            }
+            catch (Exception ex) when (IsBoltError(ex))
+            {
+                throw BoltErrors.Translate(ex);
             }
         }
 
@@ -226,17 +161,14 @@ namespace Xybrid
         /// Clears the conversation history but preserves the system prompt and ID.
         /// </summary>
         /// <exception cref="ObjectDisposedException">Thrown if this context is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if clearing fails.</exception>
-        public unsafe void Clear()
+        public void Clear()
         {
             ThrowIfDisposed();
-
-            int result = NativeMethods.xybrid_context_clear(_handle);
-            if (result != 0)
-            {
-                NativeHelpers.ThrowLastError("Failed to clear conversation context");
-            }
+            _bolt.Clear();
         }
+
+        private static bool IsBoltError(Exception ex) =>
+            ex is XybridBolt.XybridErrorException || ex is XybridBolt.BoltException;
 
         private void ThrowIfDisposed()
         {
@@ -246,37 +178,23 @@ namespace Xybrid
             }
         }
 
-        /// <summary>
-        /// Releases the native resources used by this context.
-        /// </summary>
-        public unsafe void Dispose()
+        /// <summary>Releases the native resources used by this context.</summary>
+        public void Dispose()
         {
             if (!_disposed)
             {
-                if (_handle != null)
-                {
-                    NativeMethods.xybrid_context_free(_handle);
-                    _handle = null;
-                }
+                _bolt.Dispose();
                 _disposed = true;
             }
         }
 
-        /// <summary>
-        /// Finalizer to ensure native resources are released.
-        /// </summary>
-        ~ConversationContext()
-        {
-            Dispose();
-        }
-
-        /// <summary>
-        /// Returns a string representation of the context.
-        /// </summary>
+        /// <summary>Returns a string representation of the context.</summary>
         public override string ToString()
         {
             if (_disposed)
+            {
                 return "ConversationContext(disposed)";
+            }
             return $"ConversationContext(Id={Id}, History={HistoryLength})";
         }
     }

--- a/bindings/unity/Runtime/Api/Envelope.cs
+++ b/bindings/unity/Runtime/Api/Envelope.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using Xybrid.Native;
+using System.Globalization;
 
 namespace Xybrid
 {
@@ -13,72 +12,40 @@ namespace Xybrid
     /// Use the static factory methods to create instances.
     /// </summary>
     /// <remarks>
-    /// This class wraps a native envelope handle and must be disposed when no longer needed.
-    /// The envelope can be reused for multiple inference calls.
+    /// The envelope is an immutable value and can be reused for multiple
+    /// inference calls. TTS voice/speed, ASR sample-rate/channels, and message
+    /// role are carried as envelope metadata.
     /// </remarks>
     public sealed class Envelope : IDisposable
     {
-        private enum PayloadKind
-        {
-            Text,
-            Audio,
-            Image,
-            UserMessage,
-        }
-
-        private unsafe XybridEnvelopeHandle* _handle;
-        private readonly PayloadKind _kind;
-        private bool _disposed;
+        /// <summary>The bolt wire value backing this envelope. For internal use.</summary>
+        internal XybridBolt.XybridEnvelope Bolt { get; }
 
         /// <summary>
-        /// Gets whether this envelope has been disposed.
+        /// Gets whether this envelope has been disposed. Retained for source
+        /// compatibility; the envelope now holds no native resources.
         /// </summary>
-        public bool IsDisposed => _disposed;
+        public bool IsDisposed { get; private set; }
 
-        /// <summary>
-        /// Gets the internal native handle. For internal use only.
-        /// </summary>
-        internal unsafe XybridEnvelopeHandle* Handle
+        private Envelope(XybridBolt.XybridEnvelope bolt)
         {
-            get
-            {
-                ThrowIfDisposed();
-                return _handle;
-            }
-        }
-
-        private unsafe Envelope(XybridEnvelopeHandle* handle, PayloadKind kind)
-        {
-            _handle = handle;
-            _kind = kind;
+            Bolt = bolt;
         }
 
         /// <summary>
         /// Creates an envelope containing text data for TTS or LLM inference.
         /// </summary>
         /// <param name="text">The text to process.</param>
-        /// <returns>A new Envelope containing the text.</returns>
         /// <exception cref="ArgumentNullException">Thrown if text is null.</exception>
-        /// <exception cref="XybridException">Thrown if envelope creation fails.</exception>
-        public static unsafe Envelope Text(string text)
+        public static Envelope Text(string text)
         {
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
-            byte[] textBytes = NativeHelpers.ToUtf8Bytes(text);
-
-            fixed (byte* textPtr = textBytes)
-            {
-                XybridEnvelopeHandle* handle = NativeMethods.xybrid_envelope_text(textPtr);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create text envelope");
-                }
-
-                return new Envelope(handle, PayloadKind.Text);
-            }
+            return new Envelope(new XybridBolt.XybridEnvelope(
+                new XybridBolt.XybridEnvelopeKind.Text(text)));
         }
 
         /// <summary>
@@ -87,31 +54,24 @@ namespace Xybrid
         /// <param name="text">The text to synthesize.</param>
         /// <param name="voiceId">Voice ID (e.g., "af_bella"). Pass null to use the model's default voice.</param>
         /// <param name="speed">Speed multiplier (1.0 = normal, 0.5 = half speed, 2.0 = double).</param>
-        /// <returns>A new Envelope containing the text with voice options.</returns>
         /// <exception cref="ArgumentNullException">Thrown if text is null.</exception>
-        /// <exception cref="XybridException">Thrown if envelope creation fails.</exception>
-        public static unsafe Envelope Text(string text, string voiceId, double speed = 1.0)
+        public static Envelope Text(string text, string voiceId, double speed = 1.0)
         {
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
-            byte[] textBytes = NativeHelpers.ToUtf8Bytes(text);
-            byte[] voiceBytes = voiceId != null ? NativeHelpers.ToUtf8Bytes(voiceId) : null;
-
-            fixed (byte* textPtr = textBytes)
-            fixed (byte* voicePtr = voiceBytes)
+            var metadata = new List<XybridBolt.XybridMetadataEntry>();
+            if (voiceId != null)
             {
-                XybridEnvelopeHandle* handle = NativeMethods.xybrid_envelope_text_with_voice(
-                    textPtr, voicePtr, speed);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create text envelope with voice");
-                }
-
-                return new Envelope(handle, PayloadKind.Text);
+                metadata.Add(new XybridBolt.XybridMetadataEntry("voice_id", voiceId));
             }
+            metadata.Add(new XybridBolt.XybridMetadataEntry(
+                "speed", speed.ToString(CultureInfo.InvariantCulture)));
+
+            return new Envelope(new XybridBolt.XybridEnvelope(
+                new XybridBolt.XybridEnvelopeKind.Text(text), metadata.ToArray()));
         }
 
         /// <summary>
@@ -119,28 +79,20 @@ namespace Xybrid
         /// </summary>
         /// <param name="text">The text to process.</param>
         /// <param name="role">The message role for conversation context.</param>
-        /// <returns>A new Envelope containing the text with the specified role.</returns>
         /// <exception cref="ArgumentNullException">Thrown if text is null.</exception>
-        /// <exception cref="XybridException">Thrown if envelope creation fails.</exception>
-        public static unsafe Envelope Text(string text, MessageRole role)
+        public static Envelope Text(string text, MessageRole role)
         {
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
-            byte[] textBytes = NativeHelpers.ToUtf8Bytes(text);
-
-            fixed (byte* textPtr = textBytes)
+            var metadata = new[]
             {
-                XybridEnvelopeHandle* handle = NativeMethods.xybrid_envelope_text_with_role(textPtr, (int)role);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create text envelope with role");
-                }
-
-                return new Envelope(handle, PayloadKind.Text);
-            }
+                new XybridBolt.XybridMetadataEntry("xybrid.role", RoleString(role)),
+            };
+            return new Envelope(new XybridBolt.XybridEnvelope(
+                new XybridBolt.XybridEnvelopeKind.Text(text), metadata));
         }
 
         /// <summary>
@@ -149,32 +101,23 @@ namespace Xybrid
         /// <param name="audioBytes">Raw audio bytes (typically PCM or WAV format).</param>
         /// <param name="sampleRate">Sample rate in Hz (e.g., 16000 for 16kHz).</param>
         /// <param name="channels">Number of audio channels (1 = mono, 2 = stereo).</param>
-        /// <returns>A new Envelope containing the audio data.</returns>
         /// <exception cref="ArgumentNullException">Thrown if audioBytes is null.</exception>
-        /// <exception cref="XybridException">Thrown if envelope creation fails.</exception>
-        public static unsafe Envelope Audio(byte[] audioBytes, uint sampleRate = 16000, uint channels = 1)
+        public static Envelope Audio(byte[] audioBytes, uint sampleRate = 16000, uint channels = 1)
         {
             if (audioBytes == null)
             {
                 throw new ArgumentNullException(nameof(audioBytes));
             }
 
-            fixed (byte* bytesPtr = audioBytes)
+            var metadata = new[]
             {
-                XybridEnvelopeHandle* handle = NativeMethods.xybrid_envelope_audio(
-                    bytesPtr,
-                    (nuint)audioBytes.Length,
-                    sampleRate,
-                    channels
-                );
-
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create audio envelope");
-                }
-
-                return new Envelope(handle, PayloadKind.Audio);
-            }
+                new XybridBolt.XybridMetadataEntry(
+                    "sample_rate", sampleRate.ToString(CultureInfo.InvariantCulture)),
+                new XybridBolt.XybridMetadataEntry(
+                    "channels", channels.ToString(CultureInfo.InvariantCulture)),
+            };
+            return new Envelope(new XybridBolt.XybridEnvelope(
+                new XybridBolt.XybridEnvelopeKind.Audio(audioBytes), metadata));
         }
 
         /// <summary>
@@ -182,11 +125,9 @@ namespace Xybrid
         /// </summary>
         /// <param name="bytes">Encoded PNG, JPEG, or WebP bytes.</param>
         /// <param name="format">Image format: png, jpeg, jpg, or webp.</param>
-        /// <returns>A new Envelope containing the encoded image.</returns>
         /// <exception cref="ArgumentNullException">Thrown if bytes or format is null.</exception>
         /// <exception cref="ArgumentException">Thrown if format is unsupported.</exception>
-        /// <exception cref="XybridException">Thrown if native envelope creation fails.</exception>
-        public static unsafe Envelope Image(byte[] bytes, string format)
+        public static Envelope Image(byte[] bytes, string format)
         {
             if (bytes == null)
             {
@@ -194,24 +135,8 @@ namespace Xybrid
             }
 
             string normalizedFormat = NormalizeImageFormat(format);
-            byte[] formatBytes = NativeHelpers.ToUtf8Bytes(normalizedFormat);
-
-            fixed (byte* bytesPtr = bytes)
-            fixed (byte* formatPtr = formatBytes)
-            {
-                XybridEnvelopeHandle* handle = NativeMethods.xybrid_envelope_image(
-                    bytesPtr,
-                    (nuint)bytes.Length,
-                    formatPtr
-                );
-
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create image envelope");
-                }
-
-                return new Envelope(handle, PayloadKind.Image);
-            }
+            return new Envelope(new XybridBolt.XybridEnvelope(
+                new XybridBolt.XybridEnvelopeKind.Image(bytes, normalizedFormat)));
         }
 
         /// <summary>
@@ -219,58 +144,52 @@ namespace Xybrid
         /// </summary>
         /// <param name="text">The user prompt text.</param>
         /// <param name="images">Image envelopes created by <see cref="Image(byte[], string)"/>.</param>
-        /// <returns>A new Envelope containing the user message.</returns>
         /// <exception cref="ArgumentNullException">Thrown if text is null.</exception>
         /// <exception cref="ArgumentException">Thrown if any attachment is null or not an image envelope.</exception>
-        /// <exception cref="ObjectDisposedException">Thrown if an image attachment has been disposed.</exception>
-        /// <exception cref="XybridException">Thrown if native envelope creation fails.</exception>
-        public static unsafe Envelope UserMessage(string text, IList<Envelope> images = null)
+        public static Envelope UserMessage(string text, IList<Envelope> images = null)
         {
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
-            int imageCount = images?.Count ?? 0;
-            XybridEnvelopeHandle** imageHandles = null;
-            if (imageCount > 0)
+            var parts = new List<XybridBolt.XybridEnvelope>
             {
-                // Note: stackalloc must be assigned directly to a pointer-typed local;
-                // placing it inside a ternary makes the compiler infer Span<T>, which
-                // rejects pointer type arguments (CS0306/CS0029).
-                XybridEnvelopeHandle** buffer = stackalloc XybridEnvelopeHandle*[imageCount];
-                for (int i = 0; i < imageCount; i++)
+                new XybridBolt.XybridEnvelope(new XybridBolt.XybridEnvelopeKind.Text(text)),
+            };
+            if (images != null)
+            {
+                foreach (Envelope image in images)
                 {
-                    Envelope image = images[i];
                     if (image == null)
                     {
                         throw new ArgumentException("Image attachment cannot be null.", nameof(images));
                     }
-                    if (image._kind != PayloadKind.Image)
+                    if (!(image.Bolt.Kind is XybridBolt.XybridEnvelopeKind.Image))
                     {
-                        throw new ArgumentException("Envelope.UserMessage accepts only image envelopes.", nameof(images));
+                        throw new ArgumentException(
+                            "Envelope.UserMessage accepts only image envelopes.", nameof(images));
                     }
-                    buffer[i] = image.Handle;
+                    parts.Add(image.Bolt);
                 }
-                imageHandles = buffer;
             }
 
-            byte[] textBytes = NativeHelpers.ToUtf8Bytes(text);
+            return new Envelope(new XybridBolt.XybridEnvelope(
+                new XybridBolt.XybridEnvelopeKind.MultiPart(parts.ToArray())));
+        }
 
-            fixed (byte* textPtr = textBytes)
+        private static string RoleString(MessageRole role)
+        {
+            switch (role)
             {
-                XybridEnvelopeHandle* handle = NativeMethods.xybrid_envelope_user_message(
-                    textPtr,
-                    imageHandles,
-                    (nuint)imageCount
-                );
-
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to create user message envelope");
-                }
-
-                return new Envelope(handle, PayloadKind.UserMessage);
+                case MessageRole.System:
+                    return "system";
+                case MessageRole.User:
+                    return "user";
+                case MessageRole.Assistant:
+                    return "assistant";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(role));
             }
         }
 
@@ -293,41 +212,17 @@ namespace Xybrid
                 default:
                     throw new ArgumentException(
                         "Unsupported image format. Supported formats: png, jpeg, jpg, webp.",
-                        nameof(format)
-                    );
-            }
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(Envelope));
+                        nameof(format));
             }
         }
 
         /// <summary>
-        /// Releases the native resources used by this envelope.
+        /// No-op: the envelope holds no native resources. Retained so existing
+        /// <c>using</c> call sites keep compiling.
         /// </summary>
-        public unsafe void Dispose()
+        public void Dispose()
         {
-            if (!_disposed)
-            {
-                if (_handle != null)
-                {
-                    NativeMethods.xybrid_envelope_free(_handle);
-                    _handle = null;
-                }
-                _disposed = true;
-            }
-        }
-
-        /// <summary>
-        /// Finalizer to ensure native resources are released.
-        /// </summary>
-        ~Envelope()
-        {
-            Dispose();
+            IsDisposed = true;
         }
     }
 }

--- a/bindings/unity/Runtime/Api/Envelope.cs
+++ b/bindings/unity/Runtime/Api/Envelope.cs
@@ -174,8 +174,12 @@ namespace Xybrid
                 }
             }
 
+            var metadata = new[]
+            {
+                new XybridBolt.XybridMetadataEntry("xybrid.role", RoleString(MessageRole.User)),
+            };
             return new Envelope(new XybridBolt.XybridEnvelope(
-                new XybridBolt.XybridEnvelopeKind.MultiPart(parts.ToArray())));
+                new XybridBolt.XybridEnvelopeKind.MultiPart(parts.ToArray()), metadata));
         }
 
         private static string RoleString(MessageRole role)

--- a/bindings/unity/Runtime/Api/GenerationConfig.cs
+++ b/bindings/unity/Runtime/Api/GenerationConfig.cs
@@ -154,8 +154,10 @@ namespace Xybrid
         /// <see cref="Model"/>. Grammar-constrained decoding is not exposed by
         /// the Unity API, so it is always null.
         /// </summary>
-        internal XybridBolt.XybridGenerationConfig ToBolt() =>
-            new XybridBolt.XybridGenerationConfig(
+        internal XybridBolt.XybridGenerationConfig ToBolt()
+        {
+            ThrowIfDisposed();
+            return new XybridBolt.XybridGenerationConfig(
                 _maxTokens,
                 _temperature,
                 _topP,
@@ -164,6 +166,7 @@ namespace Xybrid
                 _repetitionPenalty,
                 _stopSequences.ToArray(),
                 null);
+        }
 
         private void ThrowIfDisposed()
         {

--- a/bindings/unity/Runtime/Api/GenerationConfig.cs
+++ b/bindings/unity/Runtime/Api/GenerationConfig.cs
@@ -2,8 +2,7 @@
 // LLM generation parameters for controlling inference behavior.
 
 using System;
-using System.Runtime.InteropServices;
-using Xybrid.Native;
+using System.Collections.Generic;
 
 namespace Xybrid
 {
@@ -14,16 +13,14 @@ namespace Xybrid
     /// Use this class to configure generation parameters like temperature, top-p,
     /// and max tokens. All fields start unset — the model's defaults are used for
     /// any field you don't explicitly set.
-    ///
-    /// This class must be disposed when no longer needed to release native resources.
     /// </remarks>
     /// <example>
     /// <code>
     /// // Use a preset
-    /// using var config = GenerationConfig.Greedy();
+    /// var config = GenerationConfig.Greedy();
     ///
     /// // Or customize
-    /// using var config = new GenerationConfig();
+    /// var config = new GenerationConfig();
     /// config.SetMaxTokens(512);
     /// config.SetTemperature(0.3f);
     ///
@@ -32,72 +29,59 @@ namespace Xybrid
     /// </example>
     public sealed class GenerationConfig : IDisposable
     {
-        private unsafe XybridGenerationConfigHandle* _handle;
-        private bool _disposed;
+        private uint? _maxTokens;
+        private float? _temperature;
+        private float? _topP;
+        private float? _minP;
+        private uint? _topK;
+        private float? _repetitionPenalty;
+        private readonly List<string> _stopSequences = new List<string>();
 
         /// <summary>
-        /// Gets whether this config has been disposed.
+        /// Gets whether this config has been disposed. Retained for source
+        /// compatibility; the config now holds no native resources.
         /// </summary>
-        public bool IsDisposed => _disposed;
-
-        /// <summary>
-        /// Gets the native handle for passing to native methods.
-        /// </summary>
-        internal unsafe XybridGenerationConfigHandle* Handle
-        {
-            get
-            {
-                ThrowIfDisposed();
-                return _handle;
-            }
-        }
+        public bool IsDisposed { get; private set; }
 
         /// <summary>
         /// Creates a new generation config with all fields unset (model defaults).
         /// </summary>
-        /// <remarks>
-        /// Call setter methods to override specific fields.
-        /// </remarks>
-        public unsafe GenerationConfig()
+        public GenerationConfig()
         {
-            _handle = NativeMethods.xybrid_generation_config_new();
-        }
-
-        private unsafe GenerationConfig(XybridGenerationConfigHandle* handle)
-        {
-            _handle = handle;
         }
 
         /// <summary>
         /// Creates a greedy decoding config (deterministic, temperature=0).
         /// </summary>
-        /// <remarks>
-        /// Produces the same output every time for the same input.
-        /// </remarks>
-        public static unsafe GenerationConfig Greedy()
+        public static GenerationConfig Greedy()
         {
-            return new GenerationConfig(NativeMethods.xybrid_generation_config_greedy());
+            var config = new GenerationConfig();
+            config._temperature = 0.0f;
+            config._topP = 1.0f;
+            config._topK = 0;
+            return config;
         }
 
         /// <summary>
         /// Creates a creative generation config (higher temperature).
         /// </summary>
-        /// <remarks>
-        /// Produces more varied and creative output.
-        /// </remarks>
-        public static unsafe GenerationConfig Creative()
+        public static GenerationConfig Creative()
         {
-            return new GenerationConfig(NativeMethods.xybrid_generation_config_creative());
+            var config = new GenerationConfig();
+            config._temperature = 0.9f;
+            config._topP = 0.95f;
+            config._topK = 50;
+            return config;
         }
 
         /// <summary>
         /// Set the maximum number of tokens to generate.
         /// </summary>
         /// <param name="maxTokens">Maximum tokens (e.g., 512, 2048).</param>
-        public unsafe void SetMaxTokens(int maxTokens)
+        public void SetMaxTokens(int maxTokens)
         {
             ThrowIfDisposed();
-            NativeMethods.xybrid_generation_config_set_max_tokens(_handle, (uint)maxTokens);
+            _maxTokens = (uint)maxTokens;
         }
 
         /// <summary>
@@ -107,99 +91,95 @@ namespace Xybrid
         /// Temperature value. 0.0 = deterministic, higher = more random.
         /// Typical range: 0.0 to 2.0.
         /// </param>
-        public unsafe void SetTemperature(float temperature)
+        public void SetTemperature(float temperature)
         {
             ThrowIfDisposed();
-            NativeMethods.xybrid_generation_config_set_temperature(_handle, temperature);
+            _temperature = temperature;
         }
 
         /// <summary>
         /// Set the top-p (nucleus) sampling threshold.
         /// </summary>
         /// <param name="topP">Top-p value (0.0 to 1.0). Default: 0.9.</param>
-        public unsafe void SetTopP(float topP)
+        public void SetTopP(float topP)
         {
             ThrowIfDisposed();
-            NativeMethods.xybrid_generation_config_set_top_p(_handle, topP);
+            _topP = topP;
         }
 
         /// <summary>
         /// Set the min-p sampling threshold.
         /// </summary>
         /// <param name="minP">Min-p value (0.0 to 1.0). Default: 0.05.</param>
-        public unsafe void SetMinP(float minP)
+        public void SetMinP(float minP)
         {
             ThrowIfDisposed();
-            NativeMethods.xybrid_generation_config_set_min_p(_handle, minP);
+            _minP = minP;
         }
 
         /// <summary>
         /// Set top-k sampling (0 = disabled).
         /// </summary>
         /// <param name="topK">Top-k value. 0 disables top-k filtering. Default: 40.</param>
-        public unsafe void SetTopK(int topK)
+        public void SetTopK(int topK)
         {
             ThrowIfDisposed();
-            NativeMethods.xybrid_generation_config_set_top_k(_handle, (uint)topK);
+            _topK = (uint)topK;
         }
 
         /// <summary>
         /// Set the repetition penalty.
         /// </summary>
         /// <param name="penalty">Penalty value. 1.0 = disabled. Default: 1.1.</param>
-        public unsafe void SetRepetitionPenalty(float penalty)
+        public void SetRepetitionPenalty(float penalty)
         {
             ThrowIfDisposed();
-            NativeMethods.xybrid_generation_config_set_repetition_penalty(_handle, penalty);
+            _repetitionPenalty = penalty;
         }
 
         /// <summary>
         /// Add a stop sequence. Can be called multiple times.
         /// </summary>
         /// <param name="stop">The stop sequence string.</param>
-        public unsafe void AddStop(string stop)
+        public void AddStop(string stop)
         {
             ThrowIfDisposed();
             if (stop == null)
                 throw new ArgumentNullException(nameof(stop));
-
-            var bytes = System.Text.Encoding.UTF8.GetBytes(stop + "\0");
-            fixed (byte* ptr = bytes)
-            {
-                NativeMethods.xybrid_generation_config_add_stop(_handle, ptr);
-            }
+            _stopSequences.Add(stop);
         }
+
+        /// <summary>
+        /// Snapshot the current values as the bolt wire type consumed by
+        /// <see cref="Model"/>. Grammar-constrained decoding is not exposed by
+        /// the Unity API, so it is always null.
+        /// </summary>
+        internal XybridBolt.XybridGenerationConfig ToBolt() =>
+            new XybridBolt.XybridGenerationConfig(
+                _maxTokens,
+                _temperature,
+                _topP,
+                _minP,
+                _topK,
+                _repetitionPenalty,
+                _stopSequences.ToArray(),
+                null);
 
         private void ThrowIfDisposed()
         {
-            if (_disposed)
+            if (IsDisposed)
             {
                 throw new ObjectDisposedException(nameof(GenerationConfig));
             }
         }
 
         /// <summary>
-        /// Releases the native resources used by this config.
+        /// No-op: the config holds no native resources. Retained so existing
+        /// <c>using</c> call sites keep compiling.
         /// </summary>
-        public unsafe void Dispose()
+        public void Dispose()
         {
-            if (!_disposed)
-            {
-                if (_handle != null)
-                {
-                    NativeMethods.xybrid_generation_config_free(_handle);
-                    _handle = null;
-                }
-                _disposed = true;
-            }
-        }
-
-        /// <summary>
-        /// Finalizer to ensure native resources are released.
-        /// </summary>
-        ~GenerationConfig()
-        {
-            Dispose();
+            IsDisposed = true;
         }
     }
 }

--- a/bindings/unity/Runtime/Api/InferenceResult.cs
+++ b/bindings/unity/Runtime/Api/InferenceResult.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using Xybrid.Native;
 
 namespace Xybrid
 {
@@ -31,12 +29,8 @@ namespace Xybrid
     /// <remarks>
     /// LLM-specific fields (<see cref="TtftMs"/>, <see cref="TokensPerSecond"/>,
     /// <see cref="PrefillTps"/>, <see cref="DecodeTps"/>, <see cref="TokensOut"/>)
-    /// are <c>null</c> for ASR/TTS/embedding runs. For pipeline runs they are
-    /// parsed from the final stage's envelope only, so they are also <c>null</c>
-    /// when the final stage isn't the LLM (e.g. an ASR → LLM → TTS pipeline).
-    ///
-    /// <see cref="StageLatenciesMs"/> is empty for <c>model.Run()</c> and
-    /// populated for pipeline runs.
+    /// are <c>null</c> for ASR/TTS/embedding runs. <see cref="StageLatenciesMs"/>
+    /// is empty for <c>model.Run()</c> and populated for pipeline runs.
     /// </remarks>
     public sealed class InferenceMetrics
     {
@@ -70,163 +64,141 @@ namespace Xybrid
     /// <summary>
     /// Represents the result of model inference.
     /// </summary>
-    /// <remarks>
-    /// This class wraps a native result handle and must be disposed when no longer needed.
-    /// Access the result properties before disposing.
-    /// </remarks>
     public sealed class InferenceResult : IDisposable
     {
-        private unsafe XybridResultHandle* _handle;
-        private bool _disposed;
+        /// <summary>Gets whether this result has been disposed.</summary>
+        public bool IsDisposed { get; private set; }
 
-        // Cached values (extracted before potential disposal)
-        private readonly bool _success;
-        private readonly string _error;
-        private readonly string _text;
-        private readonly uint _latencyMs;
-        private readonly OutputType _outputType;
-        private readonly byte[] _audioBytes;
-        private readonly float[] _embedding;
-        private readonly InferenceMetrics _metrics;
+        /// <summary>Gets whether the inference was successful.</summary>
+        public bool Success { get; }
 
-        /// <summary>
-        /// Gets whether this result has been disposed.
-        /// </summary>
-        public bool IsDisposed => _disposed;
+        /// <summary>Gets the error message if inference failed, or null if successful.</summary>
+        public string Error { get; }
 
-        /// <summary>
-        /// Gets whether the inference was successful.
-        /// </summary>
-        public bool Success => _success;
+        /// <summary>Gets the text output (for ASR or LLM models), or null if not applicable.</summary>
+        public string Text { get; }
 
-        /// <summary>
-        /// Gets the error message if inference failed, or null if successful.
-        /// </summary>
-        public string Error => _error;
+        /// <summary>Gets the inference latency in milliseconds.</summary>
+        public uint LatencyMs { get; }
 
-        /// <summary>
-        /// Gets the text output (for ASR or LLM models), or null if not applicable.
-        /// </summary>
-        public string Text => _text;
-
-        /// <summary>
-        /// Gets the inference latency in milliseconds.
-        /// </summary>
-        public uint LatencyMs => _latencyMs;
-
-        /// <summary>
-        /// Gets the type of output produced by inference.
-        /// </summary>
-        public OutputType OutputType => _outputType;
+        /// <summary>Gets the type of output produced by inference.</summary>
+        public OutputType OutputType { get; }
 
         /// <summary>
         /// Gets the raw audio bytes (for TTS models), or null if not applicable.
         /// Audio format is raw PCM 16-bit signed little-endian, typically 24kHz mono.
         /// </summary>
-        public byte[] AudioBytes => _audioBytes;
+        public byte[] AudioBytes { get; }
 
-        /// <summary>
-        /// Gets the embedding vector (for embedding models), or null if not applicable.
-        /// </summary>
-        public float[] Embedding => _embedding;
+        /// <summary>Gets the embedding vector (for embedding models), or null if not applicable.</summary>
+        public float[] Embedding { get; }
 
-        /// <summary>
-        /// Gets whether this result contains audio data.
-        /// </summary>
-        public bool HasAudio => _audioBytes != null && _audioBytes.Length > 0;
+        /// <summary>Gets whether this result contains audio data.</summary>
+        public bool HasAudio => AudioBytes != null && AudioBytes.Length > 0;
 
-        /// <summary>
-        /// Gets whether this result contains an embedding.
-        /// </summary>
-        public bool HasEmbedding => _embedding != null && _embedding.Length > 0;
+        /// <summary>Gets whether this result contains an embedding.</summary>
+        public bool HasEmbedding => Embedding != null && Embedding.Length > 0;
 
-        /// <summary>
-        /// Gets the typed inference metrics (TTFT, tok/s, per-stage latencies).
-        /// </summary>
-        /// <remarks>
-        /// LLM-specific fields are <c>null</c> for ASR/TTS/embedding runs;
-        /// <see cref="InferenceMetrics.StageLatenciesMs"/> is empty for
-        /// single-model runs.
-        /// </remarks>
-        public InferenceMetrics Metrics => _metrics;
+        /// <summary>Gets the typed inference metrics (TTFT, tok/s, per-stage latencies).</summary>
+        public InferenceMetrics Metrics { get; }
 
-        internal unsafe InferenceResult(XybridResultHandle* handle)
+        private InferenceResult(
+            bool success,
+            string error,
+            string text,
+            uint latencyMs,
+            OutputType outputType,
+            byte[] audioBytes,
+            float[] embedding,
+            InferenceMetrics metrics)
         {
-            _handle = handle;
+            Success = success;
+            Error = error;
+            Text = text;
+            LatencyMs = latencyMs;
+            OutputType = outputType;
+            AudioBytes = audioBytes;
+            Embedding = embedding;
+            Metrics = metrics;
+        }
 
-            // Cache all values immediately so they survive disposal
-            _success = NativeMethods.xybrid_result_success(handle) != 0;
-            _latencyMs = NativeMethods.xybrid_result_latency_ms(handle);
-
-            if (_success)
+        /// <summary>Decode a successful bolt result into the public shape.</summary>
+        internal static InferenceResult FromBolt(XybridBolt.XybridResult result)
+        {
+            string text = null;
+            byte[] audio = null;
+            float[] embedding = null;
+            switch (result.Envelope.Kind)
             {
-                byte* textPtr = NativeMethods.xybrid_result_text(handle);
-                _text = NativeHelpers.FromUtf8Ptr(textPtr);
-                _error = null;
-            }
-            else
-            {
-                byte* errorPtr = NativeMethods.xybrid_result_error(handle);
-                _error = NativeHelpers.FromUtf8Ptr(errorPtr);
-                _text = null;
-            }
-
-            // Cache output type
-            byte* outputTypePtr = NativeMethods.xybrid_result_output_type(handle);
-            string outputTypeStr = NativeHelpers.FromUtf8Ptr(outputTypePtr);
-            _outputType = ParseOutputType(outputTypeStr);
-
-            // Cache audio bytes
-            nuint audioLen = NativeMethods.xybrid_result_audio_len(handle);
-            if (audioLen > 0)
-            {
-                byte* audioPtr = NativeMethods.xybrid_result_audio_data(handle);
-                if (audioPtr != null)
-                {
-                    _audioBytes = new byte[(int)audioLen];
-                    Marshal.Copy((IntPtr)audioPtr, _audioBytes, 0, (int)audioLen);
-                }
+                case XybridBolt.XybridEnvelopeKind.Text t:
+                    text = t.Value;
+                    break;
+                case XybridBolt.XybridEnvelopeKind.Audio a:
+                    audio = a.Bytes;
+                    break;
+                case XybridBolt.XybridEnvelopeKind.Embedding e:
+                    embedding = e.Values;
+                    break;
             }
 
-            // Cache embedding
-            nuint embLen = NativeMethods.xybrid_result_embedding_len(handle);
-            if (embLen > 0)
+            return new InferenceResult(
+                success: true,
+                error: null,
+                text: text,
+                latencyMs: result.LatencyMs,
+                outputType: MapOutputType(result.OutputType),
+                audioBytes: audio,
+                embedding: embedding,
+                metrics: MapMetrics(result.Metrics));
+        }
+
+        /// <summary>
+        /// A failed result. Bolt inference throws on error; <see cref="Model"/>
+        /// catches inference failures and synthesizes this so callers that
+        /// inspect <see cref="Success"/> keep their contract.
+        /// </summary>
+        internal static InferenceResult Failed(string error) =>
+            new InferenceResult(
+                success: false,
+                error: error,
+                text: null,
+                latencyMs: 0,
+                outputType: OutputType.Unknown,
+                audioBytes: null,
+                embedding: null,
+                metrics: new InferenceMetrics(0, null, null, null, null, null, Array.Empty<StageLatency>()));
+
+        private static OutputType MapOutputType(XybridBolt.XybridOutputType outputType)
+        {
+            switch (outputType)
             {
-                float* embPtr = NativeMethods.xybrid_result_embedding_data(handle);
-                if (embPtr != null)
-                {
-                    _embedding = new float[(int)embLen];
-                    Marshal.Copy((IntPtr)embPtr, _embedding, 0, (int)embLen);
-                }
+                case XybridBolt.XybridOutputType.Text:
+                    return OutputType.Text;
+                case XybridBolt.XybridOutputType.Audio:
+                    return OutputType.Audio;
+                case XybridBolt.XybridOutputType.Embedding:
+                    return OutputType.Embedding;
+                default:
+                    return OutputType.Unknown;
+            }
+        }
+
+        private static InferenceMetrics MapMetrics(XybridBolt.XybridInferenceMetrics metrics)
+        {
+            var stages = new List<StageLatency>(metrics.StageLatenciesMs.Length);
+            foreach (XybridBolt.XybridStageLatency stage in metrics.StageLatenciesMs)
+            {
+                stages.Add(new StageLatency(stage.StageId, stage.LatencyMs));
             }
 
-            // Cache typed metrics. Sentinel conventions match the C ABI:
-            // -1 for absent optional integers, NaN for absent optional floats.
-            long ttft = NativeMethods.xybrid_result_ttft_ms(handle);
-            float tps = NativeMethods.xybrid_result_tokens_per_second(handle);
-            float prefill = NativeMethods.xybrid_result_prefill_tps(handle);
-            float decode = NativeMethods.xybrid_result_decode_tps(handle);
-            long tokensOut = NativeMethods.xybrid_result_tokens_out(handle);
-
-            nuint stageCount = NativeMethods.xybrid_result_stage_count(handle);
-            var stages = new List<StageLatency>((int)stageCount);
-            for (nuint i = 0; i < stageCount; i++)
-            {
-                byte* stageIdPtr = NativeMethods.xybrid_result_stage_id(handle, i);
-                string stageId = NativeHelpers.FromUtf8Ptr(stageIdPtr) ?? string.Empty;
-                uint stageLatencyMs = NativeMethods.xybrid_result_stage_latency_ms(handle, i);
-                stages.Add(new StageLatency(stageId, stageLatencyMs));
-            }
-
-            _metrics = new InferenceMetrics(
-                totalMs: _latencyMs,
-                ttftMs: ttft < 0 ? (uint?)null : (uint)ttft,
-                tokensPerSecond: float.IsNaN(tps) ? (float?)null : tps,
-                prefillTps: float.IsNaN(prefill) ? (float?)null : prefill,
-                decodeTps: float.IsNaN(decode) ? (float?)null : decode,
-                tokensOut: tokensOut < 0 ? (uint?)null : (uint)tokensOut,
-                stageLatenciesMs: stages
-            );
+            return new InferenceMetrics(
+                totalMs: metrics.TotalMs,
+                ttftMs: metrics.TtftMs,
+                tokensPerSecond: metrics.TokensPerSecond,
+                prefillTps: metrics.PrefillTps,
+                decodeTps: metrics.DecodeTps,
+                tokensOut: metrics.TokensOut,
+                stageLatenciesMs: stages);
         }
 
         /// <summary>
@@ -235,61 +207,28 @@ namespace Xybrid
         /// <exception cref="InferenceException">Thrown if Success is false.</exception>
         public void ThrowIfFailed()
         {
-            if (!_success)
+            if (!Success)
             {
-                throw new InferenceException(_error ?? "Unknown inference error");
+                throw new InferenceException(Error ?? "Unknown inference error");
             }
         }
 
         /// <summary>
-        /// Releases the native resources used by this result.
+        /// No-op: the result holds no native resources. Retained so existing
+        /// <c>using</c> call sites keep compiling.
         /// </summary>
-        public unsafe void Dispose()
+        public void Dispose()
         {
-            if (!_disposed)
-            {
-                if (_handle != null)
-                {
-                    NativeMethods.xybrid_result_free(_handle);
-                    _handle = null;
-                }
-                _disposed = true;
-            }
+            IsDisposed = true;
         }
 
-        /// <summary>
-        /// Finalizer to ensure native resources are released.
-        /// </summary>
-        ~InferenceResult()
-        {
-            Dispose();
-        }
-
-        /// <summary>
-        /// Returns a string representation of the result.
-        /// </summary>
+        /// <summary>Returns a string representation of the result.</summary>
         public override string ToString()
         {
-            if (_success)
-            {
-                return $"InferenceResult(Success, OutputType={_outputType}, LatencyMs={_latencyMs}, " +
-                       $"Text=\"{_text ?? "null"}\", AudioBytes={_audioBytes?.Length ?? 0})";
-            }
-            else
-            {
-                return $"InferenceResult(Failed, Error=\"{_error}\")";
-            }
-        }
-
-        private static OutputType ParseOutputType(string type)
-        {
-            switch (type)
-            {
-                case "text": return OutputType.Text;
-                case "audio": return OutputType.Audio;
-                case "embedding": return OutputType.Embedding;
-                default: return OutputType.Unknown;
-            }
+            return Success
+                ? $"InferenceResult(Success, OutputType={OutputType}, LatencyMs={LatencyMs}, " +
+                  $"Text=\"{Text ?? "null"}\", AudioBytes={AudioBytes?.Length ?? 0})"
+                : $"InferenceResult(Failed, Error=\"{Error}\")";
         }
     }
 }

--- a/bindings/unity/Runtime/Api/Model.cs
+++ b/bindings/unity/Runtime/Api/Model.cs
@@ -39,7 +39,7 @@ namespace Xybrid
         /// <returns>The inference result (<see cref="InferenceResult.Success"/> is false if inference failed).</returns>
         /// <exception cref="ArgumentNullException">Thrown if envelope is null.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if inference fails to start (e.g. the model is not loaded).</exception>
+        /// <exception cref="XybridException">Thrown only on a catastrophic backend failure; ordinary inference failures (including a not-loaded model) set <see cref="InferenceResult.Success"/> to false instead.</exception>
         public InferenceResult Run(Envelope envelope, GenerationConfig config = null)
         {
             ThrowIfDisposed();
@@ -108,7 +108,7 @@ namespace Xybrid
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if envelope or context is null.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
+        /// <exception cref="XybridException">Thrown only on a catastrophic backend failure; ordinary inference failures set <see cref="InferenceResult.Success"/> to false instead.</exception>
         public InferenceResult Run(Envelope envelope, ConversationContext context, GenerationConfig config = null)
         {
             ThrowIfDisposed();
@@ -250,7 +250,7 @@ namespace Xybrid
         /// <returns>The final inference result after all tokens are emitted.</returns>
         /// <exception cref="ArgumentNullException">Thrown if envelope or onToken is null.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
+        /// <exception cref="XybridException">Thrown only on a catastrophic backend failure; ordinary inference failures set <see cref="InferenceResult.Success"/> to false instead.</exception>
         public InferenceResult RunStreaming(Envelope envelope, Action<StreamToken> onToken, GenerationConfig config = null)
         {
             ThrowIfDisposed();
@@ -276,7 +276,7 @@ namespace Xybrid
         /// <returns>The final inference result after all tokens are emitted.</returns>
         /// <exception cref="ArgumentNullException">Thrown if any argument is null.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
+        /// <exception cref="XybridException">Thrown only on a catastrophic backend failure; ordinary inference failures set <see cref="InferenceResult.Success"/> to false instead.</exception>
         public InferenceResult RunStreaming(Envelope envelope, ConversationContext context, Action<StreamToken> onToken, GenerationConfig config = null)
         {
             ThrowIfDisposed();
@@ -323,10 +323,12 @@ namespace Xybrid
         // Internal helpers
         // ================================================================
 
-        // Bolt inference throws XybridErrorException; the public contract returns
-        // a failed InferenceResult for execution failures and only throws for
-        // start/setup failures. Map InferenceError -> failed result; translate
-        // everything else into the public exception taxonomy and rethrow.
+        // Preserve the pre-bolt contract: xybrid_model_run returned a failed
+        // result handle (Success == false) for EVERY SDK run error and only
+        // threw for null/invalid handles. Bolt surfaces those SDK errors as
+        // XybridErrorException, so map all of them to a failed InferenceResult
+        // (callers inspecting Success keep working). A BoltException is the
+        // catastrophic analog of the old null-handle path and is rethrown.
         private static InferenceResult Execute(Func<XybridBolt.XybridResult> run)
         {
             try
@@ -334,13 +336,11 @@ namespace Xybrid
                 return InferenceResult.FromBolt(run());
             }
             catch (XybridBolt.XybridErrorException ex)
-                when (ex.Error is XybridBolt.XybridError.InferenceError inferenceError)
             {
-                return InferenceResult.Failed(inferenceError.Message);
-            }
-            catch (XybridBolt.XybridErrorException ex)
-            {
-                throw BoltErrors.Translate(ex);
+                string message = ex.Error is XybridBolt.XybridError.InferenceError inferenceError
+                    ? inferenceError.Message
+                    : ex.Message;
+                return InferenceResult.Failed(message);
             }
             catch (XybridBolt.BoltException ex)
             {

--- a/bindings/unity/Runtime/Api/Model.cs
+++ b/bindings/unity/Runtime/Api/Model.cs
@@ -2,8 +2,6 @@
 // Wrapper for a loaded model ready for inference.
 
 using System;
-using System.Runtime.InteropServices;
-using Xybrid.Native;
 
 namespace Xybrid
 {
@@ -16,35 +14,21 @@ namespace Xybrid
     /// </remarks>
     public sealed class Model : IDisposable
     {
-        private unsafe XybridModelHandle* _handle;
-        private bool _disposed;
+        private readonly XybridBolt.XybridModel _bolt;
         private readonly string _modelId;
+        private bool _disposed;
+        private VoiceInfo[] _cachedVoices;
 
-        /// <summary>
-        /// Gets whether this model has been disposed.
-        /// </summary>
+        /// <summary>Gets whether this model has been disposed.</summary>
         public bool IsDisposed => _disposed;
 
-        /// <summary>
-        /// Gets the model ID.
-        /// </summary>
+        /// <summary>Gets the model ID.</summary>
         public string ModelId => _modelId;
 
-        internal unsafe Model(XybridModelHandle* handle)
+        internal Model(XybridBolt.XybridModel bolt)
         {
-            _handle = handle;
-
-            // Cache model ID
-            byte* idPtr = NativeMethods.xybrid_model_id(handle);
-            if (idPtr != null)
-            {
-                _modelId = NativeHelpers.FromUtf8Ptr(idPtr);
-                NativeMethods.xybrid_free_string(idPtr);
-            }
-            else
-            {
-                _modelId = "unknown";
-            }
+            _bolt = bolt;
+            _modelId = bolt.ModelId();
         }
 
         /// <summary>
@@ -52,37 +36,19 @@ namespace Xybrid
         /// </summary>
         /// <param name="envelope">The input data for inference.</param>
         /// <param name="config">Optional generation config for LLM parameters. Pass null for model defaults.</param>
-        /// <returns>The inference result.</returns>
+        /// <returns>The inference result (<see cref="InferenceResult.Success"/> is false if inference failed).</returns>
         /// <exception cref="ArgumentNullException">Thrown if envelope is null.</exception>
-        /// <exception cref="ObjectDisposedException">Thrown if this model or the envelope is disposed.</exception>
-        /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
-        /// <remarks>
-        /// The envelope is not consumed - it can be reused for multiple inferences.
-        /// Remember to dispose the returned <see cref="InferenceResult"/> when done.
-        /// </remarks>
-        public unsafe InferenceResult Run(Envelope envelope, GenerationConfig config = null)
+        /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
+        /// <exception cref="XybridException">Thrown if inference fails to start (e.g. the model is not loaded).</exception>
+        public InferenceResult Run(Envelope envelope, GenerationConfig config = null)
         {
             ThrowIfDisposed();
-
             if (envelope == null)
             {
                 throw new ArgumentNullException(nameof(envelope));
             }
 
-            if (envelope.IsDisposed)
-            {
-                throw new ObjectDisposedException(nameof(envelope));
-            }
-
-            var configHandle = config != null ? config.Handle : null;
-            XybridResultHandle* resultHandle = NativeMethods.xybrid_model_run(
-                _handle, envelope.Handle, configHandle);
-            if (resultHandle == null)
-            {
-                NativeHelpers.ThrowLastError("Failed to run inference");
-            }
-
-            return new InferenceResult(resultHandle);
+            return Execute(() => _bolt.Run(envelope.Bolt, ToOptions(config)));
         }
 
         /// <summary>
@@ -91,18 +57,12 @@ namespace Xybrid
         /// <param name="text">The input text for TTS or LLM inference.</param>
         /// <returns>The text output from the model.</returns>
         /// <exception cref="InferenceException">Thrown if inference fails.</exception>
-        /// <remarks>
-        /// This is a convenience method that creates an envelope, runs inference,
-        /// and extracts the text result. For more control, use <see cref="Run"/>.
-        /// </remarks>
         public string RunText(string text)
         {
-            using (var envelope = Envelope.Text(text))
-            using (var result = Run(envelope))
-            {
-                result.ThrowIfFailed();
-                return result.Text;
-            }
+            var envelope = Envelope.Text(text);
+            var result = Run(envelope);
+            result.ThrowIfFailed();
+            return result.Text;
         }
 
         /// <summary>
@@ -115,12 +75,10 @@ namespace Xybrid
         /// <exception cref="InferenceException">Thrown if inference fails.</exception>
         public string RunAudio(byte[] audioBytes, uint sampleRate = 16000, uint channels = 1)
         {
-            using (var envelope = Envelope.Audio(audioBytes, sampleRate, channels))
-            using (var result = Run(envelope))
-            {
-                result.ThrowIfFailed();
-                return result.Text;
-            }
+            var envelope = Envelope.Audio(audioBytes, sampleRate, channels);
+            var result = Run(envelope);
+            result.ThrowIfFailed();
+            return result.Text;
         }
 
         /// <summary>
@@ -130,24 +88,10 @@ namespace Xybrid
         /// <returns>Raw PCM audio bytes (16-bit signed little-endian, typically 24kHz mono).</returns>
         /// <exception cref="InferenceException">Thrown if inference fails.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the result does not contain audio.</exception>
-        /// <remarks>
-        /// This is a convenience method for TTS models. For more control, use <see cref="Run"/>.
-        /// The returned bytes can be loaded into a Unity AudioClip via AudioClip.Create() + SetData().
-        /// </remarks>
         public byte[] RunTts(string text)
         {
-            using (var envelope = Envelope.Text(text))
-            using (var result = Run(envelope))
-            {
-                result.ThrowIfFailed();
-                if (!result.HasAudio)
-                {
-                    throw new InvalidOperationException(
-                        "Model did not produce audio output. " +
-                        $"Output type was: {result.OutputType}");
-                }
-                return result.AudioBytes;
-            }
+            var envelope = Envelope.Text(text);
+            return TtsAudio(Run(envelope));
         }
 
         /// <summary>
@@ -160,44 +104,24 @@ namespace Xybrid
         /// <remarks>
         /// The context provides conversation history which is formatted into the prompt
         /// using the model's chat template. The context is NOT automatically updated
-        /// with the result - call context.Push() to add the response.
+        /// with the result — call context.Push() to add the response.
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if envelope or context is null.</exception>
-        /// <exception cref="ObjectDisposedException">Thrown if this model, envelope, or context is disposed.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
         /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
-        public unsafe InferenceResult Run(Envelope envelope, ConversationContext context, GenerationConfig config = null)
+        public InferenceResult Run(Envelope envelope, ConversationContext context, GenerationConfig config = null)
         {
             ThrowIfDisposed();
-
             if (envelope == null)
             {
                 throw new ArgumentNullException(nameof(envelope));
             }
-
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (envelope.IsDisposed)
-            {
-                throw new ObjectDisposedException(nameof(envelope));
-            }
-
-            if (context.IsDisposed)
-            {
-                throw new ObjectDisposedException(nameof(context));
-            }
-
-            var configHandle = config != null ? config.Handle : null;
-            XybridResultHandle* resultHandle = NativeMethods.xybrid_model_run_with_context(
-                _handle, envelope.Handle, context.Handle, configHandle);
-            if (resultHandle == null)
-            {
-                NativeHelpers.ThrowLastError("Failed to run inference with context");
-            }
-
-            return new InferenceResult(resultHandle);
+            return Execute(() => _bolt.RunWithContext(envelope.Bolt, context.Bolt, ToOptions(config)));
         }
 
         /// <summary>
@@ -206,72 +130,48 @@ namespace Xybrid
         /// <param name="text">The input text for LLM inference.</param>
         /// <param name="context">The conversation context with history.</param>
         /// <returns>The text output from the model.</returns>
-        /// <remarks>
-        /// This is a convenience method. The input message is NOT automatically pushed
-        /// to the context - you must call context.Push() for both input and output.
-        /// </remarks>
         /// <exception cref="InferenceException">Thrown if inference fails.</exception>
         public string RunText(string text, ConversationContext context)
         {
-            using (var envelope = Envelope.Text(text))
-            using (var result = Run(envelope, context))
-            {
-                result.ThrowIfFailed();
-                return result.Text;
-            }
+            var envelope = Envelope.Text(text);
+            var result = Run(envelope, context);
+            result.ThrowIfFailed();
+            return result.Text;
         }
 
         // ================================================================
         // Voice Discovery
         // ================================================================
 
-        private VoiceInfo[] _cachedVoices;
-
-        /// <summary>
-        /// Gets whether this model has voice support (TTS models with voice catalog).
-        /// </summary>
-        public unsafe bool HasVoices
+        /// <summary>Gets whether this model has voice support (TTS models with voice catalog).</summary>
+        public bool HasVoices
         {
             get
             {
                 ThrowIfDisposed();
-                return NativeMethods.xybrid_model_has_voices(_handle) != 0;
+                return _bolt.HasVoices();
             }
         }
 
-        /// <summary>
-        /// Gets the number of voices available for this model.
-        /// </summary>
-        public unsafe int VoiceCount
+        /// <summary>Gets the number of voices available for this model.</summary>
+        public int VoiceCount => Voices.Length;
+
+        /// <summary>Gets the default voice ID for this model, or null if not a TTS model.</summary>
+        public string DefaultVoiceId
         {
             get
             {
                 ThrowIfDisposed();
-                return (int)NativeMethods.xybrid_model_voice_count(_handle);
+                XybridBolt.XybridVoiceInfo? voice = _bolt.DefaultVoice();
+                return voice is { } value ? value.Id : null;
             }
         }
 
         /// <summary>
-        /// Gets the default voice ID for this model, or null if not a TTS model.
+        /// Gets all available voices for this model. Returns an empty array if the
+        /// model has no voice support. The result is cached after the first call.
         /// </summary>
-        public unsafe string DefaultVoiceId
-        {
-            get
-            {
-                ThrowIfDisposed();
-                byte* ptr = NativeMethods.xybrid_model_default_voice_id(_handle);
-                return NativeHelpers.FromUtf8Ptr(ptr);
-            }
-        }
-
-        /// <summary>
-        /// Gets all available voices for this model.
-        /// Returns an empty array if the model has no voice support.
-        /// </summary>
-        /// <remarks>
-        /// The result is cached after the first call.
-        /// </remarks>
-        public unsafe VoiceInfo[] Voices
+        public VoiceInfo[] Voices
         {
             get
             {
@@ -281,37 +181,11 @@ namespace Xybrid
                     return _cachedVoices;
                 }
 
-                int count = VoiceCount;
-                if (count == 0)
+                XybridBolt.XybridVoiceInfo[] boltVoices = _bolt.Voices();
+                var voices = new VoiceInfo[boltVoices.Length];
+                for (int i = 0; i < boltVoices.Length; i++)
                 {
-                    _cachedVoices = Array.Empty<VoiceInfo>();
-                    return _cachedVoices;
-                }
-
-                var voices = new VoiceInfo[count];
-                for (int i = 0; i < count; i++)
-                {
-                    byte* idPtr = NativeMethods.xybrid_model_voice_id(_handle, (uint)i);
-                    byte* namePtr = NativeMethods.xybrid_model_voice_name(_handle, (uint)i);
-                    string id = NativeHelpers.FromUtf8Ptr(idPtr);
-                    string name = NativeHelpers.FromUtf8Ptr(namePtr);
-
-                    // Parse full metadata from JSON for gender/language/style
-                    string gender = null;
-                    string language = null;
-                    string style = null;
-                    byte* jsonPtr = NativeMethods.xybrid_model_voice_json(_handle, (uint)i);
-                    if (jsonPtr != null)
-                    {
-                        string json = NativeHelpers.FromUtf8Ptr(jsonPtr);
-                        NativeMethods.xybrid_free_string(jsonPtr);
-                        // Simple JSON parsing for optional fields
-                        gender = ExtractJsonString(json, "gender");
-                        language = ExtractJsonString(json, "language");
-                        style = ExtractJsonString(json, "style");
-                    }
-
-                    voices[i] = new VoiceInfo(id, name, gender, language, style);
+                    voices[i] = MapVoice(boltVoices[i]);
                 }
 
                 _cachedVoices = voices;
@@ -323,18 +197,11 @@ namespace Xybrid
         /// Gets a specific voice by ID, or null if not found.
         /// </summary>
         /// <param name="voiceId">The voice identifier (e.g., "af_bella").</param>
-        /// <returns>The voice info, or null if the voice is not found.</returns>
         public VoiceInfo GetVoice(string voiceId)
         {
             ThrowIfDisposed();
-            foreach (var voice in Voices)
-            {
-                if (voice.Id == voiceId)
-                {
-                    return voice;
-                }
-            }
-            return null;
+            XybridBolt.XybridVoiceInfo? voice = _bolt.Voice(voiceId);
+            return voice is { } value ? MapVoice(value) : null;
         }
 
         /// <summary>
@@ -348,51 +215,8 @@ namespace Xybrid
         /// <exception cref="InvalidOperationException">Thrown if the result does not contain audio.</exception>
         public byte[] RunTts(string text, string voiceId, double speed = 1.0)
         {
-            using (var envelope = Envelope.Text(text, voiceId, speed))
-            using (var result = Run(envelope))
-            {
-                result.ThrowIfFailed();
-                if (!result.HasAudio)
-                {
-                    throw new InvalidOperationException(
-                        "Model did not produce audio output. " +
-                        $"Output type was: {result.OutputType}");
-                }
-                return result.AudioBytes;
-            }
-        }
-
-        /// <summary>
-        /// Extracts a string value from a simple JSON object.
-        /// </summary>
-        private static string ExtractJsonString(string json, string key)
-        {
-            // Look for "key":"value" or "key": "value"
-            string pattern = $"\"{key}\"";
-            int keyIndex = json.IndexOf(pattern, StringComparison.Ordinal);
-            if (keyIndex < 0) return null;
-
-            int colonIndex = json.IndexOf(':', keyIndex + pattern.Length);
-            if (colonIndex < 0) return null;
-
-            // Skip whitespace after colon
-            int valueStart = colonIndex + 1;
-            while (valueStart < json.Length && json[valueStart] == ' ')
-                valueStart++;
-
-            if (valueStart >= json.Length) return null;
-
-            // Check for null
-            if (json.Length >= valueStart + 4 && json.Substring(valueStart, 4) == "null")
-                return null;
-
-            // Must be a quoted string
-            if (json[valueStart] != '"') return null;
-
-            int valueEnd = json.IndexOf('"', valueStart + 1);
-            if (valueEnd < 0) return null;
-
-            return json.Substring(valueStart + 1, valueEnd - valueStart - 1);
+            var envelope = Envelope.Text(text, voiceId, speed);
+            return TtsAudio(Run(envelope));
         }
 
         // ================================================================
@@ -403,69 +227,43 @@ namespace Xybrid
         /// Gets whether this model supports true token-by-token streaming.
         /// </summary>
         /// <remarks>
-        /// Returns true for LLM models (GGUF format with LLM features enabled).
-        /// Non-LLM models can still use <see cref="RunStreaming"/> but will receive
-        /// a single callback with the complete result instead of token-by-token output.
+        /// Returns true for LLM models. Non-LLM models can still use
+        /// <see cref="RunStreaming(Envelope, Action{StreamToken}, GenerationConfig)"/>
+        /// but will receive a single callback with the complete result.
         /// </remarks>
-        public unsafe bool SupportsTokenStreaming
+        public bool SupportsTokenStreaming
         {
             get
             {
                 ThrowIfDisposed();
-                return NativeMethods.xybrid_model_supports_token_streaming(_handle) != 0;
+                return _bolt.SupportsTokenStreaming();
             }
         }
 
         /// <summary>
         /// Runs streaming inference, invoking the callback for each generated token.
+        /// Blocks until inference is complete.
         /// </summary>
         /// <param name="envelope">The input data for inference.</param>
-        /// <param name="onToken">Callback invoked for each token. Called on the calling thread.</param>
-        /// <param name="config">Optional generation config for LLM parameters. Pass null for model defaults.</param>
+        /// <param name="onToken">Callback invoked for each token, on the calling thread.</param>
+        /// <param name="config">Optional generation config. Pass null for model defaults.</param>
         /// <returns>The final inference result after all tokens are emitted.</returns>
-        /// <remarks>
-        /// This method blocks until inference is complete. For LLM models, the callback
-        /// is invoked for each generated token. For non-LLM models, a single callback
-        /// is invoked with the complete result.
-        /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if envelope or onToken is null.</exception>
-        /// <exception cref="ObjectDisposedException">Thrown if this model or the envelope is disposed.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
         /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
-        public unsafe InferenceResult RunStreaming(Envelope envelope, Action<StreamToken> onToken, GenerationConfig config = null)
+        public InferenceResult RunStreaming(Envelope envelope, Action<StreamToken> onToken, GenerationConfig config = null)
         {
             ThrowIfDisposed();
-
             if (envelope == null)
+            {
                 throw new ArgumentNullException(nameof(envelope));
+            }
             if (onToken == null)
+            {
                 throw new ArgumentNullException(nameof(onToken));
-            if (envelope.IsDisposed)
-                throw new ObjectDisposedException(nameof(envelope));
-
-            var configHandle = config != null ? config.Handle : null;
-
-            // Pin the managed callback so it survives the native call
-            var gcHandle = GCHandle.Alloc(onToken);
-            try
-            {
-                XybridResultHandle* resultHandle = NativeMethods.xybrid_model_run_streaming(
-                    _handle,
-                    envelope.Handle,
-                    configHandle,
-                    StreamCallbackTrampoline,
-                    (void*)GCHandle.ToIntPtr(gcHandle));
-
-                if (resultHandle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to run streaming inference");
-                }
-
-                return new InferenceResult(resultHandle);
             }
-            finally
-            {
-                gcHandle.Free();
-            }
+
+            return Execute(() => _bolt.RunStreaming(envelope.Bolt, Forward(onToken), ToOptions(config)));
         }
 
         /// <summary>
@@ -474,147 +272,132 @@ namespace Xybrid
         /// <param name="envelope">The input data for inference.</param>
         /// <param name="context">The conversation context with history.</param>
         /// <param name="onToken">Callback invoked for each token.</param>
-        /// <param name="config">Optional generation config for LLM parameters. Pass null for model defaults.</param>
+        /// <param name="config">Optional generation config. Pass null for model defaults.</param>
         /// <returns>The final inference result after all tokens are emitted.</returns>
         /// <exception cref="ArgumentNullException">Thrown if any argument is null.</exception>
-        /// <exception cref="ObjectDisposedException">Thrown if this model, envelope, or context is disposed.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown if this model is disposed.</exception>
         /// <exception cref="XybridException">Thrown if inference fails to start.</exception>
-        public unsafe InferenceResult RunStreaming(Envelope envelope, ConversationContext context, Action<StreamToken> onToken, GenerationConfig config = null)
+        public InferenceResult RunStreaming(Envelope envelope, ConversationContext context, Action<StreamToken> onToken, GenerationConfig config = null)
         {
             ThrowIfDisposed();
-
             if (envelope == null)
+            {
                 throw new ArgumentNullException(nameof(envelope));
+            }
             if (context == null)
+            {
                 throw new ArgumentNullException(nameof(context));
+            }
             if (onToken == null)
+            {
                 throw new ArgumentNullException(nameof(onToken));
-            if (envelope.IsDisposed)
-                throw new ObjectDisposedException(nameof(envelope));
-            if (context.IsDisposed)
-                throw new ObjectDisposedException(nameof(context));
-
-            var configHandle = config != null ? config.Handle : null;
-            var gcHandle = GCHandle.Alloc(onToken);
-            try
-            {
-                XybridResultHandle* resultHandle = NativeMethods.xybrid_model_run_streaming_with_context(
-                    _handle,
-                    envelope.Handle,
-                    context.Handle,
-                    configHandle,
-                    StreamCallbackTrampolineWithContext,
-                    (void*)GCHandle.ToIntPtr(gcHandle));
-
-                if (resultHandle == null)
-                {
-                    NativeHelpers.ThrowLastError("Failed to run streaming inference with context");
-                }
-
-                return new InferenceResult(resultHandle);
             }
-            finally
-            {
-                gcHandle.Free();
-            }
+
+            return Execute(() => _bolt.RunStreamingWithContext(
+                envelope.Bolt, Forward(onToken), context.Bolt, ToOptions(config)));
         }
 
         /// <summary>
         /// Convenience method: stream text inference with a callback.
         /// </summary>
-        /// <param name="text">The input text.</param>
-        /// <param name="onToken">Callback invoked for each token.</param>
-        /// <returns>The full text result after streaming completes.</returns>
         public string RunStreamingText(string text, Action<StreamToken> onToken)
         {
-            using (var envelope = Envelope.Text(text))
-            using (var result = RunStreaming(envelope, onToken))
-            {
-                result.ThrowIfFailed();
-                return result.Text;
-            }
+            var envelope = Envelope.Text(text);
+            var result = RunStreaming(envelope, onToken);
+            result.ThrowIfFailed();
+            return result.Text;
         }
 
         /// <summary>
         /// Convenience method: stream text inference with conversation context.
         /// </summary>
-        /// <param name="text">The input text.</param>
-        /// <param name="context">The conversation context.</param>
-        /// <param name="onToken">Callback invoked for each token.</param>
-        /// <returns>The full text result after streaming completes.</returns>
         public string RunStreamingText(string text, ConversationContext context, Action<StreamToken> onToken)
         {
-            using (var envelope = Envelope.Text(text))
-            using (var result = RunStreaming(envelope, context, onToken))
-            {
-                result.ThrowIfFailed();
-                return result.Text;
-            }
+            var envelope = Envelope.Text(text);
+            var result = RunStreaming(envelope, context, onToken);
+            result.ThrowIfFailed();
+            return result.Text;
         }
 
         // ================================================================
-        // Static callback trampolines for P/Invoke
+        // Internal helpers
         // ================================================================
 
-        /// <summary>
-        /// Static trampoline that bridges the unmanaged callback to the managed Action.
-        /// Must be static for IL2CPP compatibility.
-        /// </summary>
-#if ENABLE_IL2CPP
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.xybrid_model_run_streaming_callback_delegate))]
-#endif
-        private static unsafe void StreamCallbackTrampoline(
-            byte* token, long tokenId, uint index,
-            byte* cumulativeText, byte* finishReason, void* userData)
+        // Bolt inference throws XybridErrorException; the public contract returns
+        // a failed InferenceResult for execution failures and only throws for
+        // start/setup failures. Map InferenceError -> failed result; translate
+        // everything else into the public exception taxonomy and rethrow.
+        private static InferenceResult Execute(Func<XybridBolt.XybridResult> run)
         {
             try
             {
-                var gcHandle = GCHandle.FromIntPtr((IntPtr)userData);
-                var callback = (Action<StreamToken>)gcHandle.Target;
-
-                var streamToken = new StreamToken(
-                    token: NativeHelpers.FromUtf8Ptr(token),
-                    tokenId: tokenId >= 0 ? tokenId : (long?)null,
-                    index: index,
-                    cumulativeText: NativeHelpers.FromUtf8Ptr(cumulativeText),
-                    finishReason: NativeHelpers.FromUtf8Ptr(finishReason)
-                );
-
-                callback(streamToken);
+                return InferenceResult.FromBolt(run());
             }
-            catch (Exception)
+            catch (XybridBolt.XybridErrorException ex)
+                when (ex.Error is XybridBolt.XybridError.InferenceError inferenceError)
             {
-                // Swallow exceptions to prevent unwinding through native frames.
-                // Errors are reported via the returned InferenceResult.
+                return InferenceResult.Failed(inferenceError.Message);
+            }
+            catch (XybridBolt.XybridErrorException ex)
+            {
+                throw BoltErrors.Translate(ex);
+            }
+            catch (XybridBolt.BoltException ex)
+            {
+                throw BoltErrors.Translate(ex);
             }
         }
 
-#if ENABLE_IL2CPP
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.xybrid_model_run_streaming_with_context_callback_delegate))]
-#endif
-        private static unsafe void StreamCallbackTrampolineWithContext(
-            byte* token, long tokenId, uint index,
-            byte* cumulativeText, byte* finishReason, void* userData)
+        // Wrap the user callback so a throw doesn't abort streaming — the
+        // pre-bolt native trampoline swallowed callback exceptions; preserved.
+        private static Action<XybridBolt.XybridStreamToken> Forward(Action<StreamToken> onToken) =>
+            bolt =>
+            {
+                try
+                {
+                    onToken(MapToken(bolt));
+                }
+                catch
+                {
+                    // Intentionally swallowed (see above).
+                }
+            };
+
+        private static StreamToken MapToken(XybridBolt.XybridStreamToken token) =>
+            new StreamToken(
+                token.Token,
+                token.TokenId,
+                (uint)token.Index,
+                token.CumulativeText,
+                token.FinishReason);
+
+        private static VoiceInfo MapVoice(XybridBolt.XybridVoiceInfo voice) =>
+            new VoiceInfo(voice.Id, voice.Name, voice.Gender, voice.Language, voice.Style);
+
+        private static XybridBolt.XybridRunOptions? ToOptions(GenerationConfig config)
         {
-            try
+            if (config == null)
             {
-                var gcHandle = GCHandle.FromIntPtr((IntPtr)userData);
-                var callback = (Action<StreamToken>)gcHandle.Target;
-
-                var streamToken = new StreamToken(
-                    token: NativeHelpers.FromUtf8Ptr(token),
-                    tokenId: tokenId >= 0 ? tokenId : (long?)null,
-                    index: index,
-                    cumulativeText: NativeHelpers.FromUtf8Ptr(cumulativeText),
-                    finishReason: NativeHelpers.FromUtf8Ptr(finishReason)
-                );
-
-                callback(streamToken);
+                return null;
             }
-            catch (Exception)
+            return new XybridBolt.XybridRunOptions(
+                config.ToBolt(),
+                Array.Empty<XybridBolt.XybridAbortSignal>(),
+                false,
+                0u,
+                null);
+        }
+
+        private static byte[] TtsAudio(InferenceResult result)
+        {
+            result.ThrowIfFailed();
+            if (!result.HasAudio)
             {
-                // Swallow exceptions to prevent unwinding through native frames.
+                throw new InvalidOperationException(
+                    "Model did not produce audio output. " +
+                    $"Output type was: {result.OutputType}");
             }
+            return result.AudioBytes;
         }
 
         private void ThrowIfDisposed()
@@ -625,33 +408,17 @@ namespace Xybrid
             }
         }
 
-        /// <summary>
-        /// Releases the native resources used by this model.
-        /// </summary>
-        public unsafe void Dispose()
+        /// <summary>Releases the native resources used by this model.</summary>
+        public void Dispose()
         {
             if (!_disposed)
             {
-                if (_handle != null)
-                {
-                    NativeMethods.xybrid_model_free(_handle);
-                    _handle = null;
-                }
+                _bolt.Dispose();
                 _disposed = true;
             }
         }
 
-        /// <summary>
-        /// Finalizer to ensure native resources are released.
-        /// </summary>
-        ~Model()
-        {
-            Dispose();
-        }
-
-        /// <summary>
-        /// Returns a string representation of the model.
-        /// </summary>
+        /// <summary>Returns a string representation of the model.</summary>
         public override string ToString()
         {
             return $"Model({ModelId})";

--- a/bindings/unity/Runtime/Api/Model.cs
+++ b/bindings/unity/Runtime/Api/Model.cs
@@ -337,10 +337,9 @@ namespace Xybrid
             }
             catch (XybridBolt.XybridErrorException ex)
             {
-                string message = ex.Error is XybridBolt.XybridError.InferenceError inferenceError
-                    ? inferenceError.Message
-                    : ex.Message;
-                return InferenceResult.Failed(message);
+                // Match the pre-bolt failure text: "Inference failed: <message>"
+                // with the error's inner message (not its record ToString()).
+                return InferenceResult.Failed("Inference failed: " + BoltErrors.Describe(ex.Error));
             }
             catch (XybridBolt.BoltException ex)
             {

--- a/bindings/unity/Runtime/Api/ModelLoader.cs
+++ b/bindings/unity/Runtime/Api/ModelLoader.cs
@@ -2,7 +2,6 @@
 // Factory for loading models from registry or local bundles.
 
 using System;
-using Xybrid.Native;
 
 namespace Xybrid
 {
@@ -11,80 +10,58 @@ namespace Xybrid
     /// </summary>
     /// <remarks>
     /// Use the static factory methods to create a loader, then call <see cref="Load"/>
-    /// to get a ready-to-use <see cref="Model"/>.
+    /// to get a ready-to-use <see cref="Model"/>. The loader records the source and
+    /// defers the actual load (and any download) to <see cref="Load"/>.
     /// </remarks>
     public sealed class ModelLoader : IDisposable
     {
-        private unsafe XybridModelLoaderHandle* _handle;
+        private enum Source
+        {
+            Registry,
+            Bundle,
+            Directory,
+            HuggingFace,
+        }
+
+        private readonly Source _source;
+        private readonly string _value;
         private bool _disposed;
 
-        /// <summary>
-        /// Gets whether this loader has been disposed.
-        /// </summary>
+        /// <summary>Gets whether this loader has been disposed.</summary>
         public bool IsDisposed => _disposed;
 
-        private unsafe ModelLoader(XybridModelLoaderHandle* handle)
+        private ModelLoader(Source source, string value)
         {
-            _handle = handle;
+            _source = source;
+            _value = value;
         }
 
         /// <summary>
         /// Creates a model loader that will fetch from the xybrid registry.
         /// </summary>
         /// <param name="modelId">The model ID (e.g., "kokoro-82m", "whisper-tiny").</param>
-        /// <returns>A new ModelLoader configured to load from the registry.</returns>
         /// <exception cref="ArgumentNullException">Thrown if modelId is null.</exception>
-        /// <exception cref="XybridException">Thrown if loader creation fails.</exception>
-        /// <remarks>
-        /// The model will be downloaded from the registry if not already cached locally.
-        /// </remarks>
-        public static unsafe ModelLoader FromRegistry(string modelId)
+        public static ModelLoader FromRegistry(string modelId)
         {
             if (modelId == null)
             {
                 throw new ArgumentNullException(nameof(modelId));
             }
-
-            byte[] modelIdBytes = NativeHelpers.ToUtf8Bytes(modelId);
-
-            fixed (byte* modelIdPtr = modelIdBytes)
-            {
-                XybridModelLoaderHandle* handle = NativeMethods.xybrid_model_loader_from_registry(modelIdPtr);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError($"Failed to create loader for model '{modelId}'");
-                }
-
-                return new ModelLoader(handle);
-            }
+            return new ModelLoader(Source.Registry, modelId);
         }
 
         /// <summary>
         /// Creates a model loader that will load from a local bundle path.
         /// </summary>
         /// <param name="path">The file path to the model bundle (.xyb file or directory).</param>
-        /// <returns>A new ModelLoader configured to load from the local bundle.</returns>
         /// <exception cref="ArgumentNullException">Thrown if path is null.</exception>
-        /// <exception cref="XybridException">Thrown if loader creation fails.</exception>
-        public static unsafe ModelLoader FromBundle(string path)
+        public static ModelLoader FromBundle(string path)
         {
             if (path == null)
             {
                 throw new ArgumentNullException(nameof(path));
             }
-
-            byte[] pathBytes = NativeHelpers.ToUtf8Bytes(path);
-
-            fixed (byte* pathPtr = pathBytes)
-            {
-                XybridModelLoaderHandle* handle = NativeMethods.xybrid_model_loader_from_bundle(pathPtr);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError($"Failed to create loader for bundle at '{path}'");
-                }
-
-                return new ModelLoader(handle);
-            }
+            return new ModelLoader(Source.Bundle, path);
         }
 
         /// <summary>
@@ -92,92 +69,47 @@ namespace Xybrid
         /// and a <c>model_metadata.json</c>.
         /// </summary>
         /// <param name="directoryPath">Path to the directory containing model files and model_metadata.json.</param>
-        /// <returns>A new ModelLoader configured to load from the directory.</returns>
         /// <exception cref="ArgumentNullException">Thrown if directoryPath is null.</exception>
-        /// <exception cref="XybridException">Thrown if the directory does not exist, or the metadata is missing or invalid.</exception>
-        public static unsafe ModelLoader FromDirectory(string directoryPath)
+        public static ModelLoader FromDirectory(string directoryPath)
         {
             if (directoryPath == null)
             {
                 throw new ArgumentNullException(nameof(directoryPath));
             }
-
-            byte[] pathBytes = NativeHelpers.ToUtf8Bytes(directoryPath);
-
-            fixed (byte* pathPtr = pathBytes)
-            {
-                XybridModelLoaderHandle* handle = NativeMethods.xybrid_model_loader_from_directory(pathPtr);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError($"Failed to create loader from directory '{directoryPath}'");
-                }
-
-                return new ModelLoader(handle);
-            }
+            return new ModelLoader(Source.Directory, directoryPath);
         }
 
         /// <summary>
         /// Creates a model loader from a raw GGUF model file.
-        /// Auto-generates <c>model_metadata.json</c> by reading the GGUF binary header
-        /// (architecture, context length), writes it to the file's parent directory
-        /// if not already present, then loads from that directory.
         /// </summary>
         /// <param name="filePath">Path to the GGUF model file.</param>
-        /// <returns>A new ModelLoader configured to load the GGUF model.</returns>
         /// <exception cref="ArgumentNullException">Thrown if filePath is null.</exception>
-        /// <exception cref="XybridException">Thrown if the file does not exist or metadata generation fails.</exception>
-        public static unsafe ModelLoader FromModelFile(string filePath)
+        /// <exception cref="NotSupportedException">
+        /// GGUF auto-metadata loading is not yet available on the bolt backend.
+        /// </exception>
+        public static ModelLoader FromModelFile(string filePath)
         {
             if (filePath == null)
             {
                 throw new ArgumentNullException(nameof(filePath));
             }
-
-            byte[] pathBytes = NativeHelpers.ToUtf8Bytes(filePath);
-
-            fixed (byte* pathPtr = pathBytes)
-            {
-                XybridModelLoaderHandle* handle = NativeMethods.xybrid_model_loader_from_model_file(pathPtr);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError($"Failed to create loader for GGUF file '{filePath}'");
-                }
-
-                return new ModelLoader(handle);
-            }
+            throw new NotSupportedException(
+                "ModelLoader.FromModelFile (GGUF auto-metadata) is not yet available on the " +
+                "bolt backend. Use FromDirectory with a directory containing model_metadata.json.");
         }
 
         /// <summary>
         /// Creates a model loader from a HuggingFace Hub repository.
-        /// Downloads model files from HuggingFace and caches them locally.
-        /// Model metadata is auto-generated if not present in the repository.
         /// </summary>
         /// <param name="repo">The HuggingFace repository ID (e.g., "xybrid-ai/kokoro-82m").</param>
-        /// <returns>A new ModelLoader configured to download from HuggingFace.</returns>
         /// <exception cref="ArgumentNullException">Thrown if repo is null.</exception>
-        /// <exception cref="XybridException">Thrown if loader creation fails.</exception>
-        /// <remarks>
-        /// Requires the <c>huggingface</c> feature flag to be enabled at compile time.
-        /// </remarks>
-        public static unsafe ModelLoader FromHuggingFace(string repo)
+        public static ModelLoader FromHuggingFace(string repo)
         {
             if (repo == null)
             {
                 throw new ArgumentNullException(nameof(repo));
             }
-
-            byte[] repoBytes = NativeHelpers.ToUtf8Bytes(repo);
-
-            fixed (byte* repoPtr = repoBytes)
-            {
-                XybridModelLoaderHandle* handle = NativeMethods.xybrid_model_loader_from_huggingface(repoPtr);
-                if (handle == null)
-                {
-                    NativeHelpers.ThrowLastError($"Failed to create loader for HuggingFace repo '{repo}'");
-                }
-
-                return new ModelLoader(handle);
-            }
+            return new ModelLoader(Source.HuggingFace, repo);
         }
 
         /// <summary>
@@ -187,21 +119,38 @@ namespace Xybrid
         /// <exception cref="ObjectDisposedException">Thrown if this loader is disposed.</exception>
         /// <exception cref="XybridException">Thrown if model loading fails.</exception>
         /// <exception cref="ModelNotFoundException">Thrown if the model cannot be found.</exception>
-        /// <remarks>
-        /// For registry models, this may download the model if not already cached.
-        /// The loader can be disposed after loading - the model is independent.
-        /// </remarks>
-        public unsafe Model Load()
+        public Model Load()
         {
             ThrowIfDisposed();
 
-            XybridModelHandle* modelHandle = NativeMethods.xybrid_model_loader_load(_handle);
-            if (modelHandle == null)
+            try
             {
-                NativeHelpers.ThrowLastError("Failed to load model");
-            }
+                XybridBolt.XybridModel bolt;
+                switch (_source)
+                {
+                    case Source.Registry:
+                        bolt = XybridBolt.XybridModel.FromRegistry(_value);
+                        break;
+                    case Source.Bundle:
+                        bolt = XybridBolt.XybridModel.FromBundle(_value);
+                        break;
+                    case Source.Directory:
+                        bolt = XybridBolt.XybridModel.FromDirectory(_value);
+                        break;
+                    case Source.HuggingFace:
+                        bolt = XybridBolt.XybridModel.FromHuggingface(_value);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unknown model source.");
+                }
 
-            return new Model(modelHandle);
+                return new Model(bolt);
+            }
+            catch (Exception ex) when (
+                ex is XybridBolt.XybridErrorException || ex is XybridBolt.BoltException)
+            {
+                throw BoltErrors.Translate(ex);
+            }
         }
 
         private void ThrowIfDisposed()
@@ -213,27 +162,12 @@ namespace Xybrid
         }
 
         /// <summary>
-        /// Releases the native resources used by this loader.
+        /// No-op: the loader holds no native resources until <see cref="Load"/>.
+        /// Retained so existing <c>using</c> call sites keep compiling.
         /// </summary>
-        public unsafe void Dispose()
+        public void Dispose()
         {
-            if (!_disposed)
-            {
-                if (_handle != null)
-                {
-                    NativeMethods.xybrid_model_loader_free(_handle);
-                    _handle = null;
-                }
-                _disposed = true;
-            }
-        }
-
-        /// <summary>
-        /// Finalizer to ensure native resources are released.
-        /// </summary>
-        ~ModelLoader()
-        {
-            Dispose();
+            _disposed = true;
         }
     }
 }

--- a/bindings/unity/Runtime/Api/XybridClient.cs
+++ b/bindings/unity/Runtime/Api/XybridClient.cs
@@ -74,17 +74,11 @@ namespace Xybrid
                     return;
                 }
 
-                byte[] bindingBytes = NativeHelpers.ToUtf8Bytes("unity");
-                fixed (byte* bindingPtr = bindingBytes)
-                {
-                    NativeMethods.xybrid_set_binding(bindingPtr);
-                }
-
-                int result = NativeMethods.xybrid_init();
-                if (result != 0)
-                {
-                    NativeHelpers.ThrowLastError("Failed to initialize Xybrid SDK");
-                }
+                // Runtime init moves to bolt: set the binding tag (used for
+                // telemetry attribution). The pre-bolt xybrid_init() was a no-op.
+                // Advanced telemetry (below) still runs through the pre-bolt C
+                // ABI until the telemetry surface is ported (GAP-3).
+                XybridBolt.XybridBolt.SetBinding("unity");
 
                 _initialized = true;
 

--- a/bindings/unity/Runtime/Api/XybridClient.cs
+++ b/bindings/unity/Runtime/Api/XybridClient.cs
@@ -76,9 +76,17 @@ namespace Xybrid
 
                 // Runtime init moves to bolt: set the binding tag (used for
                 // telemetry attribution). The pre-bolt xybrid_init() was a no-op.
-                // Advanced telemetry (below) still runs through the pre-bolt C
-                // ABI until the telemetry surface is ported (GAP-3).
                 XybridBolt.XybridBolt.SetBinding("unity");
+
+                // Dual-library window: advanced telemetry still runs through the
+                // pre-bolt C ABI (GAP-3), which keeps its OWN binding state. Set
+                // it too so xybrid_ffi telemetry reports "unity", not the default.
+                // Drop this once telemetry is ported off xybrid_ffi in A2.2.
+                byte[] bindingBytes = NativeHelpers.ToUtf8Bytes("unity");
+                fixed (byte* bindingPtr = bindingBytes)
+                {
+                    NativeMethods.xybrid_set_binding(bindingPtr);
+                }
 
                 _initialized = true;
 

--- a/bindings/unity/Runtime/Api/XybridClient.cs
+++ b/bindings/unity/Runtime/Api/XybridClient.cs
@@ -168,12 +168,21 @@ namespace Xybrid
         }
 
         /// <summary>
-        /// Convenience method to load a model from a raw GGUF file.
-        /// Auto-generates metadata from the GGUF binary header.
+        /// Convenience method to load a model from a raw GGUF file
+        /// (auto-generates metadata from the GGUF header).
         /// </summary>
+        /// <remarks>
+        /// Not yet available on the bolt backend — this throws
+        /// <see cref="NotSupportedException"/>. Use <see cref="LoadModel"/>,
+        /// <see cref="LoadModelFromBundle"/>, or <see cref="ModelLoader.FromDirectory"/>
+        /// with a directory containing model_metadata.json instead.
+        /// </remarks>
         /// <param name="filePath">Path to the GGUF model file.</param>
         /// <returns>A loaded model ready for inference.</returns>
-        /// <exception cref="XybridException">Thrown if loading fails.</exception>
+        /// <exception cref="NotSupportedException">
+        /// GGUF auto-metadata loading is not yet available on the bolt backend.
+        /// </exception>
+        /// <exception cref="XybridException">Thrown if loading otherwise fails.</exception>
         public static Model LoadModelFromFile(string filePath)
         {
             using (var loader = ModelLoader.FromModelFile(filePath))

--- a/bindings/unity/Runtime/Api/XybridException.cs
+++ b/bindings/unity/Runtime/Api/XybridException.cs
@@ -97,7 +97,43 @@ namespace Xybrid
                 case XybridBolt.XybridError.InferenceError inferenceError:
                     return new InferenceException(inferenceError.Message);
                 default:
-                    return new XybridException(error.ToString());
+                    return new XybridException(Describe(error));
+            }
+        }
+
+        /// <summary>
+        /// A human-readable message for a typed error — the inner text, not the
+        /// record's default <c>ToString()</c>. Used for a failed
+        /// <see cref="InferenceResult.Error"/> so it reads like the pre-bolt
+        /// "Inference failed: ..." messages rather than "NotLoaded { }".
+        /// </summary>
+        internal static string Describe(XybridBolt.XybridError error)
+        {
+            switch (error)
+            {
+                case XybridBolt.XybridError.ModelNotFound e: return $"model not found: {e.Id}";
+                case XybridBolt.XybridError.DirectoryNotFound e: return $"directory not found: {e.Path}";
+                case XybridBolt.XybridError.MetadataNotFound e: return $"metadata not found: {e.Path}";
+                case XybridBolt.XybridError.MetadataInvalid e: return e.Message;
+                case XybridBolt.XybridError.LoadError e: return e.Message;
+                case XybridBolt.XybridError.InferenceError e: return e.Message;
+                case XybridBolt.XybridError.AbortedForCloudFallback e: return e.Reason;
+                case XybridBolt.XybridError.StreamingNotSupported _: return "streaming not supported";
+                case XybridBolt.XybridError.NotLoaded _: return "model not loaded";
+                case XybridBolt.XybridError.ConfigError e: return e.Message;
+                case XybridBolt.XybridError.NetworkError e: return e.Message;
+                case XybridBolt.XybridError.Offline e: return e.Message;
+                case XybridBolt.XybridError.IoError e: return e.Message;
+                case XybridBolt.XybridError.CacheError e: return e.Message;
+                case XybridBolt.XybridError.PipelineError e: return e.Message;
+                case XybridBolt.XybridError.CircuitOpen e: return e.Message;
+                case XybridBolt.XybridError.RateLimited e: return $"rate limited (retry after {e.RetryAfterSecs}s)";
+                case XybridBolt.XybridError.Timeout e: return $"timed out after {e.TimeoutMs}ms";
+                case XybridBolt.XybridError.MissingArtifact e: return e.Message;
+                case XybridBolt.XybridError.UnsupportedModelCapability e: return e.Message;
+                case XybridBolt.XybridError.UnsupportedBackendCapability e: return e.Message;
+                case XybridBolt.XybridError.InvalidImage e: return e.Message;
+                default: return error.ToString();
             }
         }
     }

--- a/bindings/unity/Runtime/Api/XybridException.cs
+++ b/bindings/unity/Runtime/Api/XybridException.cs
@@ -63,4 +63,42 @@ namespace Xybrid
         {
         }
     }
+
+    /// <summary>
+    /// Translates bolt-layer exceptions into the public Xybrid exception
+    /// taxonomy. Bolt surfaces failures as <see cref="XybridBolt.XybridErrorException"/>
+    /// (typed variants) or <see cref="XybridBolt.BoltException"/> (loader /
+    /// last-error), which the public API maps to
+    /// <see cref="ModelNotFoundException"/> / <see cref="InferenceException"/> /
+    /// <see cref="XybridException"/>.
+    /// </summary>
+    internal static class BoltErrors
+    {
+        /// <summary>Translate a bolt exception to the public taxonomy.</summary>
+        public static XybridException Translate(Exception ex)
+        {
+            switch (ex)
+            {
+                case XybridBolt.XybridErrorException typed:
+                    return TranslateError(typed.Error);
+                case XybridBolt.BoltException bolt:
+                    return new XybridException(bolt.Message, bolt);
+                default:
+                    return new XybridException(ex.Message, ex);
+            }
+        }
+
+        private static XybridException TranslateError(XybridBolt.XybridError error)
+        {
+            switch (error)
+            {
+                case XybridBolt.XybridError.ModelNotFound modelNotFound:
+                    return new ModelNotFoundException(modelNotFound.Id);
+                case XybridBolt.XybridError.InferenceError inferenceError:
+                    return new InferenceException(inferenceError.Message);
+                default:
+                    return new XybridException(error.ToString());
+            }
+        }
+    }
 }

--- a/bindings/unity/Runtime/Bolt/XybridBolt.cs
+++ b/bindings/unity/Runtime/Bolt/XybridBolt.cs
@@ -752,5 +752,12 @@ namespace XybridBolt
         internal static extern void XybridConversationContextClear(IntPtr self);
         [DllImport(LibName, EntryPoint = "boltffi_xybrid_conversation_context_id")]
         internal static extern FfiBuf XybridConversationContextId(IntPtr self);
+        [DllImport(LibName, EntryPoint = "boltffi_xybrid_conversation_context_history_len")]
+        internal static extern uint XybridConversationContextHistoryLen(IntPtr self);
+        [DllImport(LibName, EntryPoint = "boltffi_xybrid_conversation_context_has_system")]
+        [return: MarshalAs(UnmanagedType.I1)]
+        internal static extern bool XybridConversationContextHasSystem(IntPtr self);
+        [DllImport(LibName, EntryPoint = "boltffi_xybrid_conversation_context_set_max_history_len")]
+        internal static extern void XybridConversationContextSetMaxHistoryLen(IntPtr self, uint len);
     }
 }

--- a/bindings/unity/Runtime/Bolt/XybridConversationContext.cs
+++ b/bindings/unity/Runtime/Bolt/XybridConversationContext.cs
@@ -74,6 +74,33 @@ namespace XybridBolt
             }
         }
 
+        /// <summary>
+        /// Number of history turns (excludes the system envelope).
+        /// </summary>
+        public uint HistoryLen()
+        {
+            ThrowIfDisposed();
+            return NativeMethods.XybridConversationContextHistoryLen(_handle);
+        }
+
+        /// <summary>
+        /// Whether a persistent system-prompt envelope is set.
+        /// </summary>
+        public bool HasSystem()
+        {
+            ThrowIfDisposed();
+            return NativeMethods.XybridConversationContextHasSystem(_handle);
+        }
+
+        /// <summary>
+        /// Set the max history length before FIFO pruning.
+        /// </summary>
+        public void SetMaxHistoryLen(uint len)
+        {
+            ThrowIfDisposed();
+            NativeMethods.XybridConversationContextSetMaxHistoryLen(_handle, len);
+        }
+
         internal IntPtr RawHandle => _handle;
 
         private void ThrowIfDisposed()

--- a/crates/xybrid-bolt/src/lib.rs
+++ b/crates/xybrid-bolt/src/lib.rs
@@ -998,6 +998,21 @@ impl XybridConversationContext {
     pub fn id(&self) -> String {
         self.inner.id()
     }
+
+    /// Number of history turns (excludes the system envelope).
+    pub fn history_len(&self) -> u32 {
+        self.inner.history_len()
+    }
+
+    /// Whether a persistent system-prompt envelope is set.
+    pub fn has_system(&self) -> bool {
+        self.inner.has_system()
+    }
+
+    /// Set the max history length before FIFO pruning.
+    pub fn set_max_history_len(&self, len: u32) {
+        self.inner.set_max_history_len(len);
+    }
 }
 
 // ============================================================================

--- a/crates/xybrid-ffi-facade/src/lib.rs
+++ b/crates/xybrid-ffi-facade/src/lib.rs
@@ -590,9 +590,24 @@ impl ConversationContextHandle {
     }
 
     /// Set the max history length before FIFO pruning.
+    ///
+    /// Rebuilds the context and re-pushes history so pruning runs immediately
+    /// (matches the pre-bolt C ABI). `with_max_history_len` alone only changes
+    /// the cap; the SDK prunes on `push`, so a lower cap wouldn't trim existing
+    /// turns until the next push.
     pub fn set_max_history_len(&self, len: u32) {
         let mut guard = self.lock();
-        let new_ctx = std::mem::take(&mut *guard).with_max_history_len(len as usize);
+        let id = guard.id().to_string();
+        let system = guard.system_envelope().cloned();
+        let history: Vec<_> = guard.history().to_vec();
+
+        let mut new_ctx = sdk::ConversationContext::with_id(id).with_max_history_len(len as usize);
+        if let Some(sys) = system {
+            new_ctx = new_ctx.with_system(sys);
+        }
+        for envelope in history {
+            new_ctx.push(envelope);
+        }
         *guard = new_ctx;
     }
 

--- a/crates/xybrid-ffi-facade/src/lib.rs
+++ b/crates/xybrid-ffi-facade/src/lib.rs
@@ -579,6 +579,23 @@ impl ConversationContextHandle {
         self.lock().id().to_string()
     }
 
+    /// Number of history turns (excludes the system envelope).
+    pub fn history_len(&self) -> u32 {
+        self.lock().history().len() as u32
+    }
+
+    /// Whether a persistent system envelope is set.
+    pub fn has_system(&self) -> bool {
+        self.lock().system_envelope().is_some()
+    }
+
+    /// Set the max history length before FIFO pruning.
+    pub fn set_max_history_len(&self, len: u32) {
+        let mut guard = self.lock();
+        let new_ctx = std::mem::take(&mut *guard).with_max_history_len(len as usize);
+        *guard = new_ctx;
+    }
+
     pub fn history(&self) -> Vec<Envelope> {
         self.lock()
             .history()

--- a/tools/unity-bolt-compile-check/UnityBoltCompileCheck.csproj
+++ b/tools/unity-bolt-compile-check/UnityBoltCompileCheck.csproj
@@ -16,7 +16,10 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- Unity has been capped at C# 9 from 2021.2 through Unity 6. -->
     <LangVersion>9</LangVersion>
-    <Nullable>enable</Nullable>
+    <!-- Match Unity's default (nullable disabled). The generated Bolt sources
+         opt in per-file with `#nullable enable`; the hand-written Api layer is
+         nullable-oblivious, exactly as it compiles in the Unity Editor. -->
+    <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -25,6 +28,21 @@
     <Compile Include="../../bindings/unity/Runtime/Bolt/*.cs" />
     <!-- Hand-ported inference paths (run/stream/envelope) that boltffi 0.25.3 drops. -->
     <Compile Include="../../bindings/unity/Runtime/BoltSupplement/*.cs" />
+    <!-- Public managed API re-plumbed onto XybridBolt (A2.1). Listed per-file, not
+         Runtime/Api/*.cs: XybridClient / TelemetryConfig / BundleReader still bind
+         the pre-bolt C ABI (deferred gaps) and would drag Runtime/Native into this
+         project, which does not compile it. -->
+    <Compile Include="../../bindings/unity/Runtime/Api/OutputType.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/MessageRole.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/StreamToken.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/VoiceInfo.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/XybridException.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/GenerationConfig.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/Envelope.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/InferenceResult.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/ConversationContext.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/Model.cs" />
+    <Compile Include="../../bindings/unity/Runtime/Api/ModelLoader.cs" />
     <!-- Unity bundles System.Runtime.CompilerServices.Unsafe; supply it here so
          the standalone compile resolves Unsafe.SizeOf the same way Unity does. -->
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />


### PR DESCRIPTION
**A2.1 — the bulk.** Rewrites the public Unity SDK (`bindings/unity/Runtime/Api`) to call `XybridBolt` instead of the pre-bolt csbindgen C ABI (`Xybrid.Native`), keeping the public `Xybrid.*` API stable. The whole surface — load, run, TTS, voices, **streaming, and multi-turn chat** — now rides bolt. **Zero regression on the core** (−1,099/+648: the native-handle boilerplate melts away).

## Re-plumbed onto `XybridBolt` (compile-verified at netstandard2.1 / C# 9)
| Api | → bolt |
|---|---|
| `Model` | `XybridModel` (Run / RunText / RunTts / voices / streaming + context) |
| `ModelLoader` | `XybridModel.From*` factories (deferred load) |
| `Envelope` | `XybridEnvelope` + metadata (`voice_id`/`speed`/`sample_rate`/`channels`/`xybrid.role`) |
| `GenerationConfig` | managed field bag → `XybridGenerationConfig` |
| `InferenceResult` | decode `XybridResult` (`FromBolt`) + `Failed` factory |
| `ConversationContext` | `XybridConversationContext` |
| `XybridException` | `BoltErrors` translation (typed variants → taxonomy) |
| `XybridClient` | `SetBinding` via bolt; telemetry + `Version` stay on the C ABI |
| `OutputType`/`MessageRole`/`StreamToken`/`VoiceInfo` | unchanged (pure data) |

## The load-bearing detail (R1)
Bolt `Run` **throws**; the public `Model.Run` **returns** a failed `InferenceResult` for inference failures. An `Execute` helper maps `InferenceError` → failed result, other typed errors → translate + rethrow — so callers inspecting `Success` keep their contract, and start/setup failures still throw.

## Also here
- **3 bolt context exports** the aux API needs (`history_len`/`has_system`/`set_max_history_len`) so `ConversationContext.HistoryLength`/`HasSystem`/`SetMaxHistoryLength` don't regress. Simple types → generate natively (no hand-port).
- **Compile gate** extended to the 11 pure-bolt Api files, explicit per-file `Include` (not `Api/*.cs`) — `XybridClient`/`TelemetryConfig`/`BundleReader` still bind the C ABI (deferred gaps) and would drag `Runtime/Native` into the isolated project. Nullable matched to Unity (disabled; Bolt sources self-enable per-file).

## Deferred (throw `NotSupportedException`, no in-repo consumer)
`ModelLoader.FromModelFile` / `XybridClient.LoadModelFromFile` (GGUF auto-metadata, GAP-4). Telemetry-advanced + `BundleReader` stay on the old C ABI (dual-lib window), to be closed in a follow-up gap PR.

## Verified
- `cargo fmt` / `clippy` / `test` (bolt + facade, 27 tests) green.
- Compile gate: **0 warnings**, build succeeded.
- `gen --check` reproducible.
- No breakage in deferred files / Editor / Tests (the one migrated-API test, `Envelope.UserMessage`, matches the new signature + behavior).

End-to-end inference still needs an on-device run (as always for the native path).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large inference-path refactor with deliberate error-semantics bridging; GGUF auto-load is explicitly broken until a follow-up, and telemetry still depends on the legacy C ABI alongside bolt.
> 
> **Overview**
> **Replaces the pre-bolt `Xybrid.Native` P/Invoke path** for load, run, streaming, and chat with **`XybridBolt`**, while keeping the public `Xybrid.*` surface stable.
> 
> Core types now wrap bolt wire values: **`Model`** / **`ModelLoader`** delegate to `XybridModel` factories and run APIs; **`Envelope`** builds `XybridEnvelope` + metadata (TTS voice/speed, ASR rate/channels, `xybrid.role`); **`GenerationConfig`** is a managed bag converted via **`ToBolt()`**; **`InferenceResult`** is decoded from **`XybridResult`** (`FromBolt` / **`Failed`**); **`ConversationContext`** uses **`XybridConversationContext`**. **`BoltErrors`** maps bolt exceptions into **`ModelNotFoundException`** / **`InferenceException`** / **`XybridException`**.
> 
> **`Model.Execute`** preserves the old contract: bolt throws on inference errors, but **`Run`** still returns **`InferenceResult`** with **`Success == false`** for ordinary failures; **`BoltException`** still propagates as catastrophic. IL2CPP streaming trampolines are gone in favor of managed **`Forward`** (callback exceptions still swallowed).
> 
> **`Envelope`**, **`GenerationConfig`**, and **`InferenceResult`** **`Dispose`** are no-ops for source compatibility; native lifetime sits on bolt handles (**`Model`**, **`ConversationContext`**). **`ModelLoader`** defers work until **`Load`**; **`FromModelFile`** / **`LoadModelFromFile`** now throw **`NotSupportedException`** on bolt.
> 
> **`XybridClient.Initialize`** calls **`XybridBolt.SetBinding("unity")`** instead of **`xybrid_init()`**, and still sets binding on the legacy C ABI for telemetry during the dual-library window.
> 
> Rust adds conversation-context **`history_len`**, **`has_system`**, and **`set_max_history_len`** (facade rebuilds context so pruning matches the old ABI). The Unity bolt compile-check project lists the migrated Api files explicitly and aligns nullable settings with the Editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1b84cacffac625a26eb6d2c5ffb6b598578f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->