### PR TITLE
fix: restore explicit model loading across Swift and Kotlin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,6 +77,11 @@ let package = Package(
                 .linkedFramework("Security"),
             ]
         ),
+        .testTarget(
+            name: "XybridTests",
+            dependencies: ["Xybrid"],
+            path: "bindings/apple/Tests/XybridTests"
+        ),
         xybridFFITarget(),
     ]
 )

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -178,8 +178,8 @@ dependencies {
 **モデルを実行:**
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
-val result = model.run(Envelope.text("Hello world"))
+val model = Xybrid.model("kokoro-82m").load()
+val result = model.runAsync(Envelope.text("Hello world"))
 // result → 24kHz WAVオーディオ
 ```
 
@@ -196,8 +196,8 @@ dependencies: [
 **モデルを実行:**
 
 ```swift
-let model = try ModelLoader.fromRegistry(modelId: "kokoro-82m").load()
-let result = try model.run(envelope: Envelope.text("Hello world"))
+let model = try await Xybrid.model("kokoro-82m").load()
+let result = try await model.runAsync(envelope: Envelope.text("Hello world"))
 // result → 24kHz WAVオーディオ
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ dependencies {
 **Run a model:**
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
-val result = model.run(Envelope.text("Hello world"))
+val model = Xybrid.model("kokoro-82m").load()
+val result = model.runAsync(Envelope.text("Hello world"))
 // result → 24kHz WAV audio
 ```
 
@@ -184,8 +184,8 @@ dependencies: [
 **Run a model:**
 
 ```swift
-let model = try ModelLoader.fromRegistry(modelId: "kokoro-82m").load()
-let result = try model.run(envelope: Envelope.text("Hello world"))
+let model = try await Xybrid.model("kokoro-82m").load()
+let result = try await model.runAsync(envelope: Envelope.text("Hello world"))
 // result → 24kHz WAV audio
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,8 +178,8 @@ dependencies {
 **运行模型：**
 
 ```kotlin
-val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
-val result = model.run(Envelope.text("国破山河在，城春草木深"))
+val model = Xybrid.model("kokoro-82m").load()
+val result = model.runAsync(Envelope.text("国破山河在，城春草木深"))
 // 输出 → 24kHz WAV 音频
 ```
 
@@ -196,8 +196,8 @@ dependencies: [
 **运行模型：**
 
 ```swift
-let model = try ModelLoader.fromRegistry(modelId: "kokoro-82m").load()
-let result = try model.run(envelope: Envelope.text("国破山河在，城春草木深"))
+let model = try await Xybrid.model("kokoro-82m").load()
+let result = try await model.runAsync(envelope: Envelope.text("国破山河在，城春草木深"))
 // 输出 → 24kHz WAV 音频
 ```
 

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -37,8 +37,8 @@ Then add the dependency to your target:
 ```swift
 import Xybrid
 
-// Load a model from the registry (the initializer resolves + loads it)
-let model = try XybridModel(fromRegistry: "kokoro-82m")
+// Describing the source is cheap; load() is the explicit async boundary.
+let model = try await Xybrid.model("kokoro-82m").load()
 
 // Create an envelope for TTS
 let envelope = XybridEnvelope.text(
@@ -47,8 +47,8 @@ let envelope = XybridEnvelope.text(
     speed: 1.0
 )
 
-// Run inference
-let result = try model.run(envelope: envelope)
+// Run inference without blocking the caller's executor.
+let result = try await model.runAsync(envelope: envelope)
 
 // Access the result
 if result.success {
@@ -66,8 +66,8 @@ answer text and surfaces it on `reasoningContent` — `nil` for non-thinking
 models. Nothing to enable; just read it if you want it.
 
 ```swift
-let model = try XybridModel(fromRegistry: "lfm2.5-1.2b-thinking")
-let result = try model.run(envelope: XybridEnvelope.text(
+let model = try await Xybrid.model("lfm2.5-1.2b-thinking").load()
+let result = try await model.runAsync(envelope: XybridEnvelope.text(
     "Is 97 a prime number? Reason, then answer."))
 
 if let answer = result.text { print("Answer:", answer) }
@@ -78,7 +78,9 @@ if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
 
 | Type | Description |
 |------|-------------|
-| `XybridModel` | A loaded model ready for inference — construct via `XybridModel(fromRegistry:)`, `(fromBundle:)`, `(fromDirectory:)`, or `(fromHuggingface:)` |
+| `ModelSource` | Registry, bundle, directory, or Hugging Face model location |
+| `ModelLoader` | Cheap model reference; call `load()` to perform I/O |
+| `XybridModel` | A loaded model ready for inference |
 | `XybridEnvelope` | Input data container (audio, text, embedding, image, or multi-part user message) |
 | `XybridResult` | Inference result with success status and output data |
 | `XybridError` | Error enum for error handling |

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -146,6 +146,90 @@ public enum Xybrid {
     #endif
 }
 
+// MARK: - Model loading
+
+/// A model location that can be prepared without performing I/O.
+public enum ModelSource: Sendable, Equatable {
+    /// A model resolved through the Xybrid registry.
+    case registry(String)
+
+    /// A local `.xyb` model bundle.
+    case bundle(URL)
+
+    /// A local directory containing `model_metadata.json`.
+    case directory(URL)
+
+    /// A Hugging Face repository (`org/repo` or `org/repo:variant`).
+    case huggingFace(String)
+}
+
+/// A cheap model reference that defers all expensive work until ``load()``.
+///
+/// Creating a loader never performs network, disk, or native-runtime work.
+public struct ModelLoader: Sendable {
+    /// The source this loader will resolve.
+    public let source: ModelSource
+
+    /// Create a loader for an already-described source.
+    public init(source: ModelSource) {
+        self.source = source
+    }
+
+    /// Create a loader for a registry model.
+    public static func fromRegistry(_ id: String) -> Self {
+        Self(source: .registry(id))
+    }
+
+    /// Create a loader for a local `.xyb` bundle.
+    public static func fromBundle(_ url: URL) -> Self {
+        Self(source: .bundle(url))
+    }
+
+    /// Create a loader for a local model directory.
+    public static func fromDirectory(_ url: URL) -> Self {
+        Self(source: .directory(url))
+    }
+
+    /// Create a loader for a Hugging Face repository.
+    public static func fromHuggingFace(_ repo: String) -> Self {
+        Self(source: .huggingFace(repo))
+    }
+
+    /// Load the model without blocking the calling task's executor.
+    public func load() async throws -> XybridModel {
+        try await Task.detached { try loadSync() }.value
+    }
+
+    /// Load the model synchronously.
+    ///
+    /// This may resolve registry metadata, download files, access disk, and
+    /// initialize the inference runtime. Do not call it from the main actor.
+    public func loadSync() throws -> XybridModel {
+        switch source {
+        case .registry(let id):
+            return try XybridModel(fromRegistry: id)
+        case .bundle(let url):
+            return try XybridModel(fromBundle: url.path)
+        case .directory(let url):
+            return try XybridModel(fromDirectory: url.path)
+        case .huggingFace(let repo):
+            return try XybridModel(fromHuggingface: repo)
+        }
+    }
+}
+
+public extension Xybrid {
+    /// Describe a registry model without resolving, downloading, or loading it.
+    static func model(_ id: String) -> ModelLoader {
+        model(.registry(id))
+    }
+
+    /// Describe a model source without resolving, downloading, or loading it.
+    static func model(_ source: ModelSource) -> ModelLoader {
+        ModelLoader(source: source)
+    }
+}
+
 // MARK: - Public Type Re-exports
 
 /// A loaded model ready for inference.
@@ -185,23 +269,27 @@ public extension XybridModel {
 // off-thread is therefore the correct, low-risk way to surface async today.)
 public extension XybridModel {
     /// Load a model from the xybrid registry without blocking the caller.
+    @available(*, deprecated, message: "Use Xybrid.model(id).load()")
     static func fromRegistryAsync(_ id: String) async throws -> XybridModel {
-        try await Task.detached { try XybridModel(fromRegistry: id) }.value
+        try await Xybrid.model(id).load()
     }
 
     /// Load a model from a local directory without blocking the caller.
+    @available(*, deprecated, message: "Use Xybrid.model(.directory(url)).load()")
     static func fromDirectoryAsync(_ path: String) async throws -> XybridModel {
-        try await Task.detached { try XybridModel(fromDirectory: path) }.value
+        try await Xybrid.model(.directory(URL(fileURLWithPath: path))).load()
     }
 
     /// Load a model from a local `.xyb` bundle without blocking the caller.
+    @available(*, deprecated, message: "Use Xybrid.model(.bundle(url)).load()")
     static func fromBundleAsync(_ path: String) async throws -> XybridModel {
-        try await Task.detached { try XybridModel(fromBundle: path) }.value
+        try await Xybrid.model(.bundle(URL(fileURLWithPath: path))).load()
     }
 
     /// Resolve and load a model from a HuggingFace repo without blocking the caller.
+    @available(*, deprecated, message: "Use Xybrid.model(.huggingFace(repo)).load()")
     static func fromHuggingfaceAsync(_ repo: String) async throws -> XybridModel {
-        try await Task.detached { try XybridModel(fromHuggingface: repo) }.value
+        try await Xybrid.model(.huggingFace(repo)).load()
     }
 
     /// Run inference without blocking the calling thread or actor.

--- a/bindings/apple/Tests/XybridTests/ModelLoaderTests.swift
+++ b/bindings/apple/Tests/XybridTests/ModelLoaderTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+@testable import Xybrid
+
+final class ModelLoaderTests: XCTestCase {
+    func testRegistryShortcutCreatesUnloadedRegistryReference() {
+        let loader = Xybrid.model("kokoro-82m")
+
+        XCTAssertEqual(loader.source, .registry("kokoro-82m"))
+    }
+
+    func testTypedSourceCreatesUnloadedBundleReference() {
+        let url = URL(fileURLWithPath: "/models/kokoro.xyb")
+        let source = ModelSource.bundle(url)
+
+        let loader = Xybrid.model(source)
+
+        XCTAssertEqual(loader.source, source)
+    }
+}

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -36,15 +36,15 @@ dependencies {
 ### Loading a Model from Registry
 
 ```kotlin
-import ai.xybrid.XybridModel
 import ai.xybrid.Envelope
+import ai.xybrid.Xybrid
 
-// Load a model from the registry (the constructor resolves + loads it)
-val model = XybridModel("kokoro-82m")
+// Describing the source is cheap; load() is the explicit suspend boundary.
+val model = Xybrid.model("kokoro-82m").load()
 
 // Run text-to-speech
 val envelope = Envelope.text("Hello, world!", voiceId = "af_bella", speed = 1.0)
-val result = model.run(envelope)
+val result = model.runAsync(envelope)
 
 if (result.success) {
     val audioBytes = result.audioBytes
@@ -57,10 +57,11 @@ if (result.success) {
 ### Loading a Model from Bundle
 
 ```kotlin
-import ai.xybrid.XybridModel
+import ai.xybrid.ModelSource
+import ai.xybrid.Xybrid
 
 // Load from a local bundle path
-val model = XybridModel.fromBundle("/path/to/model/bundle")
+val model = Xybrid.model(ModelSource.bundle("/path/to/model/bundle")).load()
 ```
 
 ### Speech Recognition (ASR)
@@ -138,7 +139,7 @@ result.reasoningContent?.let { println("Reasoning: $it") }
 import ai.xybrid.XybridException
 
 try {
-    val model = XybridModel("unknown-model")
+    val model = Xybrid.model("unknown-model").load()
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.id}")
 } catch (e: XybridException.LoadError) {
@@ -156,23 +157,28 @@ try {
 
 | Type | Description |
 |------|-------------|
-| `XybridModel` | Loaded model ready for inference (construct/factory to load) |
+| `ModelSource` | Registry, bundle, directory, or Hugging Face model location |
+| `ModelLoader` / `XybridModelLoader` | Cheap model reference; call `load()` to perform I/O |
+| `XybridModel` | Loaded model ready for inference |
 | `Envelope` | Factory for `XybridEnvelope` inputs (`text`, `audio`, `embedding`, `image`, `userMessage`) |
 | `XybridEnvelope` | Input data container |
 | `XybridResult` | Inference output with success/error and result data |
 | `XybridException` | Error types (ModelNotFound, InferenceError, etc.) |
 
-### XybridModel (loading)
+### ModelLoader
 
 | Call | Description |
 |--------|-------------|
-| `XybridModel(id: String)` | Resolve and load a model from the Xybrid registry |
-| `XybridModel.fromBundle(path: String)` | Load a model from a local `.xyb` bundle |
-| `XybridModel.fromDirectory(path: String)` | Load a model from an extracted directory |
-| `XybridModel.fromHuggingface(repo: String)` | Resolve and load a HuggingFace repo |
+| `Xybrid.model(id: String)` | Describe a registry model without performing I/O |
+| `Xybrid.model(source: ModelSource)` | Describe an explicitly typed model source |
+| `ModelLoader.fromBundle(path: String)` | Describe a local `.xyb` bundle |
+| `ModelLoader.fromDirectory(path: String)` | Describe an extracted directory |
+| `ModelLoader.fromHuggingFace(repo: String)` | Describe a Hugging Face repository |
+| `loader.load()` | Resolve, download if needed, and load without blocking the caller's thread |
+| `loader.loadBlocking()` | Explicit synchronous load for an existing worker thread |
 
-Each loads synchronously; use the `…Async` suspend variants
-(`XybridModel.fromRegistryAsync(id)`, etc.) to load off the calling thread.
+Creating a source or loader is always cheap. Only `load()` and
+`loadBlocking()` may access the network, disk, or native inference runtime.
 
 ### XybridEnvelope
 

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -112,6 +112,21 @@ object Xybrid {
     @JvmStatic
     val isInitialized: Boolean get() = initialized
 
+    /**
+     * Describe a registry model without resolving, downloading, or loading it.
+     *
+     * Call [XybridModelLoader.load] from a coroutine to perform the load, or
+     * [XybridModelLoader.loadBlocking] from an existing worker thread.
+     */
+    @JvmStatic
+    fun model(id: String): ModelLoader = model(ModelSource.registry(id))
+
+    /**
+     * Describe a model source without resolving, downloading, or loading it.
+     */
+    @JvmStatic
+    fun model(source: ModelSource): ModelLoader = XybridModelLoader.from(source)
+
     private fun registerPlatformObservers(appContext: Context) {
         val batteryReceiver = object : BroadcastReceiver() {
             override fun onReceive(received: Context, intent: Intent) {
@@ -152,15 +167,104 @@ object Xybrid {
     }
 }
 
+// -- Model loading --
+
+/**
+ * A model location that can be prepared without performing I/O.
+ *
+ * Construct a loader with [Xybrid.model] or [XybridModelLoader.from]. Loading
+ * is always a separate, explicit operation.
+ */
+sealed interface ModelSource {
+    /** A model resolved through the Xybrid registry. */
+    data class Registry(val id: String) : ModelSource
+
+    /** A local `.xyb` model bundle. */
+    data class Bundle(val path: String) : ModelSource
+
+    /** A local directory containing `model_metadata.json`. */
+    data class Directory(val path: String) : ModelSource
+
+    /** A Hugging Face repository (`org/repo` or `org/repo:variant`). */
+    data class HuggingFace(val repo: String) : ModelSource
+
+    companion object {
+        /** Describe a registry model. */
+        @JvmStatic
+        fun registry(id: String): ModelSource = Registry(id)
+
+        /** Describe a local `.xyb` bundle. */
+        @JvmStatic
+        fun bundle(path: String): ModelSource = Bundle(path)
+
+        /** Describe a local model directory. */
+        @JvmStatic
+        fun directory(path: String): ModelSource = Directory(path)
+
+        /** Describe a Hugging Face repository. */
+        @JvmStatic
+        fun huggingFace(repo: String): ModelSource = HuggingFace(repo)
+    }
+}
+
+/**
+ * A cheap model reference that defers all expensive work until [load].
+ *
+ * Creating a loader never performs network, disk, or native-runtime work.
+ */
+class XybridModelLoader private constructor(
+    /** The source this loader will resolve. */
+    val source: ModelSource,
+) {
+    /** Load the model without blocking the calling coroutine's thread. */
+    suspend fun load(): XybridModel = withContext(Dispatchers.IO) { loadBlocking() }
+
+    /**
+     * Load the model synchronously.
+     *
+     * This may resolve registry metadata, download files, access disk, and
+     * initialize the inference runtime. Do not call it from Android's main
+     * thread.
+     */
+    fun loadBlocking(): XybridModel = when (val current = source) {
+        is ModelSource.Registry -> XybridModel(current.id)
+        is ModelSource.Bundle -> XybridModel.fromBundle(current.path)
+        is ModelSource.Directory -> XybridModel.fromDirectory(current.path)
+        is ModelSource.HuggingFace -> XybridModel.fromHuggingface(current.repo)
+    }
+
+    companion object {
+        /** Create a loader for an already-described source. */
+        @JvmStatic
+        fun from(source: ModelSource): XybridModelLoader = XybridModelLoader(source)
+
+        /** Create a loader for a registry model. */
+        @JvmStatic
+        fun fromRegistry(id: String): XybridModelLoader = from(ModelSource.registry(id))
+
+        /** Create a loader for a local `.xyb` bundle. */
+        @JvmStatic
+        fun fromBundle(path: String): XybridModelLoader = from(ModelSource.bundle(path))
+
+        /** Create a loader for a local model directory. */
+        @JvmStatic
+        fun fromDirectory(path: String): XybridModelLoader = from(ModelSource.directory(path))
+
+        /** Create a loader for a Hugging Face repository. */
+        @JvmStatic
+        fun fromHuggingFace(repo: String): XybridModelLoader =
+            from(ModelSource.huggingFace(repo))
+
+        /** Compatibility spelling retained for existing Kotlin callers. */
+        @JvmStatic
+        fun fromHuggingface(repo: String): XybridModelLoader = fromHuggingFace(repo)
+    }
+}
+
+/** Idiomatic short name for the high-level model loader. */
+typealias ModelLoader = XybridModelLoader
+
 // -- Public Type Aliases --
-//
-// Bolt collapsed `XybridModelLoader.fromRegistry(id).load()` into loading the
-// model directly — there is no loader type anymore. The registry path is the
-// `XybridModel(id)` constructor; the other sources are companion factories
-// (`fromBundle` / `fromDirectory` / `fromHuggingface`). The Model / Result /
-// VoiceInfo / GenerationConfig aliases stay for convenience.
-//
-// See [XybridModelLoader] below for the deprecated compatibility shim.
 
 /** A loaded model ready for inference. */
 typealias Model = XybridModel
@@ -188,20 +292,36 @@ fun XybridModel.run(envelope: XybridEnvelope): XybridResult = this.run(envelope,
 // dispatcher is therefore the correct, low-risk way to surface suspend today.)
 
 /** Load a model from the xybrid registry off the caller's thread. */
+@Deprecated(
+    message = "Use Xybrid.model(id).load().",
+    replaceWith = ReplaceWith("Xybrid.model(id).load()"),
+)
 suspend fun XybridModel.Companion.fromRegistryAsync(id: String): XybridModel =
-    withContext(Dispatchers.IO) { XybridModel(id) }
+    Xybrid.model(id).load()
 
 /** Load a model from a local directory off the caller's thread. */
+@Deprecated(
+    message = "Use Xybrid.model(ModelSource.directory(path)).load().",
+    replaceWith = ReplaceWith("Xybrid.model(ModelSource.directory(path)).load()"),
+)
 suspend fun XybridModel.Companion.fromDirectoryAsync(path: String): XybridModel =
-    withContext(Dispatchers.IO) { fromDirectory(path) }
+    Xybrid.model(ModelSource.directory(path)).load()
 
 /** Load a model from a local `.xyb` bundle off the caller's thread. */
+@Deprecated(
+    message = "Use Xybrid.model(ModelSource.bundle(path)).load().",
+    replaceWith = ReplaceWith("Xybrid.model(ModelSource.bundle(path)).load()"),
+)
 suspend fun XybridModel.Companion.fromBundleAsync(path: String): XybridModel =
-    withContext(Dispatchers.IO) { fromBundle(path) }
+    Xybrid.model(ModelSource.bundle(path)).load()
 
 /** Resolve and load a model from a HuggingFace repo off the caller's thread. */
+@Deprecated(
+    message = "Use Xybrid.model(ModelSource.huggingFace(repo)).load().",
+    replaceWith = ReplaceWith("Xybrid.model(ModelSource.huggingFace(repo)).load()"),
+)
 suspend fun XybridModel.Companion.fromHuggingfaceAsync(repo: String): XybridModel =
-    withContext(Dispatchers.IO) { fromHuggingface(repo) }
+    Xybrid.model(ModelSource.huggingFace(repo)).load()
 
 /** Run inference off the caller's thread (on [Dispatchers.IO]). */
 suspend fun XybridModel.runAsync(
@@ -252,75 +372,6 @@ fun XybridModel.streamTokens(
         streamClose(streamId)
     }
 }.flowOn(Dispatchers.IO)
-
-// -- Deprecated: the pre-bolt loader shape --
-//
-// Before the bolt migration, loading was two steps: build a loader, then call
-// `load()`. Bolt collapsed that into loading the model directly, and the type
-// was removed outright — so code written against the old shape (or against docs
-// that still showed it) failed with `Unresolved reference`, which says nothing
-// about what to use instead (xybrid-ai/xybrid#329).
-//
-// This shim keeps that code compiling and working, with a deprecation warning
-// naming the replacement. Scheduled for removal in 0.5.0.
-
-/**
- * Deprecated two-step loader retained for source compatibility.
- *
- * Load the model directly instead — [XybridModel] for the registry, or
- * [XybridModel.fromBundle] / [XybridModel.fromDirectory] /
- * [XybridModel.fromHuggingface] for the other sources. Each has a `suspend`
- * counterpart (`fromRegistryAsync` and friends).
- */
-@Deprecated(
-    message = "XybridModelLoader was removed in 0.4.0. Load the model directly: " +
-        "XybridModel(id) for the registry, or XybridModel.fromBundle/fromDirectory/" +
-        "fromHuggingface. Use the *Async variants to load off the caller's thread.",
-    level = DeprecationLevel.WARNING,
-)
-class XybridModelLoader private constructor(private val open: () -> XybridModel) {
-
-    /** Performs the load the pre-bolt API deferred to this call. */
-    fun load(): XybridModel = open()
-
-    companion object {
-        /** Deprecated. Use `XybridModel(id)`. */
-        @Deprecated(
-            message = "Use XybridModel(id), or fromRegistryAsync(id) to load off-thread.",
-            replaceWith = ReplaceWith("XybridModel(id)"),
-            level = DeprecationLevel.WARNING,
-        )
-        fun fromRegistry(id: String): XybridModelLoader =
-            XybridModelLoader { XybridModel(id) }
-
-        /** Deprecated. Use [XybridModel.fromBundle]. */
-        @Deprecated(
-            message = "Use XybridModel.fromBundle(path).",
-            replaceWith = ReplaceWith("XybridModel.fromBundle(path)"),
-            level = DeprecationLevel.WARNING,
-        )
-        fun fromBundle(path: String): XybridModelLoader =
-            XybridModelLoader { XybridModel.fromBundle(path) }
-
-        /** Deprecated. Use [XybridModel.fromDirectory]. */
-        @Deprecated(
-            message = "Use XybridModel.fromDirectory(path).",
-            replaceWith = ReplaceWith("XybridModel.fromDirectory(path)"),
-            level = DeprecationLevel.WARNING,
-        )
-        fun fromDirectory(path: String): XybridModelLoader =
-            XybridModelLoader { XybridModel.fromDirectory(path) }
-
-        /** Deprecated. Use [XybridModel.fromHuggingface]. */
-        @Deprecated(
-            message = "Use XybridModel.fromHuggingface(repo).",
-            replaceWith = ReplaceWith("XybridModel.fromHuggingface(repo)"),
-            level = DeprecationLevel.WARNING,
-        )
-        fun fromHuggingface(repo: String): XybridModelLoader =
-            XybridModelLoader { XybridModel.fromHuggingface(repo) }
-    }
-}
 
 /** The result of a model inference operation. */
 typealias Result = XybridResult

--- a/bindings/kotlin/src/test/kotlin/ai/xybrid/ModelLoaderTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/xybrid/ModelLoaderTest.kt
@@ -1,0 +1,33 @@
+package ai.xybrid
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ModelLoaderTest {
+    @Test
+    fun registryShortcutCreatesAnUnloadedRegistryReference() {
+        val loader = Xybrid.model("kokoro-82m")
+
+        assertEquals(ModelSource.Registry("kokoro-82m"), loader.source)
+    }
+
+    @Test
+    fun typedSourceCreatesAnUnloadedBundleReference() {
+        val source = ModelSource.Bundle("/models/kokoro.xyb")
+
+        val loader = Xybrid.model(source)
+
+        assertEquals(source, loader.source)
+    }
+
+    @Test
+    fun sourceFactoriesDescribeEverySupportedModelLocation() {
+        assertEquals(ModelSource.Registry("model"), ModelSource.registry("model"))
+        assertEquals(ModelSource.Bundle("model.xyb"), ModelSource.bundle("model.xyb"))
+        assertEquals(ModelSource.Directory("models/model"), ModelSource.directory("models/model"))
+        assertEquals(
+            ModelSource.HuggingFace("org/model"),
+            ModelSource.huggingFace("org/model"),
+        )
+    }
+}

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -3,7 +3,7 @@ title: Android
 description: Native Android SDK for on-device ML inference
 ---
 
-The Android SDK provides native Kotlin bindings to the Xybrid runtime via UniFFI, enabling on-device ML inference in Android applications.
+The Android SDK provides native Kotlin bindings to the Xybrid runtime via BoltFFI, enabling on-device ML inference in Android applications.
 
 ## Installation
 
@@ -29,11 +29,11 @@ class MyApplication : Application() {
     }
 }
 
-// Load a model from the registry
-val model = XybridModel("kokoro-82m")
+// Describe, then explicitly load a model from the registry
+val model = Xybrid.model("kokoro-82m").load()
 
 // Run inference
-val result = model.run(Envelope.text("Hello, world!"))
+val result = model.runAsync(Envelope.text("Hello, world!"))
 
 if (result.success) {
     println("Output: ${result.text}")
@@ -60,20 +60,21 @@ Without a key, telemetry is disabled and the first inference logs a one-shot hin
 ### From Registry
 
 ```kotlin
-val model = XybridModel("whisper-tiny")
+val model = Xybrid.model("whisper-tiny").load()
 ```
 
 ### From Local Bundle
 
 ```kotlin
-val model = XybridModel.fromBundle("/path/to/model.xyb")
+val model = Xybrid.model(ModelSource.bundle("/path/to/model.xyb")).load()
 ```
 
-`XybridModel.fromDirectory(path)` and `XybridModel.fromHuggingface("org/repo")` load
-from an unpacked model directory and from HuggingFace respectively. Each has a
-`suspend` counterpart — `fromRegistryAsync`, `fromBundleAsync`,
-`fromDirectoryAsync`, `fromHuggingfaceAsync` — that runs the blocking load on
-`Dispatchers.IO`.
+`Xybrid.model(...)` creates a cheap, unloaded reference. Use
+`ModelSource.directory(path)` and `ModelSource.huggingFace("org/repo")` for an
+unpacked directory and Hugging Face respectively. Suspending `load()` is the
+explicit boundary that may resolve metadata, download artifacts, access disk,
+and initialize the runtime. Use `loadBlocking()` only from Java or an existing
+worker thread.
 
 ---
 
@@ -156,8 +157,8 @@ The SDK uses sealed exception classes for type-safe error handling:
 
 ```kotlin
 try {
-    val model = XybridModel("kokoro-82m")
-    val result = model.run(envelope)
+    val model = Xybrid.model("kokoro-82m").load()
+    val result = model.runAsync(envelope)
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.modelId}")
 } catch (e: XybridException.InferenceFailed) {

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -3,7 +3,7 @@ title: Android
 description: 面向 Android 的原生 SDK，支持本地 ML 推理
 ---
 
-Android SDK 通过 UniFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支持在 Android 应用中进行本地 ML 推理。
+Android SDK 通过 BoltFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支持在 Android 应用中进行本地 ML 推理。
 
 ## 安装
 
@@ -22,12 +22,11 @@ dependencies {
 ```kotlin
 import ai.xybrid.*
 
-// 从注册表加载模型
-val loader = XybridModelLoader.fromRegistry("kokoro-82m")
-val model = loader.load()
+// 先描述模型来源，再显式加载
+val model = Xybrid.model("kokoro-82m").load()
 
 // 运行推理
-val result = model.run(Envelope.text("Hello, world!"))
+val result = model.runAsync(Envelope.text("Hello, world!"))
 
 if (result.success) {
     println("Output: ${result.text}")
@@ -52,16 +51,17 @@ Xybrid.init(this, apiKey = BuildConfig.XYBRID_API_KEY)
 ### 从注册表
 
 ```kotlin
-val loader = XybridModelLoader.fromRegistry("whisper-tiny")
-val model = loader.load()
+val model = Xybrid.model("whisper-tiny").load()
 ```
 
 ### 从本地 Bundle
 
 ```kotlin
-val loader = XybridModelLoader.fromBundle("/path/to/model.xyb")
-val model = loader.load()
+val model = Xybrid.model(ModelSource.bundle("/path/to/model.xyb")).load()
 ```
+
+`Xybrid.model(...)` 只创建廉价的、未加载的引用。`load()` 是显式的加载边界，
+可能解析元数据、下载文件、访问磁盘并初始化运行时。
 
 ---
 
@@ -144,8 +144,8 @@ SDK 使用密封异常类实现类型安全的错误处理：
 
 ```kotlin
 try {
-    val model = XybridModelLoader.fromRegistry("kokoro-82m").load()
-    val result = model.run(envelope)
+    val model = Xybrid.model("kokoro-82m").load()
+    val result = model.runAsync(envelope)
 } catch (e: XybridException.ModelNotFound) {
     println("Model not found: ${e.modelId}")
 } catch (e: XybridException.InferenceFailed) {

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -3,7 +3,7 @@ title: iOS / macOS
 description: Native Swift SDK for on-device ML inference
 ---
 
-The Swift SDK provides native bindings to the Xybrid runtime via UniFFI for iOS and macOS applications.
+The Swift SDK provides native bindings to the Xybrid runtime via BoltFFI for iOS and macOS applications.
 
 <Callout type="info">
 The Swift SDK is in early access. Releases ship a prebuilt `XybridFFI` xcframework via Swift Package Manager. Known issue: building for the iOS Simulator on Apple Silicon requires the `useLocalNatives = true` workaround — see [#179](https://github.com/xybrid-ai/xybrid/issues/179). For cross-platform development, see the [Flutter SDK](/docs/sdks/flutter).
@@ -34,13 +34,12 @@ struct MyApp: App {
     var body: some Scene { /* ... */ }
 }
 
-// Load a model from the registry
-let loader = ModelLoader.fromRegistry(modelId: "kokoro-82m")
-let model = try loader.load()
+// Describe, then explicitly load a model from the registry
+let model = try await Xybrid.model("kokoro-82m").load()
 
 // Run inference
 let envelope = Envelope.text("Hello, world!")
-let result = try model.run(envelope: envelope)
+let result = try await model.runAsync(envelope: envelope)
 
 if result.success {
     print("Output: \(result.text ?? "")")
@@ -69,16 +68,20 @@ Without a key, telemetry is disabled and the first inference logs a one-shot hin
 ### From Registry
 
 ```swift
-let loader = ModelLoader.fromRegistry(modelId: "whisper-tiny")
-let model = try loader.load()
+let model = try await Xybrid.model("whisper-tiny").load()
 ```
 
 ### From Local Bundle
 
 ```swift
-let loader = ModelLoader.fromBundle(path: bundlePath)
-let model = try loader.load()
+let model = try await Xybrid.model(.bundle(bundleURL)).load()
 ```
+
+`Xybrid.model(...)` creates a cheap, unloaded reference. Local bundle and
+directory sources use `URL` through `.bundle(url)` and `.directory(url)`;
+Hugging Face uses `.huggingFace("org/repo")`. Async `load()` is the explicit
+boundary for resolving, downloading, disk access, and runtime initialization.
+Use `loadSync()` only from an existing worker thread.
 
 ---
 
@@ -163,8 +166,8 @@ The SDK uses a Swift error enum for type-safe error handling:
 
 ```swift
 do {
-    let model = try ModelLoader.fromRegistry(modelId: "kokoro-82m").load()
-    let result = try model.run(envelope: envelope)
+    let model = try await Xybrid.model("kokoro-82m").load()
+    let result = try await model.runAsync(envelope: envelope)
 } catch XybridError.ModelNotFound(let modelId) {
     print("Model not found: \(modelId)")
 } catch XybridError.InferenceFailed(let message) {
@@ -193,9 +196,8 @@ The SDK provides short aliases for convenience:
 | `GenerationConfig` | `XybridGenerationConfig` |
 | `XybridSDKError` | `XybridError` |
 
-There is no `ModelLoader` type. Load a model directly with
-`XybridModel(fromRegistry:)`, or `XybridModel(fromBundle:)` /
-`XybridModel(fromDirectory:)` / `XybridModel(fromHuggingface:)`.
+`ModelLoader` is a cheap model reference. Construct it through
+`Xybrid.model(...)`, then call `load()` explicitly before inference.
 
 ---
 

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -3,7 +3,7 @@ title: iOS / macOS
 description: 面向 iOS 和 macOS 的原生 Swift SDK，支持本地 ML 推理
 ---
 
-Swift SDK 通过 UniFFI 为 iOS 和 macOS 应用提供到 Xybrid 运行时的原生绑定。
+Swift SDK 通过 BoltFFI 为 iOS 和 macOS 应用提供到 Xybrid 运行时的原生绑定。
 
 <Callout type="info">
 Swift SDK 处于早期访问阶段。正式版本通过 Swift Package Manager 分发预编译的 `XybridFFI` xcframework。已知问题：在 Apple Silicon 上为 iOS 模拟器构建需要 `useLocalNatives = true` 的临时方案 — 详见 [#179](https://github.com/xybrid-ai/xybrid/issues/179)。跨平台开发可使用 [Flutter SDK](/zh/docs/sdks/flutter)。
@@ -28,13 +28,12 @@ dependencies: [
 ```swift
 import Xybrid
 
-// 从注册表加载模型
-let loader = ModelLoader.fromRegistry(modelId: "kokoro-82m")
-let model = try loader.load()
+// 先描述模型来源，再显式加载
+let model = try await Xybrid.model("kokoro-82m").load()
 
 // 执行推理
 let envelope = Envelope.text("Hello, world!")
-let result = try model.run(envelope: envelope)
+let result = try await model.runAsync(envelope: envelope)
 
 if result.success {
     print("Output: \(result.text ?? "")")
@@ -61,16 +60,17 @@ Xybrid.initialize(
 ### 从注册表
 
 ```swift
-let loader = ModelLoader.fromRegistry(modelId: "whisper-tiny")
-let model = try loader.load()
+let model = try await Xybrid.model("whisper-tiny").load()
 ```
 
 ### 从本地 Bundle
 
 ```swift
-let loader = ModelLoader.fromBundle(path: bundlePath)
-let model = try loader.load()
+let model = try await Xybrid.model(.bundle(bundleURL)).load()
 ```
+
+`Xybrid.model(...)` 只创建廉价的、未加载的引用。本地 Bundle 和目录使用
+`URL` 与 `.bundle(url)` / `.directory(url)`。`load()` 是显式的异步加载边界。
 
 ---
 
@@ -155,8 +155,8 @@ SDK 使用 Swift 错误枚举实现类型安全的错误处理：
 
 ```swift
 do {
-    let model = try ModelLoader.fromRegistry(modelId: "kokoro-82m").load()
-    let result = try model.run(envelope: envelope)
+    let model = try await Xybrid.model("kokoro-82m").load()
+    let result = try await model.runAsync(envelope: envelope)
 } catch XybridError.ModelNotFound(let modelId) {
     print("Model not found: \(modelId)")
 } catch XybridError.InferenceFailed(let message) {
@@ -178,7 +178,7 @@ SDK 提供便捷短别名：
 
 | 别名 | 完整类型 |
 |-------|-----------|
-| `ModelLoader` | `XybridModelLoader` |
+| `ModelLoader` | 显式加载模型的具体类型 |
 | `Model` | `XybridModel` |
 | `Envelope` | `XybridEnvelope` |
 | `Result` | `XybridResult` |

--- a/docs/content/docs/(integration)/sdks/kotlin.mdx
+++ b/docs/content/docs/(integration)/sdks/kotlin.mdx
@@ -3,7 +3,7 @@ title: Kotlin
 description: Kotlin SDK patterns and advanced usage
 ---
 
-The Kotlin SDK (`ai.xybrid:xybrid-kotlin`) is published on Maven Central and uses UniFFI-generated bindings for type-safe ML inference from Kotlin. For installation and core API reference, see the [Android SDK guide](/docs/sdks/android).
+The Kotlin SDK (`ai.xybrid:xybrid-kotlin`) is published on Maven Central and uses BoltFFI-generated bindings with an idiomatic Kotlin facade. For installation and core API reference, see the [Android SDK guide](/docs/sdks/android).
 
 This page covers Kotlin-specific patterns and advanced usage.
 
@@ -39,24 +39,18 @@ val result = try {
 
 ## Coroutines Integration
 
-Wrap synchronous SDK calls with coroutines for non-blocking UI:
+Model loading is an explicit suspending operation. `Xybrid.model(...)` only
+describes the source and performs no I/O:
 
 ```kotlin
-import kotlinx.coroutines.*
-
 class InferenceRepository {
-    private val dispatcher = Dispatchers.IO
-
-    suspend fun loadModel(modelId: String): XybridModel = withContext(dispatcher) {
-        XybridModel(modelId)
-    }
+    suspend fun loadModel(modelId: String): XybridModel =
+        Xybrid.model(modelId).load()
 
     suspend fun runInference(
         model: XybridModel,
         envelope: XybridEnvelope
-    ): XybridResult = withContext(dispatcher) {
-        model.run(envelope)
-    }
+    ): XybridResult = model.runAsync(envelope)
 }
 ```
 
@@ -72,7 +66,7 @@ fun InferenceScreen() {
     Button(onClick = {
         scope.launch {
             isLoading = true
-            val model = XybridModel.fromRegistryAsync("kokoro-82m")
+            val model = Xybrid.model("kokoro-82m").load()
             result = model.runAsync(Envelope.text("Hello from Compose!"))
             isLoading = false
         }
@@ -93,6 +87,7 @@ The SDK provides short aliases matching the full qualified names:
 
 | Alias | Full Type |
 |-------|-----------|
+| `ModelLoader` | `XybridModelLoader` |
 | `Model` | `XybridModel` |
 | `Result` | `XybridResult` |
 | `VoiceInfo` | `XybridVoiceInfo` |
@@ -103,9 +98,10 @@ The SDK provides short aliases matching the full qualified names:
 (`Envelope.text(...)`, `Envelope.image(...)`, `Envelope.userMessage(...)`) that
 return `XybridEnvelope`.
 
-There is no `ModelLoader` type. Load a model directly with `XybridModel(id)` for
-the registry, or `XybridModel.fromBundle` / `fromDirectory` / `fromHuggingface`.
-A deprecated `XybridModelLoader` shim keeps pre-0.4.0 code compiling and will be
-removed in 0.5.0.
+Use `Xybrid.model(id)` for the registry shorthand, or pass a typed
+`ModelSource.bundle(...)`, `ModelSource.directory(...)`, or
+`ModelSource.huggingFace(...)`. These calls return an unloaded `ModelLoader`;
+call suspending `load()` to perform the work. Java and existing worker-thread
+callers can use the explicitly blocking `loadBlocking()` method.
 
 See the [Android SDK guide](/docs/sdks/android) for the complete API reference.

--- a/docs/content/docs/(integration)/sdks/kotlin.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/kotlin.zh.mdx
@@ -3,7 +3,7 @@ title: Kotlin
 description: Kotlin SDK 模式与高级用法
 ---
 
-Kotlin SDK（`ai.xybrid:xybrid-kotlin`）发布于 Maven Central，使用 UniFFI 生成的绑定实现类型安全的 Kotlin ML 推理。安装与核心 API 参考请见 [Android SDK 指南](/zh/docs/sdks/android)。
+Kotlin SDK（`ai.xybrid:xybrid-kotlin`）发布于 Maven Central，通过 BoltFFI 生成的绑定与 Kotlin 风格的 facade 实现类型安全的本地 ML 推理。安装与核心 API 参考请见 [Android SDK 指南](/zh/docs/sdks/android)。
 
 本页介绍 Kotlin 特有的使用模式与高级用法。
 
@@ -39,24 +39,17 @@ val result = try {
 
 ## 协程集成
 
-使用协程将同步的 SDK 调用封装为非阻塞 UI 操作：
+模型加载是显式的挂起操作。`Xybrid.model(...)` 只描述来源，不执行 I/O：
 
 ```kotlin
-import kotlinx.coroutines.*
-
 class InferenceRepository {
-    private val dispatcher = Dispatchers.IO
-
-    suspend fun loadModel(modelId: String): XybridModel = withContext(dispatcher) {
-        XybridModelLoader.fromRegistry(modelId).load()
-    }
+    suspend fun loadModel(modelId: String): XybridModel =
+        Xybrid.model(modelId).load()
 
     suspend fun runInference(
         model: XybridModel,
         envelope: XybridEnvelope
-    ): XybridResult = withContext(dispatcher) {
-        model.run(envelope)
-    }
+    ): XybridResult = model.runAsync(envelope)
 }
 ```
 
@@ -72,12 +65,8 @@ fun InferenceScreen() {
     Button(onClick = {
         scope.launch {
             isLoading = true
-            val model = withContext(Dispatchers.IO) {
-                XybridModelLoader.fromRegistry("kokoro-82m").load()
-            }
-            result = withContext(Dispatchers.IO) {
-                model.run(Envelope.text("Hello from Compose!"))
-            }
+            val model = Xybrid.model("kokoro-82m").load()
+            result = model.runAsync(Envelope.text("Hello from Compose!"))
             isLoading = false
         }
     }) {
@@ -102,5 +91,9 @@ SDK 提供与完整限定名对应的短别名：
 | `Envelope` | `XybridEnvelope` |
 | `Result` | `XybridResult` |
 | `XybridError` | `XybridException` |
+
+`Xybrid.model(id)` 是注册表模型的简写。本地来源使用
+`ModelSource.bundle(...)` 或 `ModelSource.directory(...)`。这些调用只返回
+未加载的 `ModelLoader`；调用 `load()` 才会执行解析、下载和加载。
 
 完整 API 参考请见 [Android SDK 指南](/zh/docs/sdks/android)。

--- a/docs/content/docs/guides/reasoning.mdx
+++ b/docs/content/docs/guides/reasoning.mdx
@@ -46,8 +46,8 @@ Same `run`, same result — reasoning is a sibling of `text`.
 ### Swift
 
 ```swift
-let model = try XybridModel(fromRegistry: "lfm2.5-1.2b-thinking")
-let result = try model.run(envelope: XybridEnvelope.text(
+let model = try await Xybrid.model("lfm2.5-1.2b-thinking").load()
+let result = try await model.runAsync(envelope: XybridEnvelope.text(
     "Is 97 a prime number? Reason, then answer."))
 
 if let answer = result.text { print("Answer:", answer) }
@@ -57,8 +57,8 @@ if let reasoning = result.reasoningContent { print("Reasoning:", reasoning) }
 ### Kotlin
 
 ```kotlin
-val model = XybridModel("lfm2.5-1.2b-thinking")
-val result = model.run(Envelope.text("Is 97 a prime number? Reason, then answer."))
+val model = Xybrid.model("lfm2.5-1.2b-thinking").load()
+val result = model.runAsync(Envelope.text("Is 97 a prime number? Reason, then answer."))
 
 result.text?.let { println("Answer: $it") }
 result.reasoningContent?.let { println("Reasoning: $it") }

--- a/docs/content/docs/guides/vision-models.mdx
+++ b/docs/content/docs/guides/vision-models.mdx
@@ -102,17 +102,17 @@ satisfied.
 
 ```kotlin
 import ai.xybrid.Envelope
-import ai.xybrid.XybridModel
+import ai.xybrid.Xybrid
 import java.io.File
 
-val model = XybridModel("gemma-4-e2b")
+val model = Xybrid.model("gemma-4-e2b").load()
 val image = Envelope.image(File("cat.jpg").readBytes(), format = "jpeg")
 val prompt = Envelope.userMessage(
     text = "Describe this image.",
     images = listOf(image),
 )
 
-val result = model.run(prompt)
+val result = model.runAsync(prompt)
 println(result.text)
 ```
 
@@ -122,7 +122,7 @@ println(result.text)
 import Foundation
 import Xybrid
 
-let model = try ModelLoader.fromRegistry(modelId: "gemma-4-e2b").load()
+let model = try await Xybrid.model("gemma-4-e2b").load()
 let imageData = try Data(contentsOf: URL(fileURLWithPath: "cat.jpg"))
 let image = try XybridEnvelope.image(imageData, format: "jpeg")
 let prompt = try XybridEnvelope.userMessage(
@@ -130,7 +130,7 @@ let prompt = try XybridEnvelope.userMessage(
     images: [image]
 )
 
-let result = try model.run(envelope: prompt)
+let result = try await model.runAsync(envelope: prompt)
 print(result.text ?? "")
 ```
 

--- a/docs/content/docs/guides/vision-models.zh.mdx
+++ b/docs/content/docs/guides/vision-models.zh.mdx
@@ -95,16 +95,17 @@ Studio 使用相同的 Envelope 形态。只有在所选模型支持图像输入
 
 ```kotlin
 import ai.xybrid.Envelope
+import ai.xybrid.Xybrid
 import java.io.File
 
-val model = XybridModelLoader.fromRegistry("gemma-4-e2b").load()
+val model = Xybrid.model("gemma-4-e2b").load()
 val image = Envelope.image(File("cat.jpg").readBytes(), format = "jpeg")
 val prompt = Envelope.userMessage(
     text = "Describe this image.",
     images = listOf(image),
 )
 
-val result = model.run(prompt)
+val result = model.runAsync(prompt)
 println(result.text)
 ```
 
@@ -114,7 +115,7 @@ println(result.text)
 import Foundation
 import Xybrid
 
-let model = try ModelLoader.fromRegistry(modelId: "gemma-4-e2b").load()
+let model = try await Xybrid.model("gemma-4-e2b").load()
 let imageData = try Data(contentsOf: URL(fileURLWithPath: "cat.jpg"))
 let image = try XybridEnvelope.image(imageData, format: "jpeg")
 let prompt = try XybridEnvelope.userMessage(
@@ -122,7 +123,7 @@ let prompt = try XybridEnvelope.userMessage(
     images: [image]
 )
 
-let result = try model.run(envelope: prompt)
+let result = try await model.runAsync(envelope: prompt)
 print(result.text ?? "")
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -67,13 +67,12 @@ import Xybrid
 // your inference traces: Xybrid.initialize(apiKey: "...")
 Xybrid.initialize()
 
-// Load a model from the registry
-let loader = ModelLoader.fromRegistry(modelId: "kokoro-82m")
-let model = try loader.load()
+// Describe, then explicitly load a model from the registry
+let model = try await Xybrid.model("kokoro-82m").load()
 
 // Run text-to-speech
 let envelope = Envelope.text("Hello from Xybrid!")
-let result = try model.run(envelope: envelope)
+let result = try await model.runAsync(envelope: envelope)
 
 // result.audioBytes contains the generated speech audio
 ```
@@ -99,12 +98,12 @@ import ai.xybrid.*
 // your inference traces: Xybrid.init(context, apiKey = "...")
 Xybrid.init(context)
 
-// Load a model from the registry
-val model = XybridModel("kokoro-82m")
+// Describe, then explicitly load a model from the registry
+val model = Xybrid.model("kokoro-82m").load()
 
 // Run text-to-speech
 val envelope = Envelope.text("Hello from Xybrid!")
-val result = model.run(envelope)
+val result = model.runAsync(envelope)
 
 // result.audioBytes contains the generated speech audio
 ```

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -67,13 +67,12 @@ import Xybrid
 // 推理轨迹：Xybrid.initialize(apiKey: "...")
 Xybrid.initialize()
 
-// 从注册表加载模型
-let loader = XybridModelLoader.fromRegistry(modelId: "kokoro-82m")
-let model = try loader.load()
+// 先描述模型来源，再显式加载
+let model = try await Xybrid.model("kokoro-82m").load()
 
 // 运行文本转语音
 let envelope = XybridEnvelope.text(text: "Hello from Xybrid!")
-let result = try model.run(envelope: envelope)
+let result = try await model.runAsync(envelope: envelope)
 
 // result.audioBytes 包含生成的语音音频
 ```
@@ -93,20 +92,18 @@ dependencies {
 **运行推理**
 
 ```kotlin
-import ai.xybrid.XybridModelLoader
-import ai.xybrid.XybridEnvelope
+import ai.xybrid.*
 
 // 默认即可本地运行。在 dashboard.xybrid.dev 免费获取密钥即可查看
 // 推理轨迹：Xybrid.init(context, apiKey = "...")
 Xybrid.init(context)
 
-// 从注册表加载模型
-val loader = XybridModelLoader.fromRegistry("kokoro-82m")
-val model = loader.load()
+// 先描述模型来源，再显式加载
+val model = Xybrid.model("kokoro-82m").load()
 
 // 运行文本转语音
 val envelope = XybridEnvelope.Text(text = "Hello from Xybrid!")
-val result = model.run(envelope)
+val result = model.runAsync(envelope)
 
 // result.audioBytes 包含生成的语音音频
 ```

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -34,6 +34,8 @@ SDKs may prefix or adjust casing:
 |-----------|------|--------|-------|-------------|
 | `Envelope` | `XybridEnvelope` | `XybridEnvelope` | `XybridEnvelope` | `Envelope` |
 | `InferenceResult` | `XybridResult` | `XybridResult` | `XybridResult` | `InferenceResult` |
+| `ModelSource` | loader factories | `ModelSource` | `ModelSource` | loader factories |
+| `ModelLoader` | `XybridModelLoader` | `XybridModelLoader` (`ModelLoader`) | `ModelLoader` | `ModelLoader` |
 | `OutputType` enum | `FfiOutputType` | `OutputType` | `OutputType` | `OutputType` |
 | `PipelineInputType` | `FfiPipelineInputType` | `PipelineInputType` | — | — |
 
@@ -44,10 +46,15 @@ SDKs may prefix or adjust casing:
 All SDKs follow the same three-step pattern:
 
 ```
-1. Create a Loader  →  Xybrid.model(modelId: "whisper-tiny")
+1. Describe a Model →  Xybrid.model("whisper-tiny")
 2. Load the Model   →  await loader.load()
 3. Run Inference    →  await model.run(envelope: input)
 ```
+
+Creating a loader is cheap and performs no network, disk, or native-runtime
+work. `load()` is the explicit boundary for resolving, downloading, and loading
+a model. Bindings may also expose an explicitly named synchronous variant for
+worker-thread and non-async callers.
 
 ---
 
@@ -100,13 +107,19 @@ object Xybrid {
   // API Key Management
   fun setApiKey(apiKey: String)
 
-  // Model Loading
-  fun model(
-    modelId: String? = null,
-    platform: String? = null,
-    bundlePath: String? = null,
-    modelDir: String? = null
-  ): XybridModelLoader
+  // Model description (no I/O)
+  fun model(id: String): ModelLoader
+  fun model(source: ModelSource): ModelLoader
+}
+```
+
+### Swift
+
+```swift
+extension Xybrid {
+  // Model description (no I/O)
+  static func model(_ id: String) -> ModelLoader
+  static func model(_ source: ModelSource) -> ModelLoader
 }
 ```
 
@@ -114,10 +127,10 @@ object Xybrid {
 
 | Method | Dart | Kotlin | Swift | C# |
 |--------|------|--------|-------|----|
-| `init()` | ✅ | ✅ | — | ✅ |
+| `init()` | ✅ | ✅ | ✅ | ✅ |
 | `setApiKey()` | ✅ | — | — | — |
 | `setGatewayUrl()` | ✅ | — | — | — |
-| `model()` | ✅ | — | — | ✅ |
+| `model()` | ✅ | ✅ | ✅ | ✅ |
 | `pipeline()` | ✅ | — | — | — |
 | `isModelCached()` | ✅ | — | — | — |
 
@@ -155,6 +168,25 @@ class XybridModelLoader {
   }
 
   suspend fun load(): XybridModel
+  fun loadBlocking(): XybridModel
+}
+```
+
+### Swift
+
+```swift
+public enum ModelSource {
+  case registry(String)
+  case bundle(URL)
+  case directory(URL)
+  case huggingFace(String)
+}
+
+public struct ModelLoader {
+  let source: ModelSource
+
+  func load() async throws -> XybridModel
+  func loadSync() throws -> XybridModel
 }
 ```
 
@@ -166,7 +198,7 @@ public class ModelLoader
     public static ModelLoader FromRegistry(string modelId);
     public static ModelLoader FromBundle(string bundlePath);
     public static ModelLoader FromDirectory(string directoryPath);
-    public InferenceResult Load();
+    public Model Load();
 }
 ```
 
@@ -201,16 +233,16 @@ final result = await model.run(envelope: XybridEnvelope.text("Hello!"));
 
 ```kotlin
 // Kotlin / Android
-val loader = XybridModelLoader.fromDirectory("/data/local/tmp/my-model")
+val loader = Xybrid.model(ModelSource.directory("/data/local/tmp/my-model"))
 val model = loader.load()
-val result = model.run(XybridEnvelope.text("Hello!"))
+val result = model.runAsync(XybridEnvelope.text("Hello!"))
 ```
 
 ```swift
 // Swift / iOS
-let loader = try XybridModelLoader.fromDirectory(path: modelPath)
+let loader = Xybrid.model(.directory(modelURL))
 let model = try await loader.load()
-let result = try await model.run(envelope: .text("Hello!"))
+let result = try await model.runAsync(envelope: .text("Hello!"))
 ```
 
 ```csharp
@@ -244,16 +276,16 @@ final result = await model.run(envelope: XybridEnvelope.text("Hello!"));
 
 ```kotlin
 // Kotlin / Android
-val loader = XybridModelLoader.fromHuggingface(repo = "xybrid-ai/kokoro-82m")
+val loader = Xybrid.model(ModelSource.huggingFace("xybrid-ai/kokoro-82m"))
 val model = loader.load()
-val result = model.run(XybridEnvelope.text("Hello!"))
+val result = model.runAsync(XybridEnvelope.text("Hello!"))
 ```
 
 ```swift
 // Swift / iOS
-let loader = XybridModelLoader.fromHuggingface(repo: "xybrid-ai/kokoro-82m")
+let loader = Xybrid.model(.huggingFace("xybrid-ai/kokoro-82m"))
 let model = try await loader.load()
-let result = try await model.run(envelope: .text("Hello!"))
+let result = try await model.runAsync(envelope: .text("Hello!"))
 ```
 
 ```csharp
@@ -1525,7 +1557,7 @@ The full wire format and the list of enum values for each header field is docume
 ### Kotlin-specific
 
 - Use `suspend` for async operations
-- Use `sealed class` for sum types (Envelope)
+- Use `sealed interface` for sum types (`Envelope`, `ModelSource`)
 - Use `data class` for value types
 - Use `companion object` for factory methods
 - Use Kotlin naming conventions (camelCase, enum UPPER_CASE)
@@ -1533,8 +1565,9 @@ The full wire format and the list of enum values for each header field is docume
 
 ### Swift-specific
 
-- Currently uses raw UniFFI-generated types with type aliases
-- No `Xybrid` singleton wrapper yet — uses `XybridModelLoader` directly
+- Uses hand-written Swift facades over BoltFFI-generated types
+- Uses `URL` for local bundle and directory model sources
+- Uses `async throws` for model loading; `loadSync()` is the explicit blocking form
 
 ### Unity/C#-specific
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -38,12 +38,10 @@ classes:
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
       model:
         params:
-          - { name: modelId, type: "String?" }
-          - { name: platform, type: "String?" }
-          - { name: bundlePath, type: "String?" }
-          - { name: modelDir, type: "String?" }
+          - { name: source, type: ModelSource }
         return: XybridModelLoader
-        status: { dart: implemented, kotlin: planned, swift: planned, csharp: implemented }
+        notes: "Bindings may provide a registry-ID string shorthand. Creating a loader performs no I/O; load() is the explicit expensive boundary."
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       pipeline:
         params:
           - { name: yaml, type: "String?" }

--- a/examples/android/app/src/main/java/ai/xybrid/example/XybridExampleApp.kt
+++ b/examples/android/app/src/main/java/ai/xybrid/example/XybridExampleApp.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 // Xybrid SDK imports
+import ai.xybrid.Xybrid
 import ai.xybrid.XybridModel
 import ai.xybrid.XybridError
 import ai.xybrid.Envelope
@@ -104,15 +105,7 @@ fun XybridExampleApp() {
                 modelState = ModelState.Loading
                 coroutineScope.launch {
                     try {
-                        val loaded = withContext(Dispatchers.IO) {
-                            // Bolt collapsed the loader-then-load 2-step into a
-                            // single XybridModel constructor. (The Kotlin
-                            // emitter exposes from_registry as the primary
-                            // secondary constructor; from_directory /
-                            // from_bundle / from_huggingface remain on the
-                            // companion object.)
-                            XybridModel(model.id)
-                        }
+                        val loaded = Xybrid.model(model.id).load()
                         modelState = ModelState.Loaded(loaded)
 
                         // Pick default voice for TTS models. Bolt returns the

--- a/examples/ios/XybridExample/ContentView.swift
+++ b/examples/ios/XybridExample/ContentView.swift
@@ -353,14 +353,11 @@ struct InferenceView: View {
         // Capture the @State input on the main actor before detaching.
         let modelId = self.modelId
 
-        // `Task.detached`, NOT `Task {}`: this method runs on the main
-        // actor (SwiftUI View), and a plain `Task` inherits that
-        // executor — the synchronous, blocking `XybridModel(fromRegistry:)`
-        // (model resolve + download + load) would run on the main thread
-        // and freeze the UI. Detaching runs it on a background executor.
-        Task.detached {
+        // The loader is cheap to create; its async load performs resolution,
+        // download, disk access, and runtime initialization off the main actor.
+        Task {
             do {
-                let loadedModel = try XybridModel(fromRegistry: modelId)
+                let loadedModel = try await Xybrid.model(modelId).load()
                 let modelVoices = loadedModel.voices()
                 let defaultVoice = loadedModel.defaultVoice()?.id
 

--- a/examples/ios/XybridExample/ExtractionView.swift
+++ b/examples/ios/XybridExample/ExtractionView.swift
@@ -246,12 +246,11 @@ struct ExtractionView: View {
         inferenceState = .loading
         let modelId = self.modelId
 
-        // `Task.detached`, NOT `Task {}`: the synchronous, blocking
-        // `XybridModel(fromRegistry:)` (resolve + download + load) must not
-        // run on the main actor. Same discipline as InferenceView.
-        Task.detached {
+        // The loader is cheap to create; its async load performs resolution,
+        // download, disk access, and runtime initialization off the main actor.
+        Task {
             do {
-                let loadedModel = try XybridModel(fromRegistry: modelId)
+                let loadedModel = try await Xybrid.model(modelId).load()
                 await MainActor.run {
                     self.model = loadedModel
                     inferenceState = .idle

--- a/examples/ios/XybridExample/LiveVision.swift
+++ b/examples/ios/XybridExample/LiveVision.swift
@@ -388,11 +388,9 @@ final class LiveVisionViewModel: ObservableObject {
         if let model, loadedModelId == modelId { return model }
         let targetId = modelId
         status = "Loading \(targetId)…"
-        // bolt collapsed the loader into a synchronous, blocking
-        // `XybridModel(fromRegistry:)`; load OFF the main actor (see `infer`).
-        let loaded = try await Task.detached {
-            try XybridModel(fromRegistry: targetId)
-        }.value
+        // Creating the loader is side-effect free; `load()` owns the expensive
+        // asynchronous boundary.
+        let loaded = try await Xybrid.model(targetId).load()
         model = loaded
         loadedModelId = targetId
         return loaded


### PR DESCRIPTION
## Summary

This pull request restores an explicit model-loading lifecycle for the Swift and Kotlin facades so describing a model source remains cheap and all network, disk, and runtime initialization work happens at a clearly named load boundary. It aligns both bindings around the cohesive Xybrid.model(source) → ModelLoader → load() → XybridModel flow while retaining existing direct constructors and factories as compatibility paths.

**API Facade Improvements:**

* Added strongly typed ModelSource APIs for registry, bundle, directory, and Hugging Face sources in Swift and Kotlin.
* Added lightweight ModelLoader facades with asynchronous load() as the primary mobile API and explicit loadSync()/loadBlocking() alternatives for worker-thread use.
* Deprecated the hidden-loading asynchronous factories in favor of the explicit loader flow while preserving existing direct loading entry points for compatibility.

**Documentation and Examples:**

* Updated the root READMEs, platform guides, API reference, API surface manifest, and Android/iOS examples to use the explicit loading lifecycle.
* Documented the Kotlin compatibility change: the formerly deprecated loader is now canonical and asynchronous, with loadBlocking() available for synchronous callers.

**Tests:**

* Added Swift and Kotlin unit coverage proving that loader construction captures model sources without performing a load.
* Validated the Kotlin facade with Gradle unit tests and Bazel hermetic compilation through //bindings/kotlin:xybrid_kotlin_classes.
* Passed workspace formatting, clippy with warnings denied, and cargo test --workspace --features ort-download.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [x] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (cargo test --workspace --features ort-download)
- [x] Code follows project style (see RUST_GUIDE.md)
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the primary public loading API for iOS and Android with broad doc/example churn; behavior is mostly a facade reshuffle with deprecations and compatibility paths, not core inference changes.
> 
> **Overview**
> Restores a **two-step model lifecycle** on the Swift and Kotlin facades: **`Xybrid.model(...)`** only describes a **`ModelSource`** (registry, bundle, directory, Hugging Face); **`ModelLoader.load()`** / **`loadSync()`** / **`loadBlocking()`** is the named boundary for resolve, download, disk, and runtime init.
> 
> Both bindings add **`ModelSource`** and **`ModelLoader`**, wire **`Xybrid.model(id)`** and **`Xybrid.model(source)`**, and **deprecate** the old **`fromRegistryAsync`**-style helpers in favor of the loader flow while keeping direct **`XybridModel`** constructors as the sync implementation behind **`loadSync()`**.
> 
> Docs, READMEs, API reference, **`api-surface.yaml`**, and Android/iOS examples are updated to **`Xybrid.model(...).load()`** and **`runAsync`**. **Unit tests** assert loader construction captures the source without loading; Swift gains an **`XybridTests`** target in **`Package.swift`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9c8386ed3b439960af62285c0015eb252a94f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->