### PR TITLE
build(bazel): enable llama.cpp vision on the windows-MSVC lane

### DIFF
--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -22,6 +22,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:aarch64-apple-ios",  # Apple parity: iOS vision
     "@rules_rs//rs/platforms/config:aarch64-apple-ios-sim",  # G4a: iOS simulator vision
     "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
+    "@rules_rs//rs/platforms/config:x86_64-pc-windows-msvc",  # Flutter/cargokit parity
 ]
 
 # First-party C++ shim: defines the _c-suffixed symbols the Rust bindings call.

--- a/crates/xybrid-llama/BUILD.bazel
+++ b/crates/xybrid-llama/BUILD.bazel
@@ -13,6 +13,7 @@ _VISION_PLATFORMS = [
     "@rules_rs//rs/platforms/config:aarch64-apple-ios",  # Apple parity: iOS vision
     "@rules_rs//rs/platforms/config:aarch64-apple-ios-sim",  # G4a: iOS simulator vision
     "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu",  # Windows .exe parity
+    "@rules_rs//rs/platforms/config:x86_64-pc-windows-msvc",  # Flutter/cargokit parity
 ]
 
 rust_library(


### PR DESCRIPTION
## Summary

#416 taught `//:llama` to build and collect `mtmd.lib` for windows-MSVC, but the Rust side was never told about it, so the archive was built, staged and handed to the linker with nothing able to reference it. `_VISION_PLATFORMS` is an explicit allowlist gating both the `vision` crate feature and the `XYBRID_LLAMA_VISION` define, and the MSVC triple was missing from it.

**Vision parity for the MSVC lane:**

* Added `x86_64-pc-windows-msvc` to `_VISION_PLATFORMS` in `crates/llama-cpp-sys/BUILD.bazel` and `crates/xybrid-llama/BUILD.bazel`, the two lists that must stay in sync with `//:llama`'s libmtmd arms. Verified by cquery: `crate_features` goes from `["bindings"]` to `["bindings", "vision"]`, `defines` from `[]` to `["XYBRID_LLAMA_VISION"]`, and `-lstatic=mtmd` now appears on the link line. Every other config resolves exactly as before — the `select` gains one arm.

**One thing worth knowing before the Flutter windows flip:**

* The MSVC binaries still carry no `mtmd` strings even with this landed, and that is expected rather than a failure. `bazel aquery` confirms `mtmd.lib` reaches the link command, so this is lld-link's `/OPT:REF` collecting code no exported symbol reaches and taking its string literals with it. **Do not reuse the linux job's `strings | grep mtmd` payload gate on this lane** — it is valid on ELF and Mach-O only, where the linker leaves unreachable code in place. Whether vision is genuinely reachable through the flutter_rust_bridge export surface on Windows is a runtime question that needs a Windows machine, and the `precompile-flutter-windows` flip stays on cargo until it is answered.

## Type of Change

- [x] Bug fix — MSVC built and linked libmtmd that the Rust side could not use
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`) — Bazel-only change; validated by building the MSVC CLI and Flutter cdylib on RBE
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable) — the caveat above is recorded in the commit message for whoever picks up the flip
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bazel-only allowlist change with no runtime logic edits; scope is limited to enabling vision linkage for one platform triple.
> 
> **Overview**
> **Vision on the Windows MSVC lane** — `x86_64-pc-windows-msvc` is added to `_VISION_PLATFORMS` in `llama-cpp-sys` and `xybrid-llama` so Bazel matches `//:llama`’s existing `libmtmd` build for that triple. On MSVC configs the Rust crates now get the `vision` feature, `XYBRID_LLAMA_VISION` on the C++ wrapper, and `-lstatic=mtmd` on the link line; every other platform is unchanged (one new `select` arm only).
> 
> The two `_VISION_PLATFORMS` lists are kept in sync on purpose — they gate the same behavior at the sys and safe-wrapper layers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08764ad48f90a0a1a262201034d850ec9423ba1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->