### PR TITLE
docs: expand Bazel CI evidence across SDK targets

### DIFF
--- a/docs/assets/bazel-ci-build-times.svg
+++ b/docs/assets/bazel-ci-build-times.svg
@@ -1,64 +1,87 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
-  <title id="title">Bazel and remote execution cut native CI build times</title>
-  <desc id="desc">Grouped horizontal bars compare median successful first-party pull request runs before and after the Bazel remote execution cutover. Android native build time fell from 31.5 to 1.8 minutes. The full end-to-end gate fell from 43.8 to 12.0 minutes.</desc>
-  <defs>
-    <linearGradient id="afterGradient" x1="0" x2="1">
-      <stop offset="0" stop-color="#19a7ff"/>
-      <stop offset="1" stop-color="#58e3c3"/>
-    </linearGradient>
-    <filter id="softGlow" x="-20%" y="-80%" width="140%" height="260%">
-      <feGaussianBlur stdDeviation="9" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-  </defs>
-  <rect width="1600" height="900" fill="#090e1a"/>
-  <circle cx="1440" cy="-20" r="310" fill="#102b48" opacity="0.42"/>
-  <circle cx="1510" cy="20" r="180" fill="#113b37" opacity="0.34"/>
+  <title id="title">Measured build times grouped by SDK and platform</title>
+  <desc id="desc">Black headers group measured SDKs. Green bars show Bazel build time by platform, while labels show Cargo to Bazel minutes and the percentage change. React Native Android, Kotlin Android, Unity Windows, and three CLI platforms became faster. The uncached Apple XCFramework became ten percent slower.</desc>
+  <rect width="1600" height="900" fill="#ffffff"/>
   <g font-family="Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
-    <text x="90" y="100" fill="#f7f9fc" font-size="52" font-weight="700">Bazel + RBE cut native CI build times</text>
-    <text x="90" y="148" fill="#9ca9ba" font-size="24">Median successful first-party PR runs · minutes</text>
-    <g font-size="20" font-weight="600">
-      <rect x="1120" y="97" width="24" height="24" rx="6" fill="#48566a"/>
-      <text x="1158" y="117" fill="#dce3ec">Before</text>
-      <rect x="1280" y="97" width="24" height="24" rx="6" fill="url(#afterGradient)"/>
-      <text x="1318" y="117" fill="#dce3ec">After</text>
+    <text x="60" y="78" fill="#050505" font-size="52" font-weight="800">BUILD TIME BY SDK / PLATFORM</text>
+    <text x="60" y="120" fill="#3f3f46" font-size="24">Framework → platform · Cargo before, Bazel after · lower is better</text>
+
+    <g font-size="17" font-weight="700">
+      <rect x="60" y="145" width="56" height="22" fill="#050505"/>
+      <text x="128" y="163" fill="#18181b">FRAMEWORK</text>
+      <rect x="270" y="145" width="56" height="22" fill="#16a34a"/>
+      <text x="338" y="163" fill="#18181b">BAZEL PLATFORM TIME</text>
+      <text x="830" y="163" fill="#71717a" font-weight="500">Green bars share a 0–20 minute scale</text>
     </g>
