### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-07-31
+
+Stable release of the 0.4.0 line. Since `0.4.0-rc1`, local Whisper gains
+correct long-audio and per-request language/task handling, the Windows Flutter
+and Unity natives move onto the tested MSVC Bazel path, and Kotlin callers get
+a compatibility shim for the loader API removed during the BoltFFI migration.
+The `0.4.0-rc1` and `0.4.0-alpha` entries below cover the rest of the changes
+since 0.3.0.
+
+### Fixed
+
+- **Candle Whisper now transcribes audio of any length** instead of failing at
+  roughly 15 seconds or truncating past 30 seconds. Audio is decoded in
+  correctly trimmed windows, padding-only output is discarded, Whisper's
+  suppress-token and no-speech rules are applied, and model-backed regression
+  tests cover clips through 66 seconds (#426).
+- **Whisper honors each request's language and task.** Transcription and
+  translation select the correct decode prefix without leaking state between
+  calls; unsupported languages, prompts, non-zero temperatures, and timestamp
+  granularities now return an explicit input error instead of being silently
+  ignored (#426).
+- **Kotlin's migration docs referenced a removed `XybridModelLoader`.** The
+  examples now use `XybridModel` directly, and a deprecated compatibility shim
+  keeps applications written against the old loader shape compiling through
+  the 0.4.x line (#329, #412).
+
+### Changed
+
+- **Flutter's Windows native is now MSVC ABI from end to end.** The shipped DLL
+  and import library are cross-compiled by the Bazel release graph, include the
+  llama.cpp vision path, and are load-tested on Windows before release
+  (#416–#420).
+- **Unity's Windows native now comes from the same Bazel graph** and is checked
+  through real IL2CPP runtime smokes on Windows and Linux (#414, #421).
+- **Release builds resolve exact Bazel outputs through one checked helper** and
+  share one remote-execution configuration, removing ambiguous `bazel-bin`
+  lookups and drift between shipping jobs (#424, #427).
+
+---
+
 ## [0.4.0-rc1] - 2026-07-28
 
 Release candidate for 0.4.0. Two consumer-visible fixes on top of `0.4.0-alpha`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.19",
  "v_frame",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1393,13 +1393,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2228,7 +2228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "http 1.4.2",
+ "http 1.5.0",
  "indicatif 0.18.6",
  "libc",
  "log",
@@ -2277,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2303,7 +2303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -2314,7 +2314,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -2398,7 +2398,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "itoa",
@@ -2414,7 +2414,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper 1.11.0",
  "hyper-util",
  "rustls",
@@ -2434,7 +2434,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper 1.11.0",
  "ipnet",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2975,19 +2975,19 @@ checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
 dependencies = [
  "macro_rules_attribute-proc_macro",
- "paste",
+ "pastey 0.2.3",
 ]
 
 [[package]]
 name = "macro_rules_attribute-proc_macro"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
 
 [[package]]
 name = "malloc_buf"
@@ -3660,6 +3660,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -4368,7 +4374,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
@@ -4466,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -5183,13 +5189,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5280,7 +5286,7 @@ dependencies = [
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
  "tower",
@@ -5573,7 +5579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
 ]
@@ -5640,9 +5646,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
+checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
 
 [[package]]
 name = "version_check"
@@ -6152,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6166,14 +6172,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6182,7 +6188,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6211,7 +6217,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6278,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -6288,7 +6294,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6297,7 +6303,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6306,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6315,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6341,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0-rc1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.4.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "60d69c78900dd89ac3c4befb9550e9d448e02aff7e5a771261a308d29b87e53e"
+let xybridFFIChecksum = "3c209ca56fafa8345bb7be03d89da40ee60fe9fbbe9c6142e2bb7d1de7b3e63e"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.4.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "65009356d3ed958933e717562ea3390fb1c027201a98b9c7e80a551718ccf875"
+let xybridFFIChecksum = "60d69c78900dd89ac3c4befb9550e9d448e02aff7e5a771261a308d29b87e53e"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.4.0-rc1"
+let sdkVersion = "0.4.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+Stable release of the 0.4.0 line. No Flutter API changes since `0.4.0-rc1`.
+
+* Changed: the precompiled Windows native is now an MSVC-ABI DLL plus import library produced by the Bazel release graph, includes the llama.cpp vision path, and is load-tested on Windows before release (xybrid-ai/xybrid#416, xybrid-ai/xybrid#418, xybrid-ai/xybrid#419, xybrid-ai/xybrid#420)
+
 ## 0.4.0-rc1
 
 Release candidate for 0.4.0.

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.4.0-rc1
+version: 0.4.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.4.0-rc1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.4.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.4.0-rc1"
+version = "0.4.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xybrid"
-version = "0.4.0-rc1"
+version = "0.4.0"
 description = "Python SDK for local-first xybrid inference"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.4.0-rc1"
+  implementation "ai.xybrid:xybrid-kotlin:0.4.0"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.4.0-rc1",
+  "version": "0.4.0",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.4.0-rc1",
+  "version": "0.4.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xybrid/web",
-  "version": "0.4.0-rc1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "Preview browser tensor runtime for Xybrid metadata backed by LiteRT.",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0-rc1", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.4.0-rc1", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.4.0", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0-rc1" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.4.0-rc1", path = "../../macros" }
+xybrid-macros = { version = "0.4.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.4.0-rc1", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.4.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.4.0-rc1", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.4.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.4.0-rc1", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.4.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Release **v0.4.0**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.4.0).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.4.0`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release versioning and documentation; behavior changes are documented as already landed since rc1, not introduced in these manifest-only edits.
> 
> **Overview**
> **Cuts stable v0.4.0** across the monorepo and binding packages, moving everything from `0.4.0-rc1` to **`0.4.0`** (workspace `Cargo.toml`, crates.io path pins, Flutter/Kotlin/Python/React Native/Unity/web manifests, integration-tests/xtask lockfile entries).
> 
> **Release notes** add a root **`[0.4.0]`** changelog section (and a matching Flutter changelog blurb) summarizing fixes since rc1—long-audio Whisper, per-request language/task, Kotlin `XybridModelLoader` shim, MSVC Windows natives for Flutter/Unity, and unified Bazel release output resolution—without new API changes called out for Flutter.
> 
> **Apple SPM consumers** get an updated **`Package.swift`**: `sdkVersion` **`0.4.0`** and a new **XCFramework zip checksum** for the published binary.
> 
> **`Cargo.lock`** refreshes transitive crates (e.g. `http` 1.5, `rustls` 0.23.43, `clang-sys`, `clap`) alongside the workspace version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64facda67842aa682eb49accf3fa6b79859a74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->