### PR TITLE
feat(unity): build the macOS native via Bazel (Unity-on-Bazel, macOS-first)

### DIFF
--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -58,29 +58,30 @@ jobs:
           toolchain: stable
           targets: aarch64-apple-darwin
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-      - name: Configure sccache environment
-        shell: bash
+      # Unity's macOS native is built by Bazel — the same
+      # //crates/xybrid-bolt:xybrid_bolt_cdylib target every other binding uses —
+      # on this macos-14 runner because --config=macos-metal compiles the
+      # llama.cpp Metal shaders locally (no Mac RBE; same as build-apple.yml).
+      # bazelisk ships on macos runners and honors .bazelversion; local_tools
+      # (rules_foreign_cc) needs cmake + pkg-config.
+      - name: Install Bazel build tools
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          which cmake >/dev/null || brew install cmake
+          which pkg-config >/dev/null || brew install pkg-config
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          prefix-key: "v1-rust"
-          shared-key: "unity-macos"
-          cache-all-crates: "true"
-          save-if: "true"
+      # Note: arm64 only. ORT has no x86_64-apple-darwin prebuilt; Intel Macs run
+      # arm64 via Rosetta 2.
+      - name: Build xybrid-bolt native (Bazel, Metal ON)
+        run: bazelisk build --config=macos-metal //crates/xybrid-bolt:xybrid_bolt_cdylib
 
