### PR TITLE
fix(flutter): default to precompiled binaries so the published package builds (#338)

### DIFF
--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Prerelease exercising the new release pipeline.
 
+* Fixed: builds failed with `error inheriting 'edition' from workspace root manifest` for anyone with a Rust toolchain installed — cargokit disabled precompiled binaries whenever `rustup` was on `PATH`, then fell back to a source build the published package cannot perform. Precompiled binaries are now the default; source builds stay available via `use_precompiled_binaries: false`, and when they cannot succeed they now fail with an explanation instead of a cargo error (xybrid-ai/xybrid#338)
 * Fixed: `libxybrid_flutter.so` not found when compiling from source on Linux (xybrid-ai/xybrid#340)
 * Changed: the precompiled binaries (desktop + mobile) are now built by Bazel with hermetic toolchains — same download, naming, and signature; the Linux `.so` now loads on older-glibc distros than before (xybrid-ai/xybrid#369, xybrid-ai/xybrid#371)
 

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -251,7 +251,20 @@ Native ML runtimes are resolved automatically at build time:
 - **iOS**: ONNX Runtime xcframework downloaded from HuggingFace and cached at `~/.xybrid/cache/ort-ios/`
 - **macOS/Linux/Windows**: ONNX Runtime downloaded by the `ort` Rust crate at compile time
 
-Precompiled Rust binaries are available for all platforms via [cargokit](https://github.com/nicklocking/cargokit) — no Rust toolchain required for most users.
+The Rust library itself ships as a precompiled, signature-verified binary for
+every supported platform via [cargokit](https://github.com/nicklocking/cargokit),
+downloaded at build time. No Rust toolchain is required, and having one
+installed does not change anything — the published package is precompiled-only
+and cannot be built from source, because its Rust crate lives in the xybrid
+monorepo workspace.
+
+Building from source is for monorepo development. Depend on
+`bindings/flutter` by path and add a `cargokit_options.yaml` next to your app's
+`pubspec.yaml`:
+
+```yaml
+use_precompiled_binaries: false
+```
 
 ## Example App
 

--- a/bindings/flutter/cargokit/build_tool/lib/src/artifacts_provider.dart
+++ b/bindings/flutter/cargokit/build_tool/lib/src/artifacts_provider.dart
@@ -63,6 +63,20 @@ class ArtifactProvider {
       return result;
     }
 
+    // xybrid addition. Upstream cargokit falls straight through to a source
+    // build here. The published `xybrid_flutter` package cannot be built from
+    // source — see `_sourceBuildBlocker` — so that fallback used to surface as
+    // an unrelated cargo error (#338). Stop with an actionable message instead.
+    final blocker = _sourceBuildBlocker();
+    if (blocker != null) {
+      throw SourceBuildUnavailableException(
+        targets: pendingTargets,
+        blocker: blocker,
+        precompiledEnabled: userOptions.usePrecompiledBinaries &&
+            environment.crateOptions.precompiledBinaries != null,
+      );
+    }
+
     final rustup = Rustup();
     for (final target in targets) {
       final builder = RustBuilder(target: target, environment: environment);
@@ -94,6 +108,60 @@ class ArtifactProvider {
       result[target] = artifacts;
     }
     return result;
+  }
+
+  /// Returns a description of why this crate cannot be built from source in
+  /// its current location, or `null` if a source build is viable.
+  ///
+  /// Both checks below hold inside the monorepo and fail in the package
+  /// published to pub.dev, which ships `rust/` without the workspace root it
+  /// inherits from and without the sibling crates its path dependencies point
+  /// at.
+  String? _sourceBuildBlocker() {
+    final manifestFile = File(path.join(environment.manifestDir, 'Cargo.toml'));
+    if (!manifestFile.existsSync()) {
+      return 'no Cargo.toml in ${environment.manifestDir}';
+    }
+    final manifest = manifestFile.readAsStringSync();
+
+    if (RegExp(r'workspace\s*=\s*true').hasMatch(manifest) &&
+        _workspaceRootDir() == null) {
+      return 'Cargo.toml inherits fields from a workspace root '
+          '(`workspace = true`) but no workspace root exists above '
+          '${environment.manifestDir}';
+    }
+
+    final missingPathDeps = RegExp(r'path\s*=\s*"([^"]+)"')
+        .allMatches(manifest)
+        .map((m) => m.group(1)!)
+        .where((dep) => !Directory(
+                path.normalize(path.join(environment.manifestDir, dep)))
+            .existsSync())
+        .toSet();
+    if (missingPathDeps.isNotEmpty) {
+      return 'Cargo.toml has path dependencies that are not present: '
+          '${missingPathDeps.join(', ')}';
+    }
+
+    return null;
+  }
+
+  /// Nearest ancestor directory holding a `Cargo.toml` with a `[workspace]`
+  /// table, or `null` if there is none.
+  String? _workspaceRootDir() {
+    var dir = Directory(environment.manifestDir).absolute;
+    while (true) {
+      final manifest = File(path.join(dir.path, 'Cargo.toml'));
+      if (manifest.existsSync() &&
+          RegExp(r'^\s*\[workspace[\].]', multiLine: true)
+              .hasMatch(manifest.readAsStringSync())) {
+        return dir.path;
+      }
+      if (dir.parent.path == dir.path) {
+        return null;
+      }
+      dir = dir.parent;
+    }
   }
 
   Future<Map<Target, List<Artifact>>> _getPrecompiledArtifacts(
@@ -215,6 +283,50 @@ class ArtifactProvider {
     } else {
       _log.shout('Signature verification failed! Ignoring binary.');
     }
+  }
+}
+
+/// Thrown when precompiled binaries did not cover every target and the crate
+/// cannot be built from source either.
+class SourceBuildUnavailableException implements Exception {
+  SourceBuildUnavailableException({
+    required this.targets,
+    required this.blocker,
+    required this.precompiledEnabled,
+  });
+
+  /// Targets left without an artifact.
+  final List<Target> targets;
+
+  /// Why the source-build fallback cannot succeed.
+  final String blocker;
+
+  /// Whether precompiled binaries were attempted before this fallback.
+  final bool precompiledEnabled;
+
+  @override
+  String toString() {
+    return [
+      ' ',
+      'No native library available for: ${targets.join(', ')}.',
+      ' ',
+      if (precompiledEnabled)
+        'This package ships precompiled binaries, but none matched. '
+            'Building from source is not possible here:'
+      else
+        'Precompiled binaries are disabled (`use_precompiled_binaries: false`), '
+            'and building from source is not possible here:',
+      ' ',
+      '  $blocker',
+      ' ',
+      if (!precompiledEnabled)
+        'Remove `use_precompiled_binaries: false` from cargokit_options.yaml '
+            'to use the precompiled binaries.'
+      else
+        'Please report this at https://github.com/xybrid-ai/xybrid/issues '
+            'with the target above and your Flutter version.',
+      ' ',
+    ].join('\n');
   }
 }
 

--- a/bindings/flutter/cargokit/build_tool/lib/src/options.dart
+++ b/bindings/flutter/cargokit/build_tool/lib/src/options.dart
@@ -13,7 +13,6 @@ import 'package:yaml/yaml.dart';
 
 import 'builder.dart';
 import 'environment.dart';
-import 'rustup.dart';
 
 final _log = Logger('options');
 
@@ -231,10 +230,20 @@ class CargokitCrateOptions {
 }
 
 class CargokitUserOptions {
-  // When Rustup is installed always build locally unless user opts into
-  // using precompiled binaries.
+  // xybrid deviates from upstream cargokit here. Upstream builds from source
+  // whenever Rustup is installed, which silently disables precompiled binaries
+  // for anyone who has ever installed Rust. The published `xybrid_flutter`
+  // package cannot be built from source at all — `rust/Cargo.toml` inherits
+  // `edition` from a workspace root that is not published, and its `xybrid-*`
+  // dependencies are path dependencies into the monorepo — so that fallback
+  // produced an inscrutable cargo error instead of a working build (#338).
+  //
+  // Precompiled binaries are the shipping path, so they are the default.
+  // Building from source stays available via `use_precompiled_binaries: false`
+  // in `cargokit_options.yaml`, and inside the monorepo it also happens
+  // automatically whenever the crate hash has no published assets yet.
   static bool defaultUsePrecompiledBinaries() {
-    return Rustup.executablePath() == null;
+    return true;
   }
 
   CargokitUserOptions({


### PR DESCRIPTION
Fixes #338.

## The bug

cargokit's upstream default:

```dart
static bool defaultUsePrecompiledBinaries() {
  return Rustup.executablePath() == null;  // rustup installed → build from source
}
```

- Anyone with a Rust toolchain installed got the **source** path.
- The published package **cannot** be built from source: `rust/Cargo.toml` has `edition.workspace = true` with no workspace root in the package, and `xybrid-sdk` / `xybrid-core` / `xybrid-ffi-facade` are path deps into the monorepo (not on crates.io).
- Result: `error inheriting 'edition' from workspace root manifest' / 'failed to find a workspace root`.

Precompiled assets were fine the whole time — cargokit never asked for them.

## Changes

- **Precompiled binaries are the default.** Source builds stay available via `use_precompiled_binaries: false`, and still happen automatically in the monorepo when a crate hash has no published assets.
- **Fail fast instead of an unrelated cargo error.** If the source fallback is entered when it cannot succeed (workspace inheritance with no root, or missing path deps), error with the target name and the reason.
- README + CHANGELOG.

## Verified locally (macOS, rustup installed)

Package copied outside the workspace to mimic the pub.dev layout:

| scenario | result |
|---|---|
| before | reproduces the reported `edition` error, preceded by `INFO: Precompiled binaries are disabled` |
| after | downloads `precompiled/07c000c1…/aarch64-apple-darwin_libxybrid_flutter_ffi.a`, `✓ Built x338app.app`, zero cargo |
| after + `use_precompiled_binaries: false` | new message: `No native library available for: aarch64-apple-darwin` + reason |
| in-repo + `use_precompiled_binaries: false` | still proceeds to `Building xybrid_flutter for aarch64-apple-darwin` |

## Notes

- Crate hash unchanged (`07c000c1e590f7789d15f60cef8475a8`) — cargokit hashes `rust/`, not `cargokit/`. Existing precompiled releases stay valid.
- No CI impact: `build-flutter.yml` builds through `cargo xtask build-flutter`, and the release jobs use `precompile-binaries` — neither goes through `ArtifactProvider`.
- Reaches users only on the next pub.dev publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time cargokit behavior only; no runtime or API changes, and monorepo source builds remain available when the manifest layout is valid.
> 
> **Overview**
> Fixes broken **pub.dev** builds for Flutter apps when **rustup** is on `PATH`: cargokit no longer treats an installed Rust toolchain as a signal to skip precompiled binaries and compile from source.
> 
> **Cargokit defaults** now always prefer signature-verified precompiled natives (`defaultUsePrecompiledBinaries()` returns `true`). Monorepo devs can still opt into source builds with `use_precompiled_binaries: false` in `cargokit_options.yaml`.
> 
> Before attempting a source fallback, **`ArtifactProvider`** checks whether a local cargo build is viable (missing workspace root for `workspace = true`, or absent path dependencies). If not, it raises **`SourceBuildUnavailableException`** with the target and a clear reason instead of cargo’s `edition` / workspace errors.
> 
> **README** and **CHANGELOG** document precompiled-only publishing and the dev-only source-build flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca91a62dd6f35b1f0c311832e07a0166a4d8b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->