### PR TITLE
build(bazel): cross-compile Windows-MSVC artifacts from Linux and macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,11 @@ common --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=False
 # rules_rust allocator-library handling used by the known-good e2e config.
 common --@rules_rust//rust/settings:experimental_use_allocator_libraries_with_mangled_symbols
 
+# xybrid is open source and uses the MSVC runtime under Microsoft's applicable
+# Visual Studio terms. Required by hermeticbuild/windows_support before it
+# materializes @msvc_runtime on developer and CI machines.
+common --repo_env=BAZEL_MSVC_RUNTIME_VISUAL_STUDIO_EULA=1
+
 # Bazelified LINUX NDK (see MODULE.bazel + rules_android_ndk.patch): the NDK is
 # DOWNLOADED as a pinned repository input (r27 = the CI pin, sha256-verified) —
 # no local install, no machine setup, works identically on any host/CI. The
@@ -36,6 +41,13 @@ build:android-x86_64 --compilation_mode=opt
 # x86_64-pc-windows-gnu PE — NOT the MSVC binary today's cargo windows-latest
 # build ships. Combine with --config=remote so exec=Linux RBE.
 build:windows --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-gnu
+
+# Desktop Windows with the MSVC ABI — the artifacts Flutter's cargokit links
+# against (`.dll` + MSVC-format `.dll.lib`), which the GNU lane above cannot
+# produce. Served by //bazel/toolchains/windows_msvc: the same hermetic clang,
+# with Microsoft's CRT + Windows SDK from @windows_support as the sysroot.
+# Reaching any target under this config downloads ~1.3 GB of Microsoft payload.
+build:windows-msvc --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-msvc
 
 # Desktop macOS (CPU lane), cross-compiled from Linux RBE via hermetic clang +
 # @macos_sdk. Metal/Accelerate stay OFF (//:llama default arm): CPU-only is

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -205,6 +205,27 @@ cmake(
             "CMAKE_C_FLAGS": "-D_USE_MATH_DEFINES",
             "CMAKE_CXX_FLAGS": "-D_USE_MATH_DEFINES",
         },
+        # Desktop Windows cross (MSVC ABI) — the Flutter/cargokit lane. Same
+        # CMAKE_SYSTEM seeding and vision set as the GNU arm above, but the C++
+        # runtime is Microsoft's STL, autolinked by `#pragma comment(lib, ...)`
+        # out of @msvc_runtime's headers. So NO CMAKE_CXX_STANDARD_LIBRARIES:
+        # the libc++/libcxxabi/libunwind trio the MinGW arm has to hand-feed is
+        # exactly what the MSVC sysroot already provides.
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-msvc": _LLAMA_CACHE_ENTRIES | {
+            "CMAKE_SYSTEM_NAME": "Windows",
+            "CMAKE_SYSTEM_PROCESSOR": "AMD64",
+            "LLAMA_BUILD_TOOLS": "ON",
+            "LLAMA_BUILD_COMMON": "ON",
+            # CMake's Windows-Clang module enables the RC language and there is
+            # no resource compiler on a Linux worker's PATH ("No
+            # CMAKE_RC_COMPILER could be found"). llvm-rc is the hermetic
+            # equivalent; the label rides in via build_data (cfg=exec).
+            "CMAKE_RC_COMPILER": "$$EXT_BUILD_ROOT/$(execpath @llvm//tools:llvm-rc)",
+            # mtmd-audio's M_PI, same as the MinGW arm: Microsoft's math.h is
+            # where _USE_MATH_DEFINES comes from in the first place.
+            "CMAKE_C_FLAGS": "-D_USE_MATH_DEFINES",
+            "CMAKE_CXX_FLAGS": "-D_USE_MATH_DEFINES",
+        },
         # macOS cross from Linux RBE (the macOS-CPU lane): same rfcc gap as
         # windows — no darwin entry in rfcc's _TARGET_OS_PARAMS, so without
         # CMAKE_SYSTEM_NAME cmake detects the Linux exec host and ggml defines
@@ -268,6 +289,11 @@ cmake(
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
             "@llvm//tools:llvm-install-name-tool",
             "@llvm//tools:llvm-otool",
+        ],
+        # windows-msvc: the resource compiler CMake's Windows-Clang module
+        # insists on, referenced by that arm's CMAKE_RC_COMPILER.
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-msvc": [
+            "@llvm//tools:llvm-rc",
         ],
         "//conditions:default": [],
     }),

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -338,6 +338,17 @@ cmake(
         # on WIN32, so the ggml archives have NO `lib` prefix (ggml.a, not
         # libggml.a) — while llama (sibling scope) keeps it (libllama.a), and
         # so does mtmd (tools/mtmd, also outside ggml's directory scope).
+        # Windows/MSVC: CMake's Windows-Clang module sets
+        # CMAKE_STATIC_LIBRARY_PREFIX="" and _SUFFIX=".lib" for every target, so
+        # unlike the MinGW arm there is no `lib` prefix anywhere and llama/mtmd
+        # follow the same rule as ggml.
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-msvc": [
+            "mtmd.lib",
+            "llama.lib",
+            "ggml.lib",
+            "ggml-base.lib",
+            "ggml-cpu.lib",
+        ],
         "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
             "libmtmd.a",
             "libllama.a",
