### PR TITLE
docs: bump install pins to v0.4.0

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 **モデルを実行:**
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.0")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.3.0"
+xybrid = "0.4.0"
 ```
 
 **モデルを実行:**

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 **Run a model:**
@@ -177,7 +177,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.0")
 ]
 ```
 
@@ -216,7 +216,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.3.0"
+xybrid = "0.4.0"
 ```
 
 **Run a model:**

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 **运行模型：**
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.0")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.3.0"
+xybrid = "0.4.0"
 ```
 
 **运行模型：**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -12,14 +12,14 @@ Add Xybrid to your Xcode project:
 
 1. In Xcode, select **File > Add Package Dependencies...**
 2. Enter: `https://github.com/xybrid-ai/xybrid`
-3. Set **Dependency Rule** to **Up to Next Major Version** → `0.3.0`
+3. Set **Dependency Rule** to **Up to Next Major Version** → `0.4.0`
 4. Select the **Xybrid** library product
 
 Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
 ]
 ```
 

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -15,7 +15,7 @@ Or add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 <details>

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -12,7 +12,7 @@ Add to your `build.gradle.kts`:
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -42,7 +42,7 @@ Or edit `Packages/manifest.json` directly:
     }
   ],
   "dependencies": {
-    "ai.xybrid.sdk": "0.3.0"
+    "ai.xybrid.sdk": "0.4.0"
   }
 }
 ```
@@ -59,7 +59,7 @@ https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 Pin a version by appending a tag:
 
 ```
-https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.3.0
+https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.4.0
 ```
 
 (**Window → Package Manager → + → Add package from git URL**, or add it under

--- a/bindings/web/README.md
+++ b/bindings/web/README.md
@@ -1,6 +1,6 @@
 # @xybrid/web preview
 
-`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.3.0` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
+`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.4.0` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
 
 ## Supported now
 

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -11,7 +11,7 @@ Add the Xybrid SDK from Maven Central:
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -11,7 +11,7 @@ Android SDK 通过 BoltFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支�
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/flutter.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.mdx
@@ -11,7 +11,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 ## Initialization

--- a/docs/content/docs/(integration)/sdks/flutter.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.zh.mdx
@@ -11,7 +11,7 @@ Flutter SDK（`xybrid_flutter`）通过 FFI 提供到 Xybrid Rust 核心的 Dart
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 ## 初始化

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -15,7 +15,7 @@ Add the Xybrid package via Swift Package Manager:
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -15,7 +15,7 @@ Swift SDK 处于早期访问阶段。正式版本通过 Swift Package Manager �
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/web.mdx
+++ b/docs/content/docs/(integration)/sdks/web.mdx
@@ -6,7 +6,7 @@ description: Browser SDK preview for on-device ML inference with WebAssembly and
 The Web SDK (`@xybrid/web`) runs Xybrid models directly in the browser. It has two surfaces: a tensor surface (`XybridModel`) for TfLite models and a text-generation surface (`XybridLlm`) for `.litertlm` language models. Inference executes locally through WebAssembly, with WebGPU acceleration when available — no server round-trip.
 
 <Callout type="info">
-`@xybrid/web` `0.3.0` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
+`@xybrid/web` `0.4.0` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
 </Callout>
 
 ## Try the Demo

--- a/docs/content/docs/(integration)/sdks/web.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/web.zh.mdx
@@ -6,7 +6,7 @@ description: 基于 WebAssembly 与 WebGPU 的浏览器端设备内 ML 推理 SD
 Web SDK（`@xybrid/web`）让 Xybrid 模型直接在浏览器中运行。它包含两个界面：用于 TfLite 模型的张量界面（`XybridModel`），以及用于 `.litertlm` 语言模型的文本生成界面（`XybridLlm`）。推理通过 WebAssembly 在本地执行，在可用时使用 WebGPU 加速——无需服务器往返。
 
 <Callout type="info">
-`@xybrid/web` `0.3.0` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
+`@xybrid/web` `0.4.0` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
 </Callout>
 
 ## 体验示例

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Get Xybrid running in your app with a few lines of code. Choose your SDK below.
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 ```bash
@@ -54,7 +54,7 @@ Or add to `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
 ]
 ```
 
@@ -119,7 +119,7 @@ In Unity, go to **Window > Package Manager > + > Add package from git URL** and 
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.3.0` to the git URL.
+Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.4.0` to the git URL.
 
 **Run inference**
 
@@ -191,7 +191,7 @@ See the [Web SDK guide](/docs/sdks/web) for the tensor surface, registry loading
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.3.0"
+xybrid = "0.4.0"
 ```
 
 **Run inference**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -12,7 +12,7 @@ description: 几分钟内开始使用 Xybrid
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.3.0
+  xybrid_flutter: ^0.4.0
 ```
 
 ```bash
