### PR TITLE
test(bazel): run the first tests/ integration binaries under Bazel

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -157,19 +157,20 @@ jobs:
       # binaries execute remotely at all — a darwin-target build of the same
       # targets fails with Exit 126 on a Linux worker.
       #
-      # Covers the inline `#[cfg(test)] mod tests` of each crate. Still outside
-      # Bazel: the `tests/` integration binaries (separate targets), and among
-      # them xybrid-core's tests/system_validation.rs — the ONLY thing that needs
-      # core's dev-dependency on xybrid-sdk, the cycle Bazel cannot express.
-      # core's inline tests are unaffected: nothing in its src/ uses xybrid_sdk.
+      # The inline `#[cfg(test)] mod tests` of each crate, plus the first
+      # `tests/` integration binaries (one target per file, since each is its own
+      # binary). Still outside Bazel: the remaining tests/ binaries under
+      # xybrid-core, xybrid-cli and integration-tests, and xybrid-sdk's
+      # cloud_fallback_e2e (cargo gates it behind `dev-tools` and it needs a
+      # feature propagated sdk -> core, which Bazel does not do automatically).
       - name: Run Rust tests on RBE
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk test --config=remote -c opt --test_output=errors \
             //crates/xybrid-core:xybrid-core_test \
             //crates/xybrid-ffi-facade:xybrid-ffi-facade_test \
-            //crates/xybrid-llama:xybrid_llama_test \
-            //crates/xybrid-sdk:xybrid-sdk_test \
+            //crates/xybrid-llama:all \
+            //crates/xybrid-sdk:all \
             //xtask:xtask_test
 
       # Desktop lanes on RBE: linux CLI (native) + the macOS-CPU cross

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -38,6 +38,27 @@ rust_test(
     crate = ":xybrid_llama",
 )
 