@@ -354,6 +365,7 @@ cmake(
     # which has its own rule, does). Copy the built ggml archives into lib/ so
     # rfcc can collect them. No-op on other platforms (proven install works there).
     postfix_script = select({
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-msvc": "mkdir -p $$INSTALLDIR/lib && find $$BUILD_TMPDIR \\( -name '*.a' -o -name '*.lib' \\) -exec cp -f {} $$INSTALLDIR/lib/ \\;",
         "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": "mkdir -p $$INSTALLDIR/lib && find $$BUILD_TMPDIR -name '*.a' -exec cp -f {} $$INSTALLDIR/lib/ \\;",
         "//conditions:default": "",
     }),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,17 @@ cargo xtask build-android                 # Android .so libraries
 cargo xtask build-flutter                 # Flutter native libraries
 ```
 
+### Building for Windows (MSVC)
+
+`bazel build --config=windows-msvc //...` cross-compiles MSVC-ABI Windows
+binaries from Linux or macOS. It downloads Microsoft's Visual C++ runtime and
+Windows SDK (~1.3 GB) via the [`windows_support`](https://github.com/hermeticbuild/windows_support)
+Bazel module, which requires accepting Microsoft's terms. `.bazelrc` sets
+`BAZEL_MSVC_RUNTIME_VISUAL_STUDIO_EULA=1` on the project's behalf — by building
+this configuration you are asserting your machine may use those files under the
+[Visual Studio license terms](https://visualstudio.microsoft.com/license-terms).
+No other build configuration fetches them.
+
 ## Testing
 
 ```bash

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,47 @@ single_version_override(
 )
 bazel_dep(name = "hermetic_launcher", version = "0.0.11")
 
+# Microsoft's CRT + Windows SDK, the sysroot half of the Windows-MSVC lane
+# (--config=windows-msvc). windows_support deliberately ships no cc_toolchain:
+# @llvm stays the compiler provider and //bazel/toolchains/windows_msvc composes
+# the two. Pinned exactly — upstream is pre-1.0 and documents that its extension
+# APIs may change without notice. Fetching either repository below downloads
+# ~1.3 GB, and is gated on the EULA acknowledgement in .bazelrc.
+bazel_dep(name = "windows_support", version = "0.2.0")
+
+msvc_runtime = use_extension(
+    "@windows_support//windows:extensions.bzl",
+    "msvc_runtime",
+)
+msvc_runtime.configure(
+    architectures = ["x64"],
+    msvc_version = "14.50.35717",
+    visual_studio_installer_manifest_integrity = "sha256-qOhU+p8/uurCfXME4pfxZg1xN0ATid61fPeYPzPBb+8=",
+    visual_studio_installer_manifest_url = "https://download.visualstudio.microsoft.com/download/pr/fdc37f6e-59f6-4054-838a-b476eeaa6ec3/1d82370739911457e0a2f6be15d8b5f569531b352b2eabb961429eea1e99e356/VisualStudio.vsman",
+)
+use_repo(msvc_runtime, "msvc_runtime")
+
+windows_sdk = use_extension(
+    "@windows_support//windows:extensions.bzl",
+    "windows_sdk",
+)
+# NOTE: upstream's `transformations` attribute is deliberately NOT used. It runs
+# in the repository rule, i.e. on the Bazel *client*: on a case-insensitive macOS
+# volume its aliases collapse onto the originals, so a Mac-fetched sysroot
+# reaches a Linux RBE worker still missing them — and the two hosts would
+# materialise different repositories, splitting the remote cache. The case
+# handling lives in //bazel/toolchains/windows_msvc:case_insensitivity.bzl
+# instead, derived from the file list and therefore host-independent.
+windows_sdk.configure(
+    architectures = ["x64"],
+    windows_sdk_integrity = {
+        "Microsoft.Windows.SDK.CPP": "sha256-/0VWYL7gcadEcVqWZWZvopwHaBV509gVlZqe7FpVZCQ=",
+        "Microsoft.Windows.SDK.CPP.x64": "sha256-rWzpD/lAEGmdKVSLPCseUsieuBFD4hmRVdmlw4ABtSs=",
+    },
+    windows_sdk_version = "10.0.26100.7705",
+)
+use_repo(windows_sdk, "windows_sdk")
+
 # rules_cc must be a direct dep so the `@rules_cc//...` flag in .bazelrc resolves.
 bazel_dep(name = "rules_cc", version = "0.2.20")
 
@@ -182,6 +223,12 @@ register_toolchains("@androidndk//:all")
 # )
 
 # --- C/C++ toolchain: hermetic LLVM (desktop targets) -------------------------
+# ORDER MATTERS. @llvm's Windows toolchain declares no ABI constraint, so it also
+# matches a *-pc-windows-msvc platform; ours constrains on
+# @llvm//constraints/windows/abi:msvc and must be registered first to win there.
+# On windows-gnu platforms ours does not match at all and @llvm's is used.
+register_toolchains("//bazel/toolchains/windows_msvc:all")
+
 register_toolchains("@llvm//toolchain:all")
 
 # Hermetic macOS SDK (replaces xcrun) — needed on darwin host/target.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -328,6 +328,9 @@ crate.from_cargo(
         "x86_64-unknown-linux-gnu",
         # Desktop Windows cross (GNU/MinGW ABI — hermetic-llvm ships no MSVC CRT).
         "x86_64-pc-windows-gnu",
+        # Desktop Windows cross (MSVC ABI — the CRT + SDK come from
+        # @windows_support; see //bazel/toolchains/windows_msvc).
+        "x86_64-pc-windows-msvc",
         "aarch64-apple-darwin",
         # iOS device (Apple G1). Mac-bound — builds locally via Xcode's iOS SDK
         # (apple_support toolchain), never on Linux RBE.

--- a/bazel/toolchains/windows_msvc/BUILD.bazel
+++ b/bazel/toolchains/windows_msvc/BUILD.bazel
@@ -114,15 +114,12 @@ cc_args(
     args = ["--target=x86_64-pc-windows-msvc"],
 )
 
-# The link half never sees the clang driver, so the target comes from lld-link's
-# own switch rather than `--target=`.
-cc_args(
-    name = "machine_flags",
-    actions = [
-        "@rules_cc//cc/toolchains/actions:link_actions",
-    ],
-    args = ["/machine:x64"],
-)
+# NOTE: no `/machine:x64` here, deliberately. lld-link infers the machine from
+# the objects, and rules_foreign_cc hands the toolchain's link flags to CMake,
+# which links through the clang driver — clang reads `/machine:x64` as an input
+# filename and llama.cpp's first try-compile dies with "no such file or
+# directory". (`-LIBPATH:<dir>` survives that trip because clang parses it as
+# `-L IBPATH:<dir>`: a bogus search path, but harmless.)
 
 # Dynamic UCRT (`/MD`), matching what rustc emits for *-pc-windows-msvc without
 # `+crt-static` — the two halves of a shipped DLL must agree on the CRT. Compile
@@ -237,11 +234,28 @@ cc_args(
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
+    # Each directory is passed twice, because this toolchain has two kinds of
+    # link consumer and neither spelling reaches both:
+    #
+    #   -LIBPATH:  lld-link's own form, used by Bazel's link actions and by
+    #              rustc. The clang driver misparses it as `-L IBPATH:<dir>`,
+    #              silently losing the path.
+    #   -L         what rules_foreign_cc needs: CMake links through the clang
+    #              driver, so without it llama.cpp's try-compile cannot find
+    #              kernel32.lib. lld-link answers with "ignoring unknown
+    #              argument", which is where the per-link warnings come from.
+    #
+    # An `env = {"LIB": ...}` would serve both, but `cc_args` format strings
+    # take a single variable, so the four directories cannot be joined into one.
     args = [
         "-LIBPATH:{lowercase_aliases}",
+        "-L{lowercase_aliases}",
         "-LIBPATH:{msvc_lib}",
+        "-L{msvc_lib}",
         "-LIBPATH:{ucrt_lib}",
+        "-L{ucrt_lib}",
         "-LIBPATH:{um_lib}",
+        "-L{um_lib}",
     ],
     data = [
         ":case_insensitive_libraries",
@@ -322,7 +336,6 @@ cc_args_list(
         ":ms_runtime_lib",
         ":case_insensitive_header_lookup",
         ":headers_include_search_paths",
-        ":machine_flags",
         ":library_search_paths",
         "@llvm//toolchain/args:ignore_unused_command_line_argument",
     ],

--- a/bazel/toolchains/windows_msvc/BUILD.bazel
+++ b/bazel/toolchains/windows_msvc/BUILD.bazel
@@ -1,0 +1,336 @@
+"""Bazel C++ toolchain targeting `*-pc-windows-msvc` with hermetic LLVM.
+
+hermetic-llvm ships a MinGW sysroot only, so `@llvm`'s own Windows toolchain
+produces GNU-ABI PEs. This package composes the SAME hermetic clang/lld with
+Microsoft's CRT + Windows SDK (fetched by `@windows_support`, see MODULE.bazel)
+to produce MSVC-ABI PEs instead — the artifacts Flutter's cargokit links against.
+
+Only the `@llvm//toolchain/args:*` pieces that are ABI-neutral are reused; every
+sysroot-bearing argument is defined here, because `@llvm` cannot reference our
+`@msvc_runtime` / `@windows_sdk` repositories.
+"""
+
+load("@llvm//toolchain:selects.bzl", "platform_llvm_binary")
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:artifacts.bzl", "cc_artifact_name_pattern")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
+load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
+load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
+load(":case_insensitivity.bzl", "lowercase_library_aliases", "vfs_overlay")
+load(":declare_toolchains.bzl", "declare_toolchains")
+
+package(default_visibility = ["//visibility:private"])
+
+# --- tools -------------------------------------------------------------------
+
+# The same hermetic clang binaries `@llvm` uses, re-declared here for one reason:
+# `@llvm`'s `:clang` / `:clang++` advertise
+# `@rules_cc//cc/toolchains/capabilities:supports_pic`, which makes rules_cc pass
+# `-fPIC` unconditionally. clang's MSVC driver rejects it outright
+# ("unsupported option '-fPIC' for target 'x86_64-pc-windows-msvc'"), and PE code
+# is position independent by construction — Bazel's own MSVC toolchain likewise
+# reports supports_pic = False. The capability cannot be switched off downstream:
+# `--features=-supports_pic` fails with "toolchain unconditionally implies
+# feature 'supports_pic'". Dropping it from the tool is the only lever.
+cc_tool(
+    name = "clang",
+    src = platform_llvm_binary("clang"),
+)
+
+cc_tool(
+    name = "clang++",
+    src = platform_llvm_binary("clang++"),
+)
+
+# The clang driver, invoked as the linker. `-fuse-ld=lld` resolves to `lld-link`
+# for an MSVC target, so that binary has to be staged alongside the driver.
+# `platform_llvm_binary` returns a `select`, which cannot appear inside a list
+# attribute — the aliases give `data` plain labels to hang off.
+alias(
+    name = "lld_binary",
+    actual = platform_llvm_binary("lld"),
+)
+
+alias(
+    name = "lld_link_binary",
+    actual = platform_llvm_binary("lld-link"),
+)
+
+cc_tool(
+    name = "lld",
+    src = platform_llvm_binary("clang++"),
+    data = [
+        ":lld_binary",
+        ":lld_link_binary",
+    ],
+)
+
+cc_tool(
+    name = "llvm-ar",
+    src = platform_llvm_binary("llvm-ar"),
+)
+
+cc_tool(
+    name = "llvm-objcopy",
+    src = platform_llvm_binary("llvm-objcopy"),
+)
+
+cc_tool(
+    name = "llvm-strip",
+    src = platform_llvm_binary("llvm-strip"),
+)
+
+cc_tool(
+    name = "llvm-dwp",
+    src = platform_llvm_binary("llvm-dwp"),
+)
+
+cc_tool(
+    name = "llvm-cov",
+    src = platform_llvm_binary("llvm-cov"),
+)
+
+cc_tool(
+    name = "llvm-profdata",
+    src = platform_llvm_binary("llvm-profdata"),
+)
+
+cc_tool_map(
+    name = "tools",
+    tools = {
+        "@rules_cc//cc/toolchains/actions:assembly_actions": ":clang",
+        "@rules_cc//cc/toolchains/actions:c_compile": ":clang",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions": ":clang++",
+        "@rules_cc//cc/toolchains/actions:link_actions": ":lld",
+        "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
+        "@rules_cc//cc/toolchains/actions:objcopy_embed_data": ":llvm-objcopy",
+        "@rules_cc//cc/toolchains/actions:strip": ":llvm-strip",
+        "@rules_cc//cc/toolchains/actions:dwp": ":llvm-dwp",
+        "@rules_cc//cc/toolchains/actions:llvm_cov": ":llvm-cov",
+        "@rules_cc//cc/toolchains/actions:llvm_profdata": ":llvm-profdata",
+    },
+)
+
+# --- target selection --------------------------------------------------------
+
+# @llvm//toolchain/args:target_flags hardcodes the MinGW triple for Windows
+# (LLVM_TARGET_TRIPLE -> x86_64-w64-windows-gnu), so the MSVC lane supplies its
+# own. This is the single flag that flips the ABI: calling convention, name
+# mangling, EH model, and the CRT clang autolinks against.
+cc_args(
+    name = "target_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["--target=x86_64-pc-windows-msvc"],
+)
+
+# Dynamic UCRT (`/MD`), matching what rustc emits for *-pc-windows-msvc without
+# `+crt-static` — the two halves of a shipped DLL must agree on the CRT.
+cc_args(
+    name = "ms_runtime_lib",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["-fms-runtime-lib=dll"],
+)
+
+# --- sysroot -----------------------------------------------------------------
+
+# @llvm//toolchain/args:hermetic_compile_flags already passes -nostdlibinc, so
+# clang keeps only its builtin resource-dir headers and every system header
+# below comes from Microsoft's payload.
+cc_args(
+    name = "headers_include_search_paths",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    allowlist_include_directories = [
+        "@msvc_runtime//:msvc_include",
+        "@windows_sdk//:winsdk_ucrt_include",
+        "@windows_sdk//:winsdk_shared_include",
+        "@windows_sdk//:winsdk_um_include",
+    ],
+    # `-Xclang -internal-isystem`, not `-isystem`. Microsoft's headers must be
+    # searched AFTER clang's builtin resource dir: <immintrin.h> exists in both,
+    # and Microsoft's declares the intrinsics as extern functions its own
+    # compiler provides — pick that one under clang and the link fails with
+    # `undefined symbol: _mm_set1_epi32`. `-isystem` would shadow the builtins;
+    # `-internal-isystem` appends in command-line order behind them, which is
+    # what clang-cl's `-imsvc` lowers to (`-imsvc` itself is a clang-cl-only
+    # driver flag and the gcc-style driver rejects it).
+    #
+    # ORDER-SENSITIVE: `resource_dir_arg()` must come before `:toolchain_args`
+    # in the cc_toolchain `args` list — see declare_toolchains.bzl.
+    args = [
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{msvc_include}",
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{ucrt_include}",
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{shared_include}",
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{um_include}",
+    ],
+    data = [
+        "@msvc_runtime//:msvc_include",
+        "@windows_sdk//:winsdk_shared_include",
+        "@windows_sdk//:winsdk_ucrt_include",
+        "@windows_sdk//:winsdk_um_include",
+    ],
+    format = {
+        "msvc_include": "@msvc_runtime//:msvc_include",
+        "shared_include": "@windows_sdk//:winsdk_shared_include",
+        "ucrt_include": "@windows_sdk//:winsdk_ucrt_include",
+        "um_include": "@windows_sdk//:winsdk_um_include",
+    },
+)
+
+vfs_overlay(
+    name = "case_insensitive_headers",
+    directories = [
+        "@msvc_runtime//:msvc_include",
+        "@windows_sdk//:winsdk_shared_include",
+        "@windows_sdk//:winsdk_ucrt_include",
+        "@windows_sdk//:winsdk_um_include",
+    ],
+)
+
+cc_args(
+    name = "case_insensitive_header_lookup",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-ivfsoverlay",
+        "{overlay}",
+    ],
+    data = [":case_insensitive_headers"],
+    format = {"overlay": ":case_insensitive_headers"},
+)
+
+lowercase_library_aliases(
+    name = "case_insensitive_libraries",
+    directories = [
+        "@msvc_runtime//:msvc_lib",
+        "@windows_sdk//:winsdk_ucrt_lib",
+        "@windows_sdk//:winsdk_um_lib",
+    ],
+)
+
+# No explicit -l: MSVC headers carry `#pragma comment(lib, ...)` autolink
+# directives, so the CRT and SDK import libraries resolve from these paths.
+# The `:msvc_lib` / `:winsdk_*_lib` aliases pick the arch-correct subdirectory;
+# `:case_insensitive_libraries` supplies lowercase names for the mixed-case ones
+# and is searched first.
+cc_args(
+    name = "library_search_paths",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-L{lowercase_aliases}",
+        "-L{msvc_lib}",
+        "-L{ucrt_lib}",
+        "-L{um_lib}",
+    ],
+    data = [
+        ":case_insensitive_libraries",
+        "@msvc_runtime//:msvc_lib",
+        "@windows_sdk//:winsdk_ucrt_lib",
+        "@windows_sdk//:winsdk_um_lib",
+    ],
+    format = {
+        "lowercase_aliases": ":case_insensitive_libraries",
+        "msvc_lib": "@msvc_runtime//:msvc_lib",
+        "ucrt_lib": "@windows_sdk//:winsdk_ucrt_lib",
+        "um_lib": "@windows_sdk//:winsdk_um_lib",
+    },
+)
+
+# Bazel hands `cc_shared_library` a generated `.def`. rules_cc's own `def_file`
+# feature passes the path bare, which GNU ld accepts as a linker input but
+# lld-link rejects ("unknown file type"); MSVC spells it `/def:`.
+cc_args(
+    name = "def_file_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-Xlinker",
+        "/def:{def_file_path}",
+    ],
+    format = {"def_file_path": "@rules_cc//cc/toolchains/variables:def_file_path"},
+    requires_not_none = "@rules_cc//cc/toolchains/variables:def_file_path",
+)
+
+# Deliberately NOT named `def_file`: rules_cc's own `def_file` feature arrives
+# through `@llvm//toolchain/features:all_non_legacy_builtin_features` and two
+# features may not share a name. Ours is enabled, theirs is only known.
+cc_feature(
+    name = "msvc_def_file",
+    args = [":def_file_args"],
+    feature_name = "msvc_def_file",
+)
+
+# --- artifact naming ---------------------------------------------------------
+
+cc_artifact_name_pattern(
+    name = "executable_pattern",
+    category = "@rules_cc//cc/toolchains/artifacts:executable",
+    extension = ".exe",
+    prefix = "",
+)
+
+cc_artifact_name_pattern(
+    name = "dynamic_library_pattern",
+    category = "@rules_cc//cc/toolchains/artifacts:dynamic_library",
+    extension = ".dll",
+    prefix = "",
+)
+
+cc_artifact_name_pattern(
+    name = "interface_library_pattern",
+    category = "@rules_cc//cc/toolchains/artifacts:interface_library",
+    extension = ".lib",
+    prefix = "",
+)
+
+cc_artifact_name_pattern(
+    name = "static_library_pattern",
+    category = "@rules_cc//cc/toolchains/artifacts:static_library",
+    extension = ".lib",
+    prefix = "",
+)
+
+# --- toolchain ---------------------------------------------------------------
+
+cc_args_list(
+    name = "toolchain_args",
+    args = [
+        ":target_flags",
+        "@llvm//toolchain/args:no_absolute_paths_for_builtins",
+        "@llvm//toolchain/args:deterministic_compile_flags",
+        "@llvm//toolchain/args:module_map",
+        "@llvm//toolchain/args:hermetic_compile_flags",
+        ":ms_runtime_lib",
+        ":case_insensitive_header_lookup",
+        ":headers_include_search_paths",
+        "@llvm//toolchain/args:fuse_ld",
+        ":library_search_paths",
+        "@llvm//toolchain/args:ignore_unused_command_line_argument",
+    ],
+)
+
+declare_toolchains()

--- a/bazel/toolchains/windows_msvc/BUILD.bazel
+++ b/bazel/toolchains/windows_msvc/BUILD.bazel
@@ -43,27 +43,15 @@ cc_tool(
     src = platform_llvm_binary("clang++"),
 )
 
-# The clang driver, invoked as the linker. `-fuse-ld=lld` resolves to `lld-link`
-# for an MSVC target, so that binary has to be staged alongside the driver.
-# `platform_llvm_binary` returns a `select`, which cannot appear inside a list
-# attribute — the aliases give `data` plain labels to hang off.
-alias(
-    name = "lld_binary",
-    actual = platform_llvm_binary("lld"),
-)
-
-alias(
-    name = "lld_link_binary",
-    actual = platform_llvm_binary("lld-link"),
-)
-
+# lld-link is invoked DIRECTLY, not through the clang driver. rustc accepts only
+# the `msvc-lld`, `msvc` and `lld-link` linker flavours for a
+# `*-pc-windows-msvc` target ("linker flavor `gcc` is incompatible with the
+# current target"), and rules_rust takes its linker from the cc toolchain — so
+# the C++ half links MSVC-style too. //bazel/toolchains/windows_msvc/link
+# carries the matching argument spellings.
 cc_tool(
-    name = "lld",
-    src = platform_llvm_binary("clang++"),
-    data = [
-        ":lld_binary",
-        ":lld_link_binary",
-    ],
+    name = "lld-link",
+    src = platform_llvm_binary("lld-link"),
 )
 
 cc_tool(
@@ -102,7 +90,7 @@ cc_tool_map(
         "@rules_cc//cc/toolchains/actions:assembly_actions": ":clang",
         "@rules_cc//cc/toolchains/actions:c_compile": ":clang",
         "@rules_cc//cc/toolchains/actions:cpp_compile_actions": ":clang++",
-        "@rules_cc//cc/toolchains/actions:link_actions": ":lld",
+        "@rules_cc//cc/toolchains/actions:link_actions": ":lld-link",
         "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
         "@rules_cc//cc/toolchains/actions:objcopy_embed_data": ":llvm-objcopy",
         "@rules_cc//cc/toolchains/actions:strip": ":llvm-strip",
@@ -122,18 +110,28 @@ cc_args(
     name = "target_flags",
     actions = [
         "@rules_cc//cc/toolchains/actions:compile_actions",
-        "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = ["--target=x86_64-pc-windows-msvc"],
 )
 
+# The link half never sees the clang driver, so the target comes from lld-link's
+# own switch rather than `--target=`.
+cc_args(
+    name = "machine_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["/machine:x64"],
+)
+
 # Dynamic UCRT (`/MD`), matching what rustc emits for *-pc-windows-msvc without
-# `+crt-static` — the two halves of a shipped DLL must agree on the CRT.
+# `+crt-static` — the two halves of a shipped DLL must agree on the CRT. Compile
+# only: it works by steering the `#pragma comment(lib, ...)` autolink directives
+# the MSVC headers emit.
 cc_args(
     name = "ms_runtime_lib",
     actions = [
         "@rules_cc//cc/toolchains/actions:compile_actions",
-        "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = ["-fms-runtime-lib=dll"],
 )
@@ -240,10 +238,10 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = [
-        "-L{lowercase_aliases}",
-        "-L{msvc_lib}",
-        "-L{ucrt_lib}",
-        "-L{um_lib}",
+        "-LIBPATH:{lowercase_aliases}",
+        "-LIBPATH:{msvc_lib}",
+        "-LIBPATH:{ucrt_lib}",
+        "-LIBPATH:{um_lib}",
     ],
     data = [
         ":case_insensitive_libraries",
@@ -267,10 +265,7 @@ cc_args(
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
-    args = [
-        "-Xlinker",
-        "/def:{def_file_path}",
-    ],
+    args = ["/def:{def_file_path}"],
     format = {"def_file_path": "@rules_cc//cc/toolchains/variables:def_file_path"},
     requires_not_none = "@rules_cc//cc/toolchains/variables:def_file_path",
 )
@@ -327,7 +322,7 @@ cc_args_list(
         ":ms_runtime_lib",
         ":case_insensitive_header_lookup",
         ":headers_include_search_paths",
-        "@llvm//toolchain/args:fuse_ld",
+        ":machine_flags",
         ":library_search_paths",
         "@llvm//toolchain/args:ignore_unused_command_line_argument",
     ],

--- a/bazel/toolchains/windows_msvc/BUILD.bazel
+++ b/bazel/toolchains/windows_msvc/BUILD.bazel
@@ -17,7 +17,7 @@ load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
-load(":case_insensitivity.bzl", "lowercase_library_aliases", "vfs_overlay")
+load(":case_insensitivity.bzl", "lowercase_aliases")
 load(":declare_toolchains.bzl", "declare_toolchains")
 
 package(default_visibility = ["//visibility:private"])
@@ -192,7 +192,7 @@ cc_args(
     },
 )
 
-vfs_overlay(
+lowercase_aliases(
     name = "case_insensitive_headers",
     directories = [
         "@msvc_runtime//:msvc_include",
@@ -200,6 +200,15 @@ vfs_overlay(
         "@windows_sdk//:winsdk_ucrt_include",
         "@windows_sdk//:winsdk_um_include",
     ],
+    # The four headers Microsoft's own sources include under a casing that is
+    # not what is on disk. Same list upstream's `transformations` example
+    # carries; a fifth would surface as a "file not found" naming it.
+    extra_aliases = {
+        "driverspecs.h": "DriverSpecs.h",
+        "specstrings.h": "SpecStrings.h",
+        "ole2.h": "Ole2.h",
+        "olectl.h": "OleCtl.h",
+    },
 )
 
 cc_args(
@@ -208,14 +217,16 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:compile_actions",
     ],
     args = [
-        "-ivfsoverlay",
-        "{overlay}",
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{aliases}",
     ],
     data = [":case_insensitive_headers"],
-    format = {"overlay": ":case_insensitive_headers"},
+    format = {"aliases": ":case_insensitive_headers"},
 )
 
-lowercase_library_aliases(
+lowercase_aliases(
     name = "case_insensitive_libraries",
     directories = [
         "@msvc_runtime//:msvc_lib",

--- a/bazel/toolchains/windows_msvc/case_insensitivity.bzl
+++ b/bazel/toolchains/windows_msvc/case_insensitivity.bzl
@@ -1,0 +1,141 @@
+"""Makes Microsoft's case-insensitive filenames work on a case-sensitive host.
+
+Windows SDK payloads mix casings freely — `Windows.h` is included as
+`<windows.h>`, while `kernelspecs.h` includes `"DriverSpecs.h"` for a file named
+`driverspecs.h`, and `uuid.lib` is on disk as `Uuid.Lib`. That is invisible on
+Windows and on a default macOS APFS volume, and fatal on Linux:
+
+    bazel/windows_msvc/smoke.cc:8:10: fatal error: 'windows.h' file not found
+    lld-link: error: could not open 'uuid.lib': No such file or directory
+
+`@windows_support`'s `transformations` attribute cannot fix this for us, because
+repository rules run on the Bazel *client*. Fetch on a Mac and the alias names
+collapse onto the originals; that repository is then uploaded verbatim to a
+case-sensitive Linux RBE worker, still missing them. Both rules below derive
+their output from the file list instead, so they are correct whichever host
+fetched the payload.
+
+Headers and libraries need different mechanisms because `-ivfsoverlay` is a
+clang flag and lld-link never sees it.
+
+Upstream plans to expose an overlay directly — hermeticbuild/windows_support#3.
+"""
+
+load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
+
+def _vfs_overlay_impl(ctx):
+    # Containing directory -> [(basename, path)]. Each key becomes one overlay
+    # root. EVERY file is listed, not just the mixed-case ones: the miscasing
+    # goes both ways, so there is no single canonical casing to normalise
+    # towards. `case-sensitive: false` makes every listed entry match any
+    # casing, which covers both directions at once.
+    entries = {}
+    for target in ctx.attr.directories:
+        for source in target[DirectoryInfo].transitive_files.to_list():
+            slash = source.path.rfind("/")
+            entries.setdefault(source.path[:slash], []).append(
+                (source.path[slash + 1:], source.path),
+            )
+
+    overlay = ctx.actions.declare_file(ctx.label.name + ".yaml")
+    ctx.actions.write(
+        overlay,
+        # JSON is valid YAML, and json.encode handles the escaping. Paths stay
+        # execution-root-relative: clang resolves them against the compiler's
+        # working directory, which Bazel sets to the execution root, and
+        # absolute paths would bake in the generating action's sandbox.
+        json.encode({
+            "version": 0,
+            "case-sensitive": False,
+            "roots": [
+                {
+                    "name": directory,
+                    "type": "directory",
+                    "contents": [
+                        {
+                            "name": basename,
+                            "type": "file",
+                            "external-contents": path,
+                        }
+                        for basename, path in sorted(entries[directory])
+                    ],
+                }
+                for directory in sorted(entries)
+            ],
+        }),
+    )
+    return [DefaultInfo(files = depset([overlay]))]
+
+vfs_overlay = rule(
+    implementation = _vfs_overlay_impl,
+    doc = "Emits a clang -ivfsoverlay file making the given header directories case-insensitive.",
+    attrs = {
+        "directories": attr.label_list(
+            doc = "Header directories to make case-insensitive.",
+            mandatory = True,
+            providers = [DirectoryInfo],
+        ),
+    },
+)
+
+def _lowercase_library_aliases_impl(ctx):
+    # Only the mixed-case libraries are copied — 179 files / ~40 MB of the
+    # SDK's 400 MB — so the action's input set stays small. Autolink pragmas
+    # (`#pragma comment(lib, "uuid.lib")`) always spell the name lowercase, so
+    # one direction is enough here, unlike the header overlay.
+    sources = []
+    aliases = {}
+    for target in ctx.attr.directories:
+        for source in target[DirectoryInfo].transitive_files.to_list():
+            lowercased = source.basename.lower()
+            if lowercased == source.basename:
+                continue
+            if lowercased in aliases:
+                fail("{} and {} both lowercase to {}".format(
+                    aliases[lowercased],
+                    source.path,
+                    lowercased,
+                ))
+            aliases[lowercased] = source.path
+            sources.append(source)
+
+    manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
+    ctx.actions.write(
+        manifest,
+        "".join([
+            "{}\t{}\n".format(aliases[lowercased], lowercased)
+            for lowercased in sorted(aliases)
+        ]),
+    )
+
+    directory = ctx.actions.declare_directory(ctx.label.name)
+    ctx.actions.run_shell(
+        arguments = [manifest.path, directory.path],
+        # Copies rather than symlinks: a symlink out of a tree artifact does not
+        # survive remote execution. The copies share content digests with the
+        # originals, so the CAS stores them once.
+        command = """
+set -euo pipefail
+mkdir -p "$2"
+while IFS=$'\\t' read -r source alias; do
+    cp -f "${source}" "$2/${alias}"
+done < "$1"
+""",
+        inputs = depset(direct = [manifest] + sources),
+        outputs = [directory],
+        mnemonic = "WindowsSdkLibraryAliases",
+        progress_message = "Aliasing %{label}",
+    )
+    return [DefaultInfo(files = depset([directory]))]
+
+lowercase_library_aliases = rule(
+    implementation = _lowercase_library_aliases_impl,
+    doc = "Collects lowercase copies of every mixed-case import library into one directory.",
+    attrs = {
+        "directories": attr.label_list(
+            doc = "Library directories to alias.",
+            mandatory = True,
+            providers = [DirectoryInfo],
+        ),
+    },
+)

--- a/bazel/toolchains/windows_msvc/case_insensitivity.bzl
+++ b/bazel/toolchains/windows_msvc/case_insensitivity.bzl
@@ -5,106 +5,66 @@ Windows SDK payloads mix casings freely — `Windows.h` is included as
 `driverspecs.h`, and `uuid.lib` is on disk as `Uuid.Lib`. That is invisible on
 Windows and on a default macOS APFS volume, and fatal on Linux:
 
-    bazel/windows_msvc/smoke.cc:8:10: fatal error: 'windows.h' file not found
+    ggml/src/ggml.c:51:10: fatal error: 'windows.h' file not found
     lld-link: error: could not open 'uuid.lib': No such file or directory
 
 `@windows_support`'s `transformations` attribute cannot fix this for us, because
 repository rules run on the Bazel *client*. Fetch on a Mac and the alias names
 collapse onto the originals; that repository is then uploaded verbatim to a
-case-sensitive Linux RBE worker, still missing them. Both rules below derive
-their output from the file list instead, so they are correct whichever host
-fetched the payload.
+case-sensitive Linux RBE worker, still missing them. The rule below derives its
+aliases from the file list instead, so it is correct whichever host fetched the
+payload.
 
-Headers and libraries need different mechanisms because `-ivfsoverlay` is a
-clang flag and lld-link never sees it.
+Real files, not a clang `-ivfsoverlay`. An overlay is cheaper and needs no
+enumeration, but it only works for compiler invocations Bazel spawns itself:
+rules_foreign_cc absolutises include paths (`absolutize_path_in_str` prefixes
+any `external/` or `bazel-out/` token) while the overlay names its roots
+execroot-relative, so the roots stop matching and the overlay silently goes
+inert. Nor can the overlay carry absolute paths — the generating action's
+sandbox is not the consuming action's. A directory of real files survives every
+consumer: Bazel actions, cc-rs build scripts, and CMake.
 
-Upstream plans to expose an overlay directly — hermeticbuild/windows_support#3.
+Upstream tracks a first-class overlay at hermeticbuild/windows_support#3.
 """
 
 load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
 
-def _vfs_overlay_impl(ctx):
-    # Containing directory -> [(basename, path)]. Each key becomes one overlay
-    # root. EVERY file is listed, not just the mixed-case ones: the miscasing
-    # goes both ways, so there is no single canonical casing to normalise
-    # towards. `case-sensitive: false` makes every listed entry match any
-    # casing, which covers both directions at once.
-    entries = {}
-    for target in ctx.attr.directories:
-        for source in target[DirectoryInfo].transitive_files.to_list():
-            slash = source.path.rfind("/")
-            entries.setdefault(source.path[:slash], []).append(
-                (source.path[slash + 1:], source.path),
-            )
-
-    overlay = ctx.actions.declare_file(ctx.label.name + ".yaml")
-    ctx.actions.write(
-        overlay,
-        # JSON is valid YAML, and json.encode handles the escaping. Paths stay
-        # execution-root-relative: clang resolves them against the compiler's
-        # working directory, which Bazel sets to the execution root, and
-        # absolute paths would bake in the generating action's sandbox.
-        json.encode({
-            "version": 0,
-            "case-sensitive": False,
-            "roots": [
-                {
-                    "name": directory,
-                    "type": "directory",
-                    "contents": [
-                        {
-                            "name": basename,
-                            "type": "file",
-                            "external-contents": path,
-                        }
-                        for basename, path in sorted(entries[directory])
-                    ],
-                }
-                for directory in sorted(entries)
-            ],
-        }),
-    )
-    return [DefaultInfo(files = depset([overlay]))]
-
-vfs_overlay = rule(
-    implementation = _vfs_overlay_impl,
-    doc = "Emits a clang -ivfsoverlay file making the given header directories case-insensitive.",
-    attrs = {
-        "directories": attr.label_list(
-            doc = "Header directories to make case-insensitive.",
-            mandatory = True,
-            providers = [DirectoryInfo],
-        ),
-    },
-)
-
-def _lowercase_library_aliases_impl(ctx):
-    # Only the mixed-case libraries are copied — 179 files / ~40 MB of the
-    # SDK's 400 MB — so the action's input set stays small. Autolink pragmas
-    # (`#pragma comment(lib, "uuid.lib")`) always spell the name lowercase, so
-    # one direction is enough here, unlike the header overlay.
-    sources = []
+def _lowercase_aliases_impl(ctx):
+    # alias basename -> real path. Only files whose name is not already
+    # lowercase produce one, so the copy set stays a fraction of the payload.
     aliases = {}
+    sources = []
+
+    def add(alias, source):
+        if alias in aliases:
+            fail("{} and {} both map to {}".format(aliases[alias], source.path, alias))
+        aliases[alias] = source.path
+        sources.append(source)
+
+    # `extra_aliases` covers the other direction, which cannot be derived: a
+    # file that IS lowercase on disk but gets included under a mixed-case name
+    # (`kernelspecs.h` includes "DriverSpecs.h" for `driverspecs.h`). The set is
+    # fixed per SDK version, and a missing entry fails the build loudly rather
+    # than silently mis-resolving.
+    wanted = ctx.attr.extra_aliases
     for target in ctx.attr.directories:
         for source in target[DirectoryInfo].transitive_files.to_list():
             lowercased = source.basename.lower()
-            if lowercased == source.basename:
-                continue
-            if lowercased in aliases:
-                fail("{} and {} both lowercase to {}".format(
-                    aliases[lowercased],
-                    source.path,
-                    lowercased,
-                ))
-            aliases[lowercased] = source.path
-            sources.append(source)
+            if lowercased != source.basename:
+                add(lowercased, source)
+            if source.basename in wanted:
+                add(wanted[source.basename], source)
+
+    for real, alias in ctx.attr.extra_aliases.items():
+        if alias not in aliases:
+            fail("extra_aliases: no file named {} to alias as {}".format(real, alias))
 
     manifest = ctx.actions.declare_file(ctx.label.name + ".manifest")
     ctx.actions.write(
         manifest,
         "".join([
-            "{}\t{}\n".format(aliases[lowercased], lowercased)
-            for lowercased in sorted(aliases)
+            "{}\t{}\n".format(aliases[alias], alias)
+            for alias in sorted(aliases)
         ]),
     )
 
@@ -123,19 +83,22 @@ done < "$1"
 """,
         inputs = depset(direct = [manifest] + sources),
         outputs = [directory],
-        mnemonic = "WindowsSdkLibraryAliases",
+        mnemonic = "WindowsSdkCaseAliases",
         progress_message = "Aliasing %{label}",
     )
     return [DefaultInfo(files = depset([directory]))]
 
-lowercase_library_aliases = rule(
-    implementation = _lowercase_library_aliases_impl,
-    doc = "Collects lowercase copies of every mixed-case import library into one directory.",
+lowercase_aliases = rule(
+    implementation = _lowercase_aliases_impl,
+    doc = "Collects case-variant copies of Microsoft's mixed-case files into one directory.",
     attrs = {
         "directories": attr.label_list(
-            doc = "Library directories to alias.",
+            doc = "Directories to scan.",
             mandatory = True,
             providers = [DirectoryInfo],
+        ),
+        "extra_aliases": attr.string_dict(
+            doc = "Real basename -> additional alias basename, for files that are lowercase on disk.",
         ),
     },
 )

--- a/bazel/toolchains/windows_msvc/declare_toolchains.bzl
+++ b/bazel/toolchains/windows_msvc/declare_toolchains.bzl
@@ -1,0 +1,99 @@
+"""Declares the hermetic-LLVM-to-Windows-MSVC C++ toolchains.
+
+Mirrors `@llvm//toolchain:declare_toolchains.bzl`: one `cc_toolchain` per exec
+platform (Bazel cannot bind one `cc_toolchain` to several `toolchain()`s with
+different `exec_compatible_with`), each registered for Windows targets carrying
+`@llvm//constraints/windows/abi:msvc`.
+
+`@llvm`'s own Windows toolchain is declared with no ABI constraint, so it also
+matches an MSVC platform. These toolchains must therefore be registered BEFORE
+`@llvm//toolchain:all` in MODULE.bazel — first match wins.
+"""
+
+load("@llvm//platforms:common.bzl", "SUPPORTED_EXECS")
+load("@llvm//toolchain:selects.bzl", "resource_dir_arg")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
+load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
+
+# x86_64 only: MODULE.bazel configures both sysroot repositories with
+# `architectures = ["x64"]`, so no arm64 import libraries are fetched. Adding
+# aarch64 here means adding it there too — the `:msvc_lib` / `:winsdk_*_lib`
+# aliases already select the right subdirectory.
+_TARGET_CPUS = ["x86_64"]
+
+def declare_toolchains():
+    """Declares one cc_toolchain per exec platform plus its toolchain() bindings."""
+    for (exec_os, exec_cpu) in SUPPORTED_EXECS:
+        name = "{}_{}_cc_toolchain".format(exec_os, exec_cpu)
+
+        cc_feature_set(
+            name = name + "_known_features",
+            all_of = [
+                ":msvc_def_file",
+                "@llvm//toolchain/features:external_include_paths",
+                "@llvm//toolchain/features:generate_pdb_file",
+                "@llvm//toolchain/features:targets_windows",
+                # Enabled internally by the --compilation_mode flag family:
+                # known, but not enabled here.
+                "@llvm//toolchain/features:all_non_legacy_builtin_features",
+                "@llvm//toolchain/features/legacy:all_legacy_builtin_features",
+                # Always last: carries user_compile_flags / user_link_flags.
+                "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",
+            ],
+        )
+
+        cc_feature_set(
+            name = name + "_enabled_features",
+            all_of = [
+                # Bazel hands the linker a generated .def file for DLLs.
+                ":msvc_def_file",
+                "@llvm//toolchain/features:targets_windows",
+                "@llvm//toolchain/features:opt",
+                "@llvm//toolchain/features:dbg",
+                "@llvm//toolchain/features:archive_param_file",
+                "@llvm//toolchain/features/legacy:all_legacy_builtin_features",
+                "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",
+            ],
+        )
+
+        cc_toolchain(
+            name = name,
+            # ORDER-SENSITIVE: the resource dir emits `-Xclang
+            # -internal-isystem` for clang's builtin headers and must precede
+            # the Microsoft include paths, which use the same mechanism — that
+            # list is searched in command-line order. See the
+            # `headers_include_search_paths` comment in BUILD.bazel.
+            args = [
+                resource_dir_arg(exec_os, exec_cpu),
+                ":toolchain_args",
+            ],
+            artifact_name_patterns = [
+                ":executable_pattern",
+                ":dynamic_library_pattern",
+                ":interface_library_pattern",
+                ":static_library_pattern",
+            ],
+            compiler = "clang",
+            enabled_features = [name + "_enabled_features"],
+            known_features = [name + "_known_features"],
+            supports_param_files = True,
+            target_system_name = "x86_64-pc-windows-msvc",
+            tool_map = ":tools",
+        )
+
+        for target_cpu in _TARGET_CPUS:
+            native.toolchain(
+                name = "{}_{}_to_windows_msvc_{}".format(exec_os, exec_cpu, target_cpu),
+                exec_compatible_with = [
+                    "@platforms//cpu:{}".format(exec_cpu),
+                    "@platforms//os:{}".format(exec_os),
+                ],
+                target_compatible_with = [
+                    "@platforms//cpu:{}".format(target_cpu),
+                    "@platforms//os:windows",
+                    "@llvm//constraints/windows/abi:msvc",
+                ],
+                toolchain = name,
+                toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+                visibility = ["//visibility:public"],
+            )

--- a/bazel/toolchains/windows_msvc/declare_toolchains.bzl
+++ b/bazel/toolchains/windows_msvc/declare_toolchains.bzl
@@ -38,7 +38,7 @@ def declare_toolchains():
                 "@llvm//toolchain/features:all_non_legacy_builtin_features",
                 "@llvm//toolchain/features/legacy:all_legacy_builtin_features",
                 # Always last: carries user_compile_flags / user_link_flags.
-                "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",
+                "//bazel/toolchains/windows_msvc/link:features",
             ],
         )
 
@@ -52,7 +52,7 @@ def declare_toolchains():
                 "@llvm//toolchain/features:dbg",
                 "@llvm//toolchain/features:archive_param_file",
                 "@llvm//toolchain/features/legacy:all_legacy_builtin_features",
-                "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",
+                "//bazel/toolchains/windows_msvc/link:features",
             ],
         )
 

--- a/bazel/toolchains/windows_msvc/link/BUILD.bazel
+++ b/bazel/toolchains/windows_msvc/link/BUILD.bazel
@@ -1,0 +1,305 @@
+"""MSVC-flavoured replacements for rules_cc's legacy link features.
+
+The MSVC lane links with `lld-link`, not the clang driver, because rustc refuses
+any other shape: for a `*-pc-windows-msvc` target it accepts only the `msvc-lld`,
+`msvc` and `lld-link` linker flavours (the gcc-style ones are rejected outright,
+and `gnu-lld-cc` is nightly-only), and rules_rust takes its linker from the cc
+toolchain. One toolchain, one flavour — so the C++ half moves to MSVC spelling
+too.
+
+rules_cc's and `@llvm`'s legacy replacements are GNU-shaped (`-o`, `-shared`,
+`-L`, `-Wl,--start-lib`). `@llvm`'s aggregate is a single `cc_feature_set` that
+cannot be subtracted from, so this package rebuilds the set: the ABI-neutral
+members are referenced from rules_cc directly, and the six that spell flags are
+overridden here.
+
+`rules_rs` already expects this — its `declare_rustc_toolchains.bzl` branches on
+`@llvm//constraints/windows/abi:msvc` for `staticlib_ext` (`.lib`) and
+`stdlib_linkflags` (`advapi32.lib`, `ws2_32.lib`, …).
+"""
+
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
+load("@rules_cc//cc/toolchains:nested_args.bzl", "cc_nested_args")
+
+package(default_visibility = ["//bazel/toolchains/windows_msvc:__subpackages__"])
+
+# --- the aggregate ------------------------------------------------------------
+
+# Mirrors @llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features,
+# with the link-shaping members swapped for MSVC spellings. Compile-side members
+# are ABI-neutral and taken from rules_cc unchanged.
+cc_feature_set(
+    name = "features",
+    all_of = [
+        ":no_legacy_features",
+        "@rules_cc//cc/toolchains/args/archiver_flags:feature",
+        "@rules_cc//cc/toolchains/args/pic_flags:feature",
+        ":libraries_to_link",
+        "@rules_cc//cc/toolchains/args/linker_param_file:feature",
+        "@rules_cc//cc/toolchains/args/preprocessor_defines:feature",
+        "@rules_cc//cc/toolchains/args/random_seed:feature",
+        "@rules_cc//cc/toolchains/args/runtime_library_search_directories:feature",
+        ":strip_debug_symbols",
+        "@rules_cc//cc/toolchains/args/strip_flags:feature",
+        "@rules_cc//cc/toolchains/args/objc_arc_flags:feature",
+        "@rules_cc//cc/toolchains/args/soname_flags:feature",
+        "@rules_cc//cc/toolchains/args/include_flags:feature",
+        "@rules_cc//cc/toolchains/args/fission_flags:feature",
+        ":user_link_flags",
+        ":legacy_link_flags",
+        ":output_execpath_flags",
+        ":shared_flag",
+        "@rules_cc//cc/toolchains/args/linkstamp_flags:feature",
+        ":library_search_directories",
+        "@rules_cc//cc/toolchains/args/dependency_file:feature",
+
+        # user_compile_flags: must come after the features it may override, but
+        # before the compiler inputs.
+        "@rules_cc//cc/toolchains/args/compile_flags:feature",
+        "@rules_cc//cc/toolchains/args/compiler_input_flags:feature",
+        "@rules_cc//cc/toolchains/args/compiler_output_flags:feature",
+    ],
+    visibility = ["//bazel/toolchains/windows_msvc:__subpackages__"],
+)
+
+# Suppresses Bazel's built-in legacy features so only the replacements above
+# apply. `@llvm`'s identical declaration is private to that module.
+cc_feature(
+    name = "no_legacy_features",
+    feature_name = "no_legacy_features",
+)
+
+# --- output and link mode -----------------------------------------------------
+
+cc_feature(
+    name = "output_execpath_flags",
+    args = [":output_execpath_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:output_execpath_flags",
+)
+
+cc_args(
+    name = "output_execpath_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["/out:{output_execpath}"],
+    format = {"output_execpath": "@rules_cc//cc/toolchains/variables:output_execpath"},
+    requires_not_none = "@rules_cc//cc/toolchains/variables:output_execpath",
+)
+
+cc_feature(
+    name = "shared_flag",
+    args = [":shared_flag_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:shared_flag",
+)
+
+cc_args(
+    name = "shared_flag_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:dynamic_library_link_actions",
+    ],
+    args = ["/dll"],
+)
+
+cc_feature(
+    name = "library_search_directories",
+    args = [":library_search_directories_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:library_search_directories",
+)
+
+cc_args(
+    name = "library_search_directories_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["-LIBPATH:{library_search_directories}"],
+    format = {"library_search_directories": "@rules_cc//cc/toolchains/variables:library_search_directories"},
+    iterate_over = "@rules_cc//cc/toolchains/variables:library_search_directories",
+    requires_not_none = "@rules_cc//cc/toolchains/variables:library_search_directories",
+)
+
+# lld-link emits no debug info unless asked, so Bazel's strip request is already
+# satisfied. Overridden to empty because the GNU spelling (`-Wl,-S`) reaches
+# lld-link as an unknown argument and warns on every link.
+cc_feature(
+    name = "strip_debug_symbols",
+    overrides = "@rules_cc//cc/toolchains/features/legacy:strip_debug_symbols",
+)
+
+# --- passthrough flags --------------------------------------------------------
+
+cc_feature(
+    name = "user_link_flags",
+    args = [":user_link_flags_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:user_link_flags",
+)
+
+cc_args(
+    name = "user_link_flags_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["{user_link_flags}"],
+    format = {"user_link_flags": "@rules_cc//cc/toolchains/variables:user_link_flags"},
+    iterate_over = "@rules_cc//cc/toolchains/variables:user_link_flags",
+    requires_not_none = "@rules_cc//cc/toolchains/variables:user_link_flags",
+)
+
+cc_feature(
+    name = "legacy_link_flags",
+    args = [":legacy_link_flags_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:legacy_link_flags",
+)
+
+cc_args(
+    name = "legacy_link_flags_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = ["{legacy_link_flags}"],
+    format = {"legacy_link_flags": "@rules_cc//cc/toolchains/variables:legacy_link_flags"},
+    iterate_over = "@rules_cc//cc/toolchains/variables:legacy_link_flags",
+    requires_not_none = "@rules_cc//cc/toolchains/variables:legacy_link_flags",
+)
+
+# --- libraries to link --------------------------------------------------------
+
+# Simpler than the GNU form: lld-link takes `.obj` and `.lib` paths positionally,
+# so every entry type reduces to its path. Only whole-archive and object-file
+# groups need a spelling, and lld-link takes those directly rather than through
+# a `-Wl,` escape.
+cc_feature(
+    name = "libraries_to_link",
+    args = [":libraries_to_link_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:libraries_to_link",
+)
+
+cc_args(
+    name = "libraries_to_link_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    nested = [
+        ":thinlto_param_file",
+        ":all_libraries",
+    ],
+)
+
+cc_nested_args(
+    name = "thinlto_param_file",
+    args = ["@{param_file}"],
+    format = {"param_file": "@rules_cc//cc/toolchains/variables:thinlto_param_file"},
+    requires_not_none = "@rules_cc//cc/toolchains/variables:thinlto_param_file",
+)
+
+cc_nested_args(
+    name = "all_libraries",
+    nested = [":each_library"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:libraries_to_link",
+)
+
+cc_nested_args(
+    name = "each_library",
+    iterate_over = "@rules_cc//cc/toolchains/variables:libraries_to_link",
+    nested = [
+        ":object_file_group_start",
+        ":library_path",
+        ":object_file_group_end",
+    ],
+)
+
+cc_nested_args(
+    name = "object_file_group_start",
+    nested = [":start_lib_arg"],
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "object_file_group",
+)
+
+cc_nested_args(
+    name = "start_lib_arg",
+    args = ["/start-lib"],
+    requires_false = "@rules_cc//cc/toolchains/variables:libraries_to_link.is_whole_archive",
+)
+
+cc_nested_args(
+    name = "object_file_group_end",
+    nested = [":end_lib_arg"],
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "object_file_group",
+)
+
+cc_nested_args(
+    name = "end_lib_arg",
+    args = ["/end-lib"],
+    requires_false = "@rules_cc//cc/toolchains/variables:libraries_to_link.is_whole_archive",
+)
+
+cc_nested_args(
+    name = "library_path",
+    nested = [
+        ":object_files",
+        ":object_file",
+        ":interface_library",
+        ":static_library",
+        ":dynamic_library",
+    ],
+)
+
+cc_nested_args(
+    name = "object_files",
+    args = ["{library}"],
+    format = {"library": "@rules_cc//cc/toolchains/variables:libraries_to_link.object_files"},
+    iterate_over = "@rules_cc//cc/toolchains/variables:libraries_to_link.object_files",
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "object_file_group",
+)
+
+cc_nested_args(
+    name = "object_file",
+    args = ["{library}"],
+    format = {"library": "@rules_cc//cc/toolchains/variables:libraries_to_link.name"},
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "object_file",
+)
+
+cc_nested_args(
+    name = "interface_library",
+    args = ["{library}"],
+    format = {"library": "@rules_cc//cc/toolchains/variables:libraries_to_link.name"},
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "interface_library",
+)
+
+cc_nested_args(
+    name = "static_library",
+    nested = [
+        ":whole_static_library",
+        ":plain_static_library",
+    ],
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "static_library",
+)
+
+cc_nested_args(
+    name = "whole_static_library",
+    args = ["/wholearchive:{library}"],
+    format = {"library": "@rules_cc//cc/toolchains/variables:libraries_to_link.name"},
+    requires_true = "@rules_cc//cc/toolchains/variables:libraries_to_link.is_whole_archive",
+)
+
+cc_nested_args(
+    name = "plain_static_library",
+    args = ["{library}"],
+    format = {"library": "@rules_cc//cc/toolchains/variables:libraries_to_link.name"},
+    requires_false = "@rules_cc//cc/toolchains/variables:libraries_to_link.is_whole_archive",
+)
+
+cc_nested_args(
+    name = "dynamic_library",
+    args = ["{library}"],
+    format = {"library": "@rules_cc//cc/toolchains/variables:libraries_to_link.name"},
+    requires_equal = "@rules_cc//cc/toolchains/variables:libraries_to_link.type",
+    requires_equal_value = "dynamic_library",
+)

--- a/bazel/windows_msvc/BUILD.bazel
+++ b/bazel/windows_msvc/BUILD.bazel
@@ -1,0 +1,36 @@
+"""Smoke targets proving //bazel/toolchains/windows_msvc end to end.
+
+Build with the MSVC platform, from any host:
+
+    bazel build --platforms=@rules_rs//rs/platforms:x86_64-pc-windows-msvc \
+        //bazel/windows_msvc:smoke_exe //bazel/windows_msvc:smoke_dll
+
+Everything here is `manual`: reaching these targets fetches ~1.3 GB of Microsoft
+CRT + SDK payload, which a stray `bazel build //...` should not pull.
+"""
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_library(
+    name = "smoke",
+    srcs = ["smoke.cc"],
+    alwayslink = True,
+    tags = ["manual"],
+)
+
+cc_binary(
+    name = "smoke_exe",
+    srcs = ["main.cc"],
+    tags = ["manual"],
+    deps = [":smoke"],
+)
+
+cc_shared_library(
+    name = "smoke_dll",
+    tags = ["manual"],
+    deps = [":smoke"],
+)

--- a/bazel/windows_msvc/main.cc
+++ b/bazel/windows_msvc/main.cc
@@ -1,0 +1,11 @@
+// Executable half of the Windows-MSVC smoke: proves the CRT startup path links,
+// not just that objects compile.
+
+#include <cstdio>
+
+extern "C" unsigned int xybrid_msvc_smoke();
+
+int main() {
+    std::printf("xybrid_msvc_smoke=%u\n", xybrid_msvc_smoke());
+    return 0;
+}

--- a/bazel/windows_msvc/smoke.cc
+++ b/bazel/windows_msvc/smoke.cc
@@ -1,0 +1,33 @@
+// Smoke source for the Windows-MSVC toolchain (//bazel/toolchains/windows_msvc).
+//
+// Deliberately pulls the three header families that a real target needs and
+// that a MinGW-flavoured toolchain would satisfy from the wrong place: the
+// Windows SDK (windows.h), the MSVC C++ standard library (string/vector), and
+// clang's own builtin resource-dir headers (immintrin.h).
+
+#include <windows.h>
+
+#include <immintrin.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string ProcessIdText() {
+    std::vector<char> buffer(32, '\0');
+    const DWORD pid = GetCurrentProcessId();
+    std::snprintf(buffer.data(), buffer.size(), "%lu", static_cast<unsigned long>(pid));
+    return std::string(buffer.data());
+}
+
+}  // namespace
+
+extern "C" __declspec(dllexport) unsigned int xybrid_msvc_smoke() {
+    // Exercise the STL (heap allocation through the MSVC CRT) and an intrinsic
+    // so a missing compiler-rt builtin or a mis-selected CRT fails here.
+    const std::string text = ProcessIdText();
+    const __m128i lanes = _mm_set1_epi32(static_cast<int>(text.size()));
+    return static_cast<unsigned int>(_mm_cvtsi128_si32(lanes));
+}

--- a/rules_rust.patch
+++ b/rules_rust.patch
@@ -13,32 +13,3 @@ diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
          # Rustc generates the import library with a `.dll.lib` extension rather than the usual `.lib` one that msvc
          # expects (see https://github.com/rust-lang/rust/pull/29520 for more context).
          interface_library = ctx.actions.declare_file(crate_info.output.basename + ".lib", sibling = crate_info.output)
-diff --git a/cargo/private/cargo_build_script.bzl b/cargo/private/cargo_build_script.bzl
---- a/cargo/private/cargo_build_script.bzl
-+++ b/cargo/private/cargo_build_script.bzl
-@@ -231,6 +231,16 @@
- def _pwd_flags_imacros(args):
-     """Prefix execroot-relative paths in -imacros arguments with ${pwd}."""
-     return _prefix_pwd_to_flag(args, ["-imacros"])
-+
-+# xybrid patch: -ivfsoverlay takes a path exactly like -isystem does, but was
-+# missing from the list, so the overlay stayed execroot-relative and every cc-rs
-+# build script died with "virtual filesystem overlay file ... not found" (build
-+# scripts run from their own working directory). The windows-MSVC toolchain uses
-+# an overlay to make Microsoft's mixed-case headers resolve on a case-sensitive
-+# filesystem, so this affects every -sys crate on that target.
-+def _pwd_flags_ivfsoverlay(args):
-+    """Prefix execroot-relative paths in -ivfsoverlay arguments with ${pwd}."""
-+    return _prefix_pwd_to_flag(args, ["-ivfsoverlay"])
- 
- _DIRECT_LIB_EXTENSIONS = (".a", ".o", ".so", ".dylib")
- 
-@@ -264,7 +274,7 @@
-     return _prefix_pwd_to_paths(args)
- 
- def _pwd_flags(args):
--    return _pwd_flags_direct_libs(_pwd_flags_imacros(_pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_L(_pwd_flags_B(_pwd_flags_resource_dir(_pwd_flags_sysroot(args))))))))
-+    return _pwd_flags_direct_libs(_pwd_flags_ivfsoverlay(_pwd_flags_imacros(_pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_L(_pwd_flags_B(_pwd_flags_resource_dir(_pwd_flags_sysroot(args)))))))))
- 
- def _feature_enabled(ctx, feature_name, default = False):
-     """Check if a feature is enabled.

--- a/rules_rust.patch
+++ b/rules_rust.patch
@@ -1,3 +1,4 @@
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
 --- a/rust/private/rustc.bzl
 +++ b/rust/private/rustc.bzl
 @@ -2028,7 +2028,10 @@
@@ -12,3 +13,32 @@
          # Rustc generates the import library with a `.dll.lib` extension rather than the usual `.lib` one that msvc
          # expects (see https://github.com/rust-lang/rust/pull/29520 for more context).
          interface_library = ctx.actions.declare_file(crate_info.output.basename + ".lib", sibling = crate_info.output)
+diff --git a/cargo/private/cargo_build_script.bzl b/cargo/private/cargo_build_script.bzl
+--- a/cargo/private/cargo_build_script.bzl
++++ b/cargo/private/cargo_build_script.bzl
+@@ -231,6 +231,16 @@
+ def _pwd_flags_imacros(args):
+     """Prefix execroot-relative paths in -imacros arguments with ${pwd}."""
+     return _prefix_pwd_to_flag(args, ["-imacros"])
++
++# xybrid patch: -ivfsoverlay takes a path exactly like -isystem does, but was
++# missing from the list, so the overlay stayed execroot-relative and every cc-rs
++# build script died with "virtual filesystem overlay file ... not found" (build
++# scripts run from their own working directory). The windows-MSVC toolchain uses
++# an overlay to make Microsoft's mixed-case headers resolve on a case-sensitive
++# filesystem, so this affects every -sys crate on that target.
++def _pwd_flags_ivfsoverlay(args):
++    """Prefix execroot-relative paths in -ivfsoverlay arguments with ${pwd}."""
++    return _prefix_pwd_to_flag(args, ["-ivfsoverlay"])
+ 
+ _DIRECT_LIB_EXTENSIONS = (".a", ".o", ".so", ".dylib")
+ 
+@@ -264,7 +274,7 @@
+     return _prefix_pwd_to_paths(args)
+ 
+ def _pwd_flags(args):
+-    return _pwd_flags_direct_libs(_pwd_flags_imacros(_pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_L(_pwd_flags_B(_pwd_flags_resource_dir(_pwd_flags_sysroot(args))))))))
++    return _pwd_flags_direct_libs(_pwd_flags_ivfsoverlay(_pwd_flags_imacros(_pwd_flags_fsanitize_ignorelist(_pwd_flags_isystem(_pwd_flags_L(_pwd_flags_B(_pwd_flags_resource_dir(_pwd_flags_sysroot(args)))))))))
+ 
+ def _feature_enabled(ctx, feature_name, default = False):
+     """Check if a feature is enabled.


### PR DESCRIPTION
This pull request adds a Bazel C++ toolchain that cross-compiles **MSVC-ABI** Windows artifacts from Linux or macOS, using the same hermetic LLVM already in the tree plus Microsoft's CRT and Windows SDK fetched by the `windows_support` module. It closes the last real gap in the Bazel migration: Flutter's cargokit links our DLL at build time and only accepts MSVC output, which is why `precompile-flutter-windows` and the Unity Windows native still build under cargo. The lane now produces `xybrid_flutter_ffi.dll` alongside a real MSVC `.dll.lib` import library — the artifact the MinGW lane could never emit.

Non-shipping. Nothing is flipped off cargo yet, and no CI job builds this; the existing windows-gnu lane is untouched.

**New toolchain**

* `//bazel/toolchains/windows_msvc` composes hermetic clang + `@msvc_runtime`/`@windows_sdk` into a `cc_toolchain` registered on `@llvm//constraints/windows/abi:msvc`. Build anything with `--config=windows-msvc`.
* Registered **before** `@llvm//toolchain:all` in `MODULE.bazel`: `@llvm`'s Windows toolchain declares no ABI constraint, so it also matches an MSVC platform and ours has to win there. On windows-gnu platforms ours does not match at all.
* `//bazel/toolchains/windows_msvc/link` carries MSVC-flavoured replacements for rules_cc's legacy link features (`/out:`, `/dll`, `-LIBPATH:`, `/def:`, MSVC `libraries_to_link`). This is forced, not stylistic — see below.
* `//bazel/windows_msvc` is a smoke target that deliberately pulls `windows.h`, `<string>` and `immintrin.h`, so the SDK, the MSVC STL and clang's builtin headers are all exercised rather than just the easy one.

**Why the link half is MSVC-shaped**

* rustc rejects every gcc-style linker flavour on a `*-pc-windows-msvc` target — *"compatible flavors are: msvc-lld, msvc, lld-link"* — and the gnu-cc ones are nightly-only. rules_rust takes its linker from `cc_common.get_tool_for_action`, so there is no per-language override: one toolchain, one flavour, and the C++ half moves with it.
* `@llvm`'s legacy-replacement feature set is a single `cc_feature_set` that cannot be subtracted from, so the package rebuilds it — ABI-neutral members referenced from rules_cc unchanged, the six that spell flags overridden.
* `rules_rs` already assumes this shape: its `declare_rustc_toolchains.bzl` branches on the MSVC ABI constraint for `staticlib_ext` (`.lib`) and `stdlib_linkflags` (`advapi32.lib`, `ws2_32.lib`, …).

**Case-sensitivity**

* Microsoft's payload mixes casings freely: `Windows.h` is included as `<windows.h>`, `kernelspecs.h` includes `"DriverSpecs.h"` for a file that is lowercase on disk, and `uuid.lib` ships as `Uuid.Lib`. Invisible on Windows and on APFS, fatal on Linux.
* Upstream's `transformations` attribute cannot fix it and is deliberately unused: repository rules run on the Bazel **client**, so a Mac-fetched sysroot loses the aliases before it ever reaches a Linux RBE worker — and the two hosts would materialise different repositories, splitting the remote cache.
* `case_insensitivity.bzl` derives the aliases from the file list instead, as real copies. A clang `-ivfsoverlay` is cheaper but only works for compiler invocations Bazel spawns itself; rules_foreign_cc absolutises include paths while the overlay names its roots execroot-relative, so it silently goes inert mid-build.

**llama.cpp**

* New windows-msvc arm on `//:llama`, mirroring the MinGW arm minus `CMAKE_CXX_STANDARD_LIBRARIES` — the libc++/libcxxabi/libunwind trio that arm hand-feeds is exactly what Microsoft's STL already provides.
* `CMAKE_RC_COMPILER=@llvm//tools:llvm-rc`, because CMake's Windows-Clang module enables the RC language and a Linux worker has no resource compiler.
* Archive names have no `lib` prefix and a `.lib` suffix on every target, not just ggml — CMake's Windows-Clang module sets that globally.

**One upstream patch**

* `rules_rust.patch` gains the MSVC gate on the `.dll.lib` output. The `-ivfsoverlay` hunk added mid-review was reverted once the overlay went away.

**Verified**

* Linux RBE and macOS host: C++ smoke exe + DLL, `//spike:hello`, `//crates/xybrid-core`, `//crates/xybrid-sdk`, `//:llama`, and `//bindings/flutter/rust:xybrid_flutter_ffi_cdylib` → 45 MB x86-64 PE32+ importing MSVCP140/VCRUNTIME140/UCRT, 204 exports, plus a COFF import library with 204 short-import members.
* No regressions: windows-gnu CLI, windows-gnu bolt cdylib, windows-gnu `//:llama`, and the linux Flutter cdylib all still build on RBE.

**Known gaps**

* No CI lane. A cold runner pays a ~1.3 GB Microsoft fetch client-side per run, so this wants a repo cache or a scheduled job — worth deciding before anything ships on it.
* Library search paths are passed twice, `-LIBPATH:` for lld-link and `-L` for rules_foreign_cc's clang-driver link, because neither spelling reaches both. lld-link answers the `-L` copies with "ignoring unknown argument", so every link carries four cosmetic warnings.
* `windows_support` is pre-1.0 and documents that its extension APIs may change without notice. Pinned exactly.
* cc-produced DLLs get no import library; Rust cdylibs get one from rustc, which is what the shipping artifact needs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new build surface (custom cc toolchain, ~1.3 GB Microsoft fetch, toolchain registration order) with limited CI coverage; existing windows-gnu paths are intentionally unchanged.
> 
> **Overview**
> Adds a **Bazel path for MSVC-ABI Windows** (`--config=windows-msvc`) so cross-builds can emit `.dll` + MSVC `.dll.lib` for Flutter/cargokit—something the existing MinGW lane cannot do.
> 
> **Toolchain & deps:** New `//bazel/toolchains/windows_msvc` pairs hermetic clang/`lld-link` with `@msvc_runtime` and `@windows_sdk` from `windows_support` (pinned in `MODULE.bazel`, EULA via `BAZEL_MSVC_RUNTIME_VISUAL_STUDIO_EULA`). MSVC toolchains register **before** `@llvm//toolchain:all` so they win on `*-pc-windows-msvc`. A dedicated `link/` package replaces GNU link flags with MSVC spellings (`/out:`, `/dll`, `-LIBPATH:`, `/def:`). `case_insensitivity.bzl` builds host-independent filename aliases for Linux RBE instead of `windows_support` `transformations`.
> 
> **Graph wiring:** `x86_64-pc-windows-msvc` is added to crate resolution; `//:llama` gets an MSVC cmake arm (`llvm-rc`, `.lib` static names, install postfix). `rules_rust.patch` only requires `.dll.lib` for **MSVC** cdylibs so MinGW stays valid.
> 
> **Docs & smoke:** `CONTRIBUTING.md` documents the MSVC Bazel build; manual `//bazel/windows_msvc` targets exercise SDK, MSVC STL, and intrinsics without pulling ~1.3 GB on accidental `//...` builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b844ffc66a669970c74670d28834c4b93d1cd634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->