### PR TITLE
fix(unity): release-build the shipped native libraries

### DIFF
--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -80,7 +80,7 @@ jobs:
       # Note: Only building arm64. ORT does not provide prebuilt binaries for x86_64-apple-darwin.
       # Intel Macs can run arm64 binaries via Rosetta 2.
       - name: Build for aarch64-apple-darwin
-        run: cargo xtask build-ffi --target aarch64-apple-darwin --deploy-unity
+        run: cargo xtask build-ffi --target aarch64-apple-darwin --release --deploy-unity
 
       - name: Strip debug symbols (macOS)
         run: strip -x bindings/unity/Runtime/Plugins/macOS/libxybrid_bolt.dylib
@@ -139,7 +139,7 @@ jobs:
           save-if: "true"
 
       - name: Build for x86_64-pc-windows-msvc
-        run: cargo xtask build-ffi --target x86_64-pc-windows-msvc --deploy-unity
+        run: cargo xtask build-ffi --target x86_64-pc-windows-msvc --release --deploy-unity
 
       - name: Stage ONNX Runtime (Windows)
         run: >-
@@ -208,7 +208,7 @@ jobs:
           save-if: "true"
 
       - name: Build for x86_64-unknown-linux-gnu
-        run: cargo xtask build-ffi --target x86_64-unknown-linux-gnu --deploy-unity
+        run: cargo xtask build-ffi --target x86_64-unknown-linux-gnu --release --deploy-unity
 
       - name: Stage ONNX Runtime (Linux)
         run: >-
@@ -312,13 +312,13 @@ jobs:
         run: which cargo-ndk || cargo install cargo-ndk
 
       - name: Build for aarch64-linux-android
-        run: cargo xtask build-ffi --target aarch64-linux-android --deploy-unity
+        run: cargo xtask build-ffi --target aarch64-linux-android --release --deploy-unity
 
       - name: Build for armv7-linux-androideabi
-        run: cargo xtask build-ffi --target armv7-linux-androideabi --deploy-unity
+        run: cargo xtask build-ffi --target armv7-linux-androideabi --release --deploy-unity
 
       - name: Build for x86_64-linux-android
-        run: cargo xtask build-ffi --target x86_64-linux-android --deploy-unity
+        run: cargo xtask build-ffi --target x86_64-linux-android --release --deploy-unity
 
       - name: Strip debug symbols (Android)
         run: |
@@ -398,7 +398,7 @@ jobs:
           echo "ORT iOS library found."
 
       - name: Build for aarch64-apple-ios
-        run: cargo xtask build-ffi --target aarch64-apple-ios --deploy-unity
+        run: cargo xtask build-ffi --target aarch64-apple-ios --release --deploy-unity
 
       - name: Strip debug symbols (iOS)
         run: strip -S bindings/unity/Runtime/Plugins/iOS/libxybrid_bolt.a


### PR DESCRIPTION
`build-unity.yml` built the per-platform Unity natives **without `--release`**, so the published `xybrid_bolt` libraries shipped as **dev-profile builds** — the xybrid Rust layer (FFI glue + facade + SDK orchestration) unoptimized at opt-level 0. This pre-dates the bolt migration (the old `xybrid_ffi` natives shipped the same way), and I noticed it while flipping the producer in A3.1.

## Change
`--release` on all 7 platform build jobs (macOS / Windows / Linux / Android ×3 / iOS).

## Why it's safe
The workspace sets **no `[profile.*]` overrides**, so the release profile keeps the default `panic = "unwind"` — identical to debug. So this changes *only* opt-level (0 → 3); no panic-behavior change (the telemetry `catch_unwind` rollback from #386 still works), and the `strip` steps stay valid (release doesn't auto-strip without `strip = true`).

## Verified
`cargo xtask build-ffi --release --deploy-unity` builds the release macOS native — **44 MB vs 96 MB debug (~55% smaller)** — and it passes the Unity 6.3 **Mono EditMode suite 24/24** (incl. the native telemetry/envelope tests via `DllImport("xybrid_bolt")`).

_(`build-unity.yml` runs only on release tags / dispatch, not PRs, so this was verified locally against the actual producer output.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only build flag change for distributed natives; no application or FFI contract changes, with default release panic behavior matching debug.
> 
> **Overview**
> **Unity native CI builds now use `--release`** for every `cargo xtask build-ffi --deploy-unity` step in `build-unity.yml`, so published `xybrid_bolt` plugins are optimized (release profile) instead of default dev builds (opt-level 0).
> 
> The flag is added across **all seven platform jobs**: macOS, Windows, Linux, Android (arm64, armv7, x86_64), and iOS. Existing **strip** and verify steps are unchanged; only the Rust compile profile for what gets copied into `bindings/unity/Runtime/Plugins/` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f4c7865dc302cfffeaa07e889c451a44fbeab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->