### PR TITLE
ci(bazel): gate the windows-MSVC lane on master merges

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -27,9 +27,15 @@ on:
       - ".bazelignore"
       - "BUILD.bazel"
       - "**/BUILD.bazel"
+      # Starlark that BUILD files load — toolchain logic lives here, and
+      # `**/BUILD.bazel` alone would let a .bzl-only change slip through.
+      - "**/*.bzl"
+      - "bazel/**"
+      - "tools/scripts/**"
       - "rules_android_ndk.patch"
       - "rules_foreign_cc.patch"
       - "rules_rs.patch"
+      - "rules_rust.patch"
       - "hermetic_llvm.patch"
       - "crates/**"
       - "bindings/kotlin/**"
@@ -72,7 +78,7 @@ jobs:
           FILES=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
             --jq '.[].filename')
-          if printf '%s\n' "$FILES" | grep -qE '^(MODULE\.bazel|\.bazelrc|\.bazelversion|\.bazelignore|BUILD\.bazel|.*/BUILD\.bazel|rules_android_ndk\.patch|rules_foreign_cc\.patch|rules_rs\.patch|hermetic_llvm\.patch|crates/|bindings/kotlin/|macros/|vendor/llama-cpp|vendor/ort-macos/|Cargo\.toml|Cargo\.lock|tools/unity-runtime-smoke/|\.github/workflows/bazel\.yml)'; then
+          if printf '%s\n' "$FILES" | grep -qE '^(MODULE\.bazel|\.bazelrc|\.bazelversion|\.bazelignore|BUILD\.bazel|.*/BUILD\.bazel|.*\.bzl|bazel/|tools/scripts/|rules_android_ndk\.patch|rules_foreign_cc\.patch|rules_rs\.patch|rules_rust\.patch|hermetic_llvm\.patch|crates/|bindings/kotlin/|macros/|vendor/llama-cpp|vendor/ort-macos/|Cargo\.toml|Cargo\.lock|tools/unity-runtime-smoke/|\.github/workflows/bazel\.yml)'; then
             REL=true
           else
             REL=false
@@ -423,6 +429,125 @@ jobs:
           test "$(nm "$BIN" | grep -c '_mtmd_')" -gt 0 || { echo "MISSING vision symbols"; exit 1; }
           strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface"; exit 1; }
           echo "Metal CLI smoke: OK"
