### PR TITLE
fix(docs,kotlin): stop documenting the removed XybridModelLoader (#329)

### DIFF
--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -149,10 +149,13 @@ object Xybrid {
 
 // -- Public Type Aliases --
 //
-// Bolt collapsed `XybridModelLoader.fromRegistry(id).load()` into the
-// `XybridModel.fromRegistry(id)` companion-object factory — there is no
-// loader type anymore. The Model / Result / Envelope / VoiceInfo /
-// GenerationConfig aliases stay for convenience.
+// Bolt collapsed `XybridModelLoader.fromRegistry(id).load()` into loading the
+// model directly — there is no loader type anymore. The registry path is the
+// `XybridModel(id)` constructor; the other sources are companion factories
+// (`fromBundle` / `fromDirectory` / `fromHuggingface`). The Model / Result /
+// VoiceInfo / GenerationConfig aliases stay for convenience.
+//
+// See [XybridModelLoader] below for the deprecated compatibility shim.
 
 /** A loaded model ready for inference. */
 typealias Model = XybridModel
@@ -206,6 +209,75 @@ suspend fun XybridModel.warmupAsync() = withContext(Dispatchers.IO) { this@warmu
 
 /** Unload the model, freeing its memory, off the caller's thread (on [Dispatchers.IO]). */
 suspend fun XybridModel.unloadAsync() = withContext(Dispatchers.IO) { this@unloadAsync.unload() }
+
+// -- Deprecated: the pre-bolt loader shape --
+//
+// Before the bolt migration, loading was two steps: build a loader, then call
+// `load()`. Bolt collapsed that into loading the model directly, and the type
+// was removed outright — so code written against the old shape (or against docs
+// that still showed it) failed with `Unresolved reference`, which says nothing
+// about what to use instead (xybrid-ai/xybrid#329).
+//
+// This shim keeps that code compiling and working, with a deprecation warning
+// naming the replacement. Scheduled for removal in 0.5.0.
+
+/**
+ * Deprecated two-step loader retained for source compatibility.
+ *
+ * Load the model directly instead — [XybridModel] for the registry, or
+ * [XybridModel.fromBundle] / [XybridModel.fromDirectory] /
+ * [XybridModel.fromHuggingface] for the other sources. Each has a `suspend`
+ * counterpart (`fromRegistryAsync` and friends).
+ */
+@Deprecated(
+    message = "XybridModelLoader was removed in 0.4.0. Load the model directly: " +
+        "XybridModel(id) for the registry, or XybridModel.fromBundle/fromDirectory/" +
+        "fromHuggingface. Use the *Async variants to load off the caller's thread.",
+    level = DeprecationLevel.WARNING,
+)
+class XybridModelLoader private constructor(private val open: () -> XybridModel) {
+
+    /** Performs the load the pre-bolt API deferred to this call. */
+    fun load(): XybridModel = open()
+
+    companion object {
+        /** Deprecated. Use `XybridModel(id)`. */
+        @Deprecated(
+            message = "Use XybridModel(id), or fromRegistryAsync(id) to load off-thread.",
+            replaceWith = ReplaceWith("XybridModel(id)"),
+            level = DeprecationLevel.WARNING,
+        )
+        fun fromRegistry(id: String): XybridModelLoader =
+            XybridModelLoader { XybridModel(id) }
+
+        /** Deprecated. Use [XybridModel.fromBundle]. */
+        @Deprecated(
+            message = "Use XybridModel.fromBundle(path).",
+            replaceWith = ReplaceWith("XybridModel.fromBundle(path)"),
+            level = DeprecationLevel.WARNING,
+        )
+        fun fromBundle(path: String): XybridModelLoader =
+            XybridModelLoader { XybridModel.fromBundle(path) }
+
+        /** Deprecated. Use [XybridModel.fromDirectory]. */
+        @Deprecated(
+            message = "Use XybridModel.fromDirectory(path).",
+            replaceWith = ReplaceWith("XybridModel.fromDirectory(path)"),
+            level = DeprecationLevel.WARNING,
+        )
+        fun fromDirectory(path: String): XybridModelLoader =
+            XybridModelLoader { XybridModel.fromDirectory(path) }
+
+        /** Deprecated. Use [XybridModel.fromHuggingface]. */
+        @Deprecated(
+            message = "Use XybridModel.fromHuggingface(repo).",
+            replaceWith = ReplaceWith("XybridModel.fromHuggingface(repo)"),
+            level = DeprecationLevel.WARNING,
+        )
+        fun fromHuggingface(repo: String): XybridModelLoader =
+            XybridModelLoader { XybridModel.fromHuggingface(repo) }
+    }
+}
 
 /** The result of a model inference operation. */
 typealias Result = XybridResult

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -30,8 +30,7 @@ class MyApplication : Application() {
 }
 
 // Load a model from the registry
-val loader = XybridModelLoader.fromRegistry("kokoro-82m")
-val model = loader.load()
+val model = XybridModel("kokoro-82m")
 
 // Run inference
 val result = model.run(Envelope.text("Hello, world!"))
@@ -61,16 +60,20 @@ Without a key, telemetry is disabled and the first inference logs a one-shot hin
 ### From Registry
 
 ```kotlin
-val loader = XybridModelLoader.fromRegistry("whisper-tiny")
-val model = loader.load()
+val model = XybridModel("whisper-tiny")
 ```
 
 ### From Local Bundle
 
 ```kotlin
-val loader = XybridModelLoader.fromBundle("/path/to/model.xyb")
-val model = loader.load()
+val model = XybridModel.fromBundle("/path/to/model.xyb")
 ```
+
+`XybridModel.fromDirectory(path)` and `XybridModel.fromHuggingface("org/repo")` load
+from an unpacked model directory and from HuggingFace respectively. Each has a
+`suspend` counterpart — `fromRegistryAsync`, `fromBundleAsync`,
+`fromDirectoryAsync`, `fromHuggingfaceAsync` — that runs the blocking load on
+`Dispatchers.IO`.
 
 ---
 
@@ -153,7 +156,7 @@ The SDK uses sealed exception classes for type-safe error handling:
 
 ```kotlin
 try {
-    val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
+    val model = XybridModel("kokoro-82m")
     val result = model.run(envelope)
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.modelId}")

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -186,10 +186,16 @@ The SDK provides short aliases for convenience:
 
 | Alias | Full Type |
 |-------|-----------|
-| `ModelLoader` | `XybridModelLoader` |
 | `Model` | `XybridModel` |
 | `Envelope` | `XybridEnvelope` |
 | `Result` | `XybridResult` |
+| `VoiceInfo` | `XybridVoiceInfo` |
+| `GenerationConfig` | `XybridGenerationConfig` |
+| `XybridSDKError` | `XybridError` |
+
+There is no `ModelLoader` type. Load a model directly with
+`XybridModel(fromRegistry:)`, or `XybridModel(fromBundle:)` /
+`XybridModel(fromDirectory:)` / `XybridModel(fromHuggingface:)`.
 
 ---
 

--- a/docs/content/docs/(integration)/sdks/kotlin.mdx
+++ b/docs/content/docs/(integration)/sdks/kotlin.mdx
@@ -48,7 +48,7 @@ class InferenceRepository {
     private val dispatcher = Dispatchers.IO
 
     suspend fun loadModel(modelId: String): XybridModel = withContext(dispatcher) {
-        XybridModelLoader.fromRegistry(modelId).load()
+        XybridModel(modelId)
     }
 
     suspend fun runInference(
@@ -72,12 +72,8 @@ fun InferenceScreen() {
     Button(onClick = {
         scope.launch {
             isLoading = true
-            val model = withContext(Dispatchers.IO) {
-                XybridModelLoader.fromRegistry("kokoro-82m").load()
-            }
-            result = withContext(Dispatchers.IO) {
-                model.run(Envelope.text("Hello from Compose!"))
-            }
+            val model = XybridModel.fromRegistryAsync("kokoro-82m")
+            result = model.runAsync(Envelope.text("Hello from Compose!"))
             isLoading = false
         }
     }) {
@@ -97,10 +93,19 @@ The SDK provides short aliases matching the full qualified names:
 
 | Alias | Full Type |
 |-------|-----------|
-| `ModelLoader` | `XybridModelLoader` |
 | `Model` | `XybridModel` |
-| `Envelope` | `XybridEnvelope` |
 | `Result` | `XybridResult` |
-| `XybridError` | `XybridException` |
+| `VoiceInfo` | `XybridVoiceInfo` |
+| `GenerationConfig` | `XybridGenerationConfig` |
+| `XybridException` | `XybridError` |
+
+`Envelope` is not an alias — it is an object with factory methods
+(`Envelope.text(...)`, `Envelope.image(...)`, `Envelope.userMessage(...)`) that
+return `XybridEnvelope`.
+
+There is no `ModelLoader` type. Load a model directly with `XybridModel(id)` for
+the registry, or `XybridModel.fromBundle` / `fromDirectory` / `fromHuggingface`.
+A deprecated `XybridModelLoader` shim keeps pre-0.4.0 code compiling and will be
+removed in 0.5.0.
 
 See the [Android SDK guide](/docs/sdks/android) for the complete API reference.

--- a/docs/content/docs/guides/vision-models.mdx
+++ b/docs/content/docs/guides/vision-models.mdx
@@ -102,9 +102,10 @@ satisfied.
 
 ```kotlin
 import ai.xybrid.Envelope
+import ai.xybrid.XybridModel
 import java.io.File
 
-val model = XybridModelLoader.fromRegistry("gemma-4-e2b").load()
+val model = XybridModel("gemma-4-e2b")
 val image = Envelope.image(File("cat.jpg").readBytes(), format = "jpeg")
 val prompt = Envelope.userMessage(
     text = "Describe this image.",

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -100,8 +100,7 @@ import ai.xybrid.*
 Xybrid.init(context)
 
 // Load a model from the registry
-val loader = XybridModelLoader.fromRegistry("kokoro-82m")
-val model = loader.load()
+val model = XybridModel("kokoro-82m")
 
 // Run text-to-speech
 val envelope = Envelope.text("Hello from Xybrid!")


### PR DESCRIPTION
Fixes #329.

## The issue is bigger than its title

@chimbiwide filed this as "kotlin: XybridModelLoader is not exposed". It is not a Kotlin binding gap — the bolt migration **removed the type**, and the docs were never updated. Anyone following them gets `Unresolved reference`.

Where it was still documented (English pages):

| page | language | status |
|---|---|---|
| `quickstart.mdx` | kotlin | wrong — this is the first page a new user reads |
| `android.mdx` ×4 | kotlin | wrong |
| `kotlin.mdx` ×3 | kotlin + alias table | wrong |
| `vision-models.mdx` | kotlin | wrong |
| `ios.mdx` | alias table | wrong — Swift has no such type either |
| `flutter.mdx` ×6, `reasoning.mdx` | dart | **correct, untouched** |

Flutter still exposes `XybridModelLoader` (`bindings/flutter/lib/src/model_loader.dart:138`), so the Dart snippets were already right.

## Changes

**Docs** — Kotlin snippets load directly (`XybridModel(id)`, or `fromBundle` / `fromDirectory` / `fromHuggingface`). The Compose example now uses the `fromRegistryAsync` / `runAsync` suspend helpers rather than hand-rolled `withContext` blocks.

Both alias tables were checked against the actual `typealias` declarations and were wrong beyond the loader row:
- Kotlin listed `XybridError` → `XybridException`; the alias is the other way round.
- Kotlin listed `Envelope` as an alias; it is an object with factory methods.
- iOS was missing `VoiceInfo`, `GenerationConfig`, `XybridSDKError`.

**Kotlin** — a deprecated `XybridModelLoader` shim so pre-0.4.0 code, and code written from these docs, compiles and runs with a message naming the replacement. `DeprecationLevel.WARNING` + `ReplaceWith` per factory; removal targeted at 0.5.0.

Also fixed the comment above the type aliases, which claimed a `XybridModel.fromRegistry` companion factory that was never added — the registry path is the constructor.

## Not verified locally

The Kotlin SDK does not compile here: the Android Gradle plugin requires Java 17 and this machine has only 11. **`Compile + test Kotlin wrapper` is the gate on this PR.**

## Follow-up

`.zh.mdx` left alone — @chimbiwide maintains the translations. 12 stale references across 5 files, and they have drifted further than the English ones (`quickstart.zh.mdx` shows the loader in a Swift block the English page never had). Separate issue to follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a thin deprecated compatibility wrapper only; new call sites use existing `XybridModel` APIs with no change to inference or loading behavior.
> 
> **Overview**
> Fixes **#329**: English Kotlin docs still showed the two-step **`XybridModelLoader.fromRegistry(...).load()`** flow removed in the bolt migration, which caused **`Unresolved reference`** for copy-paste users.
> 
> **Docs** — Quickstart, Android, Kotlin, and vision-model Kotlin snippets now load via **`XybridModel(id)`** or **`fromBundle` / `fromDirectory` / `fromHuggingface`**, with notes on **`fromRegistryAsync`** and related suspend helpers. The Compose example uses **`fromRegistryAsync`** / **`runAsync`** instead of hand-rolled **`withContext`**. Kotlin and iOS alias tables are corrected (no **`ModelLoader`**; **`XybridException` → `XybridError`**; **`Envelope`** documented as a factory object, not a typealias).
> 
> **Kotlin binding** — Adds a **deprecated `XybridModelLoader`** shim that delegates to the new APIs with **`ReplaceWith`** warnings, targeted for removal in **0.5.0**. Comments above the public aliases now describe the real registry path (**constructor**) instead of a non-existent **`fromRegistry`** factory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a016ce0e0a97713253722e3874c63724a0959120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->