### PR TITLE
ci(unity): add the manual Unity license activation workflow

### DIFF
--- a/.github/workflows/unity-activation.yml
+++ b/.github/workflows/unity-activation.yml
@@ -1,0 +1,51 @@
+# Unity license activation — MANUAL, run rarely.
+#
+# GameCI runs the Unity Editor in a Docker image, and the Editor needs a license
+# file to start. This workflow produces the request half of that exchange:
+#
+#   1. Dispatch this workflow. It emits a `.alf` (activation request) artifact.
+#   2. Upload the `.alf` at https://license.unity3d.com/manual — Unity hands back
+#      a `.ulf` (the license itself).
+#   3. Store the FULL CONTENTS of the `.ulf` as the `UNITY_LICENSE` repo secret,
+#      alongside `UNITY_EMAIL` and `UNITY_PASSWORD`.
+#
+# Kept in the repo rather than deleted after first use: Unity licenses expire and
+# GameCI image bumps can invalidate them, so this is re-run whenever the Unity
+# Editor CI starts failing to activate.
+#
+# The `.alf` contains machine bindings and an account identifier, not a
+# credential — but the `.ulf` you get back IS the license, so it goes in secrets,
+# never in the repo.
+name: Unity activation (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      unityVersion:
+        description: "Unity version to request activation for"
+        required: true
+        # Matches tools/unity-runtime-smoke/ProjectSettings/ProjectVersion.txt.
+        default: "6000.3.6f1"
+
+permissions:
+  contents: read
+
+jobs:
+  request-activation-file:
+    name: Request Unity activation file
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Request activation file
+        id: get-alf
+        uses: game-ci/unity-request-activation-file@65874ef791dae6dfa5829f1cb490eafbd7b2173c # v2.2.0
+        with:
+          unityVersion: ${{ inputs.unityVersion }}
+
+      - name: Upload activation file
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: unity-activation-file
+          path: ${{ steps.get-alf.outputs.filePath }}
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
First step toward **Unity Editor CI** — the repo currently has **zero** Unity Editor jobs in any workflow.

## What this is
GameCI runs the Unity Editor in a Docker image, and the Editor needs a license file to start. This workflow emits the *request* half of that exchange.

**The one-time ritual, once this merges:**
1. Dispatch this workflow → produces a `.alf` artifact
2. Upload the `.alf` at **license.unity3d.com/manual** → Unity returns a `.ulf`
3. Store the `.ulf` contents as `UNITY_LICENSE`, plus `UNITY_EMAIL` / `UNITY_PASSWORD`

## Why it merges before it's useful
GitHub only exposes `workflow_dispatch` for workflows **present on the default branch**. It can't be dispatched from a feature branch, so it has to land first.

## Why it's kept, not deleted after use
Unity licenses expire and GameCI image bumps can invalidate them. This gets re-run whenever Editor CI stops activating — deleting it would just mean rewriting it later.

## Risk checked before writing it
The Unity version pinned by `tools/unity-runtime-smoke` is **6000.3.6f1**, which is recent. The matching GameCI image **`unityci/editor:6000.3.6f1-base-3.2.2` exists** — that was the main thing that could have sunk this approach.

## Security note
The `.alf` holds machine bindings and an account identifier, not a credential. The `.ulf` you get back **is** the license — it goes in secrets, never in the repo. Artifact retention is set to 1 day.

## Next (separate PR)
The actual Editor CI job: build the bolt **Linux** `.so` (not built in CI today — only the windows one is), stage it plus ORT into the Unity package, and run the 15 EditMode tests in a real Editor. One of those test files has 16 native call sites, so it genuinely exercises the `.so` rather than passing vacuously.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only, read-only permissions, pinned third-party actions, and no secrets or license material committed—operational risk is limited to artifact handling documented in the workflow.
> 
> **Overview**
> Adds a **manual** GitHub Actions workflow so maintainers can generate a Unity **`.alf`** activation request for GameCI Editor runs, without checking licenses into the repo.
> 
> **`workflow_dispatch`** accepts a Unity version (default **`6000.3.6f1`**, aligned with `tools/unity-runtime-smoke`). One job calls **`game-ci/unity-request-activation-file`** and uploads the result as a **1-day** artifact with **`contents: read`** only. Inline docs describe the follow-up: manual upload at Unity’s license site, then store the **`.ulf`** in **`UNITY_LICENSE`** (and related secrets).
> 
> This is groundwork for future Unity Editor CI; it does not run the Editor or consume secrets in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f430f78fa8cc625cdc2887c26247ee7bc5fc7add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->