### PR TITLE
test(bazel): run xybrid-core, xybrid-sdk, xybrid-llama and xtask tests under Bazel

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -151,18 +151,24 @@ jobs:
             //crates/llama-cpp-sys:llama_cpp_sys \
             //crates/xybrid-llama:xybrid_llama
 
-      # Tests-under-Bazel pilot. Until now Bazel BUILT every shipped artifact but
-      # RAN no tests — every `#[test]` in the workspace executed only under cargo,
-      # so "Bazel is the build of record" stopped short of verification.
-      # //crates/xybrid-ffi-facade is the cheapest proof of the rust_test pattern:
-      # 26 inline tests, pure Rust, no dev-dependencies, no model fixtures.
-      # Runs on this ubuntu runner (host == linux == the RBE executor platform),
-      # which is what lets the test binary execute remotely at all.
-      - name: Run Rust tests on RBE (tests-under-Bazel pilot)
+      # Tests under Bazel. Bazel BUILDS every shipped artifact; these targets are
+      # what stop it from shipping unverified. Runs on this ubuntu runner
+      # (host == linux == the RBE executor platform), which is what lets the test
+      # binaries execute remotely at all — a darwin-target build of the same
+      # targets fails with Exit 126 on a Linux worker.
+      #
+      # Covers the inline `#[cfg(test)] mod tests` of each crate. Not yet here:
+      # //crates/xybrid-core (1273 tests) — it dev-depends on xybrid-sdk, which
+      # depends on xybrid-core, and Bazel cannot express that cycle; and the
+      # `tests/` integration binaries, which are separate targets.
+      - name: Run Rust tests on RBE
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk test --config=remote -c opt --test_output=errors \
-            //crates/xybrid-ffi-facade:xybrid-ffi-facade_test
+            //crates/xybrid-ffi-facade:xybrid-ffi-facade_test \
+            //crates/xybrid-llama:xybrid_llama_test \
+            //crates/xybrid-sdk:xybrid-sdk_test \
+            //xtask:xtask_test
 
       # Desktop lanes on RBE: linux CLI (native) + the macOS-CPU cross
       # (hermetic clang + @macos_sdk + vendored ort; Metal/Swift stay Mac-bound

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -157,14 +157,16 @@ jobs:
       # binaries execute remotely at all — a darwin-target build of the same
       # targets fails with Exit 126 on a Linux worker.
       #
-      # Covers the inline `#[cfg(test)] mod tests` of each crate. Not yet here:
-      # //crates/xybrid-core (1273 tests) — it dev-depends on xybrid-sdk, which
-      # depends on xybrid-core, and Bazel cannot express that cycle; and the
-      # `tests/` integration binaries, which are separate targets.
+      # Covers the inline `#[cfg(test)] mod tests` of each crate. Still outside
+      # Bazel: the `tests/` integration binaries (separate targets), and among
+      # them xybrid-core's tests/system_validation.rs — the ONLY thing that needs
+      # core's dev-dependency on xybrid-sdk, the cycle Bazel cannot express.
+      # core's inline tests are unaffected: nothing in its src/ uses xybrid_sdk.
       - name: Run Rust tests on RBE
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk test --config=remote -c opt --test_output=errors \
+            //crates/xybrid-core:xybrid-core_test \
             //crates/xybrid-ffi-facade:xybrid-ffi-facade_test \
             //crates/xybrid-llama:xybrid_llama_test \
             //crates/xybrid-sdk:xybrid-sdk_test \

