### PR TITLE
fix(unity): Unsafe.SizeOf → Marshal.SizeOf (caught by a real Unity 6.3 run)

### DIFF
--- a/bindings/unity/Runtime/Bolt/XybridBolt.cs
+++ b/bindings/unity/Runtime/Bolt/XybridBolt.cs
@@ -362,7 +362,7 @@ namespace XybridBolt
             int byteCount = _length - _pos;
             if (byteCount < 0)
                 throw new InvalidOperationException("corrupt wire: read position past end");
-            int elementSize = Unsafe.SizeOf<T>();
+            int elementSize = Marshal.SizeOf<T>();
             if (byteCount % elementSize != 0)
                 throw new InvalidOperationException(
                     "corrupt wire: blittable array byte count is not a multiple of element size");
@@ -444,7 +444,7 @@ namespace XybridBolt
             int count = ReadI32();
             if (count < 0) throw new InvalidOperationException("corrupt wire: negative array length");
             if (count == 0) return Array.Empty<T>();
-            int elementSize = Unsafe.SizeOf<T>();
+            int elementSize = Marshal.SizeOf<T>();
             int byteCount = checked(count * elementSize);
             Require(byteCount, "blittable array payload");
             T[] result = new T[count];
@@ -607,7 +607,7 @@ namespace XybridBolt
         {
             WriteI32(v.Length);
             if (v.Length == 0) return;
-            int byteCount = checked(v.Length * Unsafe.SizeOf<T>());
+            int byteCount = checked(v.Length * Marshal.SizeOf<T>());
             EnsureCapacity(byteCount);
             // Reinterpret the source T[] as bytes and block-copy into the
             // managed buffer. Zero extra allocations, one copy. Little-endian

--- a/tools/scripts/gen_unity_bolt_csharp.py
+++ b/tools/scripts/gen_unity_bolt_csharp.py
@@ -142,6 +142,17 @@ LE_FLOAT_REWRITES = (
     ),
 )
 
+# --- Transform (g): Unsafe.SizeOf<T>() -> Marshal.SizeOf<T>(). boltffi's wire
+# codec sizes blittable arrays with System.Runtime.CompilerServices.Unsafe, whose
+# assembly Unity's scripting profile does not reference -- the Unity 6.3 editor
+# rejects it with `CS0103: The name 'Unsafe' does not exist`. The codecs are
+# `where T : unmanaged`, so Marshal.SizeOf<T>() (core BCL, already used
+# throughout the generated wire layer) returns the identical size. Verified with
+# an in-editor `unity test` compile on 6.3.
+UNSAFE_SIZEOF_TARGET = "Unsafe.SizeOf<T>()"
+UNSAFE_SIZEOF_REPLACEMENT = "Marshal.SizeOf<T>()"
+EXPECTED_UNSAFE_SIZEOF = 3
+
 # --- Transform (d): make XybridModel partial. boltffi 0.25.3's C# generator
 # drops the entire inference path -- no `run`, and no XybridEnvelope /
 # XybridEnvelopeKind / XybridResult (a data-carrying enum used as a function
@@ -242,6 +253,18 @@ def _rewrite_le_floats(content: str) -> tuple[str, int]:
     return content, count
 
 
+def _rewrite_unsafe_sizeof(content: str) -> tuple[str, int]:
+    """Rewrite Unsafe.SizeOf<T>() to Marshal.SizeOf<T>().
+
+    The Unsafe assembly is unreferenceable in Unity's scripting profile; the
+    codecs are `where T : unmanaged`, so the two sizes are identical.
+    """
+    count = content.count(UNSAFE_SIZEOF_TARGET)
+    if count:
+        content = content.replace(UNSAFE_SIZEOF_TARGET, UNSAFE_SIZEOF_REPLACEMENT)
+    return content, count
+
+
 def unity_guid(asset_rel_path: str) -> str:
     """Deterministic 32-hex Unity GUID keyed on the repo-relative asset path."""
     return hashlib.sha256(asset_rel_path.encode()).hexdigest()[:32]
@@ -304,6 +327,7 @@ def generate() -> dict[str, str]:
     tree: dict[str, str] = {}
     record_structs = 0
     le_floats = 0
+    unsafe_sizeof = 0
     native_memory_shimmed = False
     model_made_partial = False
     context_made_partial = False
@@ -314,6 +338,8 @@ def generate() -> dict[str, str]:
         record_structs += n
         content, n = _rewrite_le_floats(content)
         le_floats += n
