### PR TITLE
build(llama-sys): declare links = "llama" on xybrid-llama-sys

### DIFF
--- a/crates/llama-cpp-sys/Cargo.toml
+++ b/crates/llama-cpp-sys/Cargo.toml
@@ -5,6 +5,14 @@ edition.workspace = true
 license = "MIT"
 repository.workspace = true
 description = "Raw FFI bindings to llama.cpp. Build-time clones + cmake-compiles the pinned upstream commit; first-party C++ shim lives in wrapper.cpp."
+# Declares the native library this crate links. Cargo permits exactly one
+# package per dependency graph to claim a given `links` name, so a consumer
+# that pulls both this crate and another llama.cpp binding (e.g. crates.io's
+# `llama-cpp-sys-2`, which also claims `llama`) now fails resolution with a
+# clear conflict instead of silently static-linking two copies of the same
+# ggml/llama archives into one binary. Name matches `llama-cpp-sys-2`'s on
+# purpose — a distinct name would hide exactly the collision we want caught.
+links = "llama"
 
 # The llama.cpp source tree (~180MB) is fetched via the workspace-level
 # submodule consumed by build.rs (`vendor/llama-cpp/`). This path does not live under this


### PR DESCRIPTION
This pull request declares the native library that `xybrid-llama-sys` links, so Cargo can detect a conflict when a consumer pulls two llama.cpp bindings into one dependency graph. Cargo permits exactly one package per graph to claim a given `links` name; without the key, a graph containing both this crate and crates.io's `llama-cpp-sys-2` resolves cleanly and then static-links two copies of the same ggml/llama archives into one binary.

**Build Configuration:**

* Added `links = "llama"` to `crates/llama-cpp-sys/Cargo.toml`, turning that collision into a resolution-time error naming both packages instead of a duplicate-symbol link failure — or worse, a silent single-copy pick where two sets of Rust bindings built against different upstream commits and cmake flags share one ggml backend registry.
* Matched `llama-cpp-sys-2`'s `links` name deliberately. A distinct name would let both crates coexist and hide the exact collision this is meant to catch.

**Impact:**

* No compile- or link-time effect — output binaries are unchanged, and the Bazel target never reads the manifest.
* Sets up `DEP_LLAMA_*` forwarding to dependents' build scripts. Unused today, since `build.rs` only emits `rustc-link-*` and `rerun-if-*`, which are not forwarded.

## Checklist

- [x] `cargo metadata` resolves the full workspace graph
- [x] `cargo check -p xybrid-llama-sys` passes
- [x] No other llama.cpp binding in `Cargo.lock`, so nothing in-tree conflicts today
- [x] No breaking changes
