### PR TITLE
test(bazel): run the remaining tests/ binaries (cli + core fixtures)

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -160,18 +160,22 @@ jobs:
       # The inline `#[cfg(test)] mod tests` of each crate, plus the `tests/`
       # integration binaries (one target per file, since each is its own binary).
       #
-      # Still outside Bazel, each for a specific reason:
-      #  - xybrid-cli's 4 tests spawn the built binary via
-      #    env!("CARGO_BIN_EXE_xybrid"), which cargo sets and rules_rust does not.
-      #  - 7 xybrid-core tests read files off disk, so each needs its inputs
-      #    declared and its paths resolved at runtime rather than via env!.
-      #  - xybrid-sdk's cloud_fallback_e2e is gated behind `dev-tools` in cargo
-      #    and needs `test-util` propagated sdk -> core; Bazel has no cross-crate
+      # Every tests/ binary in the workspace is now covered. The two exceptions
+      # are both cargo-gated the same way in cargo itself:
+      #  - xybrid-sdk's cloud_fallback_e2e (required-features = ["dev-tools"])
+      #    needs `test-util` propagated sdk -> core, and Bazel has no cross-crate
       #    feature propagation.
+      #  - integration-tests' local_llm is gated on llm-mistral, a backend
+      #    xybrid-core's Bazel target does not build at all.
+      #
+      # Adding a target is not enough on its own: a file wrapped in
+      # `#![cfg(feature = ...)]` compiles to an EMPTY binary that still reports
+      # success, so each target's `--list` count is checked against cargo's.
       - name: Run Rust tests on RBE
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk test --config=remote -c opt --test_output=errors \
+            //crates/xybrid-cli:all \
             //crates/xybrid-core:all \
             //crates/xybrid-ffi-facade:xybrid-ffi-facade_test \
             //crates/xybrid-llama:all \

--- a/crates/xybrid-cli/BUILD.bazel
+++ b/crates/xybrid-cli/BUILD.bazel
@@ -5,11 +5,33 @@ load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
+# crate_features mirrors the LLM half of cargo's `platform-desktop`
+# (= ort-download + llm-llamacpp-vision + huggingface), which is what the shipped
+# cargo CLI is built with. Only two of those names are gated in this crate's own
+# source — llm-llamacpp and llm-mistral, 7 sites each in commands/repl.rs — the
+# rest are pure passthroughs to xybrid-sdk. Bazel does not propagate features to
+# dependencies (core/sdk set their own), so this list exists purely to open this
+# crate's cfgs.
+#
+# Without it the shipped binary took the `#[cfg(not(any(feature =
+# "llm-mistral", feature = "llm-llamacpp")))]` arms: `repl --stream` answered
+# "Streaming requested but LLM features not enabled" and refused to stream, while
+# the cargo-built CLI streams. The linux CLI smoke did not catch it because the
+# mtmd/huggingface symbols it greps for come from the dependency crates, not
+# from these cfgs.
 rust_binary(
     name = "xybrid",
     srcs = glob(["src/**/*.rs"]),
     edition = "2021",
-    crate_features = ["default"],
+    # Listed flat, not as the preset: Bazel does not expand transitive features
+    # the way Cargo does, so "llm-llamacpp-vision" alone would NOT imply
+    # "llm-llamacpp" and the cfgs would stay closed (verified against the built
+    # binary's strings). Same rule the core/sdk targets follow.
+    crate_features = [
+        "default",
+        "llm-llamacpp",
+        "llm-llamacpp-vision",
+    ],
     deps = all_crate_deps(normal = True),
     visibility = ["//visibility:public"],
 )

