### PR TITLE
fix(core): reject a model-less gateway request instead of defaulting to OpenAI

### DIFF
--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -170,11 +170,20 @@ impl Cloud {
             })
             .collect();
 
+        // No silent default: falling back to a hosted model here would route a
+        // caller who merely forgot to set `model` to OpenAI, quietly billing a
+        // third-party provider instead of running the model they asked for.
         let model = request
             .model
             .clone()
             .or_else(|| self.config.default_model.clone())
-            .unwrap_or_else(|| "gpt-4o-mini".to_string());
+            .ok_or_else(|| {
+                CloudError::GatewayError(
+                    "no model specified for the gateway request: set CompletionRequest::model or \
+                     CloudConfig::default_model"
+                        .to_string(),
+                )
+            })?;
 
         let mut body = json!({
             "model": model,

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -391,7 +391,7 @@ fn stream_with_gateway_sse(
         ));
     }
 
-    let body = gateway_chat_body(&request, config, true);
+    let body = gateway_chat_body(&request, config, true)?;
     let url = format!("{}/chat/completions", config.gateway_url);
     let agent = ureq::AgentBuilder::new()
         .timeout_connect(Duration::from_millis(10_000))
@@ -529,11 +529,21 @@ fn stream_with_gateway_sse(
     })
 }
 
+/// Build the OpenAI-compatible chat body for the gateway.
+///
+/// # Errors
+///
+/// Returns [`AdapterError::InvalidInput`] when neither the request nor the
+/// config names a model. This used to fall back to `"gpt-4o-mini"`, which the
+/// gateway routes to OpenAI — so a caller that simply forgot the model silently
+/// billed a third-party provider instead of running the model it asked for.
+/// That exact default is what made a missing `model` look like a gateway 502
+/// rather than a client bug.
 fn gateway_chat_body(
     request: &CompletionRequest,
     config: &CloudConfig,
     force_stream: bool,
-) -> serde_json::Value {
+) -> AdapterResult<serde_json::Value> {
     let messages: Vec<serde_json::Value> = request
         .to_messages()
         .into_iter()
@@ -553,7 +563,13 @@ fn gateway_chat_body(
         .model
         .clone()
         .or_else(|| config.default_model.clone())
-        .unwrap_or_else(|| "gpt-4o-mini".to_string());
+        .ok_or_else(|| {
+            AdapterError::InvalidInput(
+                "no model specified for the cloud request: set it on the envelope's `model` \
+                 metadata or via CloudConfig::default_model"
+                    .to_string(),
+            )
+        })?;
 
     let mut body = json!({
         "model": model,
@@ -576,7 +592,7 @@ fn gateway_chat_body(
         body["stream"] = json!(true);
     }
 
-    body
+    Ok(body)
 }
 
 fn gateway_stream_error(error: ureq::Error, timeout_ms: u32) -> AdapterError {
@@ -664,7 +680,7 @@ mod tests {
             .with_temperature(0.2)
             .with_max_tokens(42);
 
-        let body = gateway_chat_body(&request, &config, true);
+        let body = gateway_chat_body(&request, &config, true).expect("model is set");
 
         assert_eq!(body["stream"], true);
         assert_eq!(body["model"], "explicit-model");
@@ -672,6 +688,36 @@ mod tests {
         assert_eq!(body["max_tokens"], 42);
         assert_eq!(body["messages"][0]["role"], "user");
         assert_eq!(body["messages"][0]["content"], "hello");
+    }
+
+    /// A request naming no model must fail loudly. It used to default to
+    /// `gpt-4o-mini`, so a caller who forgot `model` silently ran (and paid
+    /// for) OpenAI instead of the model they meant — and the resulting
+    /// upstream failure surfaced as an opaque gateway error.
+    #[test]
+    fn gateway_chat_body_rejects_a_missing_model() {
+        let config = CloudConfig::gateway();
+        assert!(config.default_model.is_none(), "guard the premise");
+        let request = CompletionRequest::new("hello");
+
+        let err = gateway_chat_body(&request, &config, false)
+            .expect_err("a model-less request must not fall back to a hosted default");
+
+        assert!(
+            matches!(err, AdapterError::InvalidInput(ref m) if m.contains("no model specified")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// The config default still satisfies the requirement.
+    #[test]
+    fn gateway_chat_body_accepts_the_config_default_model() {
+        let config = CloudConfig::gateway().with_default_model("lfm2.5-350m");
+        let request = CompletionRequest::new("hello");
+
+        let body = gateway_chat_body(&request, &config, false).expect("config supplies the model");
+
+        assert_eq!(body["model"], "lfm2.5-350m");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Both gateway request builders fell back to `\"gpt-4o-mini\"` when neither the request nor the config named a model, and the gateway routes that name to OpenAI. A caller who simply forgot to set the model therefore ran — and paid for — a third-party provider instead of the model they asked for, with the resulting upstream failure surfacing as an opaque gateway 502 rather than a client bug. This is the same silent default that made the speculative-cloud routing bug so hard to see, so it now fails loudly at the boundary; no SDK path relies on it, since both the speculative and reactive cloud legs already set `model` explicitly.

**Behaviour change:**

* `gateway_chat_body` returns `AdapterResult` and errors with `AdapterError::InvalidInput` when no model is resolvable; `stream_with_gateway_sse` propagates it.
* `Cloud::call_gateway` errors with `CloudError::GatewayError` in the same situation.
* Both messages name the two places a caller can set it (the envelope's `model` metadata / `CompletionRequest::model`, or `CloudConfig::default_model`).

**Deliberately unchanged:**

* The provider-scoped `DEFAULT_OPENAI_MODEL` / `DEFAULT_ANTHROPIC_MODEL` constants in the direct `cloud_llm` client stay — those sit inside per-provider calls where the caller has already chosen that provider, so there is no cross-provider surprise.

**Tests:**

* Added coverage for the rejection and for the config-default path, alongside the existing stream-forcing test.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for any caller that relied on the implicit gateway model; failures move earlier with clearer errors but could surface new errors in misconfigured integrations.
> 
> **Overview**
> **Gateway calls no longer silently default to `gpt-4o-mini` when no model is set.** Both `Cloud::call_gateway` and `gateway_chat_body` (used by gateway streaming) now require a model from `CompletionRequest::model` or `CloudConfig::default_model`, and return clear client-side errors (`CloudError::GatewayError` / `AdapterError::InvalidInput`) instead of hitting the gateway with an implicit OpenAI route.
> 
> `gateway_chat_body` now returns `AdapterResult` so `stream_with_gateway_sse` propagates the same validation. Tests cover rejection when neither source names a model and that an explicit config default still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fcaeb37f7008a4a9c2720cb0375e6ffaa674535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->