### PR TITLE
feat(unity): prove windows-gnu bolt DLL on Bazel (non-shipping validation lane)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -235,7 +235,9 @@ jobs:
             --require-export boltffi_version \
             --require-export boltffi_configure_runtime \
             --require-export boltffi_free_buf \
-            --require-export boltffi_last_error_message
+            --require-export boltffi_last_error_message \
+            --require-exports-from-csharp bindings/unity/Runtime/Bolt/XybridBolt.cs \
+            --require-exports-from-csharp bindings/unity/Runtime/BoltSupplement/XybridInference.cs
           mkdir -p /tmp/win-bolt && cp "$DLL" /tmp/win-bolt/xybrid_bolt.dll
           echo "windows bolt DLL payload + audit: OK ✅"
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -167,7 +167,8 @@ jobs:
             //crates/xybrid-cli:xybrid \
             //crates/xybrid-bolt:xybrid_bolt_staticlib
           bazelisk build --config=remote --config=windows -c opt \
-            //crates/xybrid-cli:xybrid
+            //crates/xybrid-cli:xybrid \
+            //crates/xybrid-bolt:xybrid_bolt_cdylib
 
       # Linux-CLI smoke + parity gate (Flip 1): this is the SHIPPED artifact
       # since the release-prep build-cli-linux cutover — run it, verify the
@@ -214,6 +215,36 @@ jobs:
         with:
           name: bazel-xybrid-windows-exe
           path: /tmp/win-exe/xybrid.exe
+          retention-days: 7
+
+      # Windows bolt cdylib (Unity native) — NON-SHIPPING proof lane. Unity still
+      # ships the cargo/MSVC DLL; this validates the windows-gnu Bazel DLL end to
+      # end before any flip. Byte-inspect + audit here (PE shape, and the import
+      # table must be Windows-system-only — the static libc++/unwind trio means
+      # no MinGW/MSVC runtime carriers leak out); the run-it half loads it on
+      # windows-latest below (bazel-windows-bolt-smoke).
+      - name: Verify + audit + stage the windows bolt DLL
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          DLL=$(bazelisk cquery --config=remote --config=windows -c opt --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          echo "resolved windows bolt DLL: $DLL"
+          file "$DLL"
+          file "$DLL" | grep -q 'PE32+.*x86-64' || { echo "NOT a PE32+ x86-64 DLL"; exit 1; }
+          python3 -m pip install --quiet --user pefile
+          python3 tools/scripts/audit_windows_dll.py --dll "$DLL" \
+            --require-export boltffi_version \
+            --require-export boltffi_configure_runtime \
+            --require-export boltffi_free_buf \
+            --require-export boltffi_last_error_message
+          mkdir -p /tmp/win-bolt && cp "$DLL" /tmp/win-bolt/xybrid_bolt.dll
+          echo "windows bolt DLL payload + audit: OK ✅"
+
+      - name: Upload windows bolt DLL artifact
+        if: env.BUILDBUDDY_API_KEY != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bazel-xybrid-bolt-windows-dll
+          path: /tmp/win-bolt/xybrid_bolt.dll
           retention-days: 7
 
       # The RBE-proven Android row (PR #326 gates 6-10): NDK cross-compile +
@@ -374,3 +405,39 @@ jobs:
           grep -aq 'mtmd_' xybrid.exe || { echo "MISSING vision (mtmd) markers"; exit 1; }
           grep -aq 'huggingface\.co' xybrid.exe || { echo "MISSING huggingface support"; exit 1; }
           echo "windows .exe smoke: OK"
+
+  # Run-it half of the windows bolt-DLL proof (Unity native): a real Windows
+  # runner downloads the RBE-built xybrid_bolt.dll, stages ORT beside it, and
+  # runs a MANAGED C# smoke — loads the DLL under the CLR and P/Invokes a real
+  # boltffi entry point (stronger than a bare ctypes load, and the runtime
+  # validation the linux byte-inspection can't do). NON-SHIPPING: Unity keeps
+  # shipping the cargo/MSVC DLL until this windows-gnu lane is trusted.
+  bazel-windows-bolt-smoke:
+    name: Bazel windows bolt DLL smoke (managed C# P/Invoke)
+    needs: bazel
+    if: needs.bazel.outputs.rbe == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: bazel-xybrid-bolt-windows-dll
+          path: tools/windows-smoke
+
+      - name: Build the managed smoke
+        run: dotnet build tools/windows-smoke/xybrid-bolt-smoke.csproj -c Release
+
+      - name: Stage natives beside the smoke exe (bolt DLL + ORT)
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT=tools/windows-smoke/bin/Release/net8.0
+          cp tools/windows-smoke/xybrid_bolt.dll "$OUT/"
+          python tools/scripts/stage_unity_desktop_ort.py windows "$OUT"
+          ls -la "$OUT"
+
+      - name: Run managed C# smoke (load DLL + boltffi P/Invoke)
+        shell: bash
+        run: ./tools/windows-smoke/bin/Release/net8.0/xybrid-bolt-smoke.exe

--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -162,6 +162,9 @@ jobs:
           test -f "$PLUGINS/onnxruntime.dll.meta"
           python -c "import ctypes; ctypes.CDLL(r'$PLUGINS/onnxruntime.dll')"
           echo "Windows ORT runtime loads successfully."
+          # Load the shipped bolt plugin itself (not just ORT) and run a real
+          # boltffi call — proves the native is functional, not merely present.
+          python tools/scripts/verify_bolt_load.py "$PLUGINS/xybrid_bolt.dll"
 
       - name: Upload Windows plugins
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -225,6 +225,18 @@ use_repo(osx, "macos_sdk")
 
 # --- Rust toolchain: rules_rs (facade over rules_rust) ------------------------
 rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+
+# rules_rust fix (report upstream): the shared-library rule unconditionally
+# declares a mandatory `.dll.lib` import-library output for EVERY windows cdylib
+# (rust/private/rustc.bzl), but that `.dll.lib` name is MSVC-only — windows-GNU
+# (MinGW) rustc emits `.dll.a`, so a good gnu cdylib fails with "mandatory output
+# not created". The patch gates that output on target_abi == "msvc" (the same
+# check the rule already uses elsewhere). Needed for the bolt windows-gnu cdylib
+# (Unity), which is loaded via P/Invoke and needs no import library at all.
+rules_rust.patch(
+    patches = ["//:rules_rust.patch"],
+    strip = 1,
+)
 use_repo(rules_rust, "rules_rust")
 
 toolchains = use_extension("@rules_rs//rs/toolchains:module_extension.bzl", "toolchains")

--- a/crates/xybrid-bolt/BUILD.bazel
+++ b/crates/xybrid-bolt/BUILD.bazel
@@ -8,6 +8,7 @@
 # That stays in xtask/CI consuming these outputs (the build-once -> fan-out
 # boundary). boltffi itself is codegen, not a build script, so nothing is
 # generated at compile time.
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rs//rs:rust_shared_library.bzl", "rust_shared_library")
 load("@rules_rs//rs:rust_static_library.bzl", "rust_static_library")
 load("@crates//:defs.bzl", "all_crate_deps")
@@ -39,8 +40,37 @@ rust_shared_library(
         ],
         "//conditions:default": [],
     }),
