### PR TITLE
fix(unity): make staged Bazel natives writable

### DIFF
--- a/tools/scripts/stage_unity_native.py
+++ b/tools/scripts/stage_unity_native.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import shutil
+import stat
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -193,6 +194,8 @@ def copy_file(source: Path, destination: Path) -> None:
     temporary = destination.with_name(f".{destination.name}.tmp")
     try:
         shutil.copy2(source, temporary)
+        # Bazel outputs are read-only, but release packaging strips this copy.
+        temporary.chmod(temporary.stat().st_mode | stat.S_IWUSR)
         temporary.replace(destination)
     finally:
         temporary.unlink(missing_ok=True)

--- a/tools/scripts/tests/test_stage_unity_native.py
+++ b/tools/scripts/tests/test_stage_unity_native.py
@@ -1,3 +1,4 @@
+import stat
 import sys
 import tempfile
 import unittest
@@ -11,6 +12,26 @@ from stage_unity_native import stage_native
 
 
 class StageUnityNativeTests(unittest.TestCase):
+    def test_staged_native_is_owner_writable(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            native = root / "bazel-bin" / "libxybrid_bolt.so"
+            native.parent.mkdir()
+            native.write_bytes(b"linux-native")
+            native.chmod(0o555)
+
+            destination = stage_native(
+                native,
+                "x86_64-unknown-linux-gnu",
+                plugins_root=root / "Plugins",
+            )
+
+            self.assertNotEqual(
+                0,
+                destination.stat().st_mode & stat.S_IWUSR,
+                "staged natives must be writable by post-processing tools",
+            )
+
     def test_macos_native_is_staged_with_editor_enabled_metadata(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)


### PR DESCRIPTION
## Summary

- make staged Bazel outputs owner-writable before Unity release post-processing
- cover read-only Bazel inputs with a regression test
- unblock Linux, macOS, and iOS strip steps in Unity packaging

## Verification

- `python3 -m unittest discover -s tools/scripts/tests -p 'test_*.py'`\n- `cargo fmt --all -- --check`\n- `cargo clippy --workspace --all-targets -- -D warnings`\n- `CARGO_INCREMENTAL=0 cargo test --workspace --features ort-download`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to the Unity staging copy path plus a unit test; no auth, data, or runtime inference behavior.
> 
> **Overview**
> Unity release packaging runs **strip** and other post-processing on staged native plugins; **Bazel-built artifacts are read-only**, so those steps were failing on Linux, macOS, and iOS.
> 
> `copy_file` in `stage_unity_native.py` now sets **owner write** on the temp copy before atomically replacing the destination, so staged files in `Runtime/Plugins` are writable without changing Bazel outputs. A regression test stages a `0o555` `.so` and asserts the result has `S_IWUSR`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f4e1898c41af2176aafc51f36147fee704feaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->