--- a/crates/xybrid-cli/BUILD.bazel
+++ b/crates/xybrid-cli/BUILD.bazel
@@ -2,6 +2,7 @@
 # name `xybrid` per the resolved DEP_DATA). Deps = core + sdk + clap/console/etc,
 # all auto-resolved. Compiles once the xybrid-core ort ceiling is addressed.
 load("@rules_rs//rs:rust_binary.bzl", "rust_binary")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@crates//:defs.bzl", "all_crate_deps")
 
 rust_binary(
@@ -12,3 +13,49 @@ rust_binary(
     deps = all_crate_deps(normal = True),
     visibility = ["//visibility:public"],
 )
+
+# Integration tests. Every one of these spawns the built CLI, locating it through
+# `env!("CARGO_BIN_EXE_xybrid")`.
+#
+# That variable is not something we set by hand: rules_rust populates
+# CARGO_BIN_EXE_<name> for any `bin` crate listed in a target's `data`
+# (rust/private/rustc.bzl — "Make bin crate data deps available to tests"), using
+# the binary's runfiles-relative short_path. So `:xybrid` belongs in data, not
+# deps, and the binary is staged into the test's runfiles at the same path the
+# compile-time variable records.
+_CLI_INTEGRATION_TESTS = {
+    "init_json_test": [
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+    "reasoning_budget_cli_test": [
+        "//crates/xybrid-core:xybrid-core",
+        "@crates//:tempfile",
+    ],
+    "telemetry_status_test": [],
+    "vlm_cli_test": [
+        "//crates/xybrid-core:xybrid-core",
+        "@crates//:image",
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+}
+
+# Two of the four open with `#![cfg(feature = "llm-llamacpp")]`; without the
+# feature they compile to EMPTY binaries that still report success.
+_CLI_TEST_FEATURES = {
+    "reasoning_budget_cli_test": ["llm-llamacpp"],
+    "vlm_cli_test": ["llm-llamacpp"],
+}
+
+[
+    rust_test(
+        name = name,
+        srcs = ["tests/{}.rs".format(name)],
+        crate_features = _CLI_TEST_FEATURES.get(name, []),
+        data = [":xybrid"],
+        edition = "2021",
+        deps = deps,
+    )
+    for name, deps in _CLI_INTEGRATION_TESTS.items()
+]

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -105,20 +105,41 @@ rust_library(
 #
 # `deps` lists the dev-dependencies the inline tests really reach for; the other
 # declared dev-deps (filetime, walkdir) are used only under tests/.
-# Integration tests that need no on-disk fixtures. Each tests/*.rs is its own
-# binary, so each gets its own target: `srcs` + a dep on the library it links as
-# an external crate.
+# Integration tests. Each tests/*.rs is its own binary, so each gets its own
+# target: `srcs` + a dep on the library it links as an external crate.
 #
-# NOT here yet (each reads files off disk, so each needs its inputs declared and
-# its paths resolved at runtime rather than via `env!`):
-#   legacy_cache_names, llm_context_integration, mobilenet_vision_parity,
-#   pipeline_yaml_integration, tts_integration, tts_smoke, vlm_lfm2_smoke
+# The model-backed ones self-skip when the weights are absent (which is the case
+# on CI) but still read the committed model METADATA, so they take the fixture
+# filegroup as data — Bazel sandboxes the action, and undeclared reads fail.
 _CORE_INTEGRATION_TESTS = {
     "conformance_runtime_adapter": [":xybrid-core"],
     "integration_hiiipe": [":xybrid-core"],
+    "legacy_cache_names": [
+        ":xybrid-core",
+        "@crates//:walkdir",
+    ],
+    "llm_context_integration": [
+        ":xybrid-core",
+        "@crates//:serde_json",
+    ],
+    "mobilenet_vision_parity": [
+        ":xybrid-core",
+        "@crates//:image",
+        "@crates//:ndarray",
+        "@crates//:serde_json",
+    ],
     "multimodal_messages": [
         ":xybrid-core",
         "@crates//:image",
+    ],
+    "pipeline_yaml_integration": [":xybrid-core"],
+    "tts_integration": [
+        ":xybrid-core",
+        "@crates//:serde_json",
+    ],
+    "tts_smoke": [
+        ":xybrid-core",
+        "@crates//:serde_json",
     ],
     "vision_envelope": [
         ":xybrid-core",
@@ -130,12 +151,37 @@ _CORE_INTEGRATION_TESTS = {
         "@crates//:ndarray",
         "@crates//:serde_json",
     ],
+    "vlm_lfm2_smoke": [
+        ":xybrid-core",
+        "@crates//:image",
+        "@crates//:serde_json",
+    ],
+}
+
+# vlm_lfm2_smoke opens with `#![cfg(feature = "llm-llamacpp")]`; without the
+# feature the file compiles to an EMPTY binary that still reports success. The
+# library target above already builds with llm-llamacpp, so this lines up.
+_CORE_TEST_FEATURES = {
+    "vlm_lfm2_smoke": ["llm-llamacpp"],
+}
+
+# legacy_cache_names is a source-scanning lint: it walks the crate's own src/
+# looking for retired cache-key names, so the sources themselves are inputs.
+_CORE_TEST_DATA = {
+    "legacy_cache_names": glob(["src/**/*.rs"]),
+    "llm_context_integration": ["//integration-tests:model_metadata_fixtures"],
+    "mobilenet_vision_parity": ["//integration-tests:model_metadata_fixtures"],
+    "tts_integration": ["//integration-tests:model_metadata_fixtures"],
+    "tts_smoke": ["//integration-tests:model_metadata_fixtures"],
+    "vlm_lfm2_smoke": ["//integration-tests:model_metadata_fixtures"],
 }
 
 [
     rust_test(
         name = name,
         srcs = ["tests/{}.rs".format(name)],
+        crate_features = _CORE_TEST_FEATURES.get(name, []),
+        data = _CORE_TEST_DATA.get(name, []),
         edition = "2021",
         deps = deps,
     )

--- a/crates/xybrid-core/tests/legacy_cache_names.rs
+++ b/crates/xybrid-core/tests/legacy_cache_names.rs
@@ -19,7 +19,12 @@ fn legacy_cache_names_are_contained() {
         format!("cache{}miss{}tokens", "_", "_"),
     ];
 
-    let scan_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    // Resolve at RUNTIME rather than with `env!`: the compile-time value is baked
+    // into the binary and does not point anywhere useful when the test runs in a
+    // sandbox. Both cargo and Bazel set the variable for test execution.
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set for tests");
+    let scan_root = std::path::Path::new(&manifest_dir).join("src");
     let mut offenders = Vec::new();
     for entry in walkdir::WalkDir::new(&scan_root) {
         let e = match entry {


### PR DESCRIPTION
Completes the `tests/` migration — **38 `rust_test` targets**, covering every `tests/*.rs` in the workspace bar two that cargo itself gates the same way.

## `xybrid-cli` (4 files) — the `CARGO_BIN_EXE` problem, solved
All four spawn the built CLI via `env!("CARGO_BIN_EXE_xybrid")`. I'd assumed rules_rust didn't support that; it does.

**rules_rust populates `CARGO_BIN_EXE_<name>` for any `bin` crate listed in a target's `data`** (`rust/private/rustc.bzl` — "Make bin crate data deps available to tests"), using the binary's runfiles-relative `short_path`. So `:xybrid` goes in **`data`**, not `deps`, and the binary lands in the test's runfiles at exactly the path the compile-time variable records. No hand-set env, no wrapper.

## `xybrid-core` (7 files)
Model-backed ones self-skip without weights but still read committed model metadata → fixture filegroup as `data`. `legacy_cache_names` is a source-scanning lint over the crate's own `src/`, so the sources are declared inputs, and its scan root now resolves `CARGO_MANIFEST_DIR` at runtime instead of `env!` — the **fourth** instance of that fix.

## Process change that stuck
Feature gates were checked **before** writing targets this time, not after review. `vlm_lfm2_smoke`, `reasoning_budget_cli_test` and `vlm_cli_test` all open with `#![cfg(feature = "llm-llamacpp")]` and would otherwise have become empty binaries reporting success.

## Still out — both mirror cargo's own behaviour
| | why |
|---|---|
| `cloud_fallback_e2e` | `required-features = ["dev-tools"]`; needs `test-util` propagated sdk → core |
| `local_llm` | gated on `llm-mistral`, a backend `xybrid-core`'s Bazel target doesn't build |

## Verified
- All 11 new targets compile on RBE
- **Every `--list` count matches cargo**: cli 3/3/2/1 · core 1/6/1/13/4/1/2
- `fmt` and `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are build/CI and test wiring only; the CLI feature fix corrects behavior parity but does not touch auth, data paths, or production runtime logic beyond enabling existing LLM cfgs in the Bazel-built binary.
> 
> **Overview**
> Finishes Bazel coverage for workspace **`tests/*.rs`** integration binaries: CI now runs **`//crates/xybrid-cli:all`** alongside the existing core/sdk/integration test bundles, with workflow comments updated to note that only two tests remain excluded for the same reasons as Cargo (`dev-tools` / `llm-mistral`).
> 
> **`xybrid-cli`** adds four **`rust_test`** targets that put **`:xybrid` in `data`** so **`CARGO_BIN_EXE_xybrid`** resolves under rules_rust, and enables **`llm-llamacpp`** on feature-gated tests so they are not empty pass-through binaries. The shipped **`xybrid`** binary now lists **`llm-llamacpp`** / **`llm-llamacpp-vision`** explicitly so REPL streaming matches the Cargo desktop build.
> 
> **`xybrid-core`** registers seven more integration tests with declared **`data`** (model metadata fixtures and, for **`legacy_cache_names`**, **`src/**/*.rs`**). **`legacy_cache_names`** resolves **`CARGO_MANIFEST_DIR` at runtime** instead of **`env!`** so the source scan works in Bazel sandboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3241e2eca2d783eceea96c62ef1b92447749fbc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->