### PR TITLE
fix(flutter): resolve the precompiled-binaries default per crate location

### DIFF
--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -209,3 +209,125 @@ jobs:
             bindings/flutter/rust/target/**/release/*xybrid_flutter_ffi*
             target/**/release/*xybrid_flutter_ffi*
           if-no-files-found: error
+
+  # Builds a scratch app against the package as consumers receive it, rather
+  # than against the monorepo. The job above goes through `cargo xtask`, and
+  # the release jobs go through cargokit's `precompile-binaries`, so neither
+  # exercises `ArtifactProvider` — the code path that decides between a
+  # downloaded binary and a source build. That gap let xybrid-ai/xybrid#338
+  # ship: every consumer with a Rust toolchain installed was routed into a
+  # source build the published package cannot perform, and CI was green
+  # throughout.
+  #
+  # A Rust toolchain is installed here on purpose. It is the condition that
+  # triggered the bug.
+  packaged-consumer:
+    name: Build a consumer app against the packaged layout
+    runs-on: ubuntu-latest
+    env:
+      # Surfaces cargokit's decision (crate hash, precompiled on/off) in the
+      # build log, which the assertions below read.
+      CARGOKIT_VERBOSE: '1'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+
+      - name: Install Flutter SDK
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Install Linux desktop build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev
+
+      # `git archive` gives us the committed tree only — no workspace root, no
+      # `crates/`, no build output — which is what pub.dev serves. The extra
+      # deletions mirror .pubignore entries that are gitignored anyway.
+      - name: Materialize the packaged layout outside the workspace
+        run: |
+          set -euo pipefail
+          PKG="$RUNNER_TEMP/pkg"
+          mkdir -p "$PKG"
+          git archive HEAD bindings/flutter | tar -x -C "$PKG"
+          mv "$PKG/bindings/flutter" "$PKG/xybrid_flutter"
+          rmdir "$PKG/bindings"
+          rm -rf "$PKG/xybrid_flutter/android/src/main/jniLibs" \
+                 "$PKG/xybrid_flutter/ios/Frameworks" \
+                 "$PKG/xybrid_flutter/rust/target"
+          if [ -e "$PKG/Cargo.toml" ] || [ -d "$PKG/crates" ]; then
+            echo "::error::packaged layout is not isolated from the workspace"
+            exit 1
+          fi
+          echo "PKG=$PKG" >> "$GITHUB_ENV"
+
+      - name: Create a consumer app depending on it
+        run: |
+          set -euo pipefail
+          APP="$RUNNER_TEMP/consumer"
+          flutter config --enable-linux-desktop
+          flutter create --platforms=linux --project-name xybrid_consumer "$APP"
+          python3 - "$APP/pubspec.yaml" "$PKG/xybrid_flutter" <<'PY'
+          import sys
+          pubspec, package = sys.argv[1], sys.argv[2]
+          anchor = "dependencies:\n  flutter:\n    sdk: flutter\n"
+          text = open(pubspec).read()
+          assert anchor in text, "flutter create emitted an unexpected pubspec"
+          open(pubspec, "w").write(
+              text.replace(anchor, f"{anchor}  xybrid_flutter:\n    path: {package}\n", 1)
+          )
+          PY
+          cd "$APP"
+          flutter pub get
+          echo "APP=$APP" >> "$GITHUB_ENV"
+
+      # A failure here is not necessarily a problem — see the assertions below —
+      # so record the status instead of letting the step abort on it.
+      - name: Build it
+        run: |
+          cd "$APP"
+          set +e
+          flutter build linux --debug 2>&1 | tee "$RUNNER_TEMP/build.log"
+          status=${PIPESTATUS[0]}
+          set -e
+          echo "BUILD_STATUS=$status" >> "$GITHUB_ENV"
+
+      - name: Assert the packaged layout never falls back to a source build
+        run: |
+          set -euo pipefail
+          LOG="$RUNNER_TEMP/build.log"
+
+          # The published package cannot compile its Rust — no workspace root
+          # to inherit `edition` from, and its xybrid-* path dependencies are
+          # not shipped. Reaching cargo at all is the #338 regression.
+          if grep -q 'Building xybrid_flutter for' "$LOG"; then
+            echo "::error::cargokit ran a source build from the packaged layout"
+            exit 1
+          fi
+
+          if [ "$BUILD_STATUS" -eq 0 ]; then
+            if ! find "$APP/build" -type d -name precompiled | grep -q .; then
+              echo "::error::build succeeded without downloading a precompiled binary"
+              exit 1
+            fi
+            echo "::notice::consumer app linked the downloaded precompiled binary"
+            exit 0
+          fi
+
+          # Expected when this commit changes bindings/flutter/rust: the crate
+          # hash is new, so no precompiled_<hash> release exists yet. The
+          # packaged layout still has to refuse the source fallback and say why.
+          if grep -q 'No native library available for' "$LOG"; then
+            echo "::notice::no precompiled release for this crate hash yet; the packaged layout correctly refused to fall back to a source build"
+            exit 0
+          fi
+
+          echo "::error::consumer app failed to build for an unexpected reason"
+          exit 1

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Prerelease exercising the new release pipeline.
 
-* Fixed: builds failed with `error inheriting 'edition' from workspace root manifest` for anyone with a Rust toolchain installed — cargokit disabled precompiled binaries whenever `rustup` was on `PATH`, then fell back to a source build the published package cannot perform. Precompiled binaries are now the default; source builds stay available via `use_precompiled_binaries: false`, and when they cannot succeed they now fail with an explanation instead of a cargo error (xybrid-ai/xybrid#338)
+* Fixed: builds failed with `error inheriting 'edition' from workspace root manifest` for anyone with a Rust toolchain installed — cargokit disabled precompiled binaries whenever `rustup` was on `PATH`, then fell back to a source build the published package cannot perform. The published package now always uses precompiled binaries, and a source build that cannot succeed fails with an explanation instead of a cargo error. `use_precompiled_binaries` still overrides (xybrid-ai/xybrid#338)
 * Fixed: `libxybrid_flutter.so` not found when compiling from source on Linux (xybrid-ai/xybrid#340)
 * Changed: the precompiled binaries (desktop + mobile) are now built by Bazel with hermetic toolchains — same download, naming, and signature; the Linux `.so` now loads on older-glibc distros than before (xybrid-ai/xybrid#369, xybrid-ai/xybrid#371)
 

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -258,9 +258,14 @@ installed does not change anything — the published package is precompiled-only
 and cannot be built from source, because its Rust crate lives in the xybrid
 monorepo workspace.
 
-Building from source is for monorepo development. Depend on
-`bindings/flutter` by path and add a `cargokit_options.yaml` next to your app's
-`pubspec.yaml`:
+Building from source is for monorepo development, where the workspace root and
+the `xybrid-*` crates are present. There it is the default whenever a Rust
+toolchain is installed, because cargokit's crate hash only covers
+`bindings/flutter/rust` — a precompiled binary would not pick up edits to
+`xybrid-core`, `xybrid-sdk` or `xybrid-ffi-facade`.
+
+Either default can be overridden with a `cargokit_options.yaml` next to your
+app's `pubspec.yaml`:
 
 ```yaml
 use_precompiled_binaries: false

--- a/bindings/flutter/cargokit/build_tool/lib/src/artifacts_provider.dart
+++ b/bindings/flutter/cargokit/build_tool/lib/src/artifacts_provider.dart
@@ -53,6 +53,28 @@ class ArtifactProvider {
   final BuildEnvironment environment;
   final CargokitUserOptions userOptions;
 
+  /// Whether precompiled binaries should be used for this crate.
+  ///
+  /// xybrid deviates from upstream cargokit here. Upstream's default is "build
+  /// from source whenever Rustup is installed", which silently disabled
+  /// precompiled binaries for every consumer who had ever installed Rust and
+  /// dropped them into a build the published package cannot perform (#338).
+  ///
+  /// The default is resolved per crate location instead:
+  ///
+  /// * Published package — no workspace root, no sibling crates. Precompiled
+  ///   binaries are the only viable path, so they are used regardless of the
+  ///   local toolchain.
+  /// * Monorepo checkout — upstream's rule applies. Source builds matter here
+  ///   because [CrateHash] only covers `rust/`, so edits to `xybrid-core`,
+  ///   `xybrid-sdk` or `xybrid-ffi-facade` do not change the artifact key and a
+  ///   precompiled binary would silently ship stale code.
+  ///
+  /// An explicit `use_precompiled_binaries` in `cargokit_options.yaml` always
+  /// wins.
+  late final bool usePrecompiledBinaries = userOptions.usePrecompiledBinaries ??
+      (_sourceBuildBlocker() != null || Rustup.executablePath() == null);
+
   Future<Map<Target, List<Artifact>>> getArtifacts(List<Target> targets) async {
     final result = await _getPrecompiledArtifacts(targets);
 
@@ -72,7 +94,7 @@ class ArtifactProvider {
       throw SourceBuildUnavailableException(
         targets: pendingTargets,
         blocker: blocker,
-        precompiledEnabled: userOptions.usePrecompiledBinaries &&
+        precompiledEnabled: usePrecompiledBinaries &&
             environment.crateOptions.precompiledBinaries != null,
       );
     }
@@ -134,9 +156,9 @@ class ArtifactProvider {
     final missingPathDeps = RegExp(r'path\s*=\s*"([^"]+)"')
         .allMatches(manifest)
         .map((m) => m.group(1)!)
-        .where((dep) => !Directory(
-                path.normalize(path.join(environment.manifestDir, dep)))
-            .existsSync())
+        .where((dep) =>
+            !Directory(path.normalize(path.join(environment.manifestDir, dep)))
+                .existsSync())
         .toSet();
     if (missingPathDeps.isNotEmpty) {
       return 'Cargo.toml has path dependencies that are not present: '
@@ -166,7 +188,7 @@ class ArtifactProvider {
 
   Future<Map<Target, List<Artifact>>> _getPrecompiledArtifacts(
       List<Target> targets) async {
-    if (userOptions.usePrecompiledBinaries == false) {
+    if (!usePrecompiledBinaries) {
       _log.info('Precompiled binaries are disabled');
       return {};
     }

--- a/bindings/flutter/cargokit/build_tool/lib/src/options.dart
+++ b/bindings/flutter/cargokit/build_tool/lib/src/options.dart
@@ -230,36 +230,20 @@ class CargokitCrateOptions {
 }
 
 class CargokitUserOptions {
-  // xybrid deviates from upstream cargokit here. Upstream builds from source
-  // whenever Rustup is installed, which silently disables precompiled binaries
-  // for anyone who has ever installed Rust. The published `xybrid_flutter`
-  // package cannot be built from source at all — `rust/Cargo.toml` inherits
-  // `edition` from a workspace root that is not published, and its `xybrid-*`
-  // dependencies are path dependencies into the monorepo — so that fallback
-  // produced an inscrutable cargo error instead of a working build (#338).
-  //
-  // Precompiled binaries are the shipping path, so they are the default.
-  // Building from source stays available via `use_precompiled_binaries: false`
-  // in `cargokit_options.yaml`, and inside the monorepo it also happens
-  // automatically whenever the crate hash has no published assets yet.
-  static bool defaultUsePrecompiledBinaries() {
-    return true;
-  }
-
   CargokitUserOptions({
     required this.usePrecompiledBinaries,
     required this.verboseLogging,
   });
 
   CargokitUserOptions._()
-      : usePrecompiledBinaries = defaultUsePrecompiledBinaries(),
+      : usePrecompiledBinaries = null,
         verboseLogging = false;
 
   static CargokitUserOptions parse(YamlNode node) {
     if (node is! YamlMap) {
       throw SourceSpanException('Cargokit options must be a map', node.span);
     }
-    bool usePrecompiledBinaries = defaultUsePrecompiledBinaries();
+    bool? usePrecompiledBinaries;
     bool verboseLogging = false;
 
     for (final entry in node.nodes.entries) {
@@ -313,6 +297,10 @@ class CargokitUserOptions {
     return CargokitUserOptions._();
   }
 
-  final bool usePrecompiledBinaries;
+  /// `use_precompiled_binaries` as set in `cargokit_options.yaml`, or `null`
+  /// when the user did not express a preference. xybrid deviates from upstream
+  /// cargokit in resolving that default per crate location rather than globally
+  /// — see `ArtifactProvider.usePrecompiledBinaries`.
+  final bool? usePrecompiledBinaries;
   final bool verboseLogging;
 }


### PR DESCRIPTION
Follow-up to #408. Fixes the P1 from its review, and closes the CI gap that let #338 ship green.

## The regression

#408 made precompiled binaries the unconditional default. `CrateHash` only covers `bindings/flutter/rust` (`src/**`, `Cargo.toml`, `Cargo.lock`, `build.rs`, `cargokit.yaml`), so editing `xybrid-core` / `xybrid-sdk` / `xybrid-ffi-facade` does not change the artifact key — a monorepo developer would have silently linked the last released binary and run stale code.

## Fix: resolve the default per crate location

| location | default | why |
|---|---|---|
| published package | precompiled | no workspace root, no sibling crates — source build is impossible (#338) |
| monorepo checkout | source, when Rustup is available | crate hash can't see the sibling crates; upstream cargokit's rule |

- Same `_sourceBuildBlocker()` check that already guards the fail-fast path decides which case we're in — one definition of "can this be built from source", not two.
- `use_precompiled_binaries` is now tri-state (`bool?`), so an explicit `true` is distinguishable from an unset default. It still overrides both.

## CI job: `packaged-consumer`

Builds a scratch Flutter Linux app against the package as consumers receive it (`git archive` → outside the workspace), **with a Rust toolchain installed on purpose** — that was the #338 trigger.

- Asserts cargokit never reaches a source build from the packaged layout.
- On success, asserts a `precompiled/` artifact was actually downloaded.
- When the commit changes `rust/`, no `precompiled_<hash>` release exists yet — the job then requires the fail-fast message instead, so it stays meaningful on exactly the PRs most likely to break packaging.

Nothing exercised `ArtifactProvider` before: `build-flutter.yml` goes through `cargo xtask`, the release jobs through `precompile-binaries`.

## Verified on macOS

| scenario | path taken |
|---|---|
| packaged layout, rustup installed | `precompiled/07c000c1…/aarch64-apple-darwin_…a`, built ✓ |
| monorepo, no options file | cargo target dir `…/aarch64-apple-darwin/debug/deps`, built ✓ |

Also: `dart format` reflow in `artifacts_provider.dart` applied. The three other unformatted files under `cargokit/` are pre-existing and left alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Flutter consumer build routing in cargokit (published vs monorepo), which affects every app build; mitigated by explicit YAML override and a new CI job that reproduces the #338 consumer path.
> 
> **Overview**
> Fixes cargokit so **precompiled vs source** is chosen by where the crate lives, not a single global default. Published pub.dev layouts always prefer precompiled binaries (even with Rustup installed); monorepo checkouts default to **source** when Rustup is available so edits to sibling `xybrid-*` crates are not masked by a stale precompiled hash.
> 
> `use_precompiled_binaries` in `cargokit_options.yaml` is now **tri-state** (`bool?`); unset means “use location-based default,” and an explicit value still overrides both paths. `ArtifactProvider` centralizes the resolved flag and reuses `_sourceBuildBlocker()` for the same “can this build from source?” rule used in fail-fast errors.
> 
> Adds CI job **`packaged-consumer`**: materializes the package via `git archive` outside the workspace, builds a scratch Linux Flutter app **with Rust installed**, and asserts cargokit never runs a source build from that layout (and either downloads `precompiled/` artifacts or fails with the expected “no native library” message when no release exists for the current crate hash).
> 
> README and CHANGELOG wording updated to match the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b880fb12b6922b29859d4147997329f7cb75141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->