### PR TITLE
build(bazel): retire the ndk_smoke NDK PoC scaffolding

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -422,22 +422,11 @@ cmake(
     visibility = ["//visibility:public"],
 )
 
-# --- ANDROID PoC: validate the NDK cc_toolchain with a trivial compile before
-# wiring llama.cpp. Build with: bazel build //:ndk_smoke --platforms=//:android_arm64
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-platform(
-    name = "android_arm64",
-    constraint_values = [
-        "@platforms//os:android",
-        "@platforms//cpu:arm64",
-    ],
-)
-
-cc_library(
-    name = "ndk_smoke",
-    srcs = ["ndk_smoke.c"],
-)
+# The `//:ndk_smoke` PoC (a trivial cc_library that proved the NDK
+# cc_toolchain before llama.cpp was wired) and its `//:android_arm64`
+# platform are gone: llama.cpp has shipped through that toolchain for
+# months, and the android lanes select `@rules_rs//rs/platforms:*` via
+# `.bazelrc`'s `build:android-*` configs rather than a local platform().
 
 # Vendored ONNX Runtime (dlopened at runtime), per ABI that ships it — armv7
 # has no vendored ORT (matches today's AAR). libc++_shared.so is NOT taken from

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -104,7 +104,8 @@ bazel_dep(name = "apple_support", version = "2.2.0", repo_name = "build_bazel_ap
 bazel_dep(name = "rules_apple", version = "4.5.3", repo_name = "build_bazel_rules_apple")
 # bool_flag for the //:metal build setting (the macOS GPU lane toggle).
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-# platforms must be a direct dep so the `@platforms//...` constraints in //:android_arm64 resolve.
+# platforms must be a direct dep so the `@platforms//...` constraints in the root
+# BUILD file resolve (//:host_linux_gnu's parent, //:llama_metal's exec platform).
 bazel_dep(name = "platforms", version = "1.0.0")
 
 # --- Option B: rules_foreign_cc drives llama.cpp's own CMakeLists with the

--- a/ndk_smoke.c
+++ b/ndk_smoke.c
@@ -1,4 +1,0 @@
-// NDK toolchain smoke test — must compile for aarch64-linux-android via the
-// rules_android_ndk cc_toolchain (proves the Android C/C++ foundation works
-// before wiring llama.cpp).
-int xybrid_ndk_answer(void) { return 42; }


### PR DESCRIPTION
## Summary

Removes the root `//:ndk_smoke` cc_library, its `//:android_arm64` platform, and the orphaned `ndk_smoke.c` — a one-function C file that proved the `rules_android_ndk` cc_toolchain before llama.cpp was wired. llama.cpp has shipped through that toolchain for months, and the Android lanes now select `@rules_rs//rs/platforms:*` via `.bazelrc`'s `build:android-*` configs rather than a local `platform()`. Repoints `MODULE.bazel`'s `platforms`-dep comment at its surviving users (`//:host_linux_gnu`'s parent, `//:llama_metal`'s exec platform) instead of dropping the dep, which is still needed. Validated with the gate `bazel.yml` runs: 79 targets analyze-clean. Net −21 lines.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (bazel analyze clean: 79 targets)
- [x] Code follows project style
- [x] Documentation updated (inline comments repointed)
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and comment-only MODULE.bazel change; no build graph or Android lane behavior changes.
> 
> **Overview**
> **Removes** the root `//:ndk_smoke` `cc_library`, `//:android_arm64` `platform()`, and `ndk_smoke.c` — scaffolding that validated the NDK toolchain before llama.cpp was wired. Android builds already use `@rules_rs//rs/platforms:*` via `.bazelrc` `build:android-*` configs.
> 
> **Replaces** that block with a short comment explaining why it was deleted. **`MODULE.bazel`** keeps the direct `platforms` dependency but updates its comment to reference `//:host_linux_gnu` and `//:llama_metal` instead of the removed platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62a2186e8b1c69d11e5103c08bf297e212f7880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->