--- a/bindings/web/BUILD.bazel
+++ b/bindings/web/BUILD.bazel
@@ -1,0 +1,13 @@
+# The web SDK itself is not built by Bazel (pnpm owns it). This package exists
+# only to export the committed JSON fixture that xybrid-core's inline tests
+# compare Rust metadata serialization against — the test resolves it as
+# CARGO_MANIFEST_DIR/../../bindings/web/test/fixtures/, and Bazel sandboxes
+# actions, so it must be a declared `data` input on the test target.
+filegroup(
+    name = "rust_metadata_fixtures",
+    srcs = glob(
+        ["test/fixtures/rust-metadata-*.json"],
+        allow_empty = False,
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -17,6 +17,7 @@
 # download-binaries+tls-rustls), so this target builds GREEN on RBE.
 # The `ort-download` feature below is a retained NO-OP marker (invocation compat).
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
 # Android ships the `platform-android` backend set: candle (Whisper ASR/voice) +
@@ -91,4 +92,28 @@ rust_library(
     }),
     deps = all_crate_deps(normal = True),
     visibility = ["//visibility:public"],
+)
+
+# The workspace's largest test target: ~1180 inline `#[test]`/`#[tokio::test]`.
+#
+# xybrid-core carries a dev-dependency on xybrid-sdk, which depends back on
+# xybrid-core. Cargo permits that (dev-deps are outside the published graph);
+# Bazel cannot express the cycle. It does not block this target, because NOTHING
+# in src/ actually uses xybrid_sdk — the only mention is a doc-comment link in
+# cloud/config.rs. The dev-dep exists solely for tests/system_validation.rs, an
+# integration binary that is not part of this target.
+#
+# `deps` lists the dev-dependencies the inline tests really reach for; the other
+# declared dev-deps (filetime, walkdir) are used only under tests/.
+rust_test(
+    name = "xybrid-core_test",
+    crate = ":xybrid-core",
+    deps = [
+        "@crates//:criterion",
+        "@crates//:dirs",
+        "@crates//:hound",
+        "@crates//:libloading",
+        "@crates//:tempfile",
+        "@crates//:ureq",
+    ],
 )

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -108,6 +108,15 @@ rust_library(
 rust_test(
     name = "xybrid-core_test",
     crate = ":xybrid-core",
+    # Fixture files three inline tests read off disk (model metadata + the web
+    # SDK's serialization fixture). Cargo reads them straight from the worktree;
+    # Bazel sandboxes the action, so they have to be declared inputs. Both are
+    # resolved relative to CARGO_MANIFEST_DIR, which rules_rust points at this
+    # crate's directory, so the workspace-relative layout still applies.
+    data = [
+        "//bindings/web:rust_metadata_fixtures",
+        "//integration-tests:model_metadata_fixtures",
+    ],
     deps = [
         "@crates//:criterion",
         "@crates//:dirs",

--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -888,7 +888,13 @@ mod tests {
         };
         let serialized: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&metadata).unwrap()).unwrap();
-        let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        // Resolve the manifest dir at RUNTIME, not via `env!`. The compile-time
+        // value is baked into the binary and does not point anywhere useful when
+        // the test runs in a sandbox; the runtime variable is set by both cargo
+        // and Bazel. Same mechanism `testing::model_fixtures` already uses.
+        let manifest_dir =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set for tests");
+        let fixture_path = std::path::PathBuf::from(manifest_dir)
             .join("../../bindings/web/test/fixtures/rust-metadata-litertlm.json");
         let fixture: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(fixture_path).unwrap()).unwrap();

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -1,5 +1,6 @@
 # GATE 3: safe Rust wrapper over llama-cpp-sys. Builds once llama_cpp_sys links.
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 
 # Vision (mtmd safe wrappers): Android + desktop-linux (Flip 1) — must match
 # llama-cpp-sys/BUILD.bazel's _VISION_PLATFORMS and //:llama's libmtmd arms.
@@ -28,6 +29,13 @@ rust_library(
         "@crates//:tracing",
     ],
     visibility = ["//visibility:public"],
+)
+
+# Inline `#[cfg(test)] mod tests` (13). `crate = ` inherits srcs, edition, the
+# vision feature select and deps, so lib and test cannot drift. No dev-deps.
+rust_test(
+    name = "xybrid_llama_test",
+    crate = ":xybrid_llama",
 )
 
 # Dir-basename alias so `//crates/xybrid-llama` (the label all_crate_deps()

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -5,6 +5,7 @@
 # we lift `//macros` out. (sdk has no per-platform dep deltas, so the list is
 # plain and safe to filter; the platform feature deltas live in crate_features.)
 load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@crates//:data.bzl", "DEP_DATA")
 load("@rules_rs//rs/private:all_crate_deps.bzl", _all_crate_deps = "all_crate_deps")
 
@@ -105,4 +106,15 @@ rust_library(
         normal = True,
     ),
     visibility = ["//visibility:public"],
+)
+
+# Inline `#[cfg(test)] mod tests` (445 — the largest test target in the workspace
+# today). `crate = ` inherits srcs, edition, the platform feature select, deps and
+# proc_macro_deps; `deps` here ADDS the one dev-dependency the inline tests use
+# (httpmock, in registry_client.rs). The 37 tests under tests/ are separate
+# integration binaries and are NOT covered by this target.
+rust_test(
+    name = "xybrid-sdk_test",
+    crate = ":xybrid-sdk",
+    deps = ["@crates//:httpmock"],
 )

