### PR TITLE
build(bazel): add contributor justfile recipes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,14 @@ bazel build --config=macos-metal //crates/xybrid-cli:xybrid   # CLI (macOS; see 
 cargo xtask build-flutter --platform <linux|macos|windows>
 ```
 
+If you use `just`, the matching Bazel shortcuts are `just bazel-build`
+(the local CLI), `just bazel-analyze`, and `just bazel-test`. Each accepts
+additional Bazel flags, for example:
+
+```bash
+just bazel-build -c opt
+```
+
 ### Building for Windows (MSVC)
 
 `bazel build --config=windows-msvc //...` cross-compiles MSVC-ABI Windows

--- a/justfile
+++ b/justfile
@@ -5,6 +5,8 @@
 default:
     @just --list
 
+bazel_host_config := if os() == "macos" { "--config=macos-metal" } else { "" }
+
 # =============================================================================
 # Build & Test
 # =============================================================================
@@ -17,9 +19,34 @@ build:
 build-release:
     cargo build --workspace --release
 
+# Build the local CLI with Bazel
+bazel-build *bazel_args:
+    bazelisk build {{bazel_host_config}} {{bazel_args}} //crates/xybrid-cli:xybrid
+
+# Analyze the Bazel workspace without producing build outputs (same graph as CI)
+bazel-analyze *bazel_args:
+    bazelisk build --nobuild {{bazel_args}} \
+        //crates/... \
+        //bindings/... \
+        //macros/... \
+        //xtask/... \
+        //integration-tests/... \
+        //:llama
+
 # Run all tests
 test:
     cargo test --workspace
+
+# Run the Rust tests represented in the Bazel graph (same targets as CI)
+bazel-test *bazel_args:
+    bazelisk test {{bazel_host_config}} --test_output=errors {{bazel_args}} \
+        //crates/xybrid-cli:all \
+        //crates/xybrid-core:all \
+        //crates/xybrid-ffi-facade:xybrid-ffi-facade_test \
+        //crates/xybrid-llama:all \
+        //crates/xybrid-sdk:all \
+        //integration-tests:all \
+        //xtask:xtask_test
 
 # Run tests with output
 test-verbose:


### PR DESCRIPTION
## Summary

This pull request adds first-class Bazel shortcuts to the project `justfile`, closing the contributor-tooling gap now that Bazel is the native artifact build system. The recipes mirror CI's build, analysis, and Rust-test target sets while automatically selecting the Mac-only Metal configuration for local macOS builds.

**Contributor Tooling:**

* Added `just bazel-build` for building the local CLI, with additional Bazel flags forwarded to the underlying command.
* Added `just bazel-analyze` to configure the same 79-target workspace graph used by CI without producing build outputs.
* Added `just bazel-test` to run the same 38 Bazel Rust test targets used by CI.
* Applied `--config=macos-metal` automatically on macOS so local builds use the supported host-tool path.

**Documentation:**

* Documented the new shortcuts and flag forwarding in `CONTRIBUTING.md` alongside the existing native build commands.

**Validation:**

* Built the local Metal-enabled CLI through `just bazel-build` and passed all 38 tests through `just bazel-test`.
* Passed `cargo fmt --all -- --check`, workspace Clippy with warnings denied, and `cargo test --workspace --features ort-download`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [x] Other (build tooling)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and optional dev tooling only; no runtime, CI workflow, or product code changes.
> 
> **Overview**
> Adds **Bazel contributor shortcuts** to the `justfile` so local workflows match documented native builds without memorizing long `bazelisk` invocations.
> 
> **`just bazel-build`** builds `//crates/xybrid-cli:xybrid` via `bazelisk`, forwarding extra flags (e.g. `-c opt`). On macOS it automatically appends `--config=macos-metal`, matching the CONTRIBUTING CLI example.
> 
> **`just bazel-analyze`** runs `bazelisk build --nobuild` over the same crate/bindings/macros/xtask/integration-tests/`//:llama` graph CI uses for structural analysis.
> 
> **`just bazel-test`** runs `bazelisk test` with `--test_output=errors` on the same Rust test target set as CI (xybrid-cli/core/ffi-facade/llama/sdk, integration-tests, xtask), again applying macOS Metal config locally.
> 
> **CONTRIBUTING.md** documents these three commands and that additional Bazel flags pass through to the underlying recipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645cd47a83300ca4e694872cee6e40c76c7c2657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->