### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.4.1] - 2026-08-05
+
+Patch release on the 0.4.0 line. The headline is the explicit model-loading
+lifecycle restored on Swift and Kotlin: the documented
+`Xybrid.model(...).load()` flow existed on Flutter, Rust, and Unity but not on
+those two SDKs, so their published quickstarts described an API 0.4.0 did not
+ship. Token streaming also reaches Apple, Kotlin, and React Native, speculative
+cloud fallback lands, and the mobile telemetry pipeline is now device-verified
+on both platforms.
+
 ### Added
 
 - **Token streaming on Apple, Kotlin, and React Native.** The pull-based
@@ -19,11 +35,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   breaking out of the loop, cancelling the task/coroutine, or releasing the
   model — closes the session and aborts generation at the next token boundary
   instead of running to `max_tokens`; mid-stream failures carry the same typed
-  errors as `run`.
+  errors as `run` (#438).
+- **Speculative cloud fallback.** When a registry model has not been downloaded
+  yet and an API key is present, the SDK serves inference from the platform
+  gateway while the weights download in the background, then switches to local
+  transparently — exposed as `run`/`repl --speculative-cloud`. Both this path
+  and the existing reactive cloud fallback now send the registry model id to
+  the gateway so it routes to the same model running on the CPU cluster,
+  instead of defaulting to a hosted third-party model (#264).
+- **Grammar-constrained output on React Native.** `GenerationConfig.grammar`
+  now crosses the TurboModule boundary instead of being silently dropped, and
+  `jsonSchemaToGbnf()` is exposed in JavaScript, closing the structured-output
+  gap that Swift, Kotlin, C, and Dart already had (#442).
 
-### Planned
+### Fixed
 
-- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+- **Swift and Kotlin regain an explicit model-loading step.** `Xybrid.model(id)`
+  and `Xybrid.model(source)` return a cheap, unloaded `ModelLoader`; all
+  network, disk, and runtime initialization happens at a named `load()`
+  boundary, with `loadSync()` / `loadBlocking()` for worker threads. Registry,
+  bundle, directory, and Hugging Face sources are strongly typed through
+  `ModelSource`. The direct constructors and factories still work, so existing
+  code compiles unchanged; the hidden-loading async factories are deprecated in
+  favour of the loader flow (#451).
+- **Flutter's iOS build linked the wrong ONNX Runtime slice.** Simulator builds
+  resolved to the device `ios-arm64` slice and failed to link. The build now
+  prefers the simulator slice, falling back to a checksum-pinned fetch of the
+  same artifact the Bazel graph uses (#450).
+- **Telemetry export failures were silently discarded.** Exporter transport
+  errors are now logged with attempt count and cause, and the Flutter binding
+  installs a native log sink on both platforms (`android_logger` on Android,
+  `oslog` on iOS) so those lines reach logcat and the unified log (#448).
+- **Registry URL failover was invisible on mobile.** It now logs at `warn`
+  rather than `debug`, which the default mobile log level hides. Both mobile
+  platforms are now device-verified end to end for the metrics pipeline (#449).
+- **Unity release packaging failed on staged Bazel outputs.** Bazel's outputs
+  are read-only; they are now made owner-writable before post-processing, which
+  unblocks the Linux, macOS, and iOS strip steps (#432).
+
+### Changed
+
+- **`xybrid-llama-sys` declares `links = "llama"`.** A dependency graph pulling
+  in both this crate and crates.io's `llama-cpp-sys-2` now fails at resolution
+  time, naming both packages, instead of static-linking two copies of the same
+  ggml/llama archives into one binary. No effect on compiled output (#441).
+- Dependency bumps: `schemars` 0.8.22 → 1.2.2, `tokenizers` 0.19.1 → 0.22.2,
+  `dialoguer` 0.11.0 → 0.12.0.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -1305,13 +1305,13 @@ dependencies = [
 
 [[package]]
 name = "delegate-attr"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+checksum = "a84c9a9c129b98e707ac9a31e204c10c064dd9f949b7da362310ff1a8b137d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2751,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-terminal"
@@ -2946,9 +2946,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -3142,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.21.0"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+checksum = "ef84a52be188a1d4124bd717903fdde96ca4705f2b56adfe2d91fcc57fcb6987"
 dependencies = [
  "memo-map",
  "serde",
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.21.0"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85342f6fac0be8ccd5bd00d9066be538f34f393f577b75d81b17c8398a6b43bb"
+checksum = "fd6e279dc925840c2d9ebc1e9f85410611d01292561297463ba3e516c3ad94dd"
 dependencies = [
  "minijinja",
  "serde",
@@ -4376,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5101,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6194,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6208,14 +6208,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-bolt"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "boltffi",
  "xybrid-ffi-facade",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde_json",
  "tokio",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6339,7 +6339,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6357,7 +6357,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6383,7 +6383,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",
@@ -6583,9 +6583,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.4.0"
+let sdkVersion = "0.4.1"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.4.1"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "3c209ca56fafa8345bb7be03d89da40ee60fe9fbbe9c6142e2bb7d1de7b3e63e"
+let xybridFFIChecksum = "38642071c99779a96e26a6c4add471761c0bdacb7820440cffc201845c3157fd"
 
 let package = Package(
     name: "Xybrid",

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 **モデルを実行:**
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.1")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.4.0"
+xybrid = "0.4.1"
 ```
 
 **モデルを実行:**

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 **Run a model:**
@@ -159,7 +159,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 
@@ -177,7 +177,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.1")
 ]
 ```
 
@@ -216,7 +216,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.4.0"
+xybrid = "0.4.1"
 ```
 
 **Run a model:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 **运行模型：**
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.1")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.4.0"
+xybrid = "0.4.1"
 ```
 
 **运行模型：**

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -12,14 +12,14 @@ Add Xybrid to your Xcode project:
 
 1. In Xcode, select **File > Add Package Dependencies...**
 2. Enter: `https://github.com/xybrid-ai/xybrid`
-3. Set **Dependency Rule** to **Up to Next Major Version** → `0.4.0`
+3. Set **Dependency Rule** to **Up to Next Major Version** → `0.4.1`
 4. Select the **Xybrid** library product
 
 Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
 ]
 ```
 

--- a/bindings/apple/XybridFFI-Info.plist
+++ b/bindings/apple/XybridFFI-Info.plist
@@ -7,8 +7,8 @@
 	     CFBundlePackageType) on top of these; only the version keys must be
 	     supplied. This is the embedded static framework's Info.plist. -->
 	<key>CFBundleVersion</key>
-	<string>0.4.0</string>
+	<string>0.4.1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.4.1</string>
 </dict>
 </plist>

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.1
+
+No Dart API changes. Fixes to the iOS build and to diagnostics on both mobile
+platforms.
+
+* Fixed: iOS builds linked the device ONNX Runtime slice when targeting the simulator and failed with `building for 'iOS-simulator', but linking in object file built for 'iOS'`. The simulator slice is now preferred, falling back to a checksum-pinned fetch of the same artifact (xybrid-ai/xybrid#450)
+* Fixed: telemetry export failures were discarded silently and the binding installed no native log sink, so nothing reached logcat or the unified log. Export errors now log with attempt count and cause, and `Xybrid.init` installs `android_logger` on Android and `oslog` on iOS (xybrid-ai/xybrid#448)
+* Fixed: registry URL failover logged at `debug`, below the default mobile log level, so a failing registry looked like a silent hang. It now logs at `warn` (xybrid-ai/xybrid#449)
+
 ## 0.4.0
 
 Stable release of the 0.4.0 line. No Flutter API changes since `0.4.0-rc1`.

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -15,7 +15,7 @@ Or add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 <details>

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.4.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.4.1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -12,7 +12,7 @@ Add to your `build.gradle.kts`:
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.4.0"
+version = "0.4.1"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xybrid"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python SDK for local-first xybrid inference"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.4.0"
+  implementation "ai.xybrid:xybrid-kotlin:0.4.1"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -42,7 +42,7 @@ Or edit `Packages/manifest.json` directly:
     }
   ],
   "dependencies": {
-    "ai.xybrid.sdk": "0.4.0"
+    "ai.xybrid.sdk": "0.4.1"
   }
 }
 ```
@@ -59,7 +59,7 @@ https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 Pin a version by appending a tag:
 
 ```
-https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.4.0
+https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.4.1
 ```
 
 (**Window → Package Manager → + → Add package from git URL**, or add it under

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/web/README.md
+++ b/bindings/web/README.md
@@ -1,6 +1,6 @@
 # @xybrid/web preview
 
-`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.4.0` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
+`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.4.1` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
 
 ## Supported now
 

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xybrid/web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "description": "Preview browser tensor runtime for Xybrid metadata backed by LiteRT.",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,8 +25,8 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.4.0", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.1", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.4.1", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.1" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.4.0", path = "../../macros" }
+xybrid-macros = { version = "0.4.1", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.4.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.4.1", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.4.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.4.1", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.4.0", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.4.1", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -11,7 +11,7 @@ Add the Xybrid SDK from Maven Central:
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -11,7 +11,7 @@ Android SDK 通过 BoltFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支�
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/flutter.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.mdx
@@ -11,7 +11,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 ## Initialization

--- a/docs/content/docs/(integration)/sdks/flutter.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.zh.mdx
@@ -11,7 +11,7 @@ Flutter SDK（`xybrid_flutter`）通过 FFI 提供到 Xybrid Rust 核心的 Dart
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 ## 初始化

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -15,7 +15,7 @@ Add the Xybrid package via Swift Package Manager:
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -15,7 +15,7 @@ Swift SDK 处于早期访问阶段。正式版本通过 Swift Package Manager �
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/web.mdx
+++ b/docs/content/docs/(integration)/sdks/web.mdx
@@ -6,7 +6,7 @@ description: Browser SDK preview for on-device ML inference with WebAssembly and
 The Web SDK (`@xybrid/web`) runs Xybrid models directly in the browser. It has two surfaces: a tensor surface (`XybridModel`) for TfLite models and a text-generation surface (`XybridLlm`) for `.litertlm` language models. Inference executes locally through WebAssembly, with WebGPU acceleration when available — no server round-trip.
 
 <Callout type="info">
-`@xybrid/web` `0.4.0` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
+`@xybrid/web` `0.4.1` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
 </Callout>
 
 ## Try the Demo

--- a/docs/content/docs/(integration)/sdks/web.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/web.zh.mdx
@@ -6,7 +6,7 @@ description: 基于 WebAssembly 与 WebGPU 的浏览器端设备内 ML 推理 SD
 Web SDK（`@xybrid/web`）让 Xybrid 模型直接在浏览器中运行。它包含两个界面：用于 TfLite 模型的张量界面（`XybridModel`），以及用于 `.litertlm` 语言模型的文本生成界面（`XybridLlm`）。推理通过 WebAssembly 在本地执行，在可用时使用 WebGPU 加速——无需服务器往返。
 
 <Callout type="info">
-`@xybrid/web` `0.4.0` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
+`@xybrid/web` `0.4.1` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
 </Callout>
 
 ## 体验示例

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Get Xybrid running in your app with a few lines of code. Choose your SDK below.
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 ```bash
@@ -54,7 +54,7 @@ Or add to `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
 ]
 ```
 
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 
@@ -119,7 +119,7 @@ In Unity, go to **Window > Package Manager > + > Add package from git URL** and 
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.4.0` to the git URL.
+Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.4.1` to the git URL.
 
 **Run inference**
 
@@ -191,7 +191,7 @@ See the [Web SDK guide](/docs/sdks/web) for the tensor surface, registry loading
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.4.0"
+xybrid = "0.4.1"
 ```
 
 **Run inference**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -12,7 +12,7 @@ description: 几分钟内开始使用 Xybrid
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.4.0
+  xybrid_flutter: ^0.4.1
 ```
 
 ```bash
@@ -54,7 +54,7 @@ https://github.com/xybrid-ai/xybrid
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
 ]
 ```
 
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
 }
 ```
 
@@ -119,7 +119,7 @@ val result = model.runAsync(envelope)
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.4.0`。
+或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.4.1`。
 
 **运行推理**
 
@@ -190,7 +190,7 @@ const llm = await XybridLlm.fromHuggingFace("litert-community/SmolLM2-135M-Instr
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.4.0"
+xybrid = "0.4.1"
 ```
 
 **运行推理**


### PR DESCRIPTION
Release **v0.4.1**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.4.1).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.4.1`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation sync with no application logic in the diff; main operational risk is the automated publish/tag workflow on merge, not runtime behavior changes in this PR.
> 
> **Overview**
> **Release v0.4.1** — version and packaging only; merging is intended to tag `v0.4.1` and publish crates.io, pub.dev, Maven Central, and related release assets.
> 
> The workspace and every shipping surface move from `0.4.0` to `0.4.1`: root `Cargo.toml`, internal crate path versions, Flutter/Kotlin/React Native/Unity/Python manifests, and `Cargo.lock` (including routine transitive crate bumps). **CHANGELOG** gains a full **[0.4.1]** section (streaming on Apple/Kotlin/RN, speculative cloud fallback, Swift/Kotlin `ModelLoader`, mobile telemetry and iOS simulator fixes, etc.) and moves “Planned” multimodal KV reuse under **[Unreleased]**.
> 
> **Package.swift** sets `sdkVersion` to `0.4.1` and replaces the **XybridFFI** xcframework zip checksum. READMEs, binding changelogs (e.g. Flutter **0.4.1** notes), and docs quickstart/SDK pages update consumer install pins to `^0.4.1` / `0.4.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7e27e6b3f25ce92e122ecf224c23644e60c8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->