-      # Note: Only building arm64. ORT does not provide prebuilt binaries for x86_64-apple-darwin.
-      # Intel Macs can run arm64 binaries via Rosetta 2.
-      - name: Build for aarch64-apple-darwin
-        run: cargo xtask build-ffi --target aarch64-apple-darwin --release --deploy-unity
+      # Stage the Bazel output into the Unity plugins tree (copy + generate the
+      # per-platform .meta) — the same staging build-ffi --deploy-unity did, just
+      # fed from Bazel instead of cargo.
+      - name: Stage into Unity plugins
+        run: |
+          LIB=$(bazelisk cquery --config=macos-metal --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          echo "Bazel output: $LIB"
+          cargo xtask deploy-unity-native --lib "$LIB" --target aarch64-apple-darwin
 
       - name: Strip debug symbols (macOS)
         run: strip -x bindings/unity/Runtime/Plugins/macOS/libxybrid_bolt.dylib

--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -71,15 +71,20 @@ jobs:
 
       # Note: arm64 only. ORT has no x86_64-apple-darwin prebuilt; Intel Macs run
       # arm64 via Rosetta 2.
-      - name: Build xybrid-bolt native (Bazel, Metal ON)
-        run: bazelisk build --config=macos-metal //crates/xybrid-bolt:xybrid_bolt_cdylib
+      # `-c opt` is required: --config=macos-metal sets the platform + Metal but
+      # NOT compilation_mode (unlike the android configs), so without it Bazel
+      # defaults to fastbuild — a non-optimized native. Matches the release
+      # profile the replaced `build-ffi --release` shipped.
+      - name: Build xybrid-bolt native (Bazel, Metal ON, opt)
+        run: bazelisk build --config=macos-metal -c opt //crates/xybrid-bolt:xybrid_bolt_cdylib
 
       # Stage the Bazel output into the Unity plugins tree (copy + generate the
       # per-platform .meta) — the same staging build-ffi --deploy-unity did, just
-      # fed from Bazel instead of cargo.
+      # fed from Bazel instead of cargo. Must match the build's `-c opt` so cquery
+      # resolves the same (opt) output path.
       - name: Stage into Unity plugins
         run: |
-          LIB=$(bazelisk cquery --config=macos-metal --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          LIB=$(bazelisk cquery --config=macos-metal -c opt --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
           echo "Bazel output: $LIB"
           cargo xtask deploy-unity-native --lib "$LIB" --target aarch64-apple-darwin
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -243,6 +243,23 @@ enum Commands {
         deploy_unity: bool,
     },
 
+    /// Stage a pre-built native library into the Unity plugins tree.
+    ///
+    /// Decouples staging from the cargo build so a Bazel-built
+    /// `//crates/xybrid-bolt:xybrid_bolt_cdylib` (or `_staticlib`) can be dropped
+    /// into `bindings/unity/Runtime/Plugins/<Platform>/` with the correct
+    /// per-platform `.meta`. Same copy + meta logic `build-ffi --deploy-unity`
+    /// uses; the source lib just comes from Bazel instead of cargo.
+    DeployUnityNative {
+        /// Path to the pre-built native library (e.g. bazel-bin/crates/xybrid-bolt/libxybrid_bolt.dylib).
+        #[arg(long)]
+        lib: PathBuf,
+
+        /// Target triple the lib was built for (selects the Unity platform dir + .meta).
+        #[arg(long)]
+        target: Option<String>,
+    },
+
     /// Build Apple XCFramework for iOS and macOS platforms
     BuildXcframework {
         /// Build in release mode (default: true)
@@ -523,6 +540,10 @@ fn main() -> Result<()> {
             deploy_unity,
         } => {
             build_ffi(target, release, platform_preset, deploy_unity)?;
+        }
+        Commands::DeployUnityNative { lib, target } => {
+            let lib_str = lib.to_str().context("--lib path is not valid UTF-8")?;
+            deploy_ffi_to_unity(lib_str, target.as_deref())?;
         }
         Commands::BuildXcframework {
             release,


### PR DESCRIPTION
Unity was the **last cargo-built native** — every other binding (CLI, Apple xcframework, Kotlin AAR, Flutter) ships from the Bazel graph. This flips the **macOS** Unity job onto the same `//crates/xybrid-bolt:xybrid_bolt_cdylib` target Kotlin/Apple already use. First step of a **staged** rollout — the other 6 platform jobs stay on cargo and flip in follow-ups.

## What changed
- **xtask** — new `deploy-unity-native --lib <path> --target <triple>`: stages a *pre-built* native into `Runtime/Plugins/<Platform>/` with the correct `.meta` (reuses the exact copy+meta logic `build-ffi --deploy-unity` uses; the source lib just comes from Bazel now).
- **build-unity.yml (macOS job only)** — `bazelisk build --config=macos-metal //crates/xybrid-bolt:xybrid_bolt_cdylib` (Mac-local, Metal ON — no Mac RBE, same pattern as `build-apple.yml`) → `cargo xtask deploy-unity-native`. Dropped the now-unused sccache/rust-cache (the heavy C++ build moved to Bazel).

## Verified locally
_(build-unity.yml runs only on release tags, not PRs — so proven against the real artifact via the local Unity 6.3 harness, same as the `--release` fix.)_

The Bazel macOS bolt cdylib:
- **builds with Metal ON** (compiles `llama_metal` shaders — no GPU regression),
- is **44 MB = the cargo release lib** (equivalent output),
- **links ORT statically** (`otool` shows no `onnxruntime` dep) — matching the cargo macOS model exactly,
- passes the **Unity 6.3 Mono EditMode suite 24/24** through `DllImport("xybrid_bolt")`.

## On the ORT "gap" (it isn't one)
The static/dynamic ORT split is set in `xybrid-core` per-target (`[target.'cfg(apple)']` → static; else `load-dynamic`), so it's **identical under cargo and Bazel** — the macOS Bazel lib is static, same as today. Confirmed empirically above.

## Remaining (follow-up PRs, per `.context/bazel-unity-scope.md`)
Android (reuses Kotlin's `jni_bolt_` .so), Linux, iOS staticlib, and Windows — the last is the one to validate carefully (Bazel `windows-gnu` vs cargo `windows-msvc`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the release macOS Unity plugin binary to a new build pipeline; wrong Bazel flags or staging could ship a non-opt or mis-staged dylib, though scope is limited to the macOS job only.
> 
> **Overview**
> **macOS Unity native** now comes from the shared Bazel target `//crates/xybrid-bolt:xybrid_bolt_cdylib` instead of `cargo xtask build-ffi --release --deploy-unity`, aligning Unity with Kotlin/Apple/Flutter for that platform.
> 
> The **build-unity.yml** macOS job runs `bazelisk build --config=macos-metal -c opt` (Metal shaders built on the runner; **`-c opt`** so output stays release-grade), resolves the artifact with `bazelisk cquery`, then stages it. **sccache** and **rust-cache** steps were removed from that job because the heavy native compile moved to Bazel.
> 
> **xtask** adds **`deploy-unity-native --lib <path> --target <triple>`**, which copies a pre-built library into `bindings/unity/Runtime/Plugins/` and applies the same `.meta` logic as `build-ffi --deploy-unity`, without running Cargo. Other Unity platform jobs are unchanged and still use cargo **build-ffi**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7292513688faf4e4821ab4ce4949eb4f5de2ef36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->