### PR TITLE
feat(react-native): expose GBNF grammar constraint + jsonSchemaToGbnf

### DIFF
--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -124,6 +124,28 @@ console.log(result.text);
 await model.unload();
 ```
 
+### Structured output (JSON Schema / GBNF)
+
+Constrain a local LLM to schema-valid JSON by setting
+`generationConfig.grammar` — produce a grammar from a JSON Schema with
+`jsonSchemaToGbnf()` (the same native converter every other binding uses), or
+pass raw GBNF. Local llama backend only.
+
+```ts
+import { jsonSchemaToGbnf } from 'react-native-xybrid';
+
+const grammar = await jsonSchemaToGbnf({
+  type: 'object',
+  properties: { name: { type: 'string' }, total: { type: 'number' } },
+  required: ['name', 'total'],
+});
+const result = await model.run(
+  { kind: 'text', text: 'Extract: 2x espresso, 8.40 EUR total' },
+  { generationConfig: { grammar, maxTokens: 128 } },
+);
+JSON.parse(result.text!); // guaranteed schema-valid
+```
+
 ### Streaming
 
 `model.runStreaming()` returns an async generator that yields each token as it

--- a/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
+++ b/bindings/react-native/android/src/main/java/ai/xybrid/reactnative/XybridModule.kt
@@ -27,6 +27,7 @@ import ai.xybrid.clearBatteryLevel
 import ai.xybrid.clearThermalState
 import ai.xybrid.embedding
 import ai.xybrid.initSdkCacheDir
+import ai.xybrid.jsonSchemaToGbnf
 import ai.xybrid.reasoningContent
 import ai.xybrid.setBatteryLevel
 import ai.xybrid.setBinding
@@ -346,6 +347,21 @@ class XybridModule(reactContext: ReactApplicationContext) :
     promise.resolve(null)
   }
 
+  // -- Utilities --
+
+  @ReactMethod
+  fun jsonSchemaToGbnf(schemaJson: String, promise: Promise) {
+    try {
+      // Shared JSON-Schema→GBNF converter from the bolt bindings. Fast (pure
+      // string transform), so no coroutine hop is needed.
+      promise.resolve(jsonSchemaToGbnf(schemaJson))
+    } catch (e: XybridError) {
+      rejectXybrid(promise, e)
+    } catch (t: Throwable) {
+      promise.reject("xybrid", t.message, t)
+    }
+  }
+
   // MARK: - Helpers
 
   private fun runLoad(promise: Promise, factory: suspend () -> XybridModel) {
@@ -492,6 +508,7 @@ class XybridModule(reactContext: ReactApplicationContext) :
       topK = uintOrNull("topK"),
       repetitionPenalty = floatOrNull("repetitionPenalty"),
       stopSequences = stops,
+      grammar = if (map.hasKey("grammar") && !map.isNull("grammar")) map.getString("grammar") else null,
     )
   }
 

--- a/bindings/react-native/ios/XybridModule.mm
+++ b/bindings/react-native/ios/XybridModule.mm
@@ -174,6 +174,15 @@ RCT_REMAP_METHOD(clearThermalState,
   [_impl clearThermalState:resolve reject:reject];
 }
 
+#pragma mark - Utilities
+
+RCT_REMAP_METHOD(jsonSchemaToGbnf,
+                 jsonSchemaToGbnf:(NSString *)schemaJson
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  [_impl jsonSchemaToGbnf:schemaJson resolve:resolve reject:reject];
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params {

--- a/bindings/react-native/ios/XybridModuleImpl.swift
+++ b/bindings/react-native/ios/XybridModuleImpl.swift
@@ -306,6 +306,23 @@ public final class XybridModuleImpl: NSObject {
     resolve(nil)
   }
 
+  // -- Utilities --
+
+  @objc public func jsonSchemaToGbnf(_ schemaJson: String,
+                                     resolve: @escaping RCTPromiseResolveBlock,
+                                     reject: @escaping RCTPromiseRejectBlock) {
+    do {
+      // Free function from xybrid_bolt.swift; the shared JSON-Schema→GBNF
+      // converter every binding uses. Fast (pure string transform), so no
+      // Task.detached hop is needed.
+      resolve(try jsonSchemaToGbnf(schemaJson: schemaJson))
+    } catch let error as XybridError {
+      rejectXybrid(error, reject)
+    } catch {
+      reject("xybrid", error.localizedDescription, error)
+    }
+  }
+
   // MARK: - Helpers
 
   private func lookup(_ handle: String) -> XybridModel? {
@@ -441,7 +458,8 @@ public final class XybridModuleImpl: NSObject {
       minP: (dict["minP"] as? NSNumber)?.floatValue,
       topK: uint32OrNil("topK"),
       repetitionPenalty: (dict["repetitionPenalty"] as? NSNumber)?.floatValue,
-      stopSequences: dict["stopSequences"] as? [String] ?? []
+      stopSequences: dict["stopSequences"] as? [String] ?? [],
+      grammar: dict["grammar"] as? String
     )
   }
 

--- a/bindings/react-native/src/NativeXybrid.ts
+++ b/bindings/react-native/src/NativeXybrid.ts
@@ -66,6 +66,12 @@ export interface Spec extends TurboModule {
   clearBatteryLevel(): Promise<void>;
   setThermalState(state: string): Promise<void>;
   clearThermalState(): Promise<void>;
+
+  // -- Utilities --
+  // Convert a JSON Schema (as a JSON string) into a GBNF grammar for
+  // `GenerationConfig.grammar`. Rejects on invalid JSON or an unsupported
+  // schema construct.
+  jsonSchemaToGbnf(schemaJson: string): Promise<string>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNXybrid');

--- a/bindings/react-native/src/index.ts
+++ b/bindings/react-native/src/index.ts
@@ -29,6 +29,28 @@ export type {
 
 export { GenerationConfigs, creative, greedy } from './presets';
 
+/**
+ * Convert a JSON Schema (as an object or JSON string) into a GBNF grammar for
+ * {@link GenerationConfig.grammar}, so a local LLM emits schema-valid JSON.
+ *
+ * ```ts
+ * const grammar = await jsonSchemaToGbnf({
+ *   type: 'object',
+ *   properties: { name: { type: 'string' } },
+ *   required: ['name'],
+ * });
+ * const result = await model.run(envelope, { generationConfig: { grammar } });
+ * ```
+ *
+ * Rejects with a config error on invalid JSON or an unsupported schema
+ * construct. Conversion runs natively — the same converter every other
+ * binding uses.
+ */
+export function jsonSchemaToGbnf(schema: object | string): Promise<string> {
+  const json = typeof schema === 'string' ? schema : JSON.stringify(schema);
+  return NativeXybrid.jsonSchemaToGbnf(json);
+}
+
 // Keys that only appear on `RunOptions`, never on a bare `GenerationConfig`.
 // Used to tell the two apart when a caller passes either form to `run()`.
 const RUN_OPTION_KEYS = [

--- a/bindings/react-native/src/types.ts
+++ b/bindings/react-native/src/types.ts
@@ -38,6 +38,12 @@ export interface GenerationConfig {
   topK?: number;
   repetitionPenalty?: number;
   stopSequences?: string[];
+  /**
+   * Optional GBNF grammar constraining generation to structured output
+   * (local llama backend only). Produce one from a JSON Schema with
+   * {@link jsonSchemaToGbnf}, or pass raw GBNF.
+   */
+  grammar?: string;
 }
 
 /**


### PR DESCRIPTION
Closes the structured-output parity gap for React Native (#310/#311 reached Swift/Kotlin/C/Dart but not RN).

- `GenerationConfig.grammar` crosses the TurboModule boundary — both shims thread it onto bolt's `XybridGenerationConfig` (previously silently dropped)
- `jsonSchemaToGbnf()` exposed in JS — accepts an object or JSON string, converts natively via the shared converter
- Grammar failures ride the existing config-error path; no new error variant crosses the FFI
- README: structured-output section with receipt-extraction example

Verified: TS typecheck + build green. Swift/Kotlin shim changes follow existing overload patterns; compiled by the `build-react-native` CI gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e5c7b72cd74397548f4cea866b42f718142b5e64. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->