+# Integration tests: each tests/*.rs is its own binary, so each gets its own
+# target. Unlike the inline target above, these use `srcs` + a dep on the library
+# (they link it as an external crate, exactly as cargo does).
+#
+# The two GGUF smokes are `#[ignore]`d — they need multi-hundred-MB models on
+# disk. Building them still type-checks the public surface they exercise, which
+# is the point of having them here; the ignored cases stay skipped.
+[
+    rust_test(
+        name = name,
+        srcs = ["tests/{}.rs".format(name)],
+        edition = "2021",
+        deps = [":xybrid_llama"],
+    )
+    for name in [
+        "prefix_cache_hit_smoke",
+        "recurrent_gating_smoke",
+        "wrapper_invariants",
+    ]
+]
+
 # Dir-basename alias so `//crates/xybrid-llama` (the label all_crate_deps()
 # emits for xybrid-core) resolves to the proven target above.
 alias(

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -42,21 +42,26 @@ rust_test(
 # target. Unlike the inline target above, these use `srcs` + a dep on the library
 # (they link it as an external crate, exactly as cargo does).
 #
-# The two GGUF smokes are `#[ignore]`d — they need multi-hundred-MB models on
-# disk. Building them still type-checks the public surface they exercise, which
-# is the point of having them here; the ignored cases stay skipped.
+# crate_features matters here: both GGUF smokes open with
+# `#![cfg(feature = "bindings")]`, so without that feature the file compiles to
+# an EMPTY binary — `--list` reports "0 tests" and nothing is type-checked. They
+# are `#[ignore]`d (each wants a multi-hundred-MB model on disk), so compiling
+# them is the entire value of having them here.
+_LLAMA_INTEGRATION_TESTS = {
+    "prefix_cache_hit_smoke": ["bindings"],
+    "recurrent_gating_smoke": ["bindings"],
+    "wrapper_invariants": [],
+}
+
 [
     rust_test(
         name = name,
         srcs = ["tests/{}.rs".format(name)],
+        crate_features = features,
         edition = "2021",
         deps = [":xybrid_llama"],
     )
-    for name in [
-        "prefix_cache_hit_smoke",
-        "recurrent_gating_smoke",
-        "wrapper_invariants",
-    ]
+    for name, features in _LLAMA_INTEGRATION_TESTS.items()
 ]
 
 # Dir-basename alias so `//crates/xybrid-llama` (the label all_crate_deps()

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -118,3 +118,52 @@ rust_test(
     crate = ":xybrid-sdk",
     deps = ["@crates//:httpmock"],
 )
+
+# Integration tests: each tests/*.rs is its own binary, so each gets its own
+# target with `srcs` + an explicit dep on whichever library it links as an
+# external crate (some reach xybrid-core directly, not through the sdk).
+_SDK_INTEGRATION_TESTS = {
+    "async_test": [
+        ":xybrid-sdk",
+        "@crates//:tokio",
+    ],
+    # NOTE: no cloud_fallback_e2e. Cargo declares it
+    # `required-features = ["dev-tools"]`, so a default `cargo test -p xybrid-sdk`
+    # skips it too; it reaches xybrid_core::orchestrator::authority::test_seams,
+    # which needs the `test-util` feature propagated sdk -> core. Bazel has no
+    # cross-crate feature propagation, so enabling it means hand-expanding the
+    # feature on both targets — deliberately left for whoever needs that lane.
+    "fixture_validation_test": [
+        ":xybrid-sdk",
+        "//crates/xybrid-core:xybrid-core",
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+    "from_directory_test": [":xybrid-sdk"],
+    "macro_test": [":xybrid-sdk"],
+    "metadata_gen_test": [
+        ":xybrid-sdk",
+        "//crates/xybrid-core:xybrid-core",
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+    "telemetry_integration": [
+        ":xybrid-sdk",
+        "//crates/xybrid-core:xybrid-core",
+        "@crates//:serde",
+        "@crates//:serde_json",
+    ],
+}
+
+[
+    rust_test(
+        name = name,
+        srcs = ["tests/{}.rs".format(name)],
+        edition = "2021",
+        # macro_test exercises the `xybrid_model!` proc-macro the sdk re-exports,
+        # so it needs the macro crate on its own compile line.
+        proc_macro_deps = ["//macros"] if name == "macro_test" else [],
+        deps = deps,
+    )
+    for name, deps in _SDK_INTEGRATION_TESTS.items()
+]

--- a/crates/xybrid-sdk/BUILD.bazel
+++ b/crates/xybrid-sdk/BUILD.bazel
@@ -139,6 +139,8 @@ _SDK_INTEGRATION_TESTS = {
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
+    # Reads integration-tests/fixtures/models/mnist/model_metadata.json, so it
+    # needs the fixture filegroup declared as data (see _SDK_TEST_DATA below).
     "from_directory_test": [":xybrid-sdk"],
     "macro_test": [":xybrid-sdk"],
     "metadata_gen_test": [
@@ -155,10 +157,18 @@ _SDK_INTEGRATION_TESTS = {
     ],
 }
 
+# Fixture files individual integration tests read off disk. Cargo reads them
+# straight from the worktree; Bazel sandboxes the action, so they must be
+# declared inputs or the reads fail.
+_SDK_TEST_DATA = {
+    "from_directory_test": ["//integration-tests:model_metadata_fixtures"],
+}
+
 [
     rust_test(
         name = name,
         srcs = ["tests/{}.rs".format(name)],
+        data = _SDK_TEST_DATA.get(name, []),
         edition = "2021",
         # macro_test exercises the `xybrid_model!` proc-macro the sdk re-exports,
         # so it needs the macro crate on its own compile line.

--- a/crates/xybrid-sdk/tests/from_directory_test.rs
+++ b/crates/xybrid-sdk/tests/from_directory_test.rs
@@ -5,8 +5,13 @@ use xybrid_sdk::model::{ModelLoader, SdkError};
 
 /// Helper to get the path to fixture models from the workspace root.
 fn fixtures_dir() -> PathBuf {
-    // Tests run from the crate directory; fixtures are at the workspace level
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Tests run from the crate directory; fixtures are at the workspace level.
+    // Resolve at RUNTIME rather than with `env!`: the compile-time value is baked
+    // into the binary and does not point anywhere useful when the test runs in a
+    // sandbox. Both cargo and Bazel set the variable for test execution.
+    let manifest_dir = PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set for tests"),
+    );
     manifest_dir
         .parent() // crates/
         .unwrap()


### PR DESCRIPTION
With the dev-dependency cycle gone (#399), the `tests/` binaries can move.

Each `tests/*.rs` is its own binary, so each gets its own target — `srcs` plus an explicit dep on whichever library it links as an external crate. Different shape from the inline targets, which use `crate = `.

## Added
- **`crates/xybrid-llama`** — all 3 files. The two GGUF smokes are `#[ignore]`d (they want multi-hundred-MB models on disk); building them still type-checks the public surface they exercise.
- **`crates/xybrid-sdk`** — 6 of 7. Several reach `xybrid-core` directly rather than through the sdk, and `macro_test` needs `//macros` on its own compile line for the re-exported `xybrid_model!` proc-macro.

## Deliberately absent: `cloud_fallback_e2e`
Cargo declares it `required-features = ["dev-tools"]`, so a default `cargo test -p xybrid-sdk` skips it too. It reaches `xybrid_core::orchestrator::authority::test_seams`, which needs `test-util` propagated sdk → core. **Bazel has no cross-crate feature propagation**, so that lane needs the feature hand-expanded on both targets — left for whoever wants it.

## One thing worth noting
My first dep pass scanned only `use` lines and failed to compile on RBE — it missed `serde_json::…` / `xybrid_sdk::…` referenced inline. Deps are now extracted by scanning fully-qualified crate paths.

## Verified
- Every target compiles on RBE
- Cargo parity where tests actually run: `wrapper_invariants` 4, `macro_test` 2, `async_test` 2

## Remaining
`tests/` binaries under `xybrid-core` (12), `xybrid-cli` (4) and `integration-tests` (8) — most are model-gated and need fixture wiring, so they're their own follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Bazel test wiring plus a small test helper change; no production runtime or security-sensitive logic.
> 
> **Overview**
> Extends the Bazel RBE test gate from inline `#[cfg(test)]` targets to the first wave of **`tests/` integration binaries** in `xybrid-llama` and `xybrid-sdk`. CI now runs `bazelisk test` on `//crates/xybrid-llama:all` and `//crates/xybrid-sdk:all` instead of only each crate’s single inline test target.
> 
> **`xybrid-llama`** adds one `rust_test` per integration file (`prefix_cache_hit_smoke`, `recurrent_gating_smoke`, `wrapper_invariants`), with explicit `crate_features` so GGUF smokes gated on `bindings` still compile and type-check under Bazel (they stay `#[ignore]` at runtime).
> 
> **`xybrid-sdk`** adds six integration targets with per-file `deps` (including direct `xybrid-core` and `//macros` for `macro_test`), plus `data` wiring for `from_directory_test` via `//integration-tests:model_metadata_fixtures`. **`cloud_fallback_e2e`** is intentionally omitted (Cargo `dev-tools` / cross-crate `test-util` features Bazel does not propagate).
> 
> **`from_directory_test`** resolves `CARGO_MANIFEST_DIR` at **runtime** so fixture paths work in Bazel’s sandbox, not only with compile-time `env!`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c1373984d36a03a00a09dd049e04453a048f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->