### PR TITLE
ci(bazel): build the Flutter iOS-device staticlib in the macOS lane

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -393,13 +393,22 @@ jobs:
             //crates/xybrid-cli:xybrid \
             //bindings/flutter/rust:xybrid_flutter_ffi_staticlib
 
-      # Release-critical since the Flutter precompile flip (release-prep
-      # precompile-flutter-darwin ships it): the iOS-simulator staticlib.
-      # Mac-local like the ios configs themselves; the device slice is
-      # already covered per-PR by build-apple.yml's xcframework build.
-      - name: Build Flutter iOS-sim staticlib
+      # Release-critical since the Flutter precompile flip: release-prep's
+      # precompile-flutter-darwin stages THREE Apple slices of this staticlib —
+      # aarch64-apple-darwin (built above), aarch64-apple-ios and
+      # aarch64-apple-ios-sim. Both ios configs are Mac-local, like the configs
+      # themselves.
+      #
+      # The device slice used to be skipped here on the grounds that
+      # build-apple.yml already covered it. It does not: that workflow builds
+      # //bindings/apple:XybridFFI, which is the BOLT staticlib from a different
+      # crate. Nothing was compiling //bindings/flutter/rust for iOS-device
+      # until release time.
+      - name: Build Flutter iOS staticlibs (device + simulator)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
+          bazelisk build --config=ios \
+            //bindings/flutter/rust:xybrid_flutter_ffi_staticlib
           bazelisk build --config=ios-sim \
             //bindings/flutter/rust:xybrid_flutter_ffi_staticlib
 


### PR DESCRIPTION
Scoping "Flutter desktop per-PR" turned up that the real gap isn't desktop — it's an **Apple slice that ships every release but was built nowhere in between**.

## The gap
`release-prep`'s `precompile-flutter-darwin` stages **three** Apple slices of `//bindings/flutter/rust:xybrid_flutter_ffi_staticlib`:

| slice | built by the macOS lane before |
|---|---|
| `aarch64-apple-darwin` | ✅ (macos-metal) |
| `aarch64-apple-ios-sim` | ✅ (ios-sim) |
| `aarch64-apple-ios` | ❌ **nothing** |

The step's comment claimed the device slice was "already covered per-PR by build-apple.yml's xcframework build". **It isn't** — that workflow builds `//bindings/apple:XybridFFI`, the *bolt* staticlib from a different crate. Nothing compiled `//bindings/flutter/rust` for iOS-device between release cuts.

## Correction to my own first framing
I initially wrote this up as closing a *per-PR* gap. It isn't: `bazel-macos-metal` is `if: github.event_name != 'pull_request'`, so it runs on **master pushes**, not PRs. The Apple flutter slices were never PR-gated — that's a deliberate macos-14 cost decision, and this PR doesn't change it. What improves is detection moving from *release-cut time* to *the master push that introduces the break*.

## Verified it's genuinely the device slice
```
arm64 · LC_BUILD_VERSION platform 2 (PLATFORM_IOS; simulator is 7) · minos 16.0
```
438 actions on a cold Mac; fewer in the lane, where the ios graph is partly warm from the xcframework build.

## Deliberately unchanged
- **`precompile-flutter-windows` stays on cargo/MSVC** — `bindings/flutter/rust/BUILD.bazel` documents why: cargokit's asset name pins `x86_64-pc-windows-msvc`, so a MinGW `.dll` carries the wrong triple and consumers never download it. Packaging contract, not oversight.
- **`build-flutter.yml`'s linux-only matrix** — it exercises the cargokit/Dart path, not the natives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change on an existing Mac lane; no product runtime or auth/data paths touched.
> 
> **Overview**
> **Closes a release-critical CI gap** for Flutter Darwin precompiles: `release-prep` ships three Apple slices of `//bindings/flutter/rust:xybrid_flutter_ffi_staticlib`, but the **iOS device** slice was never built in CI between releases.
> 
> The **`bazel-macos-metal`** job (master pushes only, not PRs) now runs **`bazelisk build --config=ios`** for that target alongside the existing **ios-sim** build. The step is renamed to reflect **device + simulator** staticlibs, and comments clarify that **`build-apple.yml`** builds **`//bindings/apple:XybridFFI`** (BOLT), not the Flutter Rust crate—so the old assumption that device was already covered was wrong.
> 
> **Effect:** iOS-device Flutter native breaks surface on the **next master push** after the change lands, instead of only when release prep compiles that slice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ccfae17c9bc2ede3c97c5b5888435783b6af62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->