### PR TITLE
feat(asr): faster first partial + flicker-free transcript for live streaming

### DIFF
--- a/crates/xybrid-core/src/streaming/audio_buffer.rs
+++ b/crates/xybrid-core/src/streaming/audio_buffer.rs
@@ -17,6 +17,14 @@ pub struct AudioBufferConfig {
     pub overlap_secs: f32,
     /// Maximum buffer duration before oldest samples are discarded
     pub max_buffer_secs: f32,
+    /// Warm-up window durations for the first chunks of a stream (seconds).
+    ///
+    /// Each entry is a *growing* window measured from the stream start: the
+    /// buffer does not advance past a warm-up chunk, so the next chunk
+    /// re-covers the same audio with more context. This gets a first partial
+    /// out after `warmup_chunk_secs[0]` seconds instead of a full
+    /// `chunk_duration_secs`. Empty (the default) disables warm-up.
+    pub warmup_chunk_secs: Vec<f32>,
 }
 
 impl Default for AudioBufferConfig {
@@ -26,6 +34,7 @@ impl Default for AudioBufferConfig {
             chunk_duration_secs: 30.0, // Whisper's 30-second window
             overlap_secs: 1.0,         // 1 second overlap for continuity
             max_buffer_secs: 120.0,    // 2 minutes max buffer
+            warmup_chunk_secs: Vec::new(),
         }
     }
 }
@@ -43,6 +52,7 @@ impl AudioBufferConfig {
             chunk_duration_secs: 10.0, // Wav2Vec2 works better with shorter chunks
             overlap_secs: 0.5,
             max_buffer_secs: 60.0,
+            warmup_chunk_secs: Vec::new(),
         }
     }
 
@@ -59,6 +69,22 @@ impl AudioBufferConfig {
     /// Maximum buffer samples
     pub fn max_buffer_samples(&self) -> usize {
         (self.sample_rate as f32 * self.max_buffer_secs) as usize
+    }
+
+    /// Window size in samples for the chunk with the given sequence number.
+    ///
+    /// Warm-up sequences use their (smaller, growing) configured window; all
+    /// later sequences use the steady-state `chunk_samples()`.
+    pub fn chunk_samples_for(&self, sequence: u64) -> usize {
+        self.warmup_chunk_secs
+            .get(sequence as usize)
+            .map(|secs| (self.sample_rate as f32 * secs) as usize)
+            .unwrap_or_else(|| self.chunk_samples())
+    }
+
+    /// Whether the chunk with the given sequence number is a warm-up chunk.
+    pub fn is_warmup_chunk(&self, sequence: u64) -> bool {
+        (sequence as usize) < self.warmup_chunk_secs.len()
     }
 }
 
@@ -174,8 +200,11 @@ impl AudioBuffer {
     }
 
     /// Check if a full chunk is ready for processing.
+    ///
+    /// During warm-up the required window is smaller, so early chunks become
+    /// ready sooner than the steady-state `chunk_duration_secs`.
     pub fn has_chunk_ready(&self) -> bool {
-        self.available_samples() >= self.config.chunk_samples()
+        self.available_samples() >= self.config.chunk_samples_for(self.next_sequence)
     }
 
     /// Check if any audio is available (for final flush).