-    deps = all_crate_deps(normal = True),
+    # Windows (GNU/MinGW) cdylib: the hermetic toolchain links libc++ into
+    # EXECUTABLES by default (the CLI .exe links clean — xybrid-cli needs no
+    # windows linkopts) but NOT into a -shared cdylib, so llama.cpp's C++
+    # (libllama.a / libwrapper_cc.a) leaves __cxa_* / std::* undefined at the
+    # final link. :win_cxx_runtime hands the link the same static libc++/abi/
+    # unwind trio the llama tool exes get (//BUILD.bazel:200) — self-contained
+    # in the DLL (Bolt's boundary is C ABI, no C++ objects cross it). A
+    # cc_library dep, NOT compile_data: compile_data perturbs the crate's source
+    # staging and breaks boltffi's macro source-scan on RBE, and lld resolves
+    # the archives order-independently so no link-order plumbing is needed.
+    deps = all_crate_deps(normal = True) + select({
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [":win_cxx_runtime"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
+)
+
+# Static C++ runtime trio for the windows-gnu cdylib link (see the cdylib's
+# deps note). Windows-target-built by the hermetic llvm (it compiles its
+# runtimes per target); the srcs select keeps it an empty no-op under every
+# other config so a package-wide build elsewhere never demands the win archives.
+cc_library(
+    name = "win_cxx_runtime",
+    srcs = select({
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
+            "@llvm//runtimes/libcxx:libcxx.static",
+            "@llvm//runtimes/libcxx:libcxxabi.static",
+            "@llvm//runtimes/libunwind:libunwind.static",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 # staticlib — libxybrid_bolt.a (what `boltffi pack` relinks into the xcframework/aar)

--- a/rules_rust.patch
+++ b/rules_rust.patch
@@ -1,0 +1,14 @@
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -2028,7 +2028,10 @@
+     # For a cdylib that might be added as a dependency to a cc_* target on Windows, it is important to include the
+     # interface library that rustc generates in the output files.
+     interface_library = None
+-    if rust_toolchain.target_os == "windows" and crate_info.type == "cdylib":
++    # xybrid patch: only windows-MSVC rustc emits the `.dll.lib` import library;
++    # windows-GNU (MinGW) emits `.dll.a`, so a mandatory `.dll.lib` output fails a
++    # good gnu cdylib. GNU cdylibs are consumed via dlopen/P-Invoke (no implib).
++    if rust_toolchain.target_os == "windows" and rust_toolchain.target_abi == "msvc" and crate_info.type == "cdylib":
+         # Rustc generates the import library with a `.dll.lib` extension rather than the usual `.lib` one that msvc
+         # expects (see https://github.com/rust-lang/rust/pull/29520 for more context).
+         interface_library = ctx.actions.declare_file(crate_info.output.basename + ".lib", sibling = crate_info.output)

--- a/tools/scripts/audit_windows_dll.py
+++ b/tools/scripts/audit_windows_dll.py
@@ -11,8 +11,10 @@ appears in the import table, or if an expected boltffi export is missing.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 
 # Windows DLLs guaranteed present on a stock machine (system32). MinGW/MSVC
@@ -88,6 +90,16 @@ FORBIDDEN_HINTS = (
 class AuditResult:
     ok: bool
     lines: tuple[str, ...]
+
+
+DLL_IMPORT_ENTRY_POINT = re.compile(
+    r'(?m)^\s*\[DllImport\([^\r\n]*?\bEntryPoint\s*=\s*"([^"]+)"'
+)
+
+
+def extract_csharp_entry_points(source: str) -> list[str]:
+    """Return unique native entry points declared by active C# DllImport attributes."""
+    return list(dict.fromkeys(DLL_IMPORT_ENTRY_POINT.findall(source)))
 
 
 def is_system_import(dll: str, *, extra_allowed: frozenset[str]) -> bool:
@@ -184,6 +196,13 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="An extra non-system DLL to permit, e.g. onnxruntime.dll (repeatable).",
     )
+    parser.add_argument(
+        "--require-exports-from-csharp",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Require every DllImport EntryPoint declared in a C# source (repeatable).",
+    )
     return parser.parse_args()
 
 
@@ -195,10 +214,30 @@ def main() -> int:
         print(f"audit-windows-dll: cannot read {args.dll}: {error}", file=sys.stderr)
         return 2
 
+    required_exports = list(args.require_export)
+    for source_path in args.require_exports_from_csharp:
+        try:
+            source = Path(source_path).read_text(encoding="utf-8")
+        except OSError as error:
+            print(
+                f"audit-windows-dll: cannot read {source_path}: {error}",
+                file=sys.stderr,
+            )
+            return 2
+        entry_points = extract_csharp_entry_points(source)
+        if not entry_points:
+            print(
+                f"audit-windows-dll: no DllImport entry points found in {source_path}",
+                file=sys.stderr,
+            )
+            return 2
+        required_exports.extend(entry_points)
+    required_exports = list(dict.fromkeys(required_exports))
+
     result = audit(
         imports,
         exports,
-        required_exports=args.require_export,
+        required_exports=required_exports,
         extra_allowed=frozenset(a.lower() for a in args.allow_import),
     )
     print(f"== PE audit: {args.dll} ==")

--- a/tools/scripts/audit_windows_dll.py
+++ b/tools/scripts/audit_windows_dll.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Audit a Windows PE DLL's import table and exports.
+
+The windows-gnu bolt cdylib statically links the C++ runtime trio
+(libc++/libc++abi/libunwind), so a correct build imports ONLY Windows system
+DLLs — no MinGW/MSVC redistributables and no link-time onnxruntime.dll (ORT is
+loaded dynamically at runtime). This gate fails the build if any non-system DLL
+appears in the import table, or if an expected boltffi export is missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+
+# Windows DLLs guaranteed present on a stock machine (system32). MinGW/MSVC
+# runtime carriers are deliberately absent so they surface as failures.
+SYSTEM_DLLS = frozenset(
+    name.lower()
+    for name in (
+        "kernel32.dll",
+        "kernelbase.dll",
+        "ntdll.dll",
+        "advapi32.dll",
+        "user32.dll",
+        "gdi32.dll",
+        "shell32.dll",
+        "shlwapi.dll",
+        "ole32.dll",
+        "oleaut32.dll",
+        "combase.dll",
+        "propsys.dll",
+        "ws2_32.dll",
+        "wsock32.dll",
+        "iphlpapi.dll",
+        "netapi32.dll",
+        "secur32.dll",
+        "sspicli.dll",
+        "crypt32.dll",
+        "bcrypt.dll",
+        "bcryptprimitives.dll",
+        "ncrypt.dll",
+        "psapi.dll",
+        "userenv.dll",
+        "powrprof.dll",
+        "pdh.dll",
+        "dxgi.dll",
+        "d3d11.dll",
+        "d3d12.dll",
+        "dxcore.dll",
+        "winmm.dll",
+        "version.dll",
+        "rpcrt4.dll",
+        "cfgmgr32.dll",
+        "setupapi.dll",
+        "dbghelp.dll",
+        # The legacy C runtime that ships with Windows itself (MinGW links it).
+        # NOT to be confused with msvcp140.dll / vcruntime140.dll, which are the
+        # redistributable MSVC runtimes and are intentionally NOT allow-listed.
+        "msvcrt.dll",
+    )
+)
+
+# API-set contract stubs ("api-ms-win-*", "ext-ms-*") always resolve on modern
+# Windows via apisetschema — treat any of them as system.
+SYSTEM_PREFIXES = ("api-ms-win-", "ext-ms-")
+
+# Runtime carriers that MUST NOT appear — their presence means the C++ runtime
+# (or an MSVC redist) leaked out as a dynamic dependency instead of being
+# statically contained. Reported explicitly for a clearer failure message.
+FORBIDDEN_HINTS = (
+    "libc++",
+    "libc++abi",
+    "libunwind",
+    "libwinpthread",
+    "libgcc",
+    "libstdc++",
+    "msvcp",
+    "vcruntime",
+    "libgomp",
+    "libssp",
+)
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    ok: bool
+    lines: tuple[str, ...]
+
+
+def is_system_import(dll: str, *, extra_allowed: frozenset[str]) -> bool:
+    """Return True if `dll` is an allowed (system or explicitly-permitted) import."""
+    name = dll.lower()
+    if name in SYSTEM_DLLS or name in extra_allowed:
+        return True
+    return any(name.startswith(prefix) for prefix in SYSTEM_PREFIXES)
+
+
+def audit(
+    imports: list[str],
+    exports: list[str],
+    *,
+    required_exports: list[str],
+    extra_allowed: frozenset[str] = frozenset(),
+) -> AuditResult:
+    """Check imports against the allowlist and confirm required exports exist."""
+    lines: list[str] = []
+    export_set = set(exports)
+
+    forbidden: list[str] = []
+    unexpected: list[str] = []
+    for dll in sorted({d.lower() for d in imports}):
+        if is_system_import(dll, extra_allowed=extra_allowed):
+            continue
+        if any(hint in dll for hint in FORBIDDEN_HINTS):
+            forbidden.append(dll)
+        else:
+            unexpected.append(dll)
+
+    missing = [name for name in required_exports if name not in export_set]
+
+    lines.append(f"imports: {len(set(i.lower() for i in imports))} distinct DLLs")
+    lines.append(f"exports: {len(export_set)} symbols")
+    if forbidden:
+        lines.append(
+            "FAIL: runtime-carrier DLLs imported (should be statically linked): "
+            + ", ".join(forbidden)
+        )
+    if unexpected:
+        lines.append(
+            "FAIL: non-system DLLs imported (not on the allowlist): "
+            + ", ".join(unexpected)
+        )
+    if missing:
+        lines.append("FAIL: required exports missing: " + ", ".join(missing))
+    if not (forbidden or unexpected or missing):
+        lines.append(
+            f"OK: import table is Windows-system-only; {len(required_exports)} "
+            "required exports present"
+        )
+
+    return AuditResult(ok=not (forbidden or unexpected or missing), lines=tuple(lines))
+
+
+def read_pe(path: str) -> tuple[list[str], list[str]]:
+    """Extract (imported DLL names, exported symbol names) from a PE file."""
+    import pefile  # imported lazily so the pure logic stays unit-testable
+
+    pe = pefile.PE(path, fast_load=True)
+    pe.parse_data_directories(
+        directories=[
+            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"],
+            pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_EXPORT"],
+        ]
+    )
+    imports = [
+        entry.dll.decode("ascii", "replace")
+        for entry in getattr(pe, "DIRECTORY_ENTRY_IMPORT", [])
+    ]
+    exports = [
+        exp.name.decode("ascii", "replace")
+        for exp in getattr(
+            getattr(pe, "DIRECTORY_ENTRY_EXPORT", None), "symbols", []
+        )
+        if exp.name
+    ]
+    return imports, exports
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit a Windows PE DLL.")
+    parser.add_argument("--dll", required=True)
+    parser.add_argument(
+        "--require-export",
+        action="append",
+        default=[],
+        help="An export that must be present (repeatable).",
+    )
+    parser.add_argument(
+        "--allow-import",
+        action="append",
+        default=[],
+        help="An extra non-system DLL to permit, e.g. onnxruntime.dll (repeatable).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        imports, exports = read_pe(args.dll)
+    except Exception as error:  # noqa: BLE001 - surface any pefile failure cleanly
+        print(f"audit-windows-dll: cannot read {args.dll}: {error}", file=sys.stderr)
+        return 2
+
+    result = audit(
+        imports,
+        exports,
+        required_exports=args.require_export,
+        extra_allowed=frozenset(a.lower() for a in args.allow_import),
+    )
+    print(f"== PE audit: {args.dll} ==")
+    for line in result.lines:
+        print(f"  {line}")
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/tests/test_audit_windows_dll.py
+++ b/tools/scripts/tests/test_audit_windows_dll.py
@@ -1,0 +1,100 @@
+"""Unit tests for the Windows PE audit logic (no real DLL required)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from audit_windows_dll import audit, is_system_import
+
+
+SYSTEM_IMPORTS = ["KERNEL32.dll", "ntdll.dll", "ws2_32.dll", "bcrypt.dll"]
+BOLT_EXPORTS = ["boltffi_version", "boltffi_free_buf", "boltffi_configure_runtime"]
+
+
+class AuditWindowsDllTests(unittest.TestCase):
+    def test_clean_system_only_imports_pass(self):
+        result = audit(
+            SYSTEM_IMPORTS + ["api-ms-win-core-synch-l1-2-0.dll"],
+            BOLT_EXPORTS,
+            required_exports=["boltffi_version", "boltffi_free_buf"],
+        )
+        self.assertTrue(result.ok)
+        self.assertTrue(any("Windows-system-only" in line for line in result.lines))
+
+    def test_forbidden_runtime_carrier_fails(self):
+        result = audit(
+            SYSTEM_IMPORTS + ["libc++.dll"],
+            BOLT_EXPORTS,
+            required_exports=["boltffi_version"],
+        )
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any("runtime-carrier" in line and "libc++.dll" in line for line in result.lines)
+        )
+
+    def test_mingw_pthread_and_gcc_flagged(self):
+        for carrier in ("libwinpthread-1.dll", "libgcc_s_seh-1.dll", "libstdc++-6.dll"):
+            result = audit(
+                SYSTEM_IMPORTS + [carrier],
+                BOLT_EXPORTS,
+                required_exports=[],
+            )
+            self.assertFalse(result.ok, carrier)
+            self.assertTrue(
+                any("runtime-carrier" in line for line in result.lines), carrier
+            )
+
+    def test_msvc_redist_flagged(self):
+        # msvcrt.dll is system; msvcp140/vcruntime140 are redistributables.
+        result = audit(
+            ["msvcrt.dll", "vcruntime140.dll"],
+            BOLT_EXPORTS,
+            required_exports=[],
+        )
+        self.assertFalse(result.ok)
+        self.assertTrue(any("vcruntime140.dll" in line for line in result.lines))
+
+    def test_unexpected_non_system_import_fails(self):
+        result = audit(
+            SYSTEM_IMPORTS + ["random_third_party.dll"],
+            BOLT_EXPORTS,
+            required_exports=[],
+        )
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(
+                "non-system" in line and "random_third_party.dll" in line
+                for line in result.lines
+            )
+        )
+
+    def test_missing_required_export_fails(self):
+        result = audit(
+            SYSTEM_IMPORTS,
+            ["boltffi_version"],
+            required_exports=["boltffi_version", "boltffi_run"],
+        )
+        self.assertFalse(result.ok)
+        self.assertTrue(any("boltffi_run" in line for line in result.lines))
+
+    def test_extra_allowed_import_permitted(self):
+        result = audit(
+            SYSTEM_IMPORTS + ["onnxruntime.dll"],
+            BOLT_EXPORTS,
+            required_exports=[],
+            extra_allowed=frozenset({"onnxruntime.dll"}),
+        )
+        self.assertTrue(result.ok)
+
+    def test_is_system_import_prefixes_and_case(self):
+        allowed = frozenset()
+        self.assertTrue(is_system_import("API-MS-Win-Core-Heap-L1-1-0.dll", extra_allowed=allowed))
+        self.assertTrue(is_system_import("ext-ms-win-foo.dll", extra_allowed=allowed))
+        self.assertTrue(is_system_import("KeRnEl32.DLL", extra_allowed=allowed))
+        self.assertFalse(is_system_import("libunwind.dll", extra_allowed=allowed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/tests/test_audit_windows_dll.py
+++ b/tools/scripts/tests/test_audit_windows_dll.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from audit_windows_dll import audit, is_system_import
+from audit_windows_dll import audit, extract_csharp_entry_points, is_system_import
 
 
 SYSTEM_IMPORTS = ["KERNEL32.dll", "ntdll.dll", "ws2_32.dll", "bcrypt.dll"]
@@ -94,6 +94,21 @@ class AuditWindowsDllTests(unittest.TestCase):
         self.assertTrue(is_system_import("ext-ms-win-foo.dll", extra_allowed=allowed))
         self.assertTrue(is_system_import("KeRnEl32.DLL", extra_allowed=allowed))
         self.assertFalse(is_system_import("libunwind.dll", extra_allowed=allowed))
+
+    def test_extracts_real_csharp_dllimport_entry_points_only(self):
+        source = """
+            [DllImport(LibName, EntryPoint = "boltffi_version")]
+            private static extern FfiBuf Version();
+            // [DllImport(LibName, EntryPoint = "commented_out")]
+            [DllImport(NativeMethods.LibName, EntryPoint="boltffi_model_run")]
+            private static extern FfiBuf Run();
+            [DllImport(LibName, EntryPoint = "boltffi_version")]
+            private static extern FfiBuf VersionAgain();
+        """
+        self.assertEqual(
+            extract_csharp_entry_points(source),
+            ["boltffi_version", "boltffi_model_run"],
+        )
 
 
 if __name__ == "__main__":

--- a/tools/scripts/tests/test_verify_bolt_load.py
+++ b/tools/scripts/tests/test_verify_bolt_load.py
@@ -1,12 +1,13 @@
-"""Unit tests for the boltffi wire-string decode (no native library required)."""
+"""Unit tests for the boltffi smoke helpers (no native library required)."""
 
+import ctypes
 import sys
 import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from verify_bolt_load import _decode_wire_string
+from verify_bolt_load import FfiBuf, _decode_wire_string
 
 
 def wire(text: str) -> bytes:
@@ -41,6 +42,15 @@ class DecodeWireStringTests(unittest.TestCase):
     def test_ignores_trailing_bytes(self):
         # A well-formed prefix + payload is decoded even if the buffer is longer.
         self.assertEqual(_decode_wire_string(wire("ok") + b"\x00\x00"), "ok")
+
+
+class FfiBufLayoutTests(unittest.TestCase):
+    def test_matches_four_word_boltffi_abi(self):
+        self.assertEqual(
+            [name for name, _field_type in FfiBuf._fields_],
+            ["ptr", "len", "cap", "align"],
+        )
+        self.assertEqual(ctypes.sizeof(FfiBuf), 4 * ctypes.sizeof(ctypes.c_size_t))
 
 
 if __name__ == "__main__":

--- a/tools/scripts/tests/test_verify_bolt_load.py
+++ b/tools/scripts/tests/test_verify_bolt_load.py
@@ -1,13 +1,16 @@
 """Unit tests for the boltffi smoke helpers (no native library required)."""
 
 import ctypes
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from verify_bolt_load import FfiBuf, _decode_wire_string
+from verify_bolt_load import FfiBuf, _decode_wire_string, verify
 
 
 def wire(text: str) -> bytes:
@@ -51,6 +54,41 @@ class FfiBufLayoutTests(unittest.TestCase):
             ["ptr", "len", "cap", "align"],
         )
         self.assertEqual(ctypes.sizeof(FfiBuf), 4 * ctypes.sizeof(ctypes.c_size_t))
+
+
+class VerifyLibraryTests(unittest.TestCase):
+    def test_keeps_windows_dll_search_directory_active_through_call(self):
+        raw = ctypes.create_string_buffer(wire("0.1.0"))
+
+        class FakeFunction:
+            def __init__(self, result=None):
+                self.result = result
+
+            def __call__(self, *_args):
+                return self.result
+
+        fake_lib = MagicMock()
+        fake_lib.boltffi_version = FakeFunction(
+            FfiBuf(ctypes.addressof(raw), len(raw.raw) - 1, len(raw.raw) - 1, 1)
+        )
+        fake_lib.boltffi_free_buf = FakeFunction()
+        directory_handle = MagicMock()
+
+        with tempfile.TemporaryDirectory() as directory:
+            library = str(Path(directory) / "xybrid_bolt.dll")
+            with (
+                patch.object(
+                    os,
+                    "add_dll_directory",
+                    return_value=directory_handle,
+                    create=True,
+                ),
+                patch.object(ctypes, "CDLL", return_value=fake_lib),
+            ):
+                self.assertEqual(verify(library), "0.1.0")
+
+        directory_handle.__enter__.assert_called_once_with()
+        directory_handle.__exit__.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tools/scripts/tests/test_verify_bolt_load.py
+++ b/tools/scripts/tests/test_verify_bolt_load.py
@@ -1,0 +1,47 @@
+"""Unit tests for the boltffi wire-string decode (no native library required)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from verify_bolt_load import _decode_wire_string
+
+
+def wire(text: str) -> bytes:
+    payload = text.encode("utf-8")
+    return len(payload).to_bytes(4, "little", signed=True) + payload
+
+
+class DecodeWireStringTests(unittest.TestCase):
+    def test_decodes_length_prefixed_utf8(self):
+        # The exact bytes the CI smoke first returned: [i32 5]["0.0.0"].
+        self.assertEqual(_decode_wire_string(bytes([5, 0, 0, 0]) + b"0.0.0"), "0.0.0")
+
+    def test_roundtrips_typical_version(self):
+        self.assertEqual(_decode_wire_string(wire("0.1.0-beta12")), "0.1.0-beta12")
+
+    def test_zero_length_is_empty(self):
+        self.assertEqual(_decode_wire_string(bytes([0, 0, 0, 0])), "")
+
+    def test_undersized_buffer_rejected(self):
+        with self.assertRaises(RuntimeError):
+            _decode_wire_string(bytes([1, 0]))
+
+    def test_overlong_prefix_rejected(self):
+        # prefix claims 9 bytes but only 5 follow → corrupt.
+        with self.assertRaises(RuntimeError):
+            _decode_wire_string(bytes([9, 0, 0, 0]) + b"0.0.0")
+
+    def test_negative_prefix_rejected(self):
+        with self.assertRaises(RuntimeError):
+            _decode_wire_string(bytes([0xFF, 0xFF, 0xFF, 0xFF]) + b"junk")
+
+    def test_ignores_trailing_bytes(self):
+        # A well-formed prefix + payload is decoded even if the buffer is longer.
+        self.assertEqual(_decode_wire_string(wire("ok") + b"\x00\x00"), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/verify_bolt_load.py
+++ b/tools/scripts/verify_bolt_load.py
@@ -22,6 +22,7 @@ class FfiBuf(ctypes.Structure):
         ("ptr", ctypes.c_void_p),
         ("len", ctypes.c_size_t),
         ("cap", ctypes.c_size_t),
+        ("align", ctypes.c_size_t),
     ]
 
 

--- a/tools/scripts/verify_bolt_load.py
+++ b/tools/scripts/verify_bolt_load.py
@@ -76,12 +76,7 @@ def main() -> int:
         print(f"verify-bolt-load: {error}", file=sys.stderr)
         return 1
     print(f"bolt native loads; boltffi_version -> {version!r}")
-    # Hard-exit before interpreter teardown unloads the DLL: the boltffi native
-    # (llama.cpp / ggml C++ statics) runs destructors at unload, and abrupt
-    # teardown of that native state is out of scope for a load+call check (the
-    # real SDK guards its lifecycle). stdout is already flushed by print().
-    sys.stdout.flush()
-    os._exit(0)
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/scripts/verify_bolt_load.py
+++ b/tools/scripts/verify_bolt_load.py
@@ -10,6 +10,7 @@ smoke in `.github/workflows/bazel.yml`.
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import os
 import sys
@@ -44,26 +45,31 @@ def verify(lib_path: str) -> str:
     """Load `lib_path`, call boltffi_version, and return the decoded version."""
     directory = os.path.dirname(os.path.abspath(lib_path))
     # Let the OS loader resolve sibling deps (e.g. a co-located onnxruntime.dll)
-    # if the library references any. No-op on platforms without the API.
-    if hasattr(os, "add_dll_directory") and os.path.isdir(directory):
+    # if the library references any. Keep the returned handle alive through the
+    # native call; closing/discarding it removes the directory from Windows'
+    # process search path. No-op on platforms without the API.
+    dll_directory = (
         os.add_dll_directory(directory)
+        if hasattr(os, "add_dll_directory") and os.path.isdir(directory)
+        else contextlib.nullcontext()
+    )
+    with dll_directory:
+        lib = ctypes.CDLL(os.path.abspath(lib_path))
+        lib.boltffi_version.restype = FfiBuf
+        lib.boltffi_free_buf.argtypes = [FfiBuf]
+        lib.boltffi_free_buf.restype = None
 
-    lib = ctypes.CDLL(os.path.abspath(lib_path))
-    lib.boltffi_version.restype = FfiBuf
-    lib.boltffi_free_buf.argtypes = [FfiBuf]
-    lib.boltffi_free_buf.restype = None
-
-    buf = lib.boltffi_version()
-    try:
-        if not buf.ptr or not buf.len:
-            raise RuntimeError("boltffi_version returned an empty buffer")
-        raw = ctypes.string_at(buf.ptr, int(buf.len))
-        version = _decode_wire_string(raw)
-        if not version:
-            raise RuntimeError("boltffi_version decoded to an empty string")
-        return version
-    finally:
-        lib.boltffi_free_buf(buf)
+        buf = lib.boltffi_version()
+        try:
+            if not buf.ptr or not buf.len:
+                raise RuntimeError("boltffi_version returned an empty buffer")
+            raw = ctypes.string_at(buf.ptr, int(buf.len))
+            version = _decode_wire_string(raw)
+            if not version:
+                raise RuntimeError("boltffi_version decoded to an empty string")
+            return version
+        finally:
+            lib.boltffi_free_buf(buf)
 
 
 def main() -> int:

--- a/tools/scripts/verify_bolt_load.py
+++ b/tools/scripts/verify_bolt_load.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Load a deployed bolt native library and exercise a real boltffi call.
+
+Proves a native plugin is *functional* — loads under the OS loader and completes
+a live FFI round-trip (boltffi_version -> owned buffer -> free) — not merely
+present on disk. Used by the Windows Unity verify to guard the shipped
+cargo/MSVC `xybrid_bolt.dll`; the Bazel windows-gnu DLL gets a fuller managed C#
+smoke in `.github/workflows/bazel.yml`.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+
+
+class FfiBuf(ctypes.Structure):
+    """Mirrors the boltffi FfiBuf (bindings/unity/Runtime/Bolt/XybridBolt.cs)."""
+
+    _fields_ = [
+        ("ptr", ctypes.c_void_p),
+        ("len", ctypes.c_size_t),
+        ("cap", ctypes.c_size_t),
+    ]
+
+
+def verify(lib_path: str) -> str:
+    """Load `lib_path`, call boltffi_version, and return the version string."""
+    directory = os.path.dirname(os.path.abspath(lib_path))
+    # Let the OS loader resolve sibling deps (e.g. a co-located onnxruntime.dll)
+    # if the library references any. No-op on platforms without the API.
+    if hasattr(os, "add_dll_directory") and os.path.isdir(directory):
+        os.add_dll_directory(directory)
+
+    lib = ctypes.CDLL(os.path.abspath(lib_path))
+    lib.boltffi_version.restype = FfiBuf
+    lib.boltffi_free_buf.argtypes = [FfiBuf]
+    lib.boltffi_free_buf.restype = None
+
+    buf = lib.boltffi_version()
+    try:
+        if not buf.ptr or not buf.len:
+            raise RuntimeError("boltffi_version returned an empty buffer")
+        version = ctypes.string_at(buf.ptr, buf.len).decode("utf-8")
+        if not version:
+            raise RuntimeError("boltffi_version decoded to an empty string")
+        return version
+    finally:
+        lib.boltffi_free_buf(buf)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: verify_bolt_load.py <path-to-native-lib>", file=sys.stderr)
+        return 2
+    try:
+        version = verify(sys.argv[1])
+    except (OSError, RuntimeError) as error:
+        print(f"verify-bolt-load: {error}", file=sys.stderr)
+        return 1
+    print(f"bolt native loads; boltffi_version -> {version!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scripts/verify_bolt_load.py
+++ b/tools/scripts/verify_bolt_load.py
@@ -2,8 +2,8 @@
 """Load a deployed bolt native library and exercise a real boltffi call.
 
 Proves a native plugin is *functional* — loads under the OS loader and completes
-a live FFI round-trip (boltffi_version -> owned buffer -> free) — not merely
-present on disk. Used by the Windows Unity verify to guard the shipped
+a live FFI round-trip (boltffi_version -> owned wire buffer -> decode -> free) —
+not merely present on disk. Used by the Windows Unity verify to guard the shipped
 cargo/MSVC `xybrid_bolt.dll`; the Bazel windows-gnu DLL gets a fuller managed C#
 smoke in `.github/workflows/bazel.yml`.
 """
@@ -25,8 +25,22 @@ class FfiBuf(ctypes.Structure):
     ]
 
 
+def _decode_wire_string(raw: bytes) -> str:
+    """Decode a boltffi wire string: an i32 LE length prefix, then UTF-8 bytes.
+
+    Mirrors WireReader.ReadString in XybridBolt.cs — the FfiBuf is wire-encoded,
+    NOT a raw C string.
+    """
+    if len(raw) < 4:
+        raise RuntimeError(f"undersized wire buffer ({len(raw)} bytes)")
+    length = int.from_bytes(raw[0:4], "little", signed=True)
+    if length < 0 or 4 + length > len(raw):
+        raise RuntimeError(f"corrupt wire buffer (prefix len={length}, total={len(raw)})")
+    return raw[4 : 4 + length].decode("utf-8")
+
+
 def verify(lib_path: str) -> str:
-    """Load `lib_path`, call boltffi_version, and return the version string."""
+    """Load `lib_path`, call boltffi_version, and return the decoded version."""
     directory = os.path.dirname(os.path.abspath(lib_path))
     # Let the OS loader resolve sibling deps (e.g. a co-located onnxruntime.dll)
     # if the library references any. No-op on platforms without the API.
@@ -42,7 +56,8 @@ def verify(lib_path: str) -> str:
     try:
         if not buf.ptr or not buf.len:
             raise RuntimeError("boltffi_version returned an empty buffer")
-        version = ctypes.string_at(buf.ptr, buf.len).decode("utf-8")
+        raw = ctypes.string_at(buf.ptr, int(buf.len))
+        version = _decode_wire_string(raw)
         if not version:
             raise RuntimeError("boltffi_version decoded to an empty string")
         return version
@@ -56,11 +71,16 @@ def main() -> int:
         return 2
     try:
         version = verify(sys.argv[1])
-    except (OSError, RuntimeError) as error:
+    except (OSError, RuntimeError, UnicodeDecodeError) as error:
         print(f"verify-bolt-load: {error}", file=sys.stderr)
         return 1
     print(f"bolt native loads; boltffi_version -> {version!r}")
-    return 0
+    # Hard-exit before interpreter teardown unloads the DLL: the boltffi native
+    # (llama.cpp / ggml C++ statics) runs destructors at unload, and abrupt
+    # teardown of that native state is out of scope for a load+call check (the
+    # real SDK guards its lifecycle). stdout is already flushed by print().
+    sys.stdout.flush()
+    os._exit(0)
 
 
 if __name__ == "__main__":

--- a/tools/windows-smoke/Program.cs
+++ b/tools/windows-smoke/Program.cs
@@ -28,15 +28,6 @@ internal static class Smoke
     [DllImport(Lib, EntryPoint = "boltffi_free_buf")]
     private static extern void FreeBuf(FfiBuf buf);
 
-    // Terminate immediately with a clean exit code. The boltffi native (llama.cpp
-    // / ggml C++ statics) runs destructors at DLL unload; abrupt teardown of that
-    // native state on process exit is out of scope for a load+call smoke — the
-    // real SDK guards it (e.g. TelemetryDomainReloadGuard) and the Unity IL2CPP
-    // player smoke exercises the true lifecycle. Exiting here keeps a noisy
-    // native unload from masking the already-verified result.
-    [DllImport("kernel32.dll")]
-    private static extern void ExitProcess(uint exitCode);
-
     private static int Main()
     {
         FfiBuf buf;
@@ -89,8 +80,6 @@ internal static class Smoke
 
         Console.WriteLine($"smoke: boltffi_version -> \"{version}\"");
         Console.WriteLine("windows managed C# bolt smoke: OK");
-        Console.Out.Flush();
-        ExitProcess(0); // clean, teardown-free exit (see note above)
-        return 0; // unreachable
+        return 0;
     }
 }

--- a/tools/windows-smoke/Program.cs
+++ b/tools/windows-smoke/Program.cs
@@ -19,6 +19,7 @@ internal static class Smoke
         public IntPtr ptr;
         public UIntPtr len;
         public UIntPtr cap;
+        public UIntPtr align;
     }
 
     [DllImport(Lib, EntryPoint = "boltffi_version")]

--- a/tools/windows-smoke/Program.cs
+++ b/tools/windows-smoke/Program.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Managed C# smoke for the windows-gnu xybrid_bolt.dll. The first P/Invoke below
+// forces the CLR to LoadLibrary the DLL; if the static libc++/libc++abi/libunwind
+// trio were NOT self-contained, this throws DllNotFoundException on a clean
+// Windows runner (the missing dependent DLL). Then it exercises a real boltffi
+// call that returns an owned buffer and frees it — round-tripping the FfiBuf
+// allocator across the C ABI boundary, exactly as the Unity binding does.
+internal static class Smoke
+{
+    private const string Lib = "xybrid_bolt";
+
+    // Mirrors bindings/unity/Runtime/Bolt/XybridBolt.cs (FfiBuf).
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FfiBuf
+    {
+        public IntPtr ptr;
+        public UIntPtr len;
+        public UIntPtr cap;
+    }
+
+    [DllImport(Lib, EntryPoint = "boltffi_version")]
+    private static extern FfiBuf Version();
+
+    [DllImport(Lib, EntryPoint = "boltffi_free_buf")]
+    private static extern void FreeBuf(FfiBuf buf);
+
+    private static int Main()
+    {
+        FfiBuf buf;
+        try
+        {
+            buf = Version();
+        }
+        catch (DllNotFoundException ex)
+        {
+            Console.Error.WriteLine($"smoke: FAILED to load {Lib}.dll or a dependency: {ex.Message}");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"smoke: FAILED calling boltffi_version: {ex}");
+            return 1;
+        }
+
+        try
+        {
+            if (buf.ptr == IntPtr.Zero || (nuint)buf.len == 0)
+            {
+                Console.Error.WriteLine("smoke: boltffi_version returned an empty buffer");
+                return 1;
+            }
+
+            string version = Marshal.PtrToStringUTF8(buf.ptr, checked((int)(nuint)buf.len)) ?? string.Empty;
+            if (version.Length == 0)
+            {
+                Console.Error.WriteLine("smoke: boltffi_version decoded to an empty string");
+                return 1;
+            }
+
+            Console.WriteLine($"smoke: boltffi_version -> \"{version}\"");
+        }
+        finally
+        {
+            FreeBuf(buf);
+        }
+
+        Console.WriteLine("windows managed C# bolt smoke: OK");
+        return 0;
+    }
+}

--- a/tools/windows-smoke/Program.cs
+++ b/tools/windows-smoke/Program.cs
@@ -4,9 +4,10 @@ using System.Runtime.InteropServices;
 // Managed C# smoke for the windows-gnu xybrid_bolt.dll. The first P/Invoke below
 // forces the CLR to LoadLibrary the DLL; if the static libc++/libc++abi/libunwind
 // trio were NOT self-contained, this throws DllNotFoundException on a clean
-// Windows runner (the missing dependent DLL). Then it exercises a real boltffi
-// call that returns an owned buffer and frees it — round-tripping the FfiBuf
-// allocator across the C ABI boundary, exactly as the Unity binding does.
+// Windows runner (the missing dependent DLL). It then calls a real boltffi entry
+// point that returns an owned wire buffer, decodes it exactly as the Unity
+// binding does (WireReader.ReadString), and frees it — round-tripping the FfiBuf
+// allocator across the C ABI boundary.
 internal static class Smoke
 {
     private const string Lib = "xybrid_bolt";
@@ -26,6 +27,15 @@ internal static class Smoke
     [DllImport(Lib, EntryPoint = "boltffi_free_buf")]
     private static extern void FreeBuf(FfiBuf buf);
 
+    // Terminate immediately with a clean exit code. The boltffi native (llama.cpp
+    // / ggml C++ statics) runs destructors at DLL unload; abrupt teardown of that
+    // native state on process exit is out of scope for a load+call smoke — the
+    // real SDK guards it (e.g. TelemetryDomainReloadGuard) and the Unity IL2CPP
+    // player smoke exercises the true lifecycle. Exiting here keeps a noisy
+    // native unload from masking the already-verified result.
+    [DllImport("kernel32.dll")]
+    private static extern void ExitProcess(uint exitCode);
+
     private static int Main()
     {
         FfiBuf buf;
@@ -44,29 +54,42 @@ internal static class Smoke
             return 1;
         }
 
+        string version;
+        int total = checked((int)(nuint)buf.len);
         try
         {
-            if (buf.ptr == IntPtr.Zero || (nuint)buf.len == 0)
+            if (buf.ptr == IntPtr.Zero || total < 4)
             {
-                Console.Error.WriteLine("smoke: boltffi_version returned an empty buffer");
+                Console.Error.WriteLine($"smoke: boltffi_version returned an undersized buffer (len={total})");
                 return 1;
             }
-
-            string version = Marshal.PtrToStringUTF8(buf.ptr, checked((int)(nuint)buf.len)) ?? string.Empty;
-            if (version.Length == 0)
+            // boltffi FfiBuf is wire-encoded (not a raw C string). Mirror
+            // WireReader.ReadString: an i32 little-endian length prefix, then that
+            // many UTF-8 bytes. (windows-x64 is little-endian, so Marshal.ReadInt32
+            // reads the prefix directly.)
+            int len = Marshal.ReadInt32(buf.ptr, 0);
+            if (len < 0 || 4 + len > total)
             {
-                Console.Error.WriteLine("smoke: boltffi_version decoded to an empty string");
+                Console.Error.WriteLine($"smoke: corrupt wire buffer (prefix len={len}, total={total})");
                 return 1;
             }
-
-            Console.WriteLine($"smoke: boltffi_version -> \"{version}\"");
+            version = len == 0 ? string.Empty : (Marshal.PtrToStringUTF8(buf.ptr + 4, len) ?? string.Empty);
         }
         finally
         {
             FreeBuf(buf);
         }
 
+        if (version.Length == 0)
+        {
+            Console.Error.WriteLine("smoke: boltffi_version decoded to an empty string");
+            return 1;
+        }
+
+        Console.WriteLine($"smoke: boltffi_version -> \"{version}\"");
         Console.WriteLine("windows managed C# bolt smoke: OK");
-        return 0;
+        Console.Out.Flush();
+        ExitProcess(0); // clean, teardown-free exit (see note above)
+        return 0; // unreachable
     }
 }

--- a/tools/windows-smoke/xybrid-bolt-smoke.csproj
+++ b/tools/windows-smoke/xybrid-bolt-smoke.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Managed (CLR) smoke test for the windows xybrid_bolt.dll. Proves the DLL
+    loads under the .NET runtime and a real boltffi P/Invoke round-trips —
+    stronger than a bare ctypes load. Mirrors the Unity binding's ABI
+    (bindings/unity/Runtime/Bolt/XybridBolt.cs). CI copies xybrid_bolt.dll (+
+    onnxruntime.dll) beside the built exe before `dotnet run`.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>xybrid-bolt-smoke</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Windows is the last Unity platform on cargo/MSVC. This **proves** the windows-gnu bolt DLL builds clean on Bazel and validates it end-to-end — **without flipping production** (Unity keeps shipping the cargo/MSVC DLL until this lane is trusted).

## Make the windows-gnu cdylib build (both gnu-gated, inert on every other platform)
- **Static C++ trio** — `crates/xybrid-bolt/BUILD.bazel` links `libc++`/`libc++abi`/`libunwind` via a `cc_library` dep so llama.cpp's C++ resolves. The hermetic toolchain links libc++ into executables (the CLI `.exe`) but not a `-shared` cdylib. `cc_library`, **not** `compile_data` (which broke boltffi's macro source-scan on RBE); lld resolves the archives order-independently.
- **rules_rust `.dll.lib` gate** — `rules_rust.patch` + `MODULE.bazel`. rules_rust declares a mandatory MSVC-shaped `.dll.lib` import-library output for *every* windows cdylib; windows-gnu emits `.dll.a`, so a good gnu cdylib fails "mandatory output not created". Gate it on `target_abi == "msvc"` (the rule's own idiom), applied via rules_rs's **supported** `rules_rust.patch()` hook.

## Validation lane — the acceptance ladder (`bazel.yml`, RBE + windows-latest, non-shipping)
- Build the cdylib on RBE, then **audit its PE**: import table must be Windows-system-only (the static trio means no MinGW/MSVC runtime carriers leak) and the boltffi exports must be present — `tools/scripts/audit_windows_dll.py` (+ unit tests).
- Hand the **exact artifact** to windows-latest → stage ORT beside it → run a **managed C# smoke** that loads the DLL under the CLR and P/Invokes a real boltffi entry point — stronger than a bare ctypes load.

## Gap fix (`build-unity.yml`)
- The Windows Unity verify only loaded `onnxruntime.dll`, never `xybrid_bolt.dll`. It now loads the shipped bolt native and runs a real boltffi call (`verify_bolt_load.py`) — valuable on the cargo/MSVC path regardless of the Bazel work.

## Proven in CI against the RBE artifact
- PE32+ x64 DLL, 43.5 MB · imports **Windows-system-only** (trio fully static, no `onnxruntime.dll` link dep) · **74/74** Unity P/Invoke entry points exported.

Production stays **cargo/MSVC**. The Unity IL2CPP smoke (ladder step 6) is the final gate before any flip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native linking, a vendored rules_rust patch, and CI gates for Unity’s Windows plugin; production still ships cargo/MSVC until the lane is trusted.
> 
> **Overview**
> Adds a **non-shipping** Bazel path to build and validate the windows-gnu `xybrid_bolt` cdylib for Unity before any production switch from cargo/MSVC.
> 
> **Build fixes:** `xybrid_bolt_cdylib` on `x86_64-pc-windows-gnu` now depends on a `win_cxx_runtime` `cc_library` that statically links libc++/libc++abi/libunwind so llama.cpp C++ resolves in the shared DLL. `rules_rust.patch` (wired in `MODULE.bazel`) only requires the MSVC `.dll.lib` import library when `target_abi == "msvc"`, so MinGW cdylibs can build.
> 
> **CI validation:** RBE desktop builds include `//crates/xybrid-bolt:xybrid_bolt_cdylib`; Linux jobs PE-check the DLL and run `audit_windows_dll.py` (system-only imports + boltffi exports from Unity C#). A new `bazel-windows-bolt-smoke` job on `windows-latest` runs managed C# P/Invoke smoke (`tools/windows-smoke`) with ORT staged beside the artifact.
> 
> **Shipped Unity path:** `build-unity.yml` now calls `verify_bolt_load.py` on the deployed `xybrid_bolt.dll` (real `boltffi_version` round-trip), not only ORT load checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aad5c8ef16f00860a85b0b11d3612c2fabdcc4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