@@ -54,7 +54,7 @@ https://github.com/xybrid-ai/xybrid
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.3.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
 ]
 ```
 
@@ -119,7 +119,7 @@ val result = model.runAsync(envelope)
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.3.0`。
+或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.4.0`。
 
 **运行推理**
 
@@ -190,7 +190,7 @@ const llm = await XybridLlm.fromHuggingFace("litert-community/SmolLM2-135M-Instr
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.3.0"
+xybrid = "0.4.0"
 ```
 
 **运行推理**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.3.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
 }
 ```
 


### PR DESCRIPTION
This pull request updates the documented install versions across every SDK README and docs page from `0.3.0` to `0.4.0`, so a developer copying the install snippet gets the current release. The pins had been left behind by the v0.4.0 release and were four releases stale. Each version was checked against its live registry before being bumped.

**Install pins bumped (each verified published):**

* `xybrid_flutter: ^0.4.0` — pub.dev serves 0.4.0.
* `xybrid = "0.4.0"` (Cargo) — crates.io serves 0.4.0.
* Swift Package Manager `from: "0.4.0"` — tag `v0.4.0` exists.
* Unity `ai.xybrid.sdk: 0.4.0` and the `#v0.4.0` git tag pin — OpenUPM serves 0.4.0, all five native bundles attached to the release.
* `implementation("ai.xybrid:xybrid-kotlin:0.4.0")` — Maven Central serves 0.4.0.
* `@xybrid/web` preview version, to match `bindings/web/package.json`.

**Note on the Kotlin pin:**

* It was held back in the first commit because `ai.xybrid:xybrid-kotlin:0.4.0` was missing from Maven Central at the time — the v0.4.0 deployment had been uploaded but never released, so the publish job reported success while nothing landed.
* That deployment has since been published by hand. The pom, aar, sources jar and GPG signature all resolve, and `maven-metadata.xml` now lists 0.4.0 as both `latest` and `release`, so the pin is bumped in the second commit.
* Whether the release step should be automated or stay a deliberate manual gate is a separate question, tracked in #455. No workflow or Gradle changes here.

**Scope:**

* Documentation only. Same file set as the #317 pin bump, plus the Unity and web pages that did not exist then. No code, no workflow, no manifest changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only version string updates with no code or infrastructure changes; the only caveat is if any pin (notably Kotlin on Maven Central) is not actually published yet, copied snippets could fail to resolve.
> 
> **Overview**
> **Documentation-only release alignment:** install snippets and version callouts now point at **v0.4.0** instead of **0.3.0** so copy-paste installs match the current release.
> 
> Coverage spans **Flutter** (`xybrid_flutter`), **Kotlin** (`ai.xybrid:xybrid-kotlin`), **Swift** SPM (`from: "0.4.0"`), **Rust** (`xybrid` on crates.io), **Unity** (OpenUPM `ai.xybrid.sdk` and `#v0.4.0` git pins), and **Web** (`@xybrid/web` preview text), in English/Japanese/Chinese READMEs plus SDK and quickstart MDX pages (including Android docs that previously only existed in zh).
> 
> No runtime, manifest, or workflow changes—only user-facing version strings in docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053f74c2aa052683372329524db9174429d44193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->