### PR TITLE
perf(asr): reuse the model's loaded executor across streaming sessions

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -470,6 +470,26 @@ impl TemplateExecutor {
     }
 
     /// Execute a model based on its metadata.
+    /// Whether the model this metadata describes is already loaded in the
+    /// responsible runtime's cache.
+    ///
+    /// `false` when the template has no cache-aware runtime (GGUF, graphs,
+    /// browser-only templates) — read it as "an execution would pay a load".
+    pub fn is_model_loaded(&self, metadata: &ModelMetadata) -> bool {
+        let (runtime_type, model_file) = match &metadata.execution_template {
+            ExecutionTemplate::SafeTensors { model_file, .. } => ("candle", model_file),
+            ExecutionTemplate::Onnx { model_file } => ("onnx", model_file),
+            ExecutionTemplate::CoreMl { model_file } => ("coreml", model_file),
+            ExecutionTemplate::TfLite { model_file } => ("tflite", model_file),
+            _ => return false,
+        };
+        let model_full_path = Path::new(&self.base_path).join(model_file);
+        self.runtimes
+            .get(runtime_type)
+            .map(|r| r.is_loaded(&model_full_path))
+            .unwrap_or(false)
+    }
+
     pub fn execute(
         &mut self,
         metadata: &ModelMetadata,

--- a/crates/xybrid-core/src/runtime_adapter/candle/runtime.rs
+++ b/crates/xybrid-core/src/runtime_adapter/candle/runtime.rs
@@ -83,6 +83,17 @@ impl ModelRuntime for CandleRuntime {
         vec!["safetensors"]
     }
 
+    fn is_loaded(&self, model_path: &Path) -> bool {
+        // Same dir normalization as `load`, so the two always agree.
+        let model_dir = if model_path.is_file() {
+            model_path.parent().unwrap_or(model_path)
+        } else {
+            model_path
+        };
+        self.models
+            .contains_key(model_dir.to_string_lossy().as_ref())
+    }
+
     fn load(&mut self, model_path: &Path) -> AdapterResult<()> {
         let _path_str = model_path.to_string_lossy().to_string();
 

--- a/crates/xybrid-core/src/runtime_adapter/traits.rs
+++ b/crates/xybrid-core/src/runtime_adapter/traits.rs
@@ -16,6 +16,16 @@ pub trait ModelRuntime: Send + Sync {
     /// Load the model from the specified path
     fn load(&mut self, model_path: &Path) -> AdapterResult<()>;
 
+    /// Whether the model at `model_path` is already loaded in this runtime's
+    /// cache.
+    ///
+    /// Runtimes that keep no cache report `false` (the default), which reads
+    /// as "a load (and its cost) would happen". Used to decide whether a
+    /// warm-up inference is worth paying.
+    fn is_loaded(&self, _model_path: &Path) -> bool {
+        false
+    }
+
     /// Downcast to concrete type
     fn as_any(&self) -> &dyn std::any::Any;
 

--- a/crates/xybrid-core/src/streaming/session.rs
+++ b/crates/xybrid-core/src/streaming/session.rs
@@ -10,7 +10,7 @@ use crate::audio::vad::{VadConfig, VadSession};
 use crate::execution::{ExecutionTemplate, ModelMetadata, TemplateExecutor};
 use crate::ir::{Envelope, EnvelopeKind};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// Error type for streaming operations.
@@ -338,8 +338,12 @@ pub struct StreamSession {
     // model_dir: PathBuf,
     /// Loaded model metadata
     metadata: ModelMetadata,
-    /// Template executor for inference
-    executor: TemplateExecutor,
+    /// Template executor for inference.
+    ///
+    /// Shared so a caller that already loaded the model (e.g. the SDK's
+    /// `XybridModel`) can hand its executor to the session and the stream
+    /// reuses the loaded weights instead of paying a fresh cold start.
+    executor: Arc<Mutex<TemplateExecutor>>,
     /// Configuration
     config: StreamConfig,
     /// Audio buffer
@@ -389,6 +393,26 @@ impl StreamSession {
     /// # }
     /// ```
     pub fn new<P: AsRef<Path>>(model_dir: P, config: StreamConfig) -> StreamResult<Self> {
+        // Fresh executor owned by this session alone; the model loads on the
+        // first inference (or `warmup`).
+        let executor = Arc::new(Mutex::new(TemplateExecutor::with_base_path(
+            model_dir.as_ref().to_str().unwrap_or("."),
+        )));
+        Self::with_executor(model_dir, config, executor)
+    }
+
+    /// Create a streaming session that reuses an existing executor.
+    ///
+    /// The executor keeps its loaded-model cache, so a caller that already
+    /// ran (or warmed up) this model skips the cold start entirely — the
+    /// session's first chunk executes against warm weights. Inference from
+    /// other holders of the same executor serializes with this session on
+    /// the mutex.
+    pub fn with_executor<P: AsRef<Path>>(
+        model_dir: P,
+        config: StreamConfig,
+        executor: Arc<Mutex<TemplateExecutor>>,
+    ) -> StreamResult<Self> {
         let model_dir = model_dir.as_ref().to_path_buf();
 
         // Validate model directory exists
@@ -413,9 +437,6 @@ impl StreamSession {
 
         let metadata: ModelMetadata = serde_json::from_str(&metadata_str)
             .map_err(|e| StreamError::ConfigError(format!("Failed to parse metadata: {}", e)))?;
-
-        // Create executor with model directory as base path
-        let executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap_or("."));
 
         // Infer optimal buffer config from model type
         let buffer_config = Self::infer_buffer_config(&metadata, &config);
@@ -560,6 +581,8 @@ impl StreamSession {
         let envelope = Envelope::new(EnvelopeKind::Audio(wav_bytes));
 
         self.executor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .execute(&self.metadata, &envelope, None)
             .map(|_| ())
             .map_err(|e| StreamError::InferenceError(format!("Warm-up failed: {}", e)))
@@ -740,6 +763,8 @@ impl StreamSession {
         // Execute through TemplateExecutor (handles ONNX, Candle, etc.)
         let output = self
             .executor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .execute(&self.metadata, &envelope, None)
             .map_err(|e| StreamError::InferenceError(format!("Execution failed: {}", e)))?;
 

--- a/crates/xybrid-core/src/streaming/session.rs
+++ b/crates/xybrid-core/src/streaming/session.rs
@@ -572,6 +572,16 @@ impl StreamSession {
             return Ok(());
         }
 
+        let mut executor = self.executor.lock().unwrap_or_else(|e| e.into_inner());
+
+        // A shared executor may already hold the loaded model (a previous
+        // session or a direct run paid the cold start). The warm-up pass
+        // itself costs a full encoder pass (~2.5 s for whisper-tiny on a
+        // Pixel 8), so skip it when there is nothing left to warm.
+        if executor.is_model_loaded(&self.metadata) {
+            return Ok(());
+        }
+
         // Half a second of silence. Whisper pads every input to its fixed
         // mel window, so the duration barely matters — one encoder pass is
         // the cost either way.
@@ -580,9 +590,7 @@ impl StreamSession {
         let wav_bytes = samples_to_wav(&silence, sample_rate);
         let envelope = Envelope::new(EnvelopeKind::Audio(wav_bytes));
 
-        self.executor
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        executor
             .execute(&self.metadata, &envelope, None)
             .map(|_| ())
             .map_err(|e| StreamError::InferenceError(format!("Warm-up failed: {}", e)))

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -834,8 +834,11 @@ impl StreamConfig {
 
 /// Internal handle holding the loaded model state.
 struct ModelHandle {
-    /// Template executor for running inference
-    executor: TemplateExecutor,
+    /// Template executor for running inference.
+    ///
+    /// Shared with streaming sessions created by `stream()` so they reuse
+    /// the loaded model instead of paying a fresh cold start.
+    executor: Arc<Mutex<TemplateExecutor>>,
     /// Model metadata
     metadata: ModelMetadata,
     /// Model directory path (permanent extraction in cache)
@@ -1739,7 +1742,9 @@ impl ModelLoader {
         let placeholder = ModelHandle {
             // Lazy executor over the not-yet-populated extraction dir; never run
             // while `loaded == false` (runs route to cloud).
-            executor: TemplateExecutor::with_base_path(&model_dir.to_string_lossy()),
+            executor: Arc::new(Mutex::new(TemplateExecutor::with_base_path(
+                &model_dir.to_string_lossy(),
+            ))),
             metadata,
             model_dir,
             loaded: false,
@@ -2159,7 +2164,7 @@ impl ModelLoader {
         let executor = TemplateExecutor::with_base_path(model_dir.to_str().unwrap_or("."));
 
         Ok(ModelHandle {
-            executor,
+            executor: Arc::new(Mutex::new(executor)),
             metadata,
             model_dir: model_dir.clone(),
             loaded: true,
@@ -2738,6 +2743,8 @@ impl XybridModel {
             let metadata = handle.metadata.clone();
             handle
                 .executor
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .execute(&metadata, &warmup_input, None)
                 .map_err(|e| SdkError::inference_src("Warmup execution failed", e))?;
 
@@ -2840,6 +2847,8 @@ impl XybridModel {
                 let metadata = guard.metadata.clone();
                 guard
                     .executor
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
                     .execute(&metadata, &warmup_input, None)
                     .map_err(|e| SdkError::inference_src("Warmup failed", e))?;
 
@@ -2949,6 +2958,8 @@ impl XybridModel {
         let metadata = handle.metadata.clone();
         let output = handle
             .executor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .execute(&metadata, envelope, config)
             .map_err(|e| sdk_execution_error("Execution failed", e))?;
 
@@ -3029,6 +3040,8 @@ impl XybridModel {
 
         handle
             .executor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .execute_tts_streaming(&metadata, envelope, &mut adapter)
             .map_err(|e| sdk_execution_error("TTS streaming failed", e))?;
 
@@ -3154,6 +3167,8 @@ impl XybridModel {
         let metadata = handle.metadata.clone();
         let output = handle
             .executor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .execute_with_context(&metadata, envelope, context, config)
             .map_err(|e| sdk_execution_error("Execution failed", e))?;
 
@@ -3316,6 +3331,8 @@ impl XybridModel {
             // True streaming with context for LLM models
             handle
                 .executor
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .execute_streaming_with_context(
                     &metadata,
                     envelope,
@@ -3328,6 +3345,8 @@ impl XybridModel {
             // For non-LLM models: run with context and emit single "token" with full result
             let result = handle
                 .executor
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .execute_with_context(&metadata, envelope, context, config)
                 .map_err(|e| sdk_execution_error("Execution failed", e))?;
 
@@ -3526,12 +3545,16 @@ impl XybridModel {
             // True streaming for LLM models
             handle
                 .executor
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .execute_streaming(&metadata, envelope, Box::new(&mut on_token), config)
                 .map_err(streaming_execution_error)?
         } else {
             // For non-LLM models: run batch and emit single "token" with full result
             let result = handle
                 .executor
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .execute(&metadata, envelope, config)
                 .map_err(|e| sdk_execution_error("Execution failed", e))?;
 
@@ -3962,6 +3985,8 @@ impl XybridModel {
                     // True streaming for LLM models
                     guard
                         .executor
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
                         .execute_streaming(
                             &metadata,
                             &envelope,
@@ -3985,6 +4010,8 @@ impl XybridModel {
                     // Non-LLM: batch execution, emit single token
                     let result = guard
                         .executor
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
                         .execute(&metadata, &envelope, config.as_ref())
                         .map_err(|e| sdk_execution_error("Execution failed", e))?;
 
@@ -4126,6 +4153,8 @@ impl XybridModel {
             let metadata = guard.metadata.clone();
             let output = guard
                 .executor
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .execute(&metadata, &envelope, config.as_ref())
                 .map_err(|e| sdk_execution_error("Execution failed", e))?;
 
@@ -4213,7 +4242,15 @@ impl XybridModel {
             ..Default::default()
         };
 
-        XybridStream::new(&handle.model_dir, core_config, &self.model_id)
+        // Hand the stream this model's executor: the session reuses the
+        // loaded weights (no per-session cold start), and stream inference
+        // serializes with direct `run` calls on the executor mutex.
+        XybridStream::new(
+            &handle.model_dir,
+            core_config,
+            &self.model_id,
+            Arc::clone(&handle.executor),
+        )
     }
 
     /// Unload the model from memory.
@@ -4225,7 +4262,7 @@ impl XybridModel {
 
         handle.loaded = false;
         // Clear the session cache (drop executor and recreate empty)
-        handle.executor = TemplateExecutor::default();
+        handle.executor = Arc::new(Mutex::new(TemplateExecutor::default()));
 
         Ok(())
     }
@@ -4571,7 +4608,7 @@ mod tests {
     fn cloud_serve_engages_only_while_not_loaded() {
         let speculating = XybridModel {
             handle: Arc::new(RwLock::new(ModelHandle {
-                executor: TemplateExecutor::default(),
+                executor: Arc::new(Mutex::new(TemplateExecutor::default())),
                 metadata: ModelMetadata::onnx("spec-model", "", ""),
                 model_dir: PathBuf::from("."),
                 loaded: false,
@@ -4612,7 +4649,7 @@ mod tests {
         };
         let speculating = XybridModel {
             handle: Arc::new(RwLock::new(ModelHandle {
-                executor: TemplateExecutor::default(),
+                executor: Arc::new(Mutex::new(TemplateExecutor::default())),
                 metadata: ModelMetadata::onnx("spec-model", "", ""),
                 model_dir: PathBuf::from("."),
                 loaded: false,
@@ -4665,7 +4702,7 @@ mod tests {
         let download = Arc::new(SpeculativeDownload::default());
         let model = XybridModel {
             handle: Arc::new(RwLock::new(ModelHandle {
-                executor: TemplateExecutor::default(),
+                executor: Arc::new(Mutex::new(TemplateExecutor::default())),
                 metadata: ModelMetadata::onnx("spec-model", "", ""),
                 model_dir: PathBuf::from("."),
                 loaded: false,
@@ -5184,7 +5221,7 @@ mod tests {
         }
         XybridModel {
             handle: Arc::new(RwLock::new(ModelHandle {
-                executor: TemplateExecutor::default(),
+                executor: Arc::new(Mutex::new(TemplateExecutor::default())),
                 metadata,
                 model_dir: PathBuf::from("."),
                 loaded: true,
@@ -5204,7 +5241,7 @@ mod tests {
         let version = metadata.version.clone();
         XybridModel {
             handle: Arc::new(RwLock::new(ModelHandle {
-                executor: TemplateExecutor::default(),
+                executor: Arc::new(Mutex::new(TemplateExecutor::default())),
                 metadata,
                 model_dir: PathBuf::from("."),
                 loaded: true,
@@ -5995,7 +6032,7 @@ mod tests {
         executor.register_runtime("onnx", runtime);
         XybridModel {
             handle: Arc::new(RwLock::new(ModelHandle {
-                executor,
+                executor: Arc::new(Mutex::new(executor)),
                 metadata,
                 model_dir: PathBuf::from("."),
                 loaded: true,

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -2736,7 +2736,7 @@ impl XybridModel {
             crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
         let event_fields = {
-            let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+            let handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
             if !handle.loaded {
                 return Err(SdkError::NotLoaded);
             }
@@ -2839,7 +2839,7 @@ impl XybridModel {
             // path published nothing at all, so async warmups were
             // silent on the wire (visible only via logs).
             let event_fields = {
-                let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
+                let guard = handle.write().unwrap_or_else(|e| e.into_inner());
                 if !guard.loaded {
                     return Err(SdkError::NotLoaded);
                 }
@@ -2948,7 +2948,7 @@ impl XybridModel {
             crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
         // Recover from poisoned RwLock to prevent permanent lock errors
-        let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+        let handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
         if !handle.loaded {
             return Err(SdkError::NotLoaded);
@@ -3019,7 +3019,7 @@ impl XybridModel {
         let _telemetry_ctx =
             crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
-        let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+        let handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
         if !handle.loaded {
             return Err(SdkError::NotLoaded);
         }
@@ -3157,7 +3157,7 @@ impl XybridModel {
             crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
         // Recover from poisoned RwLock to prevent permanent lock errors
-        let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+        let handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
         if !handle.loaded {
             return Err(SdkError::NotLoaded);
@@ -3315,7 +3315,7 @@ impl XybridModel {
             crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
         // Get write lock on handle
-        let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+        let handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
         if !handle.loaded {
             return Err(SdkError::NotLoaded);
@@ -3529,7 +3529,7 @@ impl XybridModel {
             crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
         // Get write lock on handle
-        let mut handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
+        let handle = self.handle.write().unwrap_or_else(|e| e.into_inner());
 
         if !handle.loaded {
             return Err(SdkError::NotLoaded);
@@ -3969,7 +3969,7 @@ impl XybridModel {
                 }
 
                 // Get write lock on handle
-                let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
+                let guard = handle.write().unwrap_or_else(|e| e.into_inner());
 
                 if !guard.loaded {
                     return Err(SdkError::NotLoaded);
@@ -4143,7 +4143,7 @@ impl XybridModel {
                 crate::telemetry::TelemetryPipelineContextGuard::install(None, Some(trace_id));
 
             // Recover from poisoned RwLock to prevent permanent lock errors
-            let mut guard = handle.write().unwrap_or_else(|e| e.into_inner());
+            let guard = handle.write().unwrap_or_else(|e| e.into_inner());
 
             if !guard.loaded {
                 return Err(SdkError::NotLoaded);

--- a/crates/xybrid-sdk/src/stream.rs
+++ b/crates/xybrid-sdk/src/stream.rs
@@ -5,7 +5,8 @@
 
 use crate::model::SdkError;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
+use xybrid_core::execution::TemplateExecutor;
 use xybrid_core::streaming::{
     PartialResult as CorePartialResult, StreamConfig as CoreStreamConfig, StreamSession,
     StreamState as CoreStreamState, StreamStats as CoreStreamStats,
@@ -154,8 +155,9 @@ impl XybridStream {
         model_dir: P,
         config: CoreStreamConfig,
         model_id: &str,
+        executor: Arc<Mutex<TemplateExecutor>>,
     ) -> Result<Self, SdkError> {
-        let session = StreamSession::new(model_dir, config)
+        let session = StreamSession::with_executor(model_dir, config, executor)
             .map_err(|e| SdkError::load_src("Failed to create stream session", e))?;
 
         Ok(Self {


### PR DESCRIPTION
This pull request makes streaming sessions reuse the executor — and therefore the loaded model weights — of the `XybridModel` they are created from, instead of building a private executor and re-paying the cold start on every session. Combined with a warm-up that now skips itself when there is nothing to warm, a second Start on the same model opens with zero hidden compute. Device-verified on a Pixel 8: session 1 warms in ~2.8 s (hidden behind mic spin-up), session 2 logs `ASR model warmed up in 0 ms`, steady cadence 2.2–2.5 s per 5 s window.

**Executor sharing:**

* `ModelHandle.executor` is now `Arc<Mutex<TemplateExecutor>>`; `XybridModel::stream()` hands the session a clone, so stream inference runs against the model's already-loaded weights and serializes with direct `run()` calls on the mutex.
* `StreamSession::with_executor()` accepts the shared executor in core; `StreamSession::new()` keeps the owned-executor behavior for direct core users.
* `unload()` swaps in a fresh executor — live streams keep the old one alive through their `Arc`, so unloading mid-stream cannot rip weights out from under a running transcription.

**Warm-up skip:**

* `ModelRuntime::is_loaded(path)` (default `false`) lets a runtime report whether a model is already in its cache; `CandleRuntime` answers using the same directory normalization as `load()`.
* `TemplateExecutor::is_model_loaded(metadata)` resolves the same runtime and path as `execute()` and asks it.
* `StreamSession::warmup()` returns early when the model is already loaded, skipping the ~2.5 s silent encoder pass that previously ran on every session open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency (shared mutex between stream and batch inference) and lifetime of loaded weights across unload; behavior is intentional but affects hot inference paths.
> 
> **Overview**
> **Streaming ASR sessions now share the parent model’s `TemplateExecutor`**, so weights loaded by `XybridModel` are reused instead of each session paying its own cold start. `ModelHandle.executor` becomes `Arc<Mutex<TemplateExecutor>>`; `stream()` passes a clone into `StreamSession::with_executor()`, and inference on both direct `run()` and the stream serializes on that mutex.
> 
> **Warm-up is skipped when the model is already in the runtime cache.** `ModelRuntime::is_loaded` (default `false`) is implemented on Candle with the same path normalization as `load()`; `TemplateExecutor::is_model_loaded` maps metadata to the right runtime and path. `StreamSession::warmup()` returns immediately when weights are already loaded, avoiding a redundant silent encoder pass.
> 
> `unload()` replaces the handle with a fresh executor while existing streams keep the old `Arc`, so in-flight transcription is not torn down mid-session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d132e3f959f2161547aa1fc71596e47bbcfd175c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->