-    <g stroke="#253044" stroke-width="1">
-      <line x1="470" y1="218" x2="470" y2="708"/><line x1="668" y1="218" x2="668" y2="708"/>
-      <line x1="866" y1="218" x2="866" y2="708"/><line x1="1064" y1="218" x2="1064" y2="708"/>
-      <line x1="1262" y1="218" x2="1262" y2="708"/><line x1="1460" y1="218" x2="1460" y2="708"/>
-    </g>
-    <g fill="#718096" font-size="17" text-anchor="middle">
-      <text x="470" y="205">0</text><text x="668" y="205">10</text><text x="866" y="205">20</text>
-      <text x="1064" y="205">30</text><text x="1262" y="205">40</text><text x="1460" y="205">50 min</text>
-    </g>
-    <text x="90" y="326" fill="#f3f6fa" font-size="27" font-weight="700">Android native build</text>
-    <text x="90" y="360" fill="#8592a5" font-size="19">Bazel AAR + native libraries</text>
-    <text x="438" y="304" fill="#a8b2c1" font-size="19" font-weight="600" text-anchor="end">Before</text>
-    <rect x="470" y="270" width="623" height="48" rx="12" fill="#48566a"/>
-    <text x="1112" y="304" fill="#f4f7fb" font-size="25" font-weight="700">31.5 min</text>
-    <text x="438" y="384" fill="#a8b2c1" font-size="19" font-weight="600" text-anchor="end">After</text>
-    <rect x="470" y="350" width="36" height="48" rx="12" fill="url(#afterGradient)" filter="url(#softGlow)"/>
-    <text x="526" y="384" fill="#f4f7fb" font-size="25" font-weight="700">1.8 min</text>
-    <text x="1315" y="383" fill="#58e3c3" font-size="26" font-weight="700">−94%</text>
-    <text x="1315" y="410" fill="#9ca9ba" font-size="17">17.5× faster</text>
-    <text x="90" y="566" fill="#f3f6fa" font-size="27" font-weight="700">Full end-to-end gate</text>
-    <text x="90" y="600" fill="#8592a5" font-size="19">Native build → Maven → Expo APK</text>
-    <text x="438" y="544" fill="#a8b2c1" font-size="19" font-weight="600" text-anchor="end">Before</text>
-    <rect x="470" y="510" width="867" height="48" rx="12" fill="#48566a"/>
-    <text x="1356" y="544" fill="#f4f7fb" font-size="25" font-weight="700">43.8 min</text>
-    <text x="438" y="624" fill="#a8b2c1" font-size="19" font-weight="600" text-anchor="end">After</text>
-    <rect x="470" y="590" width="240" height="48" rx="12" fill="url(#afterGradient)" filter="url(#softGlow)"/>
-    <text x="730" y="624" fill="#f4f7fb" font-size="25" font-weight="700">12.0 min</text>
-    <text x="1315" y="623" fill="#58e3c3" font-size="26" font-weight="700">−72%</text>
-    <text x="1315" y="650" fill="#9ca9ba" font-size="17">3.6× faster</text>
-    <line x1="90" y1="752" x2="1510" y2="752" stroke="#253044" stroke-width="1"/>
-    <text x="90" y="802" fill="#6fd5ff" font-size="18" font-weight="700" letter-spacing="1.5">MIGRATION-MONTH CONTEXT</text>
-    <text x="425" y="802" fill="#f3f6fa" font-size="23" font-weight="700">+32%</text>
-    <text x="500" y="802" fill="#9ca9ba" font-size="20">workflow runs</text>
-    <text x="720" y="802" fill="#f3f6fa" font-size="23" font-weight="700">+22%</text>
-    <text x="795" y="802" fill="#9ca9ba" font-size="20">runner minutes</text>
-    <text x="1510" y="802" fill="#9ca9ba" font-size="18" text-anchor="end">More CI ran; each migrated build got faster.</text>
-    <text x="90" y="858" fill="#718096" font-size="17">Before: Jul 15–20, n=16 · After: Jul 22–31, n=26 · Bots and forks excluded because the RBE credential is unavailable</text>
+
+    <!-- Left column: React Native, Kotlin, Unity -->
+    <rect x="60" y="195" width="700" height="48" fill="#050505"/>
+    <text x="78" y="228" fill="#ffffff" font-size="26" font-weight="800">REACT NATIVE</text>
+    <text x="84" y="282" fill="#18181b" font-size="21" font-weight="700">ANDROID</text>
+    <rect x="270" y="258" width="54" height="34" fill="#16a34a"/>
+    <text x="340" y="282" fill="#18181b" font-size="21" font-weight="700">31.5 → 1.8 min</text>
+    <text x="680" y="282" fill="#15803d" font-size="22" font-weight="800" text-anchor="end">−94%</text>
+
+    <line x1="60" y1="315" x2="760" y2="315" stroke="#d4d4d8"/>
+    <rect x="60" y="335" width="700" height="48" fill="#050505"/>
+    <text x="78" y="368" fill="#ffffff" font-size="26" font-weight="800">KOTLIN SDK</text>
+    <text x="84" y="422" fill="#18181b" font-size="21" font-weight="700">ANDROID</text>
+    <rect x="270" y="398" width="84" height="34" fill="#16a34a"/>
+    <text x="370" y="422" fill="#18181b" font-size="21" font-weight="700">31.1 → 4.4 min</text>
+    <text x="680" y="422" fill="#15803d" font-size="22" font-weight="800" text-anchor="end">−86%</text>
+
+    <line x1="60" y1="455" x2="760" y2="455" stroke="#d4d4d8"/>
+    <rect x="60" y="475" width="700" height="48" fill="#050505"/>
+    <text x="78" y="508" fill="#ffffff" font-size="26" font-weight="800">UNITY SDK</text>
+    <text x="84" y="562" fill="#18181b" font-size="21" font-weight="700">WINDOWS</text>
+    <rect x="270" y="538" width="40" height="34" fill="#16a34a"/>
+    <text x="326" y="562" fill="#18181b" font-size="21" font-weight="700">12.5 → 2.1 min</text>
+    <text x="680" y="562" fill="#15803d" font-size="22" font-weight="800" text-anchor="end">−83%</text>
+
+    <!-- Right column: CLI and Swift -->
+    <rect x="830" y="195" width="710" height="48" fill="#050505"/>
+    <text x="848" y="228" fill="#ffffff" font-size="26" font-weight="800">CLI</text>
+    <text x="854" y="280" fill="#18181b" font-size="20" font-weight="700">WINDOWS</text>
+    <rect x="1050" y="256" width="67" height="32" fill="#16a34a"/>
+    <text x="1133" y="280" fill="#18181b" font-size="20" font-weight="700">11.2 → 3.5 min</text>
+    <text x="1510" y="280" fill="#15803d" font-size="21" font-weight="800" text-anchor="end">−69%</text>
+
+    <text x="854" y="326" fill="#18181b" font-size="20" font-weight="700">LINUX</text>
+    <rect x="1050" y="302" width="64" height="32" fill="#16a34a"/>
+    <text x="1130" y="326" fill="#18181b" font-size="20" font-weight="700">8.8 → 3.4 min</text>
+    <text x="1510" y="326" fill="#15803d" font-size="21" font-weight="800" text-anchor="end">−62%</text>
+
+    <text x="854" y="372" fill="#18181b" font-size="20" font-weight="700">MACOS</text>
+    <rect x="1050" y="348" width="80" height="32" fill="#16a34a"/>
+    <text x="1146" y="372" fill="#18181b" font-size="20" font-weight="700">8.5 → 4.2 min</text>
+    <text x="1510" y="372" fill="#15803d" font-size="21" font-weight="800" text-anchor="end">−51%</text>
+
+    <line x1="830" y1="405" x2="1540" y2="405" stroke="#d4d4d8"/>
+    <rect x="830" y="425" width="710" height="48" fill="#050505"/>
+    <text x="848" y="458" fill="#ffffff" font-size="26" font-weight="800">SWIFT SDK</text>
+    <text x="854" y="512" fill="#18181b" font-size="20" font-weight="700">XCFRAMEWORK</text>
+    <rect x="1050" y="488" width="376" height="34" fill="#16a34a"/>
+    <text x="1058" y="511" fill="#ffffff" font-size="19" font-weight="800">18.0 → 19.8 min</text>
+    <text x="1440" y="512" fill="#c2413b" font-size="19" font-weight="800">+10% SLOWER</text>
+
+    <!-- Shared axes -->
+    <line x1="270" y1="620" x2="650" y2="620" stroke="#18181b" stroke-width="2"/>
+    <line x1="270" y1="614" x2="270" y2="626" stroke="#18181b" stroke-width="2"/>
+    <line x1="650" y1="614" x2="650" y2="626" stroke="#18181b" stroke-width="2"/>
+    <text x="270" y="650" fill="#52525b" font-size="17" text-anchor="middle">0</text>
+    <text x="650" y="650" fill="#52525b" font-size="17" text-anchor="middle">20 min</text>
+
+    <line x1="1050" y1="620" x2="1430" y2="620" stroke="#18181b" stroke-width="2"/>
+    <line x1="1050" y1="614" x2="1050" y2="626" stroke="#18181b" stroke-width="2"/>
+    <line x1="1430" y1="614" x2="1430" y2="626" stroke="#18181b" stroke-width="2"/>
+    <text x="1050" y="650" fill="#52525b" font-size="17" text-anchor="middle">0</text>
+    <text x="1430" y="650" fill="#52525b" font-size="17" text-anchor="middle">20 min</text>
+
+    <!-- Method and scope -->
+    <line x1="60" y1="700" x2="1540" y2="700" stroke="#a1a1aa"/>
+    <text x="60" y="744" fill="#18181b" font-size="20" font-weight="700">HOW TO READ THIS</text>
+    <text x="280" y="744" fill="#3f3f46" font-size="19">Black = SDK grouping. Green length = Bazel time. Labels show Cargo → Bazel.</text>
+    <text x="60" y="790" fill="#52525b" font-size="18">React Native: medians from 16 before and 26 after runs. Kotlin, CLI, Swift: v0.3 → v0.4 release build steps. Unity: one successful build-step comparison.</text>
+    <text x="60" y="832" fill="#71717a" font-size="17">Flutter and Rust SDK omitted because the sampled CI history has no like-for-like Cargo baseline. Full method and source runs: docs/why-bazel.md</text>
   </g>
 </svg>