+
+  # The windows-MSVC lane — NON-SHIPPING proof, like the windows-gnu bolt DLL
+  # above. Everything compiles on Linux RBE workers; the runner only fetches
+  # repositories and inspects outputs.
+  #
+  # Master-merge / dispatch only (same shape as bazel-macos-metal), because
+  # @msvc_runtime + @windows_sdk are ~1.3 GB of Microsoft payload fetched
+  # CLIENT-side, and this workflow keeps no repository cache. Putting that on
+  # every Bazel-touching PR would cost more than the lane is worth until the
+  # Flutter windows producer actually flips to it.
+  bazel-windows-msvc:
+    name: Bazel windows-MSVC lane (non-shipping)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      # The Microsoft payload lands on top of the usual LLVM/rustc/NDK fetches,
+      # so this job needs the headroom more than the others do.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
+      - name: Configure BuildBuddy remote config
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          mkdir -p .context
+          cat > .context/buildbuddy.bazelrc <<EOF
+          common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:remote --bes_backend=grpcs://remote.buildbuddy.io
+          common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --remote_cache=grpcs://remote.buildbuddy.io
+          common:remote --remote_executor=grpcs://remote.buildbuddy.io
+          common:remote --remote_cache_compression
+          common:remote --remote_download_toplevel
+          common:remote --remote_timeout=600
+          common:remote --jobs=200
+          common:remote --extra_execution_platforms=@llvm//:rbe_linux_x86_64
+          EOF
+
+      # The toolchain smokes come first and are cheap: they pull windows.h, the
+      # MSVC STL and clang's builtin headers, so a sysroot or include-order
+      # regression fails here rather than 20 minutes into llama.cpp.
+      - name: Build the windows-MSVC toolchain smokes
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote --config=windows-msvc \
+            //bazel/windows_msvc:smoke_exe \
+            //bazel/windows_msvc:smoke_dll
+
+      - name: Build llama.cpp + the Flutter native for windows-MSVC
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote --config=windows-msvc -c opt \
+            //:llama \
+            //bindings/flutter/rust:xybrid_flutter_ffi_cdylib
+
+      # The gate that actually distinguishes this lane from windows-gnu: the DLL
+      # must import the MSVC runtime (VCRUNTIME140/MSVCP140), and cargokit needs
+      # a real MSVC import library beside it. A MinGW build satisfies neither.
+      - name: Verify the MSVC ABI + import library
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          set -euo pipefail
+          FILES=$(bazelisk cquery --config=remote --config=windows-msvc -c opt \
+            --output=files //bindings/flutter/rust:xybrid_flutter_ffi_cdylib)
+          DLL=$(printf '%s\n' "$FILES" | grep '\.dll$')
+          IMPLIB=$(printf '%s\n' "$FILES" | grep '\.dll\.lib$')
+          echo "resolved DLL: $DLL"
+          echo "resolved import library: $IMPLIB"
+          file "$DLL"
+          file "$DLL" | grep -q 'PE32+.*x86-64' || { echo "NOT a PE32+ x86-64 DLL"; exit 1; }
+          python3 -m pip install --quiet --user pefile
+          python3 tools/scripts/audit_windows_dll.py --dll "$DLL" \
+            --require-import vcruntime140.dll \
+            --require-import msvcp140.dll
+          python3 - "$DLL" "$IMPLIB" <<'PYEOF'
+          import sys
+
+          import pefile
+
+          dll_path, implib_path = sys.argv[1], sys.argv[2]
+          exports = len(pefile.PE(dll_path).DIRECTORY_ENTRY_EXPORT.symbols)
+
+          blob = open(implib_path, "rb").read()
+          if blob[:8] != b"!<arch>\n":
+              raise SystemExit(f"{implib_path}: not a COFF archive")
+          offset, short_imports = 8, 0
+          while offset + 60 <= len(blob):
+              size = int(blob[offset + 48:offset + 58].decode().strip())
+              # 0x0000FFFF marks a short-import member: the MSVC-only encoding
+              # that a MinGW `.dll.a` never contains.
+              if blob[offset + 60:offset + 64] == b"\x00\x00\xff\xff":
+                  short_imports += 1
+              offset += 60 + size + (size & 1)
+
+          print(f"exports: {exports}, short-import members: {short_imports}")
+          if short_imports != exports:
+              raise SystemExit("import library does not cover every export")
+          PYEOF
+          mkdir -p /tmp/win-msvc
+          cp "$DLL" "$IMPLIB" /tmp/win-msvc/
+          echo "windows-MSVC payload: OK"
+
+      - name: Upload windows-MSVC Flutter native
+        if: env.BUILDBUDDY_API_KEY != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bazel-xybrid-flutter-windows-msvc
+          path: /tmp/win-msvc/
+          retention-days: 7
 
   # The run-it half of the windows .exe gate: the linux job can build and
   # byte-inspect the PE but not execute it — a real Windows runner downloads

--- a/tools/scripts/audit_windows_dll.py
+++ b/tools/scripts/audit_windows_dll.py
@@ -115,7 +115,7 @@ def audit(
     exports: list[str],
     *,
     required_exports: list[str],
-    required_imports: list[str] = [],
+    required_imports: tuple[str, ...] = (),
     extra_allowed: frozenset[str] = frozenset(),
 ) -> AuditResult:
     """Check imports against the allowlist and confirm required symbols exist."""
@@ -257,7 +257,7 @@ def main() -> int:
         imports,
         exports,
         required_exports=required_exports,
-        required_imports=list(args.require_import),
+        required_imports=tuple(args.require_import),
         extra_allowed=frozenset(
             a.lower() for a in list(args.allow_import) + list(args.require_import)
         ),

--- a/tools/scripts/audit_windows_dll.py
+++ b/tools/scripts/audit_windows_dll.py
@@ -115,11 +115,13 @@ def audit(
     exports: list[str],
     *,
     required_exports: list[str],
+    required_imports: list[str] = [],
     extra_allowed: frozenset[str] = frozenset(),
 ) -> AuditResult:
-    """Check imports against the allowlist and confirm required exports exist."""
+    """Check imports against the allowlist and confirm required symbols exist."""
     lines: list[str] = []
     export_set = set(exports)
+    import_set = {name.lower() for name in imports}
 
     forbidden: list[str] = []
     unexpected: list[str] = []
@@ -132,6 +134,9 @@ def audit(
             unexpected.append(dll)
 
     missing = [name for name in required_exports if name not in export_set]
+    missing_imports = [
+        name for name in required_imports if name.lower() not in import_set
+    ]
 
     lines.append(f"imports: {len(set(i.lower() for i in imports))} distinct DLLs")
     lines.append(f"exports: {len(export_set)} symbols")
@@ -147,13 +152,16 @@ def audit(
         )
     if missing:
         lines.append("FAIL: required exports missing: " + ", ".join(missing))
-    if not (forbidden or unexpected or missing):
+    if missing_imports:
+        lines.append("FAIL: required imports missing: " + ", ".join(missing_imports))
+    failed = bool(forbidden or unexpected or missing or missing_imports)
+    if not failed:
         lines.append(
             f"OK: import table is Windows-system-only; {len(required_exports)} "
             "required exports present"
         )
 
-    return AuditResult(ok=not (forbidden or unexpected or missing), lines=tuple(lines))
+    return AuditResult(ok=not failed, lines=tuple(lines))
 
 
 def read_pe(path: str) -> tuple[list[str], list[str]]:
@@ -189,6 +197,17 @@ def parse_args() -> argparse.Namespace:
         action="append",
         default=[],
         help="An export that must be present (repeatable).",
+    )
+    parser.add_argument(
+        "--require-import",
+        action="append",
+        default=[],
+        help=(
+            "A DLL that MUST appear in the import table, and is allowed by "
+            "implication (repeatable). The windows-MSVC lane uses it to assert "
+            "the MSVC runtime is linked, which is the opposite of what the "
+            "windows-GNU lane wants."
+        ),
     )
     parser.add_argument(
         "--allow-import",
@@ -238,7 +257,10 @@ def main() -> int:
         imports,
         exports,
         required_exports=required_exports,
-        extra_allowed=frozenset(a.lower() for a in args.allow_import),
+        required_imports=list(args.require_import),
+        extra_allowed=frozenset(
+            a.lower() for a in list(args.allow_import) + list(args.require_import)
+        ),
     )
     print(f"== PE audit: {args.dll} ==")
     for line in result.lines:


### PR DESCRIPTION
## Summary

The Windows-MSVC toolchain landed in #416 with nothing exercising it. This adds the lane that does — toolchain smokes, llama.cpp and the Flutter native, built on Linux RBE and inspected on the runner — and closes a path-filter hole that let Starlark-only toolchain changes trigger no CI at all.

**New CI job:**

* Added `bazel-windows-msvc` in `.github/workflows/bazel.yml`, restricted to master merges and manual dispatch with the same `if:` shape as the existing `bazel-macos-metal` job. `@msvc_runtime` + `@windows_sdk` are ~1.3 GB of Microsoft payload fetched client-side and this workflow keeps no repository cache, so it stays off the per-PR path while the Flutter windows producer still ships from cargo. Measured cost: **9m09s** end to end.

**Verification that actually distinguishes the lane:**

* `tools/scripts/audit_windows_dll.py` gains `--require-import`, so the DLL must *import* `VCRUNTIME140`/`MSVCP140` — the mirror image of the windows-GNU bolt gate, where those same DLLs are forbidden. A required import is allowed by implication, so the GNU lane's allowlist is unchanged.
* The import library is checked structurally: short-import member count must equal export count (204/204). A MinGW `.dll.a` contains no short-import members at all, so "it built" alone would not have caught a wrong-ABI regression.

**Path-filter fix:**

* `**/BUILD.bazel` was listed but `**/*.bzl` was not, so a change to toolchain logic in Starlark triggered nothing. Adds `**/*.bzl`, `bazel/**`, `tools/scripts/**` and the previously-missing `rules_rust.patch`.

Proven on a real dispatched run (30540098910): every step executed — none skipped on a missing secret — and the pre-existing graph, windows `.exe` and windows bolt DLL jobs stayed green.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other — CI coverage for an existing, non-shipping build lane

## Checklist

- [ ] Tests pass (`cargo test`) — no Rust touched; validated by running the lane instead
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and PE audit tooling only; no runtime product code paths change, and the heavy MSVC job is excluded from PRs.
> 
> **Overview**
> Adds a **master-merge / dispatch-only** `bazel-windows-msvc` job that exercises the Windows-MSVC Bazel lane on Linux RBE: toolchain smokes, `//:llama`, and the Flutter FFI cdylib, then verifies the artifact is real MSVC (PE64, `VCRUNTIME140`/`MSVCP140` imports, MSVC-style `.dll.lib` short-import coverage) and uploads it as an artifact. It stays off PRs because of the large client-side `@msvc_runtime` + `@windows_sdk` fetch, matching the `bazel-macos-metal` pattern.
> 
> **Bazel CI path filters** now treat Starlark and script changes as relevant (`**/*.bzl`, `bazel/**`, `tools/scripts/**`, `rules_rust.patch`) in both the push `paths` list and the PR `changes` grep, so toolchain-only edits no longer skip the workflow.
> 
> `audit_windows_dll.py` gains **`--require-import`**, which asserts specific DLLs appear in the import table and implicitly allowlists them—used to prove MSVC runtime linkage without changing the windows-gnu bolt gate’s “no MSVC carriers” expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f167698b0343ef17febf9aa3948643b52c2be41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->