### PR TITLE
Release v0.4.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-
-- **`xybrid-ffi` crate (pre-bolt C ABI)**: Unity migrated fully onto BoltFFI
-  (`xybrid-bolt`) — managed layer, run/stream/context, telemetry, bundle and
-  model-file — so the C-ABI crate, its cbindgen header, and the csbindgen C#
-  generation (`Runtime/Native/NativeMethods.g.cs`) are gone. The Unity SDK now
-  loads `xybrid_bolt` on every platform (`cargo xtask build-ffi` builds bolt).
-
 ### Planned
 
 - **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.4.0-rc1] - 2026-07-28
+
+Release candidate for 0.4.0. Two consumer-visible fixes on top of `0.4.0-alpha`
+— the published Flutter package could not be built by anyone with a Rust
+toolchain installed, and Linux `.so`s linked the C++ runtime dynamically — plus
+the Unity SDK moving fully onto BoltFFI and the Bazel graph growing from
+"builds the artifacts" to "builds and tests them".
+
+### Fixed
+
+- **Flutter: the published pub.dev package would not build** for any consumer
+  with a Rust toolchain installed. cargokit disables precompiled binaries
+  whenever `rustup` is on `PATH`, and the published package cannot be built
+  from source — its Rust crate inherits `edition` from a workspace root that is
+  not published and depends on sibling crates by path — so the build died on an
+  unrelated cargo manifest error. The choice is now made from the crate's
+  location: published package always precompiled, monorepo checkout still
+  source-built so edits to `xybrid-core`/`xybrid-sdk`/`xybrid-ffi-facade` are
+  picked up (#338, #408, #409).
+- **Linux `.so`s linked `libstdc++` dynamically** while binaries got it
+  statically, so the shipped cdylibs required a C++ runtime on the host
+  (#407).
+- **Unity shipped debug natives** in the release bundles (#391), and desktop
+  ONNX Runtime was missing from them (#379).
+
+### Changed
+
+- **Unity is fully on BoltFFI.** The managed layer, run/stream/context,
+  telemetry, bundle and model-file paths all go through `xybrid_bolt`, and its
+  natives for macOS, Android, Linux and iOS are built by Bazel
+  (#380–#390, #392–#394).
+- **Bazel now runs the test suite**, not just the builds — 38 test targets
+  covering the `tests/` binaries across `xybrid-core`, `xybrid-sdk`,
+  `xybrid-llama`, `xtask`, the CLI and integration-tests (#397–#403).
+- **Unity CI runs EditMode tests in a real Unity Editor** on Linux, plus a
+  Windows IL2CPP gate for the Bazel-built DLL (#396, #406).
+
+### Removed
+
+- **`xybrid-ffi` crate (pre-bolt C ABI)**: with Unity migrated onto BoltFFI,
+  the C-ABI crate, its cbindgen header, and the csbindgen C# generation
+  (`Runtime/Native/NativeMethods.g.cs`) are gone. The Unity SDK now loads
+  `xybrid_bolt` on every platform (`cargo xtask build-ffi` builds bolt).
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -310,7 +310,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix",
 ]
@@ -375,7 +375,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -811,9 +811,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -929,14 +929,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1451,9 +1451,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "ena"
@@ -1555,11 +1555,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1570,7 +1569,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -1716,13 +1715,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2161,9 +2160,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -2677,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2868,9 +2867,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3670,9 +3669,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3680,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3690,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3703,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -4482,9 +4481,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4595,7 +4594,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4862,9 +4861,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5014,7 +5013,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5205,9 +5204,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5216,9 +5215,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5250,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -5641,9 +5640,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4ec1eb1d240636e354a30110a1dfcb37047169a4d9bd6d9d3469df574b5c4"
+checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
 name = "version_check"
@@ -6153,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6167,14 +6166,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6183,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6212,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6279,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "serde_json",
  "tokio",
@@ -6289,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6298,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "bindgen",
  "cc",
@@ -6307,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6316,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6342,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.4.0-alpha"
+let sdkVersion = "0.4.0-rc1"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let sdkVersion = "0.4.0-rc1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "0fda4249788f423a3cda94a88b79de1c1332a2a04188cc7c5dfc84a6bbad7f8f"
+let xybridFFIChecksum = "65009356d3ed958933e717562ea3390fb1c027201a98b9c7e80a551718ccf875"
 
 let package = Package(
     name: "Xybrid",

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## 0.4.0-rc1
+
+Release candidate for 0.4.0.
+
+* Fixed: the package would not build for anyone with a Rust toolchain installed — it failed with `error inheriting 'edition' from workspace root manifest`. cargokit disables precompiled binaries whenever `rustup` is on `PATH`, and this package cannot be built from source, so it fell through to a build that could never succeed. The published package now always uses its precompiled binaries, and a source build that cannot succeed fails with an explanation instead of a cargo error. `use_precompiled_binaries` still overrides (xybrid-ai/xybrid#338)
+
 ## 0.4.0-alpha
 
 Prerelease exercising the new release pipeline.
 
-* Fixed: builds failed with `error inheriting 'edition' from workspace root manifest` for anyone with a Rust toolchain installed — cargokit disabled precompiled binaries whenever `rustup` was on `PATH`, then fell back to a source build the published package cannot perform. The published package now always uses precompiled binaries, and a source build that cannot succeed fails with an explanation instead of a cargo error. `use_precompiled_binaries` still overrides (xybrid-ai/xybrid#338)
 * Fixed: `libxybrid_flutter.so` not found when compiling from source on Linux (xybrid-ai/xybrid#340)
 * Changed: the precompiled binaries (desktop + mobile) are now built by Bazel with hermetic toolchains — same download, naming, and signature; the Linux `.so` now loads on older-glibc distros than before (xybrid-ai/xybrid#369, xybrid-ai/xybrid#371)
 

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.4.0-alpha
+version: 0.4.0-rc1
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.4.0-alpha"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.4.0-rc1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xybrid"
-version = "0.4.0-alpha"
+version = "0.4.0-rc1"
 description = "Python SDK for local-first xybrid inference"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.4.0-alpha"
+  implementation "ai.xybrid:xybrid-kotlin:0.4.0-rc1"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.4.0-alpha",
+  "version": "0.4.0-rc1",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.4.0-alpha",
+  "version": "0.4.0-rc1",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xybrid/web",
-  "version": "0.4.0-alpha",
+  "version": "0.4.0-rc1",
   "private": true,
   "type": "module",
   "description": "Preview browser tensor runtime for Xybrid metadata backed by LiteRT.",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0-alpha", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.4.0-alpha", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0-rc1", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.4.0-rc1", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0-alpha" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0-rc1" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.4.0-alpha", path = "../../macros" }
+xybrid-macros = { version = "0.4.0-rc1", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.4.0-alpha", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.4.0-rc1", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.4.0-alpha", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.4.0-rc1", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.4.0-alpha", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.4.0-rc1", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Release **v0.4.0-rc1**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.4.0-rc1).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.4.0-rc1`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata and version-string changes only; no application logic in the diff. Risk is limited to mis-synced versions or an incorrect SPM checksum blocking consumers until fixed.
> 
> **Overview**
> Prepares **v0.4.0-rc1** for the release pipeline: workspace and binding manifests (Rust crates, Flutter, Kotlin, Python, React Native, Unity, web) move from `0.4.0-alpha` to `0.4.0-rc1`, with path/version pins in crate `Cargo.toml` files updated to match.
> 
> The root **CHANGELOG** gains a `[0.4.0-rc1]` section (Flutter pub build fix, static `libstdc++` on Linux `.so`s, Unity BoltFFI migration, Bazel tests, Unity CI) and moves the `xybrid-ffi` removal note out of `[Unreleased]` into that release. The Flutter package changelog gets a matching **0.4.0-rc1** entry.
> 
> **`Package.swift`** updates `sdkVersion` and the **XybridFFI** xcframework zip checksum for remote SPM consumers. **`Cargo.lock`** reflects the version bump plus routine dependency patch updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564f8cdf22cead2f0902a9ae8980e7e50a9978a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->