+        content, n = _rewrite_unsafe_sizeof(content)
+        unsafe_sizeof += n
         if src.name == SHIM_FILE:
             _drift(
                 SHIM_TARGET in content,
@@ -362,6 +388,11 @@ def generate() -> dict[str, str]:
     _drift(
         le_floats == len(LE_FLOAT_REWRITES),
         f"rewrote {le_floats} float LE writers, expected {len(LE_FLOAT_REWRITES)}",
+    )
+    _drift(
+        unsafe_sizeof == EXPECTED_UNSAFE_SIZEOF,
+        f"rewrote {unsafe_sizeof} Unsafe.SizeOf calls, expected "
+        f"{EXPECTED_UNSAFE_SIZEOF}",
     )
     _drift(native_memory_shimmed, f"{SHIM_FILE} not found in boltffi output")
     _drift(model_made_partial, f"{MODEL_FILE} not found in boltffi output")

--- a/tools/unity-bolt-compile-check/UnityBoltCompileCheck.csproj
+++ b/tools/unity-bolt-compile-check/UnityBoltCompileCheck.csproj
@@ -32,9 +32,12 @@
          pre-bolt C ABI + Runtime/Native), so the whole Api folder compiles here
          — nothing drags a C-ABI binding into this project anymore. -->
     <Compile Include="../../bindings/unity/Runtime/Api/*.cs" />
-    <!-- Unity bundles System.Runtime.CompilerServices.Unsafe; supply it here so
-         the standalone compile resolves Unsafe.SizeOf the same way Unity does. -->
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <!-- No System.Runtime.CompilerServices.Unsafe reference on purpose: Unity's
+         scripting profile does not reference that assembly (a real `unity test`
+         on 6.3 rejects `Unsafe.SizeOf` with CS0103), so neither does this gate.
+         gen_unity_bolt_csharp.py rewrites the generated Unsafe.SizeOf<T> to
+         Marshal.SizeOf<T> (core BCL) — keep the gate faithful so a reintroduced
+         Unsafe reference fails here instead of only in-editor. -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The generated bolt bindings **don't compile in a real Unity editor** — a `unity test` on 6.3 (thanks to the local Unity CLI) rejected them with:

```
error CS0103: The name 'Unsafe' does not exist   (XybridBolt.cs: 365, 447, 610)
```

`Unsafe.SizeOf<T>()` (`System.Runtime.CompilerServices.Unsafe`) is an assembly Unity's scripting profile doesn't reference. **The netstandard2.1 compile gate never caught it because its csproj explicitly added `<PackageReference Unsafe>`** — papering over the exact gap.

## Fix
- **gen script transform (g):** `Unsafe.SizeOf<T>()` → `Marshal.SizeOf<T>()`. Byte-identical — the codecs are `where T : unmanaged`, and `Marshal` is core BCL already used throughout the wire layer. Count-asserted (3) so boltffi drift trips loudly.
- **Dropped the gate's `<PackageReference Unsafe>` crutch** so the gate is now *faithful* to Unity: a reintroduced `Unsafe` reference fails CI instead of only surfacing in-editor.

## Verified in a real Unity 6.3 editor
`unity test --mode EditMode` against a staged host `xybrid_bolt.dylib`:

```
24 tests · 24 passed · 0 failed
```

including the **native-calling** tests — `TelemetryConfigTests` (construct/setters through `DllImport("xybrid_bolt")`), `XybridClientTelemetryTests` (init/flush/shutdown), and `EnvelopeVisionTests` (wire codec). So the managed layer both *compiles* and *runs* against the real bolt lib in Unity. Gate compiles 0-warning without the crutch; `gen --check` reproducible.

## Why this matters
First in-editor validation of the whole Unity-on-bolt migration. It confirms the managed layer (A0–A2.2b) is runtime-correct in Unity once the right native is present — which de-risks **A3** (the producer flip: `build-unity.yml` still ships `xybrid_ffi`, not `xybrid_bolt` — the reason the lib had to be staged by hand here).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wire sizing swaps to equivalent BCL APIs for unmanaged types; no auth, security, or behavioral wire-format changes beyond fixing Unity compile.
> 
> **Overview**
> Fixes **CS0103** in Unity 6.3 where `Unsafe.SizeOf<T>()` in the generated Bolt wire layer fails because Unity’s scripting profile does not reference `System.Runtime.CompilerServices.Unsafe`.
> 
> **`gen_unity_bolt_csharp.py`** adds transform **(g)** that rewrites all three `Unsafe.SizeOf<T>()` sites to **`Marshal.SizeOf<T>()`** (same size for `unmanaged` blittable array read/write paths), with a count assertion so boltffi drift fails CI. Committed **`XybridBolt.cs`** reflects that rewrite.
> 
> **`UnityBoltCompileCheck.csproj`** drops the **`System.Runtime.CompilerServices.Unsafe`** package reference so the netstandard2.1 gate matches Unity and would catch a reintroduced `Unsafe` dependency instead of only failing in-editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea0a9e7edc1dbb6352cb11ff9d00454ed5461a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->