### PR TITLE
fix(candle): redact Whisper request values from errors

### DIFF
--- a/crates/xybrid-core/src/runtime_adapter/candle/runtime.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/runtime.rs
@@ -230,7 +230,8 @@ fn parse_transcribe_options(
         return Err(AdapterError::InvalidInput(format!(
             "'prompt' is not supported by the Candle Whisper runtime: decoding starts from a \
              fixed forced-token prefix, so the prompt would be dropped without affecting the \
-             transcript (got {prompt:?})"
+             transcript (received a non-empty value of {} bytes)",
+            prompt.len()
         )));
     }
 
@@ -288,7 +289,7 @@ fn parse_transcribe_options(
 /// and invite a retry that cannot succeed.
 fn transcription_error(error: WhisperError) -> AdapterError {
     match error {
-        WhisperError::UnsupportedLanguage(_) => AdapterError::InvalidInput(error.to_string()),
+        WhisperError::UnsupportedLanguage { .. } => AdapterError::InvalidInput(error.to_string()),
         other => AdapterError::InferenceFailed(format!("Transcription failed: {}", other)),
     }
 }
@@ -367,13 +368,22 @@ mod tests {
 
     #[test]
     fn test_parse_options_rejects_prompt() {
+        let private_prompt = "PRIVATE_PROMPT_SENTINEL_7c1f";
         let message = invalid_input_message(parse_transcribe_options(&metadata(&[(
             "prompt",
-            "The following is a recording of a lecture.",
+            private_prompt,
         )])));
         assert!(
             message.contains("prompt"),
             "error should name the parameter: {message}"
+        );
+        assert!(
+            message.contains(&private_prompt.len().to_string()),
+            "error should report the rejected prompt's byte length: {message}"
+        );
+        assert!(
+            !message.contains(private_prompt),
+            "error must not expose the rejected prompt: {message}"
         );
     }
 
@@ -458,11 +468,11 @@ mod tests {
 
     #[test]
     fn test_unsupported_language_maps_to_invalid_input() {
-        let error = transcription_error(WhisperError::UnsupportedLanguage("xx".to_string()));
+        let error = transcription_error(WhisperError::UnsupportedLanguage { byte_len: 2 });
         match error {
             AdapterError::InvalidInput(message) => assert!(
-                message.contains("xx"),
-                "error should name the rejected language: {message}"
+                message.contains("language") && message.contains("2 bytes"),
+                "error should name the parameter and report its byte length: {message}"
             ),
             other => panic!("expected InvalidInput, got {other:?}"),
         }

--- a/crates/xybrid-core/src/runtime_adapter/candle/whisper.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/whisper.rs
@@ -41,8 +41,10 @@ pub enum WhisperError {
     /// `<|xx|>` token for a *caller-supplied* language is bad input, not a
     /// broken model, and callers map it to an invalid-input error rather than
     /// an inference failure.
-    #[error("Unsupported language '{0}': the model vocabulary has no '<|{0}|>' token")]
-    UnsupportedLanguage(String),
+    #[error(
+        "Unsupported language value ({byte_len} bytes): the model vocabulary has no matching language token"
+    )]
+    UnsupportedLanguage { byte_len: usize },
 
     /// Candle tensor/model error
     #[error("Candle error: {0}")]
@@ -965,7 +967,9 @@ fn language_token_id(tokenizer: &Tokenizer, language: &str) -> WhisperResult<u32
     let token = format!("<|{}|>", language.trim().to_ascii_lowercase());
     tokenizer
         .token_to_id(&token)
-        .ok_or_else(|| WhisperError::UnsupportedLanguage(language.to_string()))
+        .ok_or(WhisperError::UnsupportedLanguage {
+            byte_len: language.len(),
+        })
 }
 
 /// Helper to get token ID from tokenizer
@@ -978,6 +982,28 @@ fn token_id(tokenizer: &Tokenizer, token: &str) -> WhisperResult<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_unsupported_language_error_redacts_value() {
+        let tokenizer = Tokenizer::new(tokenizers::models::bpe::BPE::default());
+        let private_language = "PRIVATE_LANGUAGE_SENTINEL_8d2e";
+        let message = language_token_id(&tokenizer, private_language)
+            .expect_err("the empty tokenizer has no language token")
+            .to_string();
+
+        assert!(
+            message.contains("language"),
+            "error should name the rejected parameter: {message}"
+        );
+        assert!(
+            message.contains(&private_language.len().to_string()),
+            "error should report the rejected language's byte length: {message}"
+        );
+        assert!(
+            !message.contains(private_language),
+            "error must not expose the rejected language: {message}"
+        );
+    }
 
     #[test]
     fn test_whisper_size_as_str() {

--- a/integration-tests/tests/whisper_candle_integration.rs
+++ b/integration-tests/tests/whisper_candle_integration.rs
@@ -467,7 +467,8 @@ fn test_whisper_rejects_prompt_metadata_as_invalid_input() {
     };
 
     let pcm = read_pcm(FRENCH_CLIP);
-    let error = transcribe(&mut runtime, &pcm, &[("prompt", "x")])
+    let private_prompt = "PRIVATE_PROMPT_SENTINEL_7c1f";
+    let error = transcribe(&mut runtime, &pcm, &[("prompt", private_prompt)])
         .expect_err("'prompt' is unsupported and must be rejected");
 
     assert!(
@@ -477,5 +478,9 @@ fn test_whisper_rejects_prompt_metadata_as_invalid_input() {
     assert!(
         error.to_string().contains("prompt"),
         "error should name the rejected parameter: {error}"
+    );
+    assert!(
+        !error.to_string().contains(private_prompt),
+        "error must not expose the rejected prompt: {error}"
     );
 }


### PR DESCRIPTION
## Summary

- stop embedding rejected Whisper `prompt` content in `AdapterError::InvalidInput`
- avoid retaining unsupported `language` values in `WhisperError`
- preserve bounded diagnostics using the parameter name and UTF-8 byte length
- add unit and real-runtime regressions proving request values do not appear in surfaced errors

## Root cause

The Candle Whisper adapter formatted caller-controlled transcription metadata directly into error display strings. Those strings propagate through Xybrid runtime errors and may be persisted by SDK telemetry or downstream service logging.

## Impact

Unsupported inputs retain the same error classification and remain actionable for operators, but private request content no longer escapes into error or logging pipelines.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p xybrid-core --features "ort-download,candle" --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download`
- `cargo test -p xybrid-core --features "ort-download,candle" --lib --tests`
- targeted Whisper real-model integration test
