### PR TITLE
feat(unity): build Android natives via Bazel

### DIFF
--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -9,7 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  NDK_VERSION: "26.1.10909125"
 
 permissions: read-all
 
@@ -52,12 +51,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-          targets: aarch64-apple-darwin
-
       # Unity's macOS native is built by Bazel — the same
       # //crates/xybrid-bolt:xybrid_bolt_cdylib target every other binding uses —
       # on this macos-14 runner because --config=macos-metal compiles the
@@ -86,7 +79,9 @@ jobs:
         run: |
           LIB=$(bazelisk cquery --config=macos-metal -c opt --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
           echo "Bazel output: $LIB"
-          cargo xtask deploy-unity-native --lib "$LIB" --target aarch64-apple-darwin
+          python3 tools/scripts/stage_unity_native.py \
+            --lib "$LIB" \
+            --target aarch64-apple-darwin
 
       - name: Strip debug symbols (macOS)
         run: strip -x bindings/unity/Runtime/Plugins/macOS/libxybrid_bolt.dylib
@@ -255,83 +250,53 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
-          targets: >-
-            aarch64-linux-android,
-            armv7-linux-androideabi,
-            x86_64-linux-android
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
-      - name: Configure sccache environment
-        shell: bash
+      # Android's bolt .so is built by Bazel — the same
+      # //crates/xybrid-bolt:xybrid_bolt_cdylib target the Kotlin AAR ships (and
+      # dlopen-gates on 16 KB-page emulators), one build per ABI. The Bazel link
+      # already strips, 16 KB-aligns, and links libc++_shared (see the android
+      # rustc_flags in crates/xybrid-bolt/BUILD.bazel), so there's no NDK,
+      # cargo-ndk, or strip step here. Android builds remotely only (Linux RBE);
+      # creds come from a gitignored try-import written from the BuildBuddy secret.
+      - name: Configure BuildBuddy remote config
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote --remote_executor=grpcs://remote.buildbuddy.io
+          common:remote --remote_cache_compression
+          common:remote --remote_download_toplevel
+          EOF
+          echo "REMOTE=--config=remote" >> "$GITHUB_ENV"
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          prefix-key: "v1-rust"
-          shared-key: "unity-android"
-          cache-all-crates: "true"
-          save-if: "true"
-
-      - name: Cache Android NDK
-        id: cache-ndk
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
-          key: android-ndk-${{ env.NDK_VERSION }}
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-
-      - name: Install NDK
-        if: steps.cache-ndk.outputs.cache-hit != 'true'
-        run: sdkmanager --install "ndk;${{ env.NDK_VERSION }}"
-
-      - name: Set NDK environment
-        run: echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
-
-      - name: Cache cargo-ndk
-        id: cache-cargo-ndk
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.cargo/bin/cargo-ndk
-          key: cargo-ndk-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-ndk-${{ runner.os }}-
-
-      - name: Install cargo-ndk
-        # actions/cache sets cache-hit only on EXACT key match; with
-        # restore-keys, a fallback can populate ~/.cargo/bin/cargo-ndk while
-        # leaving cache-hit empty, which made the previous `if:`-gated
-        # `cargo install` re-run and fail with "binary already exists".
-        # `which || install` is idempotent in both states.
-        run: which cargo-ndk || cargo install cargo-ndk
-
-      - name: Build for aarch64-linux-android
-        run: cargo xtask build-ffi --target aarch64-linux-android --release --deploy-unity
-
-      - name: Build for armv7-linux-androideabi
-        run: cargo xtask build-ffi --target armv7-linux-androideabi --release --deploy-unity
-
-      - name: Build for x86_64-linux-android
-        run: cargo xtask build-ffi --target x86_64-linux-android --release --deploy-unity
-
-      - name: Strip debug symbols (Android)
+      # stage_unity_native.py copies each ABI's .so into
+      # Runtime/Plugins/Android/<abi>/ and bundles the vendored ORT and
+      # libc++_shared beside it when that ABI is available.
+      - name: Build + stage Android natives (Bazel, per ABI)
         run: |
-          NDK_STRIP="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip"
-          "$NDK_STRIP" bindings/unity/Runtime/Plugins/Android/arm64-v8a/libxybrid_bolt.so
-          "$NDK_STRIP" bindings/unity/Runtime/Plugins/Android/armeabi-v7a/libxybrid_bolt.so
-          "$NDK_STRIP" bindings/unity/Runtime/Plugins/Android/x86_64/libxybrid_bolt.so
+          set -euo pipefail
+          remote_args=()
+          if [[ -n "${REMOTE:-}" ]]; then
+            remote_args+=("$REMOTE")
+          fi
+          for spec in \
+            "aarch64-linux-android:android-arm64" \
+            "armv7-linux-androideabi:android-armv7" \
+            "x86_64-linux-android:android-x86_64"; do
+            triple="${spec%%:*}"; cfg="${spec##*:}"
+            echo "=== $triple ($cfg) ==="
+            bazelisk build "${remote_args[@]}" --config="$cfg" //crates/xybrid-bolt:xybrid_bolt_cdylib
+            LIB=$(bazelisk cquery "${remote_args[@]}" --config="$cfg" --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+            echo "Bazel output: $LIB"
+            python3 tools/scripts/stage_unity_native.py \
+              --lib "$LIB" \
+              --target "$triple"
+          done
 
       - name: Verify deployed libraries
         run: |

--- a/bindings/unity/Runtime/Plugins/.gitignore
+++ b/bindings/unity/Runtime/Plugins/.gitignore
@@ -1,9 +1,9 @@
-# The native libraries AND their Unity .meta import settings are generated at
-# build time by `cargo xtask build-ffi --deploy-unity` — CI zips them into the
-# per-platform release bundles, and the editor resolver fetches those into the
-# consuming project's Assets/Xybrid/Plugins/. Nothing platform-specific is
-# committed here (committing the .meta files would orphan them in the installed
-# package, since the binaries they describe are never shipped inside it).
+# The native libraries AND their Unity .meta import settings are staged at
+# build time — CI zips them into the per-platform release bundles, and the
+# editor resolver fetches those into the consuming project's
+# Assets/Xybrid/Plugins/. Nothing platform-specific is committed here
+# (committing the .meta files would orphan them in the installed package,
+# since the binaries they describe are never shipped inside it).
 *.so
 *.dll
 *.a

--- a/tools/scripts/stage_unity_native.py
+++ b/tools/scripts/stage_unity_native.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Stage a pre-built native library and its Unity plugin metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_PLUGINS_ROOT = Path("bindings/unity/Runtime/Plugins")
+DEFAULT_ANDROID_DEPENDENCIES = Path("vendor/ort-android")
+ANDROID_DEPENDENCY_NAMES = ("libonnxruntime.so", "libc++_shared.so")
+
+
+@dataclass(frozen=True)
+class TargetSpec:
+    platform: str
+    android_abi: str | None = None
+    android_cpu: str | None = None
+
+
+TARGETS = {
+    "aarch64-apple-darwin": TargetSpec("macOS"),
+    "x86_64-apple-darwin": TargetSpec("macOS"),
+    "aarch64-apple-ios": TargetSpec("iOS"),
+    "aarch64-apple-ios-sim": TargetSpec("iOS"),
+    "x86_64-apple-ios": TargetSpec("iOS"),
+    "aarch64-linux-android": TargetSpec("Android", "arm64-v8a", "ARM64"),
+    "armv7-linux-androideabi": TargetSpec(
+        "Android", "armeabi-v7a", "ARMv7"
+    ),
+    "x86_64-linux-android": TargetSpec("Android", "x86_64", "x86_64"),
+    "x86_64-pc-windows-msvc": TargetSpec("Windows"),
+    "x86_64-pc-windows-gnu": TargetSpec("Windows"),
+    "x86_64-unknown-linux-gnu": TargetSpec("Linux"),
+}
+
+
+def unity_guid(logical_name: str) -> str:
+    return hashlib.sha256(f"xybrid-unity:{logical_name}".encode()).hexdigest()[
+        :32
+    ]
+
+
+def folder_meta(guid: str) -> str:
+    return f"""\
+fileFormatVersion: 2
+guid: {guid}
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {{}}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+"""
+
+
+def plugin_meta(guid: str, spec: TargetSpec) -> str:
+    if spec.platform == "macOS":
+        target_data = """\
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+    Editor:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+    OSXUniversal:
+      enabled: 1
+      settings:
+        CPU: AnyCPU"""
+    elif spec.platform == "iOS":
+        target_data = """\
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+    Editor:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+    iOS:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: ARM64
+        CompileFlags:
+        FrameworkDependencies:"""
+    elif spec.platform == "Android":
+        target_data = f"""\
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+    Android:
+      enabled: 1
+      settings:
+        CPU: {spec.android_cpu}
+    Editor:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS"""
+    elif spec.platform == "Windows":
+        target_data = """\
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+    Editor:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: Windows
+    Win:
+      enabled: 1
+      settings:
+        CPU: x86
+    Win64:
+      enabled: 1
+      settings:
+        CPU: x86_64"""
+    else:
+        target_data = """\
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+    Editor:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+    Linux64:
+      enabled: 1
+      settings:
+        CPU: x86_64"""
+
+    return f"""\
+fileFormatVersion: 2
+guid: {guid}
+PluginImporter:
+  externalObjects: {{}}
+  serializedVersion: 3
+  iconMap: {{}}
+  executionOrder: {{}}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+    Any:
+      enabled: 0
+      settings:
+{target_data}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+"""
+
+
+def write_meta_if_missing(path: Path, content: str) -> None:
+    if path.exists():
+        return
+    path.write_text(content, encoding="utf-8")
+    print(f"  Created metadata: {path}")
+
+
+def copy_file(source: Path, destination: Path) -> None:
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    try:
+        shutil.copy2(source, temporary)
+        temporary.replace(destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def stage_file(
+    source: Path,
+    destination: Path,
+    spec: TargetSpec,
+    logical_name: str,
+) -> None:
+    copy_file(source, destination)
+    metadata = destination.with_name(f"{destination.name}.meta")
+    write_meta_if_missing(
+        metadata,
+        plugin_meta(unity_guid(logical_name), spec),
+    )
+    print(f"  Staged: {destination}")
+
+
+def stage_native(
+    native: Path,
+    target: str,
+    *,
+    plugins_root: Path = DEFAULT_PLUGINS_ROOT,
+    android_dependencies: Path = DEFAULT_ANDROID_DEPENDENCIES,
+) -> Path:
+    native = Path(native)
+    if not native.is_file():
+        raise FileNotFoundError(f"native library not found: {native}")
+
+    try:
+        spec = TARGETS[target]
+    except KeyError as error:
+        raise ValueError(f"unsupported target for Unity staging: {target}") from error
+
+    platform_dir = plugins_root / spec.platform
+    destination_dir = (
+        platform_dir / spec.android_abi
+        if spec.android_abi is not None
+        else platform_dir
+    )
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    platform_metadata = plugins_root / f"{spec.platform}.meta"
+    write_meta_if_missing(
+        platform_metadata,
+        folder_meta(unity_guid(f"folder:{spec.platform}")),
+    )
+
+    if spec.android_abi is not None:
+        abi_metadata = platform_dir / f"{spec.android_abi}.meta"
+        write_meta_if_missing(
+            abi_metadata,
+            folder_meta(
+                unity_guid(f"folder:{spec.platform}/{spec.android_abi}")
+            ),
+        )
+
+    destination = destination_dir / native.name
+    logical_directory = spec.platform
+    if spec.android_abi is not None:
+        logical_directory = f"{logical_directory}/{spec.android_abi}"
+    stage_file(
+        native,
+        destination,
+        spec,
+        f"{logical_directory}/{native.name}",
+    )
+
+    if spec.android_abi is not None:
+        dependencies_dir = android_dependencies / spec.android_abi
+        if not dependencies_dir.is_dir():
+            print(
+                "  Warning: Android dependencies not found for "
+                f"{spec.android_abi} at {dependencies_dir}",
+                file=sys.stderr,
+            )
+            return destination
+
+        for dependency_name in ANDROID_DEPENDENCY_NAMES:
+            dependency = dependencies_dir / dependency_name
+            if dependency.is_file():
+                stage_file(
+                    dependency,
+                    destination_dir / dependency_name,
+                    spec,
+                    f"{logical_directory}/{dependency_name}",
+                )
+
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Stage a pre-built native library into Unity plugins."
+    )
+    parser.add_argument("--lib", required=True, type=Path)
+    parser.add_argument("--target", required=True, choices=sorted(TARGETS))
+    parser.add_argument(
+        "--plugins-root",
+        type=Path,
+        default=DEFAULT_PLUGINS_ROOT,
+        help="Unity Runtime/Plugins directory.",
+    )
+    parser.add_argument(
+        "--android-dependencies",
+        type=Path,
+        default=DEFAULT_ANDROID_DEPENDENCIES,
+        help="Directory containing Android dependency libraries by ABI.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        destination = stage_native(
+            args.lib,
+            args.target,
+            plugins_root=args.plugins_root,
+            android_dependencies=args.android_dependencies,
+        )
+        print(f"Unity native staged at {destination}")
+        return 0
+    except (OSError, ValueError) as error:
+        print(f"stage-unity-native: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/tests/test_stage_unity_native.py
+++ b/tools/scripts/tests/test_stage_unity_native.py
@@ -1,0 +1,143 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from stage_unity_native import stage_native
+
+
+class StageUnityNativeTests(unittest.TestCase):
+    def test_macos_native_is_staged_with_editor_enabled_metadata(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            native = root / "bazel-bin" / "libxybrid_bolt.dylib"
+            native.parent.mkdir()
+            native.write_bytes(b"macos-native")
+
+            destination = stage_native(
+                native,
+                "aarch64-apple-darwin",
+                plugins_root=root / "Plugins",
+            )
+
+            self.assertEqual(
+                root / "Plugins" / "macOS" / native.name, destination
+            )
+            self.assertEqual(b"macos-native", destination.read_bytes())
+            metadata = destination.with_name(
+                f"{destination.name}.meta"
+            ).read_text()
+            self.assertIn("OSXUniversal:", metadata)
+            self.assertIn("Editor:\n      enabled: 1", metadata)
+            self.assertIn("Exclude OSXUniversal: 0", metadata)
+            self.assertTrue((root / "Plugins" / "macOS.meta").is_file())
+
+    def test_android_native_and_dependencies_use_the_target_abi(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            native = root / "bazel-bin" / "libxybrid_bolt.so"
+            native.parent.mkdir()
+            native.write_bytes(b"android-native")
+            dependencies = root / "ort-android" / "x86_64"
+            dependencies.mkdir(parents=True)
+            (dependencies / "libonnxruntime.so").write_bytes(b"ort")
+            (dependencies / "libc++_shared.so").write_bytes(b"cxx")
+
+            destination = stage_native(
+                native,
+                "x86_64-linux-android",
+                plugins_root=root / "Plugins",
+                android_dependencies=root / "ort-android",
+            )
+
+            output = root / "Plugins" / "Android" / "x86_64"
+            self.assertEqual(output / native.name, destination)
+            self.assertEqual(b"ort", (output / "libonnxruntime.so").read_bytes())
+            self.assertEqual(b"cxx", (output / "libc++_shared.so").read_bytes())
+            for library in (
+                "libxybrid_bolt.so",
+                "libonnxruntime.so",
+                "libc++_shared.so",
+            ):
+                metadata = (output / f"{library}.meta").read_text()
+                self.assertIn("Android:\n      enabled: 1", metadata)
+                self.assertIn("CPU: x86_64", metadata)
+            self.assertTrue((root / "Plugins" / "Android.meta").is_file())
+            self.assertTrue(
+                (root / "Plugins" / "Android" / "x86_64.meta").is_file()
+            )
+
+    def test_existing_metadata_is_not_overwritten(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            native = root / "libxybrid_bolt.dylib"
+            native.write_bytes(b"new-native")
+            output = root / "Plugins" / "macOS"
+            output.mkdir(parents=True)
+            metadata = output / "libxybrid_bolt.dylib.meta"
+            metadata.write_text("existing-guid")
+
+            stage_native(
+                native,
+                "aarch64-apple-darwin",
+                plugins_root=root / "Plugins",
+            )
+
+            self.assertEqual("existing-guid", metadata.read_text())
+
+    def test_generated_guid_does_not_depend_on_the_checkout_path(self):
+        metadata = []
+        with tempfile.TemporaryDirectory() as first_temp:
+            with tempfile.TemporaryDirectory() as second_temp:
+                for temp in (first_temp, second_temp):
+                    root = Path(temp)
+                    native = root / "libxybrid_bolt.dylib"
+                    native.write_bytes(b"native")
+                    destination = stage_native(
+                        native,
+                        "aarch64-apple-darwin",
+                        plugins_root=root / "Plugins",
+                    )
+                    metadata.append(
+                        destination.with_name(
+                            f"{destination.name}.meta"
+                        ).read_text()
+                    )
+
+        self.assertEqual(metadata[0], metadata[1])
+
+    def test_missing_native_fails_without_creating_plugin_directories(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            plugins = root / "Plugins"
+
+            with self.assertRaisesRegex(FileNotFoundError, "native library"):
+                stage_native(
+                    root / "missing" / "libxybrid_bolt.so",
+                    "aarch64-linux-android",
+                    plugins_root=plugins,
+                    android_dependencies=root / "ort-android",
+                )
+
+            self.assertFalse(plugins.exists())
+
+    def test_unknown_target_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            native = root / "libxybrid_bolt.so"
+            native.write_bytes(b"native")
+
+            with self.assertRaisesRegex(ValueError, "unsupported target"):
+                stage_native(
+                    native,
+                    "wasm32-unknown-unknown",
+                    plugins_root=root / "Plugins",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- build all three Unity Android ABI natives from the existing Bazel `xybrid_bolt_cdylib` target
- remove the Android cargo/NDK/sccache setup and use Bazel's hermetic NDK plus shared remote cache
- add a standard-library-only Python stager for native plugins, deterministic Unity metadata, and Android companion libraries
- use that stager for both Bazel-backed macOS and Android jobs, removing their otherwise-unused Rust toolchain installs
- emit ABI-correct Android importer metadata while preserving existing metadata files and GUIDs

## Verification

- `python3 -m unittest discover -s tools/scripts/tests -p 'test_*.py'` (11 passed)
- real BuildBuddy-cached Android ARM64 Bazel artifact staged successfully with bolt, ONNX Runtime, C++ runtime, and metadata; verified stripped AArch64 ELF
- macOS metadata matches the current Rust-generated importer metadata apart from its deterministic GUID
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download`

## Existing limitation

The vendored Android dependency payload contains arm64-v8a and x86_64, but not armeabi-v7a. This PR preserves the existing ARMv7 staging behavior and reports the missing dependency directory; it does not claim to add an ARMv7 ONNX Runtime binary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Android Unity release binaries are produced and packaged in CI; ARMv7 still lacks vendored ORT deps (warn-only), so behavior matches prior limitation but native artifact parity should be validated on release tags.
> 
> **Overview**
> Unity **macOS and Android** CI no longer use `cargo xtask` for deploy: Bazel-built `xybrid_bolt_cdylib` artifacts are copied into `Runtime/Plugins` via new **`stage_unity_native.py`**, which writes ABI-aware Unity `.meta` files (deterministic GUIDs, never overwrites existing metadata) and, on Android, bundles vendored **ORT** and **libc++_shared** when present.
> 
> The **Android** job drops Rust/NDK/cargo-ndk/sccache/strip in favor of **Bazel** builds per ABI (`android-arm64`, `android-armv7`, `android-x86_64`) with optional **BuildBuddy** remote config from a secret. **macOS** drops the redundant Rust toolchain install and uses the same Python stager instead of `deploy-unity-native`.
> 
> Docs in `Plugins/.gitignore` now describe generic staging rather than `build-ffi --deploy-unity`. Unit tests cover macOS/Android staging, metadata preservation, and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a86ec21fdc814c55d9e31b5d3ddd4d6a242eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->