--- a/docs/why-bazel.md
+++ b/docs/why-bazel.md
@@ -1,18 +1,19 @@
-# Why xybrid moved native CI to Bazel
+# Why xybrid moved its cross-platform builds to Bazel
 
-xybrid has one Rust execution engine, several native dependencies, six foreign-language
-surfaces, and release artifacts for Linux, macOS, iOS, Android, and Windows. We moved
-the expensive native artifact builds to Bazel because rebuilding that graph separately
-for every SDK and target had become the slowest and least reproducible part of CI.
+xybrid ships one Rust engine through React Native, Unity, Flutter, Apple, Android,
+desktop, and web SDKs. Those surfaces all depend on overlapping Rust crates, C/C++
+libraries, generated bindings, and platform toolchains. Before Bazel, separate scripts
+rebuilt much of that graph for each SDK and target.
 
-The measured result on the React Native Android end-to-end gate:
+Bazel gave us one reproducible graph for the whole platform matrix. On one of our
+heaviest cold-build gates, the measured result was:
 
 - median native build time fell from **31.48 to 1.79 minutes** (**94.3% less time**,
   or **17.5× faster**);
 - median total job time fell from **43.77 to 12.04 minutes** (**72.5% less time**,
   or **3.6× faster**).
 
-![Bazel and remote execution cut native CI build times](assets/bazel-ci-build-times.svg)
+![Measured build times grouped by SDK and platform](assets/bazel-ci-build-times.svg)
 
 Those are medians from successful, first-party pull-request runs immediately before
 and after the remote-execution cutover. The exact sample and limitations are documented
