### PR TITLE
fix(docs): update the Kotlin examples in README

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -178,7 +178,7 @@ dependencies {
 **モデルを実行:**
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
+val model = XybridModel("kokoro-82m")
 val result = model.run(Envelope.text("Hello world"))
 // result → 24kHz WAVオーディオ
 ```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ dependencies {
 **Run a model:**
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
+val model = XybridModel("kokoro-82m")
 val result = model.run(Envelope.text("Hello world"))
 // result → 24kHz WAV audio
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,7 +178,7 @@ dependencies {
 **运行模型：**
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
+val model = XybridModel("kokoro-82m)
 val result = model.run(Envelope.text("国破山河在，城春草木深"))
 // 输出 → 24kHz WAV 音频
 ```


### PR DESCRIPTION
Updated the Kotlin exmaples in README to stop using the removed XybridModelLoader

## Summary

Fixes the remaining Kotlin examples in all three language READMEs that uses the old Kotlin `XybridModelLoader`.

## What I didn't do

I did not touch any of the swift docs, which still uses `ModelLoader`. I will leave that for another day, probably should finish #337.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [ ] Tests pass (`cargo test`)
- [ ] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)