--- a/integration-tests/BUILD.bazel
+++ b/integration-tests/BUILD.bazel
@@ -14,3 +14,20 @@ rust_library(
     deps = all_crate_deps(normal = True),
     visibility = ["//visibility:public"],
 )
+
+# Committed model METADATA only (no model weights — those are downloaded and stay
+# untracked). xybrid-core's inline tests read these via `testing::model_fixtures`,
+# which resolves CARGO_MANIFEST_DIR/../../integration-tests/fixtures/models.
+# Bazel sandboxes actions, so the files must be declared as `data` on the test
+# target or those reads fail with the file simply absent.
+filegroup(
+    name = "model_metadata_fixtures",
+    srcs = glob(
+        [
+            "fixtures/models/models.json",
+            "fixtures/models/*/model_metadata.json",
+        ],
+        allow_empty = False,
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/xtask/BUILD.bazel
+++ b/xtask/BUILD.bazel
@@ -4,6 +4,7 @@
 # header gen) that Bazel deliberately does NOT own — so under a real migration
 # Bazel replaces the native-artifact CORE of xtask, not the publisher glue.
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
 rust_binary(
@@ -12,4 +13,11 @@ rust_binary(
     edition = "2021",
     deps = all_crate_deps(normal = True),
     visibility = ["//visibility:public"],
+)
+
+# Inline `#[cfg(test)] mod tests` (9) in the binary crate. `crate = ` recompiles
+# the binary above with `--test`; it inherits srcs, edition and deps. No dev-deps.
+rust_test(
+    name = "xtask_test",
+    crate = ":xtask",
 )


### PR DESCRIPTION
Extends the #397 pilot from one crate to five — from 26 tests to essentially the whole inline suite.

## Added
- **`crates/xybrid-core`** — ~1180 inline tests, the largest target in the workspace. Needs only the dev-deps its inline tests actually use: `criterion`, `dirs`, `hound`, `libloading`, `tempfile`, `ureq`.
- **`crates/xybrid-sdk`** — 445 inline tests. `deps` adds `httpmock` (used in `registry_client.rs`).
- **`crates/xybrid-llama`** — inline tests behind `bindings` (+`vision` on the linux RBE platform). No dev-deps.
- **`xtask`** — 9 inline tests in a *binary* crate; `crate = ` recompiles the `rust_binary` with `--test`.
- **`bazel.yml`** — all five run in the existing ubuntu RBE step.

## The dev-dependency cycle — not what it looked like
`xybrid-core` dev-depends on `xybrid-sdk`, which depends back on `xybrid-core`. Cargo permits this (dev-deps sit outside the published graph); Bazel can't express it.

**It does not block core's inline tests.** Nothing in `crates/xybrid-core/src` uses `xybrid_sdk` — the only mention is a doc-comment link in `cloud/config.rs`. The dev-dep exists purely for `tests/system_validation.rs`, an integration binary that is a separate target.

So no cycle-breaking refactor is needed. The earlier claim that core was blocked is corrected in this PR's workflow comment.

## Still outside Bazel
The `tests/` integration binaries — separate targets, own follow-up. `system_validation.rs` is the one that genuinely needs the cycle resolved.

## Verified
- All five test binaries compile on RBE, exit 0
- Cargo parity: core **994 passed / 1 ignored**, facade 26, llama 7 (`bindings,vision`), xtask 9
- Remote *execution* proven by this PR's CI, whose ubuntu host matches the RBE executor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI/Bazel test wiring and a test-only fixture path fix; no production runtime or auth paths.
> 
> **Overview**
> Expands the Bazel-on-RBE test step from a single **ffi-facade** pilot to five crates: **xybrid-core**, **xybrid-sdk**, **xybrid-llama**, **xtask**, plus facade. CI now runs their inline `#[cfg(test)]` suites remotely on Linux RBE.
> 
> Adds **`rust_test`** targets per crate (core pulls selected dev-deps only—no **xybrid-sdk**—so the core↔sdk dev-dep cycle stays out of the graph). **xybrid-core** declares **`data`** for web and integration-test JSON fixtures; new **`filegroup`** targets in `bindings/web` and `integration-tests` expose those files in the sandbox.
> 
> Fixes **LiteRT-LM metadata parity** test to resolve fixture paths via runtime **`CARGO_MANIFEST_DIR`** instead of **`env!`**, so paths work under Bazel sandboxes. Workflow comments clarify that **`tests/system_validation.rs`** (integration) remains outside Bazel because it needs the cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 932521368c5af3eaa0f5f8c14af388654f046c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->