@@ -24,10 +25,11 @@ below.
 
 The core implementation is Rust, but the shipped surface is larger:
 
+- React Native for iOS and Android;
 - Swift for Apple platforms;
 - Kotlin and Java for Android;
-- C# for Unity;
-- Dart for Flutter;
+- C# and native plugins for Unity;
+- Dart and native libraries for Flutter;
 - JavaScript/Wasm for the web;
 - the Rust CLI and SDK.
 
@@ -39,6 +41,20 @@ artifacts from one dependency graph instead.
 Examples include the Android AAR, Apple XCFramework, Flutter native libraries, Unity
 libraries, and desktop CLI binaries. The PR and release workflows now call the same
 Bazel targets rather than maintaining separate build recipes for the same payload.
+
+### What moved into the shared graph
+
+| Surface | Artifacts built from the Bazel graph |
+|---|---|
+| React Native | Android AAR and Apple XCFramework |
+| Unity | Android, iOS, macOS, Linux, and Windows plugins |
+| Flutter | Android, iOS, macOS, Linux, and Windows native libraries |
+| Apple | XCFramework and macOS CLI |
+| Android | Three-ABI AAR with Kotlin bindings |
+| Desktop | Linux, macOS, and Windows CLI binaries |
+
+The SDKs still have their own packaging and consumer tests. What changed is the costly
+layer underneath them: they now ask the same graph for the same native artifacts.
 
 ### The toolchains are part of the build
 
