### PR TITLE
fix(bolt): initialize native log sinks in the Swift/Kotlin SDK path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6217,7 +6217,10 @@ dependencies = [
 name = "xybrid-bolt"
 version = "0.4.1"
 dependencies = [
+ "android_logger",
  "boltffi",
+ "log",
+ "oslog",
  "xybrid-ffi-facade",
  "xybrid-sdk",
 ]

--- a/crates/xybrid-bolt/Cargo.toml
+++ b/crates/xybrid-bolt/Cargo.toml
@@ -21,6 +21,13 @@ xybrid-sdk = { path = "../xybrid-sdk", default-features = false }
 # wires in by default — we describe identifiers as plain `String` to
 # stay consistent with the facade and the FRB/uniffi crates.
 boltffi = { version = "0.25", default-features = false }
+log = "0.4"
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.15"
+
+[target.'cfg(target_os = "ios")'.dependencies]
+oslog = "0.2"
 
 [features]
 default = []

--- a/crates/xybrid-bolt/src/lib.rs
+++ b/crates/xybrid-bolt/src/lib.rs
@@ -607,6 +607,34 @@ pub fn clear_battery_level() {
 // Process-global init
 // ============================================================================
 
+/// Initialize the platform-native `log` backend exactly once per process.
+///
+/// Mirrors the Flutter binding's `ensure_native_logging` (see
+/// `bindings/flutter/rust/src/api/mod.rs`): without a registered logger every
+/// `log::warn!` in the SDK — telemetry send failures and registry failovers
+/// in particular — is silently discarded on device. Called from the
+/// process-global init entry points the Swift/Kotlin wrappers hit during
+/// `Xybrid.initialize` / `Xybrid.init`. No-op on desktop targets, where the
+/// host process owns logger setup.
+fn ensure_native_logging() {
+    static LOGGING_INIT: std::sync::Once = std::sync::Once::new();
+    LOGGING_INIT.call_once(|| {
+        #[cfg(target_os = "android")]
+        android_logger::init_once(
+            android_logger::Config::default()
+                .with_max_level(log::LevelFilter::Info)
+                .with_tag("xybrid"),
+        );
+        #[cfg(target_os = "ios")]
+        {
+            // Errors only if a logger is already registered — fine to ignore.
+            let _ = oslog::OsLogger::new("dev.xybrid.sdk")
+                .level_filter(log::LevelFilter::Info)
+                .init();
+        }
+    });
+}
+
 /// One-stop SDK initialization: API key + gateway/ingest URL overrides in
 /// one call. Delegates to [`facade::configure_runtime`]; blank strings are
 /// treated as absent. This is the canonical init the Swift
@@ -618,11 +646,13 @@ pub fn configure_runtime(
     gateway_url: Option<String>,
     ingest_url: Option<String>,
 ) {
+    ensure_native_logging();
     facade::configure_runtime(api_key, gateway_url, ingest_url);
 }
 
 #[export]
 pub fn init_sdk_cache_dir(cache_dir: String) {
+    ensure_native_logging();
     // Param name pinned to `cache_dir` (not `path`) so the emitted Swift
     // is `initSdkCacheDir(cacheDir:)`, matching the existing
     // `examples/ios/XybridExample` call site that uniffi already exposes
@@ -632,16 +662,19 @@ pub fn init_sdk_cache_dir(cache_dir: String) {
 
 #[export]
 pub fn set_binding(binding: String) {
+    ensure_native_logging();
     facade::set_binding(binding);
 }
 
 #[export]
 pub fn set_api_key(api_key: String) {
+    ensure_native_logging();
     facade::set_api_key(api_key);
 }
 
 #[export]
 pub fn set_provider_api_key(provider: String, api_key: String) {
+    ensure_native_logging();
     facade::set_provider_api_key(provider, api_key);
 }
 


### PR DESCRIPTION
## What

- `xybrid-bolt` never registered a `log` backend — every `log::warn!` in the SDK (telemetry send failures, registry failovers) was silently discarded in the native Swift/Kotlin SDKs. Same hole #448 closed for the Flutter binding.
- Adds `ensure_native_logging()` (`android_logger` tag `xybrid` / `oslog` `dev.xybrid.sdk`, Info level, once-guarded), called from the five process-global init entry points that `Xybrid.initialize` (Swift) / `Xybrid.init` (Kotlin) hit.

## Verified

- clippy + fmt clean; `cargo check --target aarch64-apple-ios` green
- Android triple check blocked locally by missing NDK clang (pre-existing, `ring`'s C build) — CI's Build Android job covers it; `android_logger` is pure Rust and already ships in the Flutter binding

Completes the mobile logging parity story: Flutter (#448), native Swift/Kotlin (this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only init at existing entry points; mirrors the Flutter binding pattern with no auth or inference behavior changes.
> 
> **Overview**
> **Native Swift/Kotlin SDKs** previously had no `log` backend in `xybrid-bolt`, so SDK `log::warn!` output (telemetry failures, registry failovers) was dropped on device—the same gap fixed for Flutter in #448.
> 
> This PR adds **`ensure_native_logging()`** (once per process): **Android** uses `android_logger` (tag `xybrid`, Info); **iOS** uses **oslog** (`dev.xybrid.sdk`, Info); desktop stays a no-op. It runs at the start of the five Bolt init exports used by `Xybrid.initialize` / `Xybrid.init`—`configure_runtime`, `init_sdk_cache_dir`, `set_binding`, `set_api_key`, and `set_provider_api_key`. Dependencies are `log` plus target-specific crates in `Cargo.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49da7df75bc0a22946a51a3133657baf9d8652bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->