### PR TITLE
ci(unity): run Linux IL2CPP runtime smoke

### DIFF
--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -10,9 +10,10 @@
 # tools/unity-runtime-smoke pins), compiles it with Unity's own compiler, and
 # runs the package's EditMode tests against a Bazel-built Linux native. One of
 # the four test files drives ~16 native call sites, so the .so is genuinely
-# exercised rather than merely present.
+# exercised rather than merely present. It then AOT-compiles the same package
+# into a Linux IL2CPP player and runs the player headlessly against that native.
 #
-# Mono + Linux only. IL2CPP and the Windows plugin loader are NOT covered here.
+# The Windows plugin loader remains outside hosted CI.
 name: Unity Editor CI
 
 on:
@@ -48,9 +49,9 @@ concurrency:
 
 jobs:
   editmode:
-    name: Unity EditMode (Linux, Mono)
+    name: Unity Editor (Linux, Mono + IL2CPP)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     env:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -172,11 +173,56 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: Unity EditMode results
 
+      - name: Build Linux IL2CPP smoke player
+        if: env.UNITY_LICENSE != ''
+        uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2 # v4.8.1
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: tools/unity-runtime-smoke
+          unityVersion: 6000.3.6f1
+          targetPlatform: StandaloneLinux64
+          buildMethod: Builder.PerformBuild
+          manualExit: true
+          allowDirtyBuild: true
+
+      - name: Run Linux IL2CPP smoke player
+        if: env.UNITY_LICENSE != ''
+        run: |
+          set -euo pipefail
+          PLAYER=tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64
+          LOG=tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
+          mkdir -p "$(dirname "$LOG")"
+          chmod +x "$PLAYER"
+
+          set +e
+          timeout 120s "$PLAYER" -batchmode -nographics -logFile "$LOG"
+          PLAYER_STATUS=$?
+          set -e
+
+          cat "$LOG"
+          if [ "$PLAYER_STATUS" -ne 0 ]; then
+            echo "Linux IL2CPP smoke player exited with status $PLAYER_STATUS."
+            exit "$PLAYER_STATUS"
+          fi
+          grep -Fq "[XybridSmoke] OK" "$LOG"
+
       - name: Upload test results
         if: always() && env.UNITY_LICENSE != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unity-editmode-results
           path: unity-editmode-results
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload IL2CPP smoke log
+        if: always() && env.UNITY_LICENSE != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: unity-linux-il2cpp-smoke-log
+          path: tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -182,7 +182,8 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           projectPath: tools/unity-runtime-smoke
-          unityVersion: 6000.3.6f1
+          # 6000.3.14f1 includes Unity's Linux player startup-crash fix.
+          unityVersion: 6000.3.14f1
           targetPlatform: StandaloneLinux64
           buildMethod: Builder.PerformBuild
           manualExit: true

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -182,8 +182,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           projectPath: tools/unity-runtime-smoke
-          # 6000.3.14f1 includes Unity's Linux player startup-crash fix.
-          unityVersion: 6000.3.14f1
+          unityVersion: 6000.3.6f1
           targetPlatform: StandaloneLinux64
           buildMethod: Builder.PerformBuild
           manualExit: true
@@ -197,9 +196,12 @@ jobs:
           LOG="$RUNNER_TEMP/linux-il2cpp-player.log"
           ls -l "$PLAYER"
           test -x "$PLAYER"
+          command -v xvfb-run
 
           set +e
-          timeout 120s "$PLAYER" -batchmode -nographics -logFile "$LOG"
+          timeout 120s xvfb-run --auto-servernum \
+            --server-args="-screen 0 1024x768x24" \
+            "$PLAYER" -batchmode -logFile "$LOG"
           PLAYER_STATUS=$?
           set -e
 

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -193,8 +193,7 @@ jobs:
         run: |
           set -euo pipefail
           PLAYER=tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64
-          LOG="$PWD/tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log"
-          mkdir -p "$(dirname "$LOG")"
+          LOG="$RUNNER_TEMP/linux-il2cpp-player.log"
           ls -l "$PLAYER"
           test -x "$PLAYER"
 
@@ -224,6 +223,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unity-linux-il2cpp-smoke-log
-          path: tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
+          path: ${{ runner.temp }}/linux-il2cpp-player.log
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -195,7 +195,8 @@ jobs:
           PLAYER=tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64
           LOG=tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
           mkdir -p "$(dirname "$LOG")"
-          chmod +x "$PLAYER"
+          ls -l "$PLAYER"
+          test -x "$PLAYER"
 
           set +e
           timeout 120s "$PLAYER" -batchmode -nographics -logFile "$LOG"

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           set -euo pipefail
           PLAYER=tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64
-          LOG=tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
+          LOG="$PWD/tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log"
           mkdir -p "$(dirname "$LOG")"
           ls -l "$PLAYER"
           test -x "$PLAYER"

--- a/tools/unity-runtime-smoke/Assets/Editor/Builder.cs
+++ b/tools/unity-runtime-smoke/Assets/Editor/Builder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
@@ -48,21 +49,29 @@ public static class Builder
         return BuildTarget.StandaloneWindows64;
 #elif UNITY_EDITOR_OSX
         return BuildTarget.StandaloneOSX;
