### PR TITLE
test(bazel): run the first Rust tests under Bazel (tests-under-Bazel pilot)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -151,6 +151,19 @@ jobs:
             //crates/llama-cpp-sys:llama_cpp_sys \
             //crates/xybrid-llama:xybrid_llama
 
+      # Tests-under-Bazel pilot. Until now Bazel BUILT every shipped artifact but
+      # RAN no tests — every `#[test]` in the workspace executed only under cargo,
+      # so "Bazel is the build of record" stopped short of verification.
+      # //crates/xybrid-ffi-facade is the cheapest proof of the rust_test pattern:
+      # 26 inline tests, pure Rust, no dev-dependencies, no model fixtures.
+      # Runs on this ubuntu runner (host == linux == the RBE executor platform),
+      # which is what lets the test binary execute remotely at all.
+      - name: Run Rust tests on RBE (tests-under-Bazel pilot)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk test --config=remote -c opt --test_output=errors \
+            //crates/xybrid-ffi-facade:xybrid-ffi-facade_test
+
       # Desktop lanes on RBE: linux CLI (native) + the macOS-CPU cross
       # (hermetic clang + @macos_sdk + vendored ort; Metal/Swift stay Mac-bound
       # and are NOT built here) + the full windows-gnu CLI (the .exe chapter —

--- a/crates/xybrid-ffi-facade/BUILD.bazel
+++ b/crates/xybrid-ffi-facade/BUILD.bazel
@@ -2,6 +2,7 @@
 # canonical SDK->foreign POD/Arc facade the bolt/flutter/ffi crates route through.
 # Free via @crates: deps = xybrid-core + xybrid-sdk + tokio, all auto-resolved.
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
 rust_library(
@@ -11,4 +12,18 @@ rust_library(
     crate_features = ["default"],
     deps = all_crate_deps(normal = True),
     visibility = ["//visibility:public"],
+)
+
+# FIRST test target in the workspace — the tests-under-Bazel pilot. Every
+# workspace `#[test]` runs only under cargo today, so Bazel builds everything it
+# ships but verifies none of it. This crate is the cheapest proof of the pattern:
+# 26 inline tests, pure Rust, no dev-dependencies, no model fixtures.
+#
+# `crate = ` (not `srcs = `) recompiles the library above with `--test`, which is
+# the rules_rust idiom for inline `#[cfg(test)] mod tests` — it inherits srcs,
+# edition, features and deps, so the two targets cannot drift.
+rust_test(
+    name = "xybrid-ffi-facade_test",
+    crate = ":xybrid-ffi-facade",
+    crate_features = ["default"],
 )


### PR DESCRIPTION
Bazel **builds** every artifact we ship but **ran no tests** — every `#[test]` in the workspace executed only under cargo. There were **zero test targets** in the whole workspace, so "Bazel is the build of record" stopped short of verification.

This is the pilot that closes that gap, on the cheapest possible crate.

## What's in it
- **`crates/xybrid-ffi-facade/BUILD.bazel`** — first `rust_test` in the workspace. 26 inline tests, pure Rust, no dev-dependencies, no model fixtures.
- **`bazel.yml`** — runs it on RBE inside the existing ubuntu job.

## Why `crate = ` and not `srcs = `
`crate = ":xybrid-ffi-facade"` recompiles the library with `--test` — the rules_rust idiom for inline `#[cfg(test)] mod tests`. It inherits srcs, edition, features and deps, so **the library and test targets cannot drift**.

## Why the ubuntu job specifically
The runner's host platform is linux, which matches the RBE executor. That's what lets the test binary execute remotely — building the same target for darwin and running it on a Linux worker fails with `Exit 126`.

## Verified
- Target builds clean on RBE (2350 actions, mostly cached)
- `cargo test -p xybrid-ffi-facade --lib` still 26/26 — same tests, both systems
- Remote *execution* is proven by this PR's CI, the first runner whose host matches the executor

## Next (not in this PR)
The remaining 1800+ tests migrate incrementally. Crates needing model fixtures or heavy dev-deps each get their own follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Bazel target wiring only; no application, auth, or data-path changes.
> 
> **Overview**
> Starts **tests-under-Bazel** so CI verifies Rust code through Bazel, not only `cargo test`. Until now the workflow built shipped artifacts on RBE but ran **no** `#[test]` targets.
> 
> Adds the workspace’s first `rust_test` on `//crates/xybrid-ffi-facade` via `crate = ":xybrid-ffi-facade"` so inline `#[cfg(test)]` modules share the library’s srcs, features, and deps. The **Bazel** job runs `bazelisk test --config=remote` for that target on the Linux ubuntu runner when BuildBuddy is available, matching the RBE executor so the test binary can execute remotely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a755c8d2f1c560c9296e740a64dc099c6d8e772a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->