### PR TITLE
build(ci): resolve Bazel artifacts through one helper

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Smoke the linux CLI (run + features + glibc floor)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          BIN=$(bazelisk cquery --config=remote -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote -c opt)
           echo "resolved linux CLI: $BIN"
           file "$BIN"
           "$BIN" --help >/dev/null
@@ -227,7 +227,7 @@ jobs:
       - name: Verify + stage the windows CLI (.exe)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          EXE=$(bazelisk cquery --config=remote --config=windows -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          EXE=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=windows -c opt)
           echo "resolved windows CLI: $EXE"
           file "$EXE"
           file "$EXE" | grep -q 'PE32+.*x86-64' || { echo "NOT a PE32+ x86-64 binary"; exit 1; }
@@ -253,7 +253,7 @@ jobs:
       - name: Verify + audit + stage the windows bolt DLL
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          DLL=$(bazelisk cquery --config=remote --config=windows -c opt --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          DLL=$(tools/scripts/bazel-output.sh //crates/xybrid-bolt:xybrid_bolt_cdylib --config=remote --config=windows -c opt)
           echo "resolved windows bolt DLL: $DLL"
           file "$DLL"
           file "$DLL" | grep -q 'PE32+.*x86-64' || { echo "NOT a PE32+ x86-64 DLL"; exit 1; }
@@ -397,7 +397,7 @@ jobs:
       - name: Smoke the Metal CLI (run + Metal + features)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
-          BIN=$(bazelisk cquery --config=remote --config=macos-metal -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=macos-metal -c opt)
           echo "resolved CLI: $BIN"
           file "$BIN"
           "$BIN" --help >/dev/null
@@ -465,10 +465,12 @@ jobs:
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           set -euo pipefail
-          FILES=$(bazelisk cquery --config=remote --config=windows-msvc -c opt \
-            --output=files //bindings/flutter/rust:xybrid_flutter_ffi_cdylib)
-          DLL=$(printf '%s\n' "$FILES" | grep '\.dll$')
-          IMPLIB=$(printf '%s\n' "$FILES" | grep '\.dll\.lib$')
+          DLL=$(tools/scripts/bazel-output.sh --ext dll \
+            //bindings/flutter/rust:xybrid_flutter_ffi_cdylib \
+            --config=remote --config=windows-msvc -c opt)
+          IMPLIB=$(tools/scripts/bazel-output.sh --ext dll.lib \
+            //bindings/flutter/rust:xybrid_flutter_ffi_cdylib \
+            --config=remote --config=windows-msvc -c opt)
           echo "resolved DLL: $DLL"
           echo "resolved import library: $IMPLIB"
           file "$DLL"

--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -77,7 +77,7 @@ jobs:
       # resolves the same (opt) output path.
       - name: Stage into Unity plugins
         run: |
-          LIB=$(bazelisk cquery --config=macos-metal -c opt --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          LIB=$(tools/scripts/bazel-output.sh //crates/xybrid-bolt:xybrid_bolt_cdylib --config=macos-metal -c opt)
           echo "Bazel output: $LIB"
           python3 tools/scripts/stage_unity_native.py \
             --lib "$LIB" \
@@ -135,8 +135,8 @@ jobs:
           [[ -n "${REMOTE:-}" ]] && remote_args+=("$REMOTE")
           bazelisk build "${remote_args[@]}" --config=windows-msvc -c opt \
             //crates/xybrid-bolt:xybrid_bolt_cdylib
-          LIB=$(bazelisk cquery "${remote_args[@]}" --config=windows-msvc -c opt \
-            --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | grep '\.dll$')
+          LIB=$(tools/scripts/bazel-output.sh --ext dll //crates/xybrid-bolt:xybrid_bolt_cdylib \
+            "${remote_args[@]}" --config=windows-msvc -c opt)
           echo "Bazel output: $LIB"
           python3 tools/scripts/stage_unity_native.py --lib "$LIB" --target x86_64-pc-windows-msvc
 
@@ -202,7 +202,7 @@ jobs:
           remote_args=()
           [[ -n "${REMOTE:-}" ]] && remote_args+=("$REMOTE")
           bazelisk build "${remote_args[@]}" -c opt //crates/xybrid-bolt:xybrid_bolt_cdylib
-          LIB=$(bazelisk cquery "${remote_args[@]}" -c opt --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          LIB=$(tools/scripts/bazel-output.sh //crates/xybrid-bolt:xybrid_bolt_cdylib "${remote_args[@]}" -c opt)
           echo "Bazel output: $LIB"
           python3 tools/scripts/stage_unity_native.py --lib "$LIB" --target x86_64-unknown-linux-gnu
 
@@ -274,7 +274,7 @@ jobs:
             triple="${spec%%:*}"; cfg="${spec##*:}"
             echo "=== $triple ($cfg) ==="
             bazelisk build "${remote_args[@]}" --config="$cfg" //crates/xybrid-bolt:xybrid_bolt_cdylib
-            LIB=$(bazelisk cquery "${remote_args[@]}" --config="$cfg" --output=files //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+            LIB=$(tools/scripts/bazel-output.sh //crates/xybrid-bolt:xybrid_bolt_cdylib "${remote_args[@]}" --config="$cfg")
             echo "Bazel output: $LIB"
             python3 tools/scripts/stage_unity_native.py \
               --lib "$LIB" \
@@ -344,7 +344,7 @@ jobs:
 
       - name: Stage into Unity plugins
         run: |
-          LIB=$(bazelisk cquery --config=ios --output=files //crates/xybrid-bolt:xybrid_bolt_staticlib | head -1)
+          LIB=$(tools/scripts/bazel-output.sh //crates/xybrid-bolt:xybrid_bolt_staticlib --config=ios)
           echo "Bazel output: $LIB"
           python3 tools/scripts/stage_unity_native.py --lib "$LIB" --target aarch64-apple-ios
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -280,7 +280,7 @@ jobs:
             local triple="$1"; shift
             bazelisk build "$@" //bindings/flutter/rust:xybrid_flutter_ffi_staticlib
             mkdir -p "prebuilt/$triple"
-            cp -L "$(bazelisk cquery "$@" --output=files //bindings/flutter/rust:xybrid_flutter_ffi_staticlib | head -1)" \
+            cp -L "$(tools/scripts/bazel-output.sh //bindings/flutter/rust:xybrid_flutter_ffi_staticlib "$@")" \
               "prebuilt/$triple/libxybrid_flutter_ffi.a"
           }
           # macOS — mixed execution (Rust graph on RBE/cache, Metal local).
@@ -382,7 +382,7 @@ jobs:
       # (Mach-O symbols carry a leading underscore.)
       - name: Verify CLI payload (run + Metal + features)
         run: |
-          BIN=$(bazelisk cquery --config=remote --config=macos-metal -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=macos-metal -c opt)
           echo "resolved CLI: $BIN"
           file "$BIN"
           "$BIN" --help >/dev/null
@@ -397,7 +397,7 @@ jobs:
           TAG: ${{ needs.check-release-branch.outputs.tag }}
         run: |
           mkdir -p dist-cli
-          BIN=$(bazelisk cquery --config=remote --config=macos-metal -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=macos-metal -c opt)
           cp "$BIN" dist-cli/xybrid-${TAG}-macos-arm64
           chmod +w dist-cli/xybrid-${TAG}-macos-arm64   # bazel outputs are read-only
           strip dist-cli/xybrid-${TAG}-macos-arm64
@@ -570,7 +570,7 @@ jobs:
             local triple="$1"; shift
             bazelisk build "$@" //bindings/flutter/rust:xybrid_flutter_ffi_cdylib
             mkdir -p "prebuilt/$triple"
-            cp -L "$(bazelisk cquery "$@" --output=files //bindings/flutter/rust:xybrid_flutter_ffi_cdylib | head -1)" \
+            cp -L "$(tools/scripts/bazel-output.sh //bindings/flutter/rust:xybrid_flutter_ffi_cdylib "$@")" \
               "prebuilt/$triple/libxybrid_flutter_ffi.so"
           }
           # linux x86_64 — hermetic glibc floor (loadable on older distros,
@@ -682,8 +682,8 @@ jobs:
           bazelisk build --config=remote --config=windows-msvc -c opt \
             //bindings/flutter/rust:xybrid_flutter_ffi_cdylib
           mkdir -p prebuilt/x86_64-pc-windows-msvc
-          bazelisk cquery --config=remote --config=windows-msvc -c opt \
-            --output=files //bindings/flutter/rust:xybrid_flutter_ffi_cdylib \
+          tools/scripts/bazel-output.sh --all //bindings/flutter/rust:xybrid_flutter_ffi_cdylib \
+            --config=remote --config=windows-msvc -c opt \
             | while read -r artifact; do
                 cp -L "$artifact" prebuilt/x86_64-pc-windows-msvc/
               done
@@ -805,7 +805,7 @@ jobs:
       # glibc floor — strictly better than the old cargo/ubuntu-24.04 build.
       - name: Verify CLI payload (run + features + glibc floor)
         run: |
-          BIN=$(bazelisk cquery --config=remote -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote -c opt)
           echo "resolved CLI: $BIN"
           "$BIN" --help >/dev/null
           test "$(nm "$BIN" | grep -c ' mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
@@ -821,7 +821,7 @@ jobs:
         run: |
           mkdir -p dist
           ARTIFACT="dist/xybrid-${TAG}-linux-x86_64"
-          BIN=$(bazelisk cquery --config=remote -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote -c opt)
           cp "$BIN" "$ARTIFACT"
           chmod +w "$ARTIFACT"   # bazel-bin outputs are read-only
           strip "$ARTIFACT"
@@ -886,7 +886,7 @@ jobs:
       # run-it half is smoke-cli-windows below.
       - name: Verify CLI payload (PE32+ + features)
         run: |
-          EXE=$(bazelisk cquery --config=remote --config=windows -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          EXE=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=windows -c opt)
           echo "resolved CLI: $EXE"
           file "$EXE"
           file "$EXE" | grep -q 'PE32+.*x86-64' || { echo "NOT a PE32+ x86-64 binary"; exit 1; }
@@ -904,7 +904,7 @@ jobs:
         run: |
           mkdir -p dist
           ARTIFACT="dist/xybrid-${TAG}-windows-x86_64.exe"
-          EXE=$(bazelisk cquery --config=remote --config=windows -c opt --output=files //crates/xybrid-cli:xybrid | head -1)
+          EXE=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=windows -c opt)
           cp "$EXE" "$ARTIFACT"
           echo "artifact_path=$ARTIFACT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -26,6 +26,8 @@ on:
       - "tools/unity-runtime-smoke/**"
       - "tools/scripts/stage_unity_native.py"
       - "tools/scripts/stage_unity_desktop_ort.py"
+      - "tools/scripts/bazel-output.sh"
+      - "tools/scripts/write-buildbuddy-rc.sh"
       - ".github/workflows/unity-editor.yml"
   push:
     branches: [master]
@@ -34,6 +36,10 @@ on:
       - "crates/xybrid-bolt/**"
       - "crates/xybrid-ffi-facade/**"
       - "tools/unity-runtime-smoke/**"
+      - "tools/scripts/stage_unity_native.py"
+      - "tools/scripts/stage_unity_desktop_ort.py"
+      - "tools/scripts/bazel-output.sh"
+      - "tools/scripts/write-buildbuddy-rc.sh"
       - ".github/workflows/unity-editor.yml"
   workflow_dispatch:
 
@@ -124,8 +130,8 @@ jobs:
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           set -euo pipefail
-          LIB=$(bazelisk cquery --config=remote -c opt --output=files \
-            //crates/xybrid-bolt:xybrid_bolt_cdylib | head -1)
+          LIB=$(tools/scripts/bazel-output.sh //crates/xybrid-bolt:xybrid_bolt_cdylib \
+            --config=remote -c opt)
           echo "bolt native: $LIB"
           python3 tools/scripts/stage_unity_native.py --lib "$LIB" \
             --target x86_64-unknown-linux-gnu

--- a/tools/scripts/bazel-output.sh
+++ b/tools/scripts/bazel-output.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Resolve a Bazel target's output file(s) to real paths.
+#
+# Why this exists: `bazel-bin/` is a symlink that tracks the LAST invocation,
+# so a job that builds several configs in sequence and then reads `bazel-bin`
+# gets whichever config ran last (this actually shipped once — a Mach-O binary
+# under a Linux name, "Exec format error"). The fix is to resolve each artifact
+# with `cquery --output=files` immediately after its build, which every job did
+# by hand, 25 times, inconsistently: mostly `| head -1`, sometimes
+# `| grep '\.dll$'`.
+#
+# `head -1` is a guess — it silently returns whichever output sorts first if a
+# target ever grows a second one. This asserts instead:
+#
+#   (default)     exactly one output, or fail with what it actually found
+#   --ext EXT     exactly one output ending in .EXT (e.g. --ext dll)
+#   --all         every output, one per line (for callers that want them all)
+#
+# Verified output counts at the time of writing: the rust binaries, cdylibs and
+# staticlibs all resolve to exactly 1 file on macos-metal / windows-gnu / ios /
+# android / linux; only the windows-MSVC cdylib emits 2 (`.dll` + `.dll.lib`),
+# which is what --ext and --all are for.
+#
+# Usage:
+#   BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote -c opt)
+#   DLL=$(tools/scripts/bazel-output.sh --ext dll //crates/xybrid-bolt:xybrid_bolt_cdylib --config=windows-msvc -c opt)
+#   tools/scripts/bazel-output.sh --all //bindings/flutter/rust:xybrid_flutter_ffi_cdylib "$@"
+#
+# This only RESOLVES paths; build the target first. Pass the same config flags
+# to both, or cquery reports a different configuration than the one you built.
+set -euo pipefail
+
+MODE=one
+EXT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) MODE=all; shift ;;
+    --ext) MODE=ext; EXT="${2:?--ext needs an extension, e.g. --ext dll}"; shift 2 ;;
+    --) shift; break ;;
+    -*) echo "bazel-output.sh: unknown option '$1'" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+TARGET="${1:?usage: bazel-output.sh [--ext EXT | --all] TARGET [BAZEL_ARGS...]}"
+shift
+
+# cquery chatter goes to stderr; the file list is stdout. Let stderr through so
+# a real analysis failure is visible in the job log instead of an empty result.
+FILES=$("${BAZEL:-bazelisk}" cquery "$@" --output=files "$TARGET")
+
+if [ "$MODE" = ext ]; then
+  # Literal suffix match — an --ext of `dll.lib` must not have its dot treated
+  # as a regex wildcard, and `--ext dll` must not swallow `.dll.lib`.
+  MATCHED=""
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case "$f" in
+      *".$EXT") MATCHED="${MATCHED}${f}"$'\n' ;;
+    esac
+  done <<< "$FILES"
+  FILES="${MATCHED%$'\n'}"
+fi
+
+if [ "$MODE" = all ]; then
+  printf '%s\n' "$FILES"
+  exit 0
+fi
+
+COUNT=$(printf '%s' "$FILES" | grep -c . || true)
+if [ "$COUNT" != "1" ]; then
+  {
+    echo "bazel-output.sh: expected exactly 1 output for $TARGET"
+    [ -n "$EXT" ] && echo "  (filtered to .$EXT)"
+    echo "  bazel args: $*"
+    echo "  got $COUNT:"
+    printf '%s\n' "$FILES" | sed 's/^/    /'
+  } >&2
+  exit 1
+fi
+
+printf '%s\n' "$FILES"

--- a/tools/scripts/tests/test_bazel_output.py
+++ b/tools/scripts/tests/test_bazel_output.py
@@ -1,0 +1,132 @@
+"""Tests for tools/scripts/bazel-output.sh.
+
+The script shells out to Bazel, which a plain CI runner has no workspace for,
+so these drive it against a stub binary via its `$BAZEL` hook. That covers
+everything worth pinning — the argument parsing, the literal `--ext` suffix
+match, and above all the strict single-output assertion, which is the reason
+the script exists (the `| head -1` it replaced silently returned whichever
+output sorted first when a target grew a second one).
+"""
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "bazel-output.sh"
+
+MSVC_CDYLIB = [
+    "bazel-out/k8-opt/bin/crates/xybrid-bolt/xybrid_bolt.dll",
+    "bazel-out/k8-opt/bin/crates/xybrid-bolt/xybrid_bolt.dll.lib",
+]
+SINGLE = ["bazel-out/k8-opt/bin/crates/xybrid-cli/xybrid"]
+
+
+class BazelOutputTests(unittest.TestCase):
+    def run_script(self, args, outputs):
+        """Run bazel-output.sh with a stub Bazel that prints `outputs`."""
+        with tempfile.TemporaryDirectory() as temp:
+            stub = Path(temp) / "fake-bazel"
+            stub.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    printf '%s\\n' {}
+                    """
+                ).format(" ".join(f"'{o}'" for o in outputs))
+                if outputs
+                else "#!/usr/bin/env bash\nexit 0\n"
+            )
+            stub.chmod(0o755)
+            env = dict(os.environ, BAZEL=str(stub))
+            return subprocess.run(
+                ["bash", str(SCRIPT), *args],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+    def test_single_output_is_printed(self):
+        result = self.run_script(["//crates/xybrid-cli:xybrid"], SINGLE)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(SINGLE[0], result.stdout.strip())
+
+    def test_two_outputs_fail_instead_of_guessing(self):
+        # The whole point: `head -1` would have silently returned the .dll.
+        result = self.run_script(["//crates/xybrid-bolt:cdylib"], MSVC_CDYLIB)
+        self.assertEqual(1, result.returncode)
+        self.assertIn("expected exactly 1 output", result.stderr)
+        # The diagnostic must name what it actually found, both paths.
+        for path in MSVC_CDYLIB:
+            self.assertIn(path, result.stderr)
+
+    def test_ext_selects_the_matching_output(self):
+        result = self.run_script(
+            ["--ext", "dll", "//crates/xybrid-bolt:cdylib"], MSVC_CDYLIB
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(MSVC_CDYLIB[0], result.stdout.strip())
+
+    def test_ext_dll_does_not_swallow_dll_lib(self):
+        # A regex `\\.dll$` would be fine here, but `--ext dll.lib` needs the
+        # dot treated literally; both directions are checked.
+        result = self.run_script(
+            ["--ext", "dll.lib", "//crates/xybrid-bolt:cdylib"], MSVC_CDYLIB
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(MSVC_CDYLIB[1], result.stdout.strip())
+
+    def test_ext_matching_nothing_fails(self):
+        result = self.run_script(
+            ["--ext", "exe", "//crates/xybrid-bolt:cdylib"], MSVC_CDYLIB
+        )
+        self.assertEqual(1, result.returncode)
+        self.assertIn("expected exactly 1 output", result.stderr)
+
+    def test_all_prints_every_output(self):
+        result = self.run_script(["--all", "//crates/xybrid-bolt:cdylib"], MSVC_CDYLIB)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(MSVC_CDYLIB, result.stdout.split())
+
+    def test_bazel_args_are_forwarded_after_the_target(self):
+        with tempfile.TemporaryDirectory() as temp:
+            stub = Path(temp) / "fake-bazel"
+            argv_log = Path(temp) / "argv"
+            stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'printf "%s\\n" "$@" > {argv_log}\n'
+                f"printf '%s\\n' '{SINGLE[0]}'\n"
+            )
+            stub.chmod(0o755)
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(SCRIPT),
+                    "//crates/xybrid-cli:xybrid",
+                    "--config=remote",
+                    "-c",
+                    "opt",
+                ],
+                capture_output=True,
+                text=True,
+                env=dict(os.environ, BAZEL=str(stub)),
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            argv = argv_log.read_text().split()
+            self.assertEqual(
+                ["cquery", "--config=remote", "-c", "opt", "--output=files",
+                 "//crates/xybrid-cli:xybrid"],
+                argv,
+            )
+
+    def test_unknown_option_is_rejected(self):
+        result = self.run_script(["--nope", "//t"], SINGLE)
+        self.assertEqual(2, result.returncode)
+        self.assertIn("unknown option", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Every shipping job resolves its artifact with `cquery` rather than reading the `bazel-bin` symlink, because that symlink tracks the **last** invocation — a job that builds several configs in sequence and then reads `bazel-bin` gets the wrong one (this shipped once: a Mach-O binary under a Linux name, "Exec format error"). That resolution was hand-rolled at **21 call sites**, mostly `| head -1` and sometimes `| grep '\.dll$'`. This replaces all of them with `tools/scripts/bazel-output.sh`. It also closes a path-filter hole found while wiring it up.

**The helper:**

* `tools/scripts/bazel-output.sh [--ext EXT | --all] TARGET [BAZEL_ARGS...]` — one place that knows how to turn a target into a real path.
* **Default mode asserts exactly one output** and fails printing every path it found. This is the upgrade over `head -1`, which is a *guess*: it silently returns whichever output sorts first if a target ever grows a second one.
* `--ext EXT` and `--all` cover the targets that legitimately emit more than one file.
* `--ext` matches a **literal** suffix, not a regex — so `--ext dll` cannot swallow `.dll.lib`, and `--ext dll.lib` cannot have its dot read as a wildcard.

**Why the strictness is safe — measured, not assumed:**

`cquery` is analysis-only, so every config resolves locally without building anything. Actual output counts:

| Target / config | Outputs |
|---|---|
| cli, cdylib, staticlib @ macos-metal / windows-gnu / ios / android / linux | **1** |
| `xybrid_bolt_cdylib` @ windows-MSVC | **2** (`.dll` + `.dll.lib`) |

So only the Windows-MSVC sites need a filter — exactly where the old code already used `grep` or consumed the whole list. Nothing that previously used `head -1` is at risk of tripping the new assertion.

**Path-filter hole closed:**

* `unity-editor.yml` shells out to both this helper and `write-buildbuddy-rc.sh`, but its `paths` filters listed neither — so a change to either triggered nothing. Both are now listed on the `pull_request` and `push` filters (the push filter had no script entries at all). Same class of gap as the missing `**/*.bzl` filter fixed in #417.

**Verified:**

* All three modes exercised against real targets; both failure paths (2 outputs under default, 0 after filtering) exit 1 with the found paths listed.
* Empty `"${remote_args[@]}"` expansion is safe — that pattern is used by three build-unity call sites.
* `shellcheck` clean; all workflows parse; `actionlint` reports only pre-existing shellcheck notes on untouched lines.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [x] Other (CI hardening: a silent-wrong-artifact class becomes a loud failure, plus a trigger-coverage fix)

## Checklist

- [ ] Tests pass (`cargo test`) — no Rust touched; validated with Bazel `cquery`, shellcheck and actionlint instead (see Verified above)
- [x] Code follows project style (see RUST_GUIDE.md)
- [x] Documentation updated (if applicable) — the helper documents the `bazel-bin` trap it exists to prevent; review findings log records what landed
- [x] No breaking changes (or breaking changes documented) — CI-only; every call site resolves the same artifact it did before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only refactor that resolves the same artifacts as before, with stricter failure modes; release behavior unchanged aside from catching ambiguous multi-output targets early.
> 
> **Overview**
> Introduces **`tools/scripts/bazel-output.sh`** so CI resolves Bazel build outputs via `cquery` in one place instead of repeating `bazelisk cquery … | head -1` or `grep` at many call sites. **Default mode requires exactly one output** and fails with the paths it found, replacing silent `head -1` guesses when a target gains extra outputs. **`--ext`** picks one file by literal suffix (e.g. `.dll` vs `.dll.lib`); **`--all`** lists every output for multi-artifact targets like Windows MSVC Flutter cdylibs.
> 
> **All prior hand-rolled resolutions** in `bazel.yml`, `build-unity.yml`, `release-prep.yml`, and `unity-editor.yml` now call the helper with the same Bazel config flags as the preceding build.
> 
> Adds **unit tests** (`test_bazel_output.py`) using a stub `$BAZEL` binary. **`unity-editor.yml`** path filters now include `bazel-output.sh`, `write-buildbuddy-rc.sh`, and staging scripts on push (they were missing on push; the helper/scripts were not listed on PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a0a6a156e8447812b50dd8a5295effec870000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->