+#elif UNITY_EDITOR_LINUX
+        return BuildTarget.StandaloneLinux64;
 #else
         throw new PlatformNotSupportedException(
-            "The Xybrid IL2CPP smoke supports Windows and macOS editors.");
+            "The Xybrid IL2CPP smoke supports Windows, macOS, and Linux editors.");
 #endif
     }
 
     private static string BuildOutputPath()
     {
+        string relativePath;
+
 #if UNITY_EDITOR_WIN
-        return "Build/windows-il2cpp/XybridSmoke.exe";
+        relativePath = "Build/windows-il2cpp/XybridSmoke.exe";
 #elif UNITY_EDITOR_OSX
-        return "Build/macos-il2cpp/XybridSmoke.app";
+        relativePath = "Build/macos-il2cpp/XybridSmoke.app";
+#elif UNITY_EDITOR_LINUX
+        relativePath = "Build/linux-il2cpp/XybridSmoke.x86_64";
 #else
         throw new PlatformNotSupportedException(
-            "The Xybrid IL2CPP smoke supports Windows and macOS editors.");
+            "The Xybrid IL2CPP smoke supports Windows, macOS, and Linux editors.");
 #endif
+
+        return Path.GetFullPath(Path.Combine(Application.dataPath, "..", relativePath));
     }
 }

--- a/tools/unity-runtime-smoke/README.md
+++ b/tools/unity-runtime-smoke/README.md
@@ -29,12 +29,13 @@ unity build tools/unity-runtime-smoke \
 
 `.github/workflows/unity-editor.yml` runs all three rungs on relevant pull
 requests and pushes to `master`. After the EditMode tests pass, GameCI builds
-the smoke project with a Unity 6000.3.14f1 Linux IL2CPP image. The workflow
-then launches this player headlessly:
+the smoke project with its Unity 6000.3.6f1 Linux IL2CPP image. The workflow
+then launches this player on a virtual X11 display:
 
 ```bash
-./tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64 \
-  -batchmode -nographics \
+xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" \
+  ./tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64 \
+  -batchmode \
   -logFile "${RUNNER_TEMP}/linux-il2cpp-player.log"
 ```
 

--- a/tools/unity-runtime-smoke/README.md
+++ b/tools/unity-runtime-smoke/README.md
@@ -20,10 +20,26 @@ unity test tools/unity-runtime-smoke --mode EditMode \
   --output tools/unity-runtime-smoke/test-results.xml
 
 unity build tools/unity-runtime-smoke \
-  --target StandaloneWindows64 \
+  --target StandaloneLinux64 \
   --execute-method Builder.PerformBuild \
   --allow-dirty-build
 ```
+
+## Linux — hosted IL2CPP validation
+
+`.github/workflows/unity-editor.yml` runs all three rungs on relevant pull
+requests and pushes to `master`. After the EditMode tests pass, GameCI builds
+the smoke project with its Unity 6000.3.6f1 Linux IL2CPP image. The workflow
+then launches this player headlessly:
+
+```bash
+./tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64 \
+  -batchmode -nographics \
+  -logFile tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
+```
+
+The gate requires both a zero process exit code and `[XybridSmoke] OK` in the
+player log. The log is uploaded on success or failure.
 
 ## Windows — one-time manual validation
 

--- a/tools/unity-runtime-smoke/README.md
+++ b/tools/unity-runtime-smoke/README.md
@@ -29,13 +29,13 @@ unity build tools/unity-runtime-smoke \
 
 `.github/workflows/unity-editor.yml` runs all three rungs on relevant pull
 requests and pushes to `master`. After the EditMode tests pass, GameCI builds
-the smoke project with its Unity 6000.3.6f1 Linux IL2CPP image. The workflow
+the smoke project with a Unity 6000.3.14f1 Linux IL2CPP image. The workflow
 then launches this player headlessly:
 
 ```bash
 ./tools/unity-runtime-smoke/Build/linux-il2cpp/XybridSmoke.x86_64 \
   -batchmode -nographics \
-  -logFile tools/unity-runtime-smoke/Logs/linux-il2cpp-player.log
+  -logFile "${RUNNER_TEMP}/linux-il2cpp-player.log"
 ```
 
 The gate requires both a zero process exit code and `[XybridSmoke] OK` in the


### PR DESCRIPTION
## Summary

- add Linux as a supported IL2CPP smoke-player target
- build the smoke player with the pinned GameCI Linux IL2CPP image after EditMode passes
- run the player headlessly and require both exit code 0 and `[XybridSmoke] OK`
- retain the player log on success or failure

## Validation

- `actionlint .github/workflows/unity-editor.yml`
- 11 Unity native/ORT staging tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download`: one pre-existing 20 ms hysteresis timing test failed after 1,155 core tests passed; reproduced as flaky in isolated reruns (pass, then fail). No Rust files changed.

The licensed Unity Editor workflow is the end-to-end validation for this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow, smoke build paths, and documentation; no production Unity SDK or Rust runtime logic is modified.
> 
> **Overview**
> **Hosted CI now exercises the third Unity smoke rung** — Linux IL2CPP AOT plus a headless player run against the Bazel-built native — after EditMode already passes on the same job.
> 
> `unity-editor.yml` adds GameCI `unity-builder` for `StandaloneLinux64`, runs the built `XybridSmoke.x86_64` under `xvfb-run` with a 120s timeout, and fails unless exit code 0 and `[XybridSmoke] OK` appear in the log; the job timeout goes to 75 minutes and the IL2CPP log is uploaded as an artifact. Comments are updated to say IL2CPP is in scope (Windows plugin loading still is not).
> 
> `Builder.cs` gains Linux editor support (`StandaloneLinux64`, `Build/linux-il2cpp/...`) and resolves the player output with an absolute path via `Path.GetFullPath`. The smoke README documents the hosted Linux IL2CPP gate and uses `StandaloneLinux64` in the local build example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257a341d5edfe2d1d57397edfccb500f6a113935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->