### PR TITLE
fix(bazel): link the C++ runtime statically into the linux cdylibs

### DIFF
--- a/bindings/flutter/rust/BUILD.bazel
+++ b/bindings/flutter/rust/BUILD.bazel
@@ -29,6 +29,19 @@ rust_shared_library(
     srcs = glob(["src/**/*.rs"]),
     crate_name = "xybrid_flutter_ffi",
     edition = "2021",
+    # Same reason as //crates/xybrid-bolt:xybrid_bolt_cdylib: rules_rust hands
+    # cdylibs the cc toolchain's DYNAMIC C++ runtime by default, which put
+    # libc++.so.1 in DT_NEEDED even though the hermetic toolchain ships no such
+    # shared object — so the link resolved only inside the build container.
+    # "static" selects static_runtime_lib, the runtime the CLI binary gets.
+    #
+    # LINUX ONLY: on android the dynamic runtime lib is the NDK's
+    # libc++_shared.so, whose DT_NEEDED is load-bearing (see the bolt cdylib's
+    # note — A/B showed a blanket "static" drops it).
+    cc_runtime_linkage = select({
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": "static",
+        "//conditions:default": "dynamic",
+    }),
     # ["default"] matches the cargokit ship (it passes no --features); the real
     # candle/vision/coreml feature set flows transitively from the //crates/
     # xybrid-sdk target this links (verified: the darwin staticlib carries

--- a/crates/xybrid-bolt/BUILD.bazel
+++ b/crates/xybrid-bolt/BUILD.bazel
@@ -28,6 +28,26 @@ rust_shared_library(
     srcs = glob(["src/**/*.rs"]),
     crate_name = "xybrid_bolt",
     edition = "2021",
+    # rules_rust hands cdylibs the cc toolchain's DYNAMIC C++ runtime by default
+    # (rustc.bzl: `if crate_type in ["dylib", "cdylib"] and linkage != "static"`),
+    # which put libc++.so.1 / libc++abi.so.1 / libunwind.so.1 in DT_NEEDED on
+    # linux. The hermetic toolchain ships no such shared objects, so the link only
+    # resolved inside the build container and the plugin failed to load anywhere
+    # else — Unity Editor CI caught it as
+    #   DllNotFoundException : libc++.so.1: cannot open shared object file
+    # "static" selects static_runtime_lib, the runtime the CLI binary already
+    # gets, which is why executables were never affected.
+    #
+    # LINUX ONLY, deliberately. On android the dynamic runtime lib IS the NDK's
+    # libc++_shared.so, and its DT_NEEDED is load-bearing (the boltffi relink /
+    # 16KB-page work, guarded by a dlopen gate). Verified by A/B: with "static"
+    # applied everywhere, libc++_shared.so disappeared from the android .so.
+    # Windows is left on the default too — its cdylib is already proven clean by
+    # the PE import audit, via the static trio in :win_cxx_runtime.
+    cc_runtime_linkage = select({
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": "static",
+        "//conditions:default": "dynamic",
+    }),
     crate_features = ["default"],
     rustc_flags = select({
         "@platforms//os:android": [


### PR DESCRIPTION
Both shipped linux cdylibs depended on a shared C++ runtime **that does not exist outside the build container**:

```
NEEDED libc++.so.1 / libc++abi.so.1 / libunwind.so.1
```

The hermetic toolchain ships only static archives — there is no `libc++.so.1` anywhere in the workspace — so the link resolved inside the RBE image and the library failed to load on any real machine.

**Unity Editor CI (#406) found it on its first successful run:**
```
System.DllNotFoundException : libc++.so.1: cannot open shared object file
editmode-results.xml - 15/24, failed: 9
```

## Cause
`rules_rust` gives cdylibs the cc toolchain's **dynamic** runtime by default:

```python
# rustc.bzl — get_cc_toolchain_runtime_libs
if crate_type in ["dylib", "cdylib"] and linkage != "static":
    return cc_toolchain.dynamic_runtime_lib(...)
return cc_toolchain.static_runtime_lib(...)
```

`rust_binary` takes the static branch — which is why the CLI was never affected and no existing smoke caught this.

## Fix
Set `cc_runtime_linkage = "static"`. It's a first-class rules_rust attribute for exactly this case — **no toolchain patch needed**.

## Scoped to linux on purpose
A blanket `"static"` **silently dropped android's `libc++_shared.so`**, whose `DT_NEEDED` is load-bearing (the boltffi relink / 16KB-page work in #287, guarded by a dlopen gate). Caught by building the android `.so` with and without the change and diffing — not by reasoning.

Windows keeps the default too: its cdylib is already proven clean by the PE import audit via the static trio in `:win_cxx_runtime`.

## Verified per artifact
Each copied off before the next build — the `bazel-out` symlink otherwise serves whichever config built last, which produced **two false readings** while diagnosing this.

| artifact | arch | `libc++.so.1` | `libc++_shared.so` |
|---|---|---|---|
| bolt linux | x86-64 | **0** | 0 |
| bolt android | aarch64 | 0 | **1** (preserved) |
| flutter linux | x86-64 | **0** | 0 |

Introduced by #394; **not released** — `v0.4.0-alpha` predates it.

Should turn the Unity Editor job green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how shipped Linux `.so` artifacts link the C++ runtime; the linux-only `select` is load-bearing because a blanket static linkage was shown to drop Android’s required `libc++_shared.so`.
> 
> **Overview**
> Fixes **Linux** `rust_shared_library` builds that were recording `DT_NEEDED` on `libc++.so.1` / `libc++abi.so.1` / `libunwind.so.1` even though the hermetic toolchain only provides static C++ runtimes, which caused `DllNotFoundException` when loading the plugins outside the build image (e.g. Unity Editor CI).
> 
> Both `xybrid_bolt_cdylib` and `xybrid_flutter_ffi_cdylib` set **`cc_runtime_linkage = "static"`** via a `select` limited to `x86_64-unknown-linux-gnu`; **Android and other platforms stay on dynamic** so NDK `libc++_shared.so` remains in `DT_NEEDED` for bolt’s JNI/16KB-page linking path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45b9dd035cd700e0048670e77af8a4b05ba0a62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->