@@ -52,8 +68,13 @@ installed on a hosted runner.
 
 ### Remote execution attacks the expensive part
 
-The old Android path compiled roughly 1,900 Rust compile units across its targets, plus
-`llama.cpp`, locally on a GitHub-hosted runner. With Bazel remote execution and a shared
+Linux-compatible actions run on remote workers and share cached outputs across
+workflows. That covers the common Rust graph, `llama.cpp`, Android, Linux, and
+cross-compiled Windows and macOS CPU artifacts. A workflow that needs one of those
+outputs can reuse it instead of starting another build from scratch.
+
+The measured cold-build path previously compiled roughly 1,900 Rust compile units plus
+`llama.cpp` on a GitHub-hosted runner. With Bazel remote execution and a shared
 BuildBuddy cache, the runner coordinates the build while cache hits and compile actions
 happen on remote workers.
 
@@ -114,6 +135,44 @@ The cutover merged on 21 July 2026 in
 
 Medians, rather than the two representative runs, are used for the headline numbers.
 
+### Release artifact build steps across SDKs
+
+The release pipeline supplies successful Cargo-era and Bazel-era build-step comparisons
+for more of the shipped surface:
+
+| SDK / artifact | Cargo-era step | Bazel-era step | Change |
+|---|---:|---:|---:|
+| Kotlin / Android native libraries | 31.07 min | 4.35 min | 86.0% faster |
+| CLI / Windows | 11.22 min | 3.47 min | 69.1% faster |
+| CLI / Linux | 8.80 min | 3.35 min | 61.9% faster |
+| CLI / macOS | 8.48 min | 4.18 min | 50.7% faster |
+| Swift / Apple XCFramework | 18.00 min | 19.78 min | 9.9% slower |
+
+These are individual build steps from the successful
+[v0.3.0 Cargo-era release-prep run](https://github.com/xybrid-ai/xybrid/actions/runs/28878515208)
+and the successful
+[v0.4.0 Bazel-era release-prep run](https://github.com/xybrid-ai/xybrid/actions/runs/30665717715).
+They are useful directional comparisons, not controlled benchmarks or medians: the two
+releases contain different code, features, and cache states.
+
+The Apple result is included because the slower row matters. Its XCFramework still
+builds locally on macOS without shared remote caching. Flutter is omitted from the
+comparison because its older release step could reuse precompiled outputs, so it does
+not provide a like-for-like Cargo baseline.
+
+### A second signal from Unity on Windows
+
+The Unity Windows native build provides another, smaller data point. In the v0.3.0
+workflow, the Cargo build step took 12.53 minutes. After that artifact moved to Bazel
+remote execution, the Bazel build-and-stage step took 2.10 minutes: an 83.2% reduction,
+or 6.0× faster.
+
+This is a one-run comparison, not a median, so it is supporting evidence rather than a
+headline claim. The Windows job itself succeeded in the later run, although unrelated
+Apple, Android, and Linux jobs made that overall workflow fail. See the
+[before run](https://github.com/xybrid-ai/xybrid/actions/runs/28887733637) and
+[after run](https://github.com/xybrid-ai/xybrid/actions/runs/30566931790).
+
 ### Why total CI usage still increased
 
 The migration month ran much more CI than the preceding month:
@@ -148,8 +207,10 @@ above.
   excluded from the after sample.
 - The Apple XCFramework gate is currently a local, uncached Bazel build. Recent runs are
   commonly around 17–24 minutes; adding shared remote caching is follow-up work.
-- The headline measurement applies to the React Native Android native-build path. It is
-  evidence for that migrated path, not a claim that every CI job became 72% faster.
+- The headline medians come from one end-to-end gate. They prove the result on that
+  measured path, not a uniform 72% reduction for every platform.
+- The release and Unity comparisons use individual successful build steps, not medians.
+  They show direction and magnitude but are not controlled benchmarks.
 - The June/July comparison measures GitHub-hosted runner usage. It does not include the
   external cost or worker time of remote execution.
 
@@ -212,6 +273,28 @@ results_minutes:
     after_median: 12.04
     reduction_percent: 72.5
     speedup: 3.6
+release_build_steps_minutes:
+  source_runs:
+    cargo_era: https://github.com/xybrid-ai/xybrid/actions/runs/28878515208
+    bazel_era: https://github.com/xybrid-ai/xybrid/actions/runs/30665717715
+  kotlin_android:
+    cargo: 31.07
+    bazel: 4.35
+  cli_windows:
+    cargo: 11.22
+    bazel: 3.47
+  cli_linux:
+    cargo: 8.80
+    bazel: 3.35
+  cli_macos:
+    cargo: 8.48
+    bazel: 4.18
+  swift_xcframework:
+    cargo: 18.00
+    bazel: 19.78
+unity_windows_build_step_minutes:
+  cargo: 12.53
+  bazel: 2.10
 migration_month_context:
   workflow_runs_change_percent: 31.6
   hosted_runner_minutes_change_percent: 21.5
@@ -219,6 +302,8 @@ migration_month_context:
   github_actions_amount_billed_usd: 0
 caveats:
   - The result is specific to the measured Android path.
+  - Release and Unity rows are single-run comparisons, not medians.
+  - Flutter has no comparable Cargo baseline in the sampled release runs.
   - Fork and Dependabot runs cannot use the RBE credential.
   - GitHub Actions figures exclude BuildBuddy usage.
   - The Apple XCFramework Bazel gate is not yet remote-cached.


### PR DESCRIPTION
## Summary

This pull request expands the Bazel migration note from one Android measurement into an auditable cross-SDK story while keeping every claim scoped to the available CI evidence. It adds release build-step comparisons for Kotlin, the Linux/macOS/Windows CLI, Swift, and Unity; records the slower uncached Apple result; and replaces the original graph with a framework-to-platform visualization containing only measured rows.

**Documentation and evidence:**

- Adds direct Actions run links, exact Cargo-era and Bazel-era step timings, methodology, and caveats for median versus single-run comparisons.
- Explains why Flutter and the Rust SDK are excluded from the performance graph when no like-for-like Cargo baseline exists.

**Visualization:**

- Replaces the two-row chart with a white-background SVG grouped by SDK in black and measured platform results in green.
- Shows the Apple XCFramework regression in red instead of hiding it.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [x] Tests pass (`cargo test --workspace --features ort-download`)
- [x] Code follows project style
- [x] Documentation updated
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static SVG only; no build, CI, or application code changes.
> 
> **Overview**
> Expands the Bazel migration note from a single Android gate into a cross-SDK, auditable story while tightening how each claim is scoped.
> 
> **`docs/why-bazel.md`** reframes the intro around the full SDK matrix, adds a table of what moved into the shared Bazel graph, and broadens the remote-execution section beyond the old Android-only narrative. New sections document **release-prep build-step** Cargo vs Bazel timings (Kotlin Android, CLI on three OSes, Swift XCFramework), a **Unity Windows** one-run comparison, and explicit omissions (Flutter, Rust) where there is no like-for-like Cargo baseline. Limitations and the agent-readable YAML block are updated with release/Unity figures, caveats, and Actions run links.
> 
> **`docs/assets/bazel-ci-build-times.svg`** replaces the dark two-row “before/after” chart with a white, SDK-grouped layout: green bars for measured Bazel platform times, Cargo→Bazel labels and % change, and the **Apple XCFramework +10% slower** row in red instead of hiding it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f621df68e89dce8026dfaf288faab0c2d787c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->