@@ -189,7 +218,8 @@ impl AudioBuffer {
     /// Use `force = true` to get a partial chunk (e.g., at end of stream).
     pub fn extract_chunk(&mut self, force: bool) -> Option<AudioChunk> {
         let available = self.available_samples();
-        let chunk_size = self.config.chunk_samples();
+        let is_warmup = self.config.is_warmup_chunk(self.next_sequence);
+        let chunk_size = self.config.chunk_samples_for(self.next_sequence);
 
         // Check if we have enough samples (or forcing partial chunk)
         if !force && available < chunk_size {
@@ -200,9 +230,11 @@ impl AudioBuffer {
             return None;
         }
 
-        // Calculate how many samples to extract
+        // Calculate how many samples to extract. A forced (flush) chunk is
+        // capped at the steady-state window, not the warm-up one, so a flush
+        // mid-warm-up still carries everything buffered so far.
         let extract_size = if force {
-            available.min(chunk_size)
+            available.min(self.config.chunk_samples())
         } else {
             chunk_size
         };
@@ -224,9 +256,14 @@ impl AudioBuffer {
             .copied()
             .collect();
 
-        // Advance processed counter (minus overlap for next chunk)
+        // Advance processed counter. Warm-up chunks don't advance at all —
+        // the next chunk re-covers the same audio from the stream start with
+        // a bigger window; the transcript layer replaces the earlier text.
+        // Steady-state chunks advance minus overlap; final chunks fully.
         let advance = if force {
             extract_size // No overlap on final chunk
+        } else if is_warmup {
+            0
         } else {
             extract_size.saturating_sub(overlap)
         };
@@ -357,6 +394,7 @@ mod tests {
             chunk_duration_secs: 0.1, // 100ms = 1600 samples
             overlap_secs: 0.01,       // 10ms = 160 samples overlap
             max_buffer_secs: 1.0,
+            warmup_chunk_secs: Vec::new(),
         };
         let mut buffer = AudioBuffer::with_config(config);
 
@@ -379,6 +417,7 @@ mod tests {
             chunk_duration_secs: 1.0,
             overlap_secs: 0.2, // 200 sample overlap
             max_buffer_secs: 10.0,
+            warmup_chunk_secs: Vec::new(),
         };
         let mut buffer = AudioBuffer::with_config(config);
 
@@ -395,6 +434,69 @@ mod tests {
         assert_eq!(chunk2.samples.len(), 1000);
         // First sample of chunk2 should be sample 800 (1000 - 200 overlap)
         assert_eq!(chunk2.samples[0], 800.0);
+    }
+
+    #[test]
+    fn test_buffer_warmup_windows_grow_from_stream_start() {
+        let config = AudioBufferConfig {
+            sample_rate: 1000, // Simplified for testing
+            chunk_duration_secs: 5.0,
+            overlap_secs: 0.5,
+            max_buffer_secs: 60.0,
+            warmup_chunk_secs: vec![1.5, 3.0],
+        };
+        let mut buffer = AudioBuffer::with_config(config);
+
+        // 1.5s in: first warm-up chunk ready, covers [0, 1.5).
+        buffer.push(&vec![0.0; 1500]);
+        assert!(buffer.has_chunk_ready());
+        let c0 = buffer.extract_chunk(false).unwrap();
+        assert_eq!(c0.samples.len(), 1500);
+        assert_eq!(c0.start_time, Duration::ZERO);
+
+        // No advance: not ready again until the *bigger* window fills.
+        assert!(!buffer.has_chunk_ready());
+
+        // 3s in: second warm-up chunk re-covers [0, 3).
+        buffer.push(&vec![0.0; 1500]);
+        let c1 = buffer.extract_chunk(false).unwrap();
+        assert_eq!(c1.samples.len(), 3000);
+        assert_eq!(c1.start_time, Duration::ZERO);
+
+        // 5s in: steady chunk covers [0, 5) and advances past the overlap.
+        buffer.push(&vec![0.0; 2000]);
+        let c2 = buffer.extract_chunk(false).unwrap();
+        assert_eq!(c2.samples.len(), 5000);
+        assert_eq!(c2.start_time, Duration::ZERO);
+
+        // 9.5s in: next steady chunk starts at 4.5s (5s - 0.5s overlap).
+        buffer.push(&vec![0.0; 4500]);
+        let c3 = buffer.extract_chunk(false).unwrap();
+        assert_eq!(c3.samples.len(), 5000);
+        assert_eq!(c3.start_time, Duration::from_millis(4500));
+    }
+
+    #[test]
+    fn test_buffer_flush_mid_warmup_carries_everything() {
+        let config = AudioBufferConfig {
+            sample_rate: 1000,
+            chunk_duration_secs: 5.0,
+            overlap_secs: 0.5,
+            max_buffer_secs: 60.0,
+            warmup_chunk_secs: vec![1.5, 3.0],
+        };
+        let mut buffer = AudioBuffer::with_config(config);
+
+        // Stop after the first warm-up chunk: 2s of audio, 0 advanced.
+        buffer.push(&vec![0.0; 2000]);
+        let _ = buffer.extract_chunk(false).unwrap(); // warm-up [0, 1.5)
+        buffer.end_stream();
+
+        // Flush must re-cover from 0, not just the un-consumed tail.
+        let flushed = buffer.extract_chunk(true).unwrap();
+        assert_eq!(flushed.start_time, Duration::ZERO);
+        assert_eq!(flushed.samples.len(), 2000);
+        assert!(flushed.is_final);
     }
 
     #[test]

--- a/crates/xybrid-core/src/streaming/session.rs
+++ b/crates/xybrid-core/src/streaming/session.rs
@@ -163,15 +163,40 @@ pub struct PartialResult {
     pub chunk_sequence: u64,
 }
 
+/// Maximum number of words checked for a duplicated seam between two
+/// consecutive overlapping chunks. The 0.5 s chunk overlap can only repeat a
+/// couple of words; a short cap keeps the match from gluing to a coincidental
+/// phrase repeat earlier in the sentence.
+const MAX_SEAM_WORDS: usize = 8;
+
+/// One transcribed span of the audio timeline.
+#[derive(Debug, Clone)]
+struct TranscriptSegment {
+    /// Transcribed text for this span (trimmed, may be empty for silence).
+    text: String,
+    /// Audio timeline position where this span starts.
+    start: Duration,
+    /// Audio timeline position where this span ends.
+    end: Duration,
+}
+
 /// Accumulated transcription across chunks.
+///
+/// Chunks arrive as windows over the audio timeline and may *re-cover* audio
+/// that earlier chunks already transcribed (warm-up windows grow from the
+/// stream start; steady-state windows overlap by a fraction of a second).
+/// Text is reconciled by span, not blindly appended:
+///
+/// - a chunk whose window starts at or before an existing segment's start
+///   *replaces* that segment (bigger window over the same audio wins);
+/// - a chunk that partially overlaps the previous segment has its seam
+///   deduplicated at word level, so the 0.5 s overlap doesn't repeat words.
 #[derive(Debug, Default)]
 struct TranscriptAccumulator {
-    /// Segments from completed chunks
-    segments: Vec<String>,
+    /// Reconciled segments, ordered by start time.
+    segments: Vec<TranscriptSegment>,
     /// Current partial (unstable) text
     current_partial: Option<String>,
-    /// Total audio duration processed
-    total_duration: Duration,
 }
 
 impl TranscriptAccumulator {
@@ -179,11 +204,32 @@ impl TranscriptAccumulator {
         Self::default()
     }
 
-    fn add_segment(&mut self, text: String, duration: Duration) {
-        if !text.trim().is_empty() {
-            self.segments.push(text.trim().to_string());
+    /// Reconcile a chunk transcription covering `start..end` into the
+    /// transcript.
+    fn add_chunk(&mut self, text: String, start: Duration, end: Duration) {
+        // Bigger window re-covering earlier spans replaces them.
+        while matches!(self.segments.last(), Some(last) if last.start >= start) {
+            self.segments.pop();
         }
-        self.total_duration += duration;
+
+        let mut text = text.trim().to_string();
+
+        // Word-level seam dedupe against the previous segment when the audio
+        // windows overlap: drop leading words that repeat its tail.
+        if let Some(prev) = self.segments.last_mut() {
+            if prev.end > start && !text.is_empty() {
+                text = strip_seam_overlap(&prev.text, &text);
+            }
+            if text.is_empty() {
+                // Nothing new to say (silence or the whole chunk was seam
+                // overlap) — just extend the covered span.
+                prev.end = prev.end.max(end);
+                self.current_partial = None;
+                return;
+            }
+        }
+
+        self.segments.push(TranscriptSegment { text, start, end });
         self.current_partial = None;
     }
 
@@ -191,25 +237,76 @@ impl TranscriptAccumulator {
         self.current_partial = Some(text);
     }
 
+    /// Audio timeline covered so far.
+    fn covered_duration(&self) -> Duration {
+        self.segments
+            .last()
+            .map(|s| s.end)
+            .unwrap_or(Duration::ZERO)
+    }
+
     fn get_full_text(&self) -> String {
-        let mut parts = self.segments.clone();
+        let mut parts: Vec<&str> = self
+            .segments
+            .iter()
+            .map(|s| s.text.as_str())
+            .filter(|t| !t.is_empty())
+            .collect();
         if let Some(ref partial) = self.current_partial {
             if !partial.trim().is_empty() {
-                parts.push(partial.trim().to_string());
+                parts.push(partial.trim());
             }
         }
         parts.join(" ")
     }
 
     fn get_stable_text(&self) -> String {
-        self.segments.join(" ")
+        self.segments
+            .iter()
+            .map(|s| s.text.as_str())
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     fn reset(&mut self) {
         self.segments.clear();
         self.current_partial = None;
-        self.total_duration = Duration::ZERO;
     }
+}
+
+/// Strip from the head of `next` the longest run of words that duplicates the
+/// tail of `prev` (case- and punctuation-insensitive), returning what remains.
+///
+/// Handles the seam between two overlapping audio windows, where the model
+/// transcribes the shared 0.5 s twice — possibly with different punctuation
+/// or casing ("go to the" / "Go to the").
+fn strip_seam_overlap(prev: &str, next: &str) -> String {
+    let prev_words: Vec<&str> = prev.split_whitespace().collect();
+    let next_words: Vec<&str> = next.split_whitespace().collect();
+
+    let normalize = |w: &str| {
+        w.chars()
+            .filter(|c| c.is_alphanumeric())
+            .collect::<String>()
+            .to_lowercase()
+    };
+
+    let max_k = MAX_SEAM_WORDS.min(prev_words.len()).min(next_words.len());
+    let matched = (1..=max_k)
+        .rev()
+        .find(|&k| {
+            prev_words[prev_words.len() - k..]
+                .iter()
+                .zip(&next_words[..k])
+                .all(|(p, n)| {
+                    let (p, n) = (normalize(p), normalize(n));
+                    !p.is_empty() && p == n
+                })
+        })
+        .unwrap_or(0);
+
+    next_words[matched..].join(" ")
 }
 
 /// Streaming ASR session.
@@ -393,12 +490,16 @@ impl StreamSession {
 
         if is_whisper {
             // Whisper: Use 5s chunks for responsive streaming (max 30s supported)
-            // This gives partial results every ~5 seconds while speaking
+            // This gives partial results every ~5 seconds while speaking.
+            // Warm-up windows get the first words on screen after ~1.5 s
+            // instead of a full window; each re-covers the stream from the
+            // start so the 5 s window then replaces them with better context.
             AudioBufferConfig {
                 sample_rate: 16000,
                 chunk_duration_secs: 5.0,
                 overlap_secs: 0.5, // Small overlap for continuity
                 max_buffer_secs: config.buffer_config.max_buffer_secs,
+                warmup_chunk_secs: vec![1.5, 3.0],
             }
         } else {
             // Default/Wav2Vec2: shorter chunks
@@ -407,6 +508,7 @@ impl StreamSession {
                 chunk_duration_secs: 5.0,
                 overlap_secs: config.buffer_config.overlap_secs,
                 max_buffer_secs: config.buffer_config.max_buffer_secs,
+                warmup_chunk_secs: Vec::new(),
             }
         }
     }
@@ -473,7 +575,7 @@ impl StreamSession {
             text,
             confidence: None,
             is_stable: false,
-            audio_duration: self.transcript.total_duration,
+            audio_duration: self.transcript.covered_duration(),
             chunk_sequence: self.buffer.stats().chunks_extracted,
         })
     }
@@ -549,7 +651,7 @@ impl StreamSession {
             samples_processed: buffer_stats.total_processed,
             chunks_processed: buffer_stats.chunks_extracted,
             transcript_length: self.transcript.get_full_text().len(),
-            audio_duration: self.transcript.total_duration,
+            audio_duration: self.transcript.covered_duration(),
         }
     }
 
@@ -612,8 +714,10 @@ impl StreamSession {
             }
         };
 
-        // Update transcript
-        self.transcript.add_segment(text.clone(), chunk.duration());
+        // Reconcile into the transcript (replaces re-covered spans, dedupes
+        // the overlap seam).
+        self.transcript
+            .add_chunk(text.clone(), chunk.start_time, chunk.end_time);
 
         // Fire callback if set
         if let Some(ref callback) = self.on_partial {
@@ -659,15 +763,20 @@ mod tests {
         assert!(config.enable_partial_results);
     }
 
+    fn secs(s: f64) -> Duration {
+        Duration::from_secs_f64(s)
+    }
+
     #[test]
-    fn test_transcript_accumulator() {
+    fn test_transcript_accumulator_disjoint_chunks_append() {
         let mut acc = TranscriptAccumulator::new();
 
-        acc.add_segment("Hello".to_string(), Duration::from_secs(1));
-        acc.add_segment("world".to_string(), Duration::from_secs(1));
+        acc.add_chunk("Hello".to_string(), secs(0.0), secs(1.0));
+        acc.add_chunk("world".to_string(), secs(1.0), secs(2.0));
 
         assert_eq!(acc.get_stable_text(), "Hello world");
         assert_eq!(acc.get_full_text(), "Hello world");
+        assert_eq!(acc.covered_duration(), secs(2.0));
 
         acc.set_partial("testing".to_string());
         assert_eq!(acc.get_full_text(), "Hello world testing");
@@ -675,12 +784,70 @@ mod tests {
     }
 
     #[test]
+    fn test_transcript_accumulator_growing_window_replaces() {
+        let mut acc = TranscriptAccumulator::new();
+
+        // Warm-up windows all start at 0 and grow: each replaces the last.
+        acc.add_chunk("I want".to_string(), secs(0.0), secs(1.5));
+        acc.add_chunk("I want to go".to_string(), secs(0.0), secs(3.0));
+        assert_eq!(acc.get_full_text(), "I want to go");
+
+        acc.add_chunk("I want to go home now".to_string(), secs(0.0), secs(5.0));
+        assert_eq!(acc.get_full_text(), "I want to go home now");
+        assert_eq!(acc.covered_duration(), secs(5.0));
+
+        // Steady-state chunk after warm-up appends, not replaces.
+        acc.add_chunk("and sleep".to_string(), secs(4.5), secs(9.5));
+        assert_eq!(acc.get_full_text(), "I want to go home now and sleep");
+    }
+
+    #[test]
+    fn test_transcript_accumulator_seam_dedupe() {
+        let mut acc = TranscriptAccumulator::new();
+
+        acc.add_chunk("I want to go".to_string(), secs(0.0), secs(5.0));
+        // Overlapping window re-transcribes the shared 0.5s ("to go"),
+        // with different casing/punctuation on the seam.
+        acc.add_chunk("To go, home now".to_string(), secs(4.5), secs(9.5));
+
+        assert_eq!(acc.get_full_text(), "I want to go home now");
+        assert_eq!(acc.covered_duration(), secs(9.5));
+    }
+
+    #[test]
+    fn test_transcript_accumulator_all_seam_extends_span() {
+        let mut acc = TranscriptAccumulator::new();
+
+        acc.add_chunk("go home".to_string(), secs(0.0), secs(5.0));
+        // Trailing chunk is entirely seam overlap (e.g. silence after speech).
+        acc.add_chunk("go home".to_string(), secs(4.5), secs(6.0));
+
+        assert_eq!(acc.get_full_text(), "go home");
+        assert_eq!(acc.covered_duration(), secs(6.0));
+    }
+
+    #[test]
     fn test_transcript_accumulator_reset() {
         let mut acc = TranscriptAccumulator::new();
-        acc.add_segment("Hello".to_string(), Duration::from_secs(1));
+        acc.add_chunk("Hello".to_string(), secs(0.0), secs(1.0));
         acc.reset();
 
         assert_eq!(acc.get_stable_text(), "");
-        assert_eq!(acc.total_duration, Duration::ZERO);
+        assert_eq!(acc.covered_duration(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_strip_seam_overlap() {
+        assert_eq!(strip_seam_overlap("I want to go", "to go home"), "home");
+        assert_eq!(
+            strip_seam_overlap("I want", "no overlap here"),
+            "no overlap here"
+        );
+        assert_eq!(strip_seam_overlap("same words", "Same words."), "");
+        // Cap: a repeat longer than MAX_SEAM_WORDS can't be a 0.5s seam, so
+        // it is kept as genuine repetition.
+        let prev = "one two three four five six seven eight nine";
+        let next = "one two three four five six seven eight nine ten";
+        assert_eq!(strip_seam_overlap(prev, next), next);
     }
 }


### PR DESCRIPTION
This pull request improves the live streaming ASR experience with two core-side changes: warm-up windowing so the first transcript appears seconds sooner, and span-based transcript reconciliation so the cumulative text no longer repeats or flickers at chunk boundaries. Both changes live entirely in `xybrid-core` — no SDK or FFI surface change, all bindings inherit them.

**Warm-up windowing (first-partial latency):**

* The first chunks of a Whisper stream use growing windows (1.5 s, 3 s) measured from the stream start instead of waiting for the full 5 s window, so the first partial lands ~3.5 s sooner.
* The buffer does not advance past a warm-up chunk: each subsequent window re-covers the same audio with more context, and the steady 5 s window then replaces the early text with a better transcription.
* Flushing mid-warm-up re-covers from the stream start, so stopping early still transcribes everything buffered.

**Span-reconciled transcript (stable partials):**

* `TranscriptAccumulator` now tracks the audio span each segment covers: a window that re-covers earlier spans replaces them (bigger context wins), instead of appending duplicate text.
* Windows that overlap the previous segment get word-level seam dedupe (case- and punctuation-insensitive, capped at 8 words), so the 0.5 s chunk overlap no longer repeats words at the seam.
* Covered-duration reporting is now derived from reconciled spans, fixing the overcount from overlapping chunks.

**Tests:**

* Eight new unit tests covering the warm-up schedule, growing-window replacement, seam dedupe, silence handling, and mid-warm-up flush; full workspace suite green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming chunk timing and how cumulative transcript text is built; behavior shifts for all Whisper live streams but stays internal to xybrid-core with solid unit coverage.
> 
> **Overview**
> Improves live streaming ASR in **xybrid-core** with **warm-up chunking** and **span-based transcript reconciliation**—no public API changes.
> 
> **Warm-up windowing** adds optional `warmup_chunk_secs` on `AudioBufferConfig`. Early chunks use smaller, growing windows from stream start; extraction does not advance the buffer on warm-up, so later chunks re-cover the same audio with more context. Whisper sessions enable **1.5 s / 3.0 s** warm-ups before the steady **5 s** window; flush mid-warm-up re-covers from zero instead of only the tail.
> 
> **Transcript handling** replaces blind append with `add_chunk(text, start, end)`: re-covering windows replace prior segments, overlapping steady chunks get **word-level seam dedupe** (`strip_seam_overlap`, capped at 8 words), and **covered duration** comes from reconciled spans rather than summed chunk lengths.
> 
> Unit tests cover warm-up scheduling, mid-warm-up flush, replacement, seam dedupe, and silence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cebbc21c65c59277add57fcc99ab5788faa3ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->