### PR TITLE
ci(bazel): load the windows-MSVC Flutter DLL on Windows

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -549,6 +549,60 @@ jobs:
           path: /tmp/win-msvc/
           retention-days: 7
 
+  # The run-it half of the windows-MSVC gate. bazel-windows-msvc can build the
+  # DLL and byte-inspect it, but a PE that inspects clean can still fail to load
+  # — a missing Visual C++ redistributable or a bad import is only visible when
+  # Windows actually resolves it. This is the first time anything built by the
+  # MSVC toolchain runs on Windows; it compiles nothing (the build happened on
+  # Linux workers) and costs a couple of windows-latest minutes per master merge.
+  bazel-windows-msvc-smoke:
+    name: Bazel windows-MSVC Flutter DLL smoke (loads it on Windows)
+    needs: bazel-windows-msvc
+    if: github.event_name != 'pull_request'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: bazel-xybrid-flutter-windows-msvc
+          path: native
+
+      # LoadLibrary is the real test: it resolves the whole import table against
+      # the machine, so a DLL that needs a runtime this box lacks fails here.
+      # GetProcAddress then proves the export table is usable, which is what
+      # Flutter reaches the library through.
+      - name: Load the DLL and resolve an export
+        shell: pwsh
+        run: |
+          $dll = (Resolve-Path native/xybrid_flutter_ffi.dll).Path
+          Write-Host "loading $dll"
+
+          Add-Type -Namespace Win -Name Native -MemberDefinition @'
+          [System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true)]
+          public static extern System.IntPtr LoadLibrary(string path);
+          [System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true)]
+          public static extern System.IntPtr GetProcAddress(System.IntPtr module, string name);
+          '@
+
+          $handle = [Win.Native]::LoadLibrary($dll)
+          if ($handle -eq [System.IntPtr]::Zero) {
+            $code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "LoadLibrary failed (Win32 error $code)"
+          }
+          Write-Host "loaded, handle $handle"
+
+          # flutter_rust_bridge's Dart-API entry point: present in every frb
+          # build and the first thing Dart calls, so its absence would break
+          # the binding outright.
+          foreach ($export in @('frb_init_frb_dart_api_dl', 'store_dart_post_cobject')) {
+            $address = [Win.Native]::GetProcAddress($handle, $export)
+            if ($address -eq [System.IntPtr]::Zero) {
+              throw "GetProcAddress('$export') failed"
+            }
+            Write-Host "resolved $export at $address"
+          }
+
+          Write-Host "windows-MSVC Flutter DLL smoke: OK"
+
   # The run-it half of the windows .exe gate: the linux job can build and
   # byte-inspect the PE but not execute it — a real Windows runner downloads
   # the RBE-built artifact and runs it. This is the only Windows machine in


### PR DESCRIPTION
## Summary

Since #419 the shipped Flutter windows library comes from the MSVC toolchain, and **nothing built by that toolchain had ever been executed**. `bazel-windows-msvc` builds the DLL and inspects its bytes, but a file that inspects clean can still fail to load — a missing Visual C++ redistributable or a bad import only surfaces when Windows resolves the import table for real. This closes that gap.

**New CI job:**

* Added `bazel-windows-msvc-smoke`, mirroring the existing `bazel-windows-bolt-smoke` shape: download the artifact the build job already uploads, then `LoadLibrary` the DLL on `windows-latest` and `GetProcAddress` two flutter_rust_bridge exports (`frb_init_frb_dart_api_dl` and `store_dart_post_cobject` — the entry points Dart reaches the library through). Master-merge and dispatch only, matching the job it depends on.
* It compiles nothing. The build happened on Linux workers, so this is the only Windows machine in the lane and it costs **10 seconds**.
* PowerShell rather than a managed C# project: the bolt smoke needs a `.csproj` because it exercises a real P/Invoke surface, whereas here the question is only whether the loader accepts the DLL and its exports resolve.

**Proven, not just authored:** dispatched run [30563237558](https://github.com/xybrid-ai/xybrid/actions/runs/30563237558) — the build lane and this smoke both green, every step executed (none skipped on a missing secret).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other — CI coverage closing a runtime gap on an artifact that already ships

## Checklist

- [ ] Tests pass (`cargo test`) — CI-only change; validated by dispatching the workflow and confirming the job runs green on a real Windows runner
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application or release logic; adds optional Windows runner time on master/dispatch.
> 
> **Overview**
> Adds **`bazel-windows-msvc-smoke`**, the run-it half of the windows-MSVC gate: after `bazel-windows-msvc` uploads `bazel-xybrid-flutter-windows-msvc`, a `windows-latest` job downloads `xybrid_flutter_ffi.dll` and uses PowerShell `LoadLibrary` / `GetProcAddress` on `frb_init_frb_dart_api_dl` and `store_dart_post_cobject` so loader and export resolution are validated on real Windows—not just PE byte checks on Linux.
> 
> Runs only when `github.event_name != 'pull_request'`, matching `bazel-windows-msvc`; it does not build anything.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b186a96f490697175ce0d5ee9185c524da41579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->