### PR TITLE
feat(asr): build whisper.cpp under Bazel and ship it in every preset

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -136,14 +136,49 @@ jobs:
           bazelisk build --nobuild \
             //crates/... //bindings/... //macros/... //xtask/... //integration-tests/... //:llama
 
-      # The RBE-proven hermetic linux chain (PR #326 gates 3B/4).
-      - name: Build llama chain on RBE (linux, hermetic)
+      # The RBE-proven hermetic linux chain (PR #326 gates 3B/4), plus the
+      # whisper.cpp chain that sits on the same ggml. //:whisper is a plain
+      # cc_library depending on //:llama, so building both here is what proves
+      # the single-ggml invariant holds in the Bazel graph — not just in cargo,
+      # where the build script has to hand-order the link flags.
+      - name: Build llama + whisper chains on RBE (linux, hermetic)
         if: env.BUILDBUDDY_API_KEY != ''
         run: |
           bazelisk build --config=remote \
             //:llama \
             //crates/llama-cpp-sys:llama_cpp_sys \
-            //crates/xybrid-llama:xybrid_llama
+            //crates/xybrid-llama:xybrid_llama \
+            //:whisper \
+            //crates/whisper-cpp-sys:xybrid_whisper_sys \
+            //crates/xybrid-whisper:xybrid_whisper
+
+      # Exactly one ggml must reach the link. A future whisper.cpp bump that
+      # stops compiling against llama's pinned ggml would otherwise be fixed by
+      # someone reaching for whisper's bundled copy, silently shipping two
+      # tensor runtimes in one binary. This asserts the graph shape instead of
+      # trusting the convention.
+      # cquery, NOT query: the unconfigured `query` loads every arm of every
+      # select in the transitive closure, which drags in hermetic-llvm's
+      # per-arch kernel-headers repos and fails to resolve one of them. cquery
+      # evaluates the resolved configuration only, which is also the graph we
+      # actually care about asserting on.
+      - name: Assert whisper links llama's ggml, not a second copy
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          deps=$(bazelisk cquery --config=remote 'deps(//:whisper)' --output=label)
+          # //:llama on every hermetic lane; //:llama_metal on --//:metal=true.
+          if ! grep -qE '^//:llama(_metal)? ' <<<"$deps"; then
+            echo "FATAL: //:whisper depends on neither //:llama nor //:llama_metal," >&2
+            echo "       so it is not building on the ggml the rest of the binary" >&2
+            echo "       already links." >&2
+            exit 1
+          fi
+          if grep -q 'vendor/whisper-cpp/ggml' <<<"$deps"; then
+            echo "FATAL: //:whisper pulled in whisper.cpp's bundled ggml." >&2
+            echo "       Two ggml copies in one binary is the failure mode the" >&2
+            echo "       whole design exists to prevent." >&2
+            exit 1
+          fi
 
       # Tests under Bazel. Bazel BUILDS every shipped artifact; these targets are
       # what stop it from shipping unverified. Runs on this ubuntu runner
@@ -174,6 +209,7 @@ jobs:
             //crates/xybrid-ffi-facade:xybrid-ffi-facade_test \
             //crates/xybrid-llama:all \
             //crates/xybrid-sdk:all \
+            //crates/xybrid-whisper:all \
             //integration-tests:all \
             //xtask:xtask_test
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,6 +6,7 @@ exports_files([
 ])
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 # The macOS GPU lane toggle (Flip 2). Both darwin lanes share the SAME Rust
 # feature set (candle-metal/CoreML/vision are bindings — pure Rust, cross-
@@ -419,6 +420,64 @@ cmake(
         "manual",
         "no-remote-exec",
     ],
+    visibility = ["//visibility:public"],
+)
+
+# whisper.cpp, built on the ggml //:llama already produced.
+#
+# A plain cc_library, NOT a second rules_foreign_cc cmake() target. Two reasons,
+# and the first is the whole point of the design:
+#
+#  1. **Exactly one ggml in the binary.** whisper.cpp vendors its own ggml under
+#     `vendor/whisper-cpp/ggml/`, and driving its CMakeLists would configure and
+#     build that copy. A second ggml means duplicate symbols, a bigger artifact,
+#     and two divergent tensor runtimes in one process. Depending on `//:llama`
+#     for both the headers and the archives makes the single-ggml invariant a
+#     property of the build graph rather than a convention.
+#  2. It is cheap and portable. Upstream's `src/CMakeLists.txt` builds
+#     `libwhisper` from ONE translation unit whose only dependencies are the
+#     ggml headers and Threads — nothing is generated at configure time. So this
+#     needs no cmake toolchain, works identically on the NDK / windows-msvc /
+#     apple lanes, and is remote-cacheable like any other cc_library.
+#
+# `src/parakeet.cpp` is deliberately not compiled: a second architecture behind
+# its own header, worth nothing until there is a Parakeet model story.
+#
+# The `//:metal_enabled` select mirrors //crates/llama-cpp-sys:wrapper_cc — on
+# that lane ggml comes from //:llama_metal instead, and linking whisper against
+# the CPU llama there would reintroduce the duplicate this target exists to
+# avoid.
+cc_library(
+    name = "whisper",
+    srcs = ["vendor/whisper-cpp/src/whisper.cpp"],
+    hdrs = [
+        "vendor/whisper-cpp/include/whisper.h",
+        "vendor/whisper-cpp/src/whisper-arch.h",
+    ],
+    copts = [
+        # Upstream pins cxx_std_11 with a "don't bump" comment, but C++17 is a
+        # superset for this TU and matches the rest of our native surface.
+        "-std=c++17",
+        # Vendored third-party code: silence its noise so it cannot drown real
+        # diagnostics from first-party targets.
+        "-Wno-unused-function",
+        "-Wno-unused-variable",
+        "-Wno-deprecated-declarations",
+    ],
+    # Upstream's CMake injects this as a private compile definition and
+    # `whisper_version()` returns it; without it the TU does not compile. Keep in
+    # step with `project(... VERSION x.y.z)` in vendor/whisper-cpp/CMakeLists.txt
+    # on every submodule bump — the cargo build script parses that file for the
+    # same value.
+    local_defines = ['WHISPER_VERSION=\\"1.9.2\\"'],
+    includes = [
+        "vendor/whisper-cpp/include",
+        "vendor/whisper-cpp/src",
+    ],
+    deps = select({
+        "//:metal_enabled": ["//:llama_metal"],
+        "//conditions:default": ["//:llama"],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -469,7 +469,15 @@ cc_library(
     # step with `project(... VERSION x.y.z)` in vendor/whisper-cpp/CMakeLists.txt
     # on every submodule bump — the cargo build script parses that file for the
     # same value.
-    local_defines = ['WHISPER_VERSION=\\"1.9.2\\"'],
+    local_defines = [
+        # whisper-arch.h pulls in C++ headers before whisper.cpp defines this
+        # itself. MinGW can therefore process <math.h> too early and hide the
+        # non-standard M_PI constant in strict language modes. Define it from
+        # the command line so it is visible from the first header; the empty
+        # replacement matches upstream's later definition without a warning.
+        "_USE_MATH_DEFINES=",
+        'WHISPER_VERSION=\\"1.9.2\\"',
+    ],
     includes = [
         "vendor/whisper-cpp/include",
         "vendor/whisper-cpp/src",

--- a/crates/whisper-cpp-sys/BUILD.bazel
+++ b/crates/whisper-cpp-sys/BUILD.bazel
@@ -1,0 +1,44 @@
+# xybrid-whisper-sys, Bazel-native. No build.rs, no bindgen, no libclang —
+# build.rs's three jobs are replaced by:
+#   whisper compile -> //:whisper (a cc_library on //:llama's ggml)
+#   bindgen         -> COMMITTED src/bindings.rs (regenerated offline via cargo)
+#   link ordering   -> the cc_library dep edge, which Bazel orders for us
+#
+# That third one is the interesting difference. On the cargo path the build
+# script must re-emit `-lggml*` and the platform libraries AFTER `-lwhisper`,
+# because cargo emits a dependency's link flags before its dependents' and GNU
+# ld resolves static archives left to right. Bazel derives link order from the
+# dep graph, so //:whisper depending on //:llama is enough.
+load("@rules_rs//rs:rust_library.bzl", "rust_library")
+
+# `committed-bindings` makes lib.rs `include!` the committed src/bindings.rs
+# instead of $OUT_DIR. Cargo builds do NOT enable it — they stay on fresh
+# bindgen output so whisper.cpp bumps keep working there.
+rust_library(
+    name = "xybrid_whisper_sys",
+    srcs = glob(["src/**/*.rs"]),
+    crate_features = [
+        "bindings",
+        "committed-bindings",
+    ],
+    edition = "2021",
+    # //:whisper carries llama's ggml transitively, so this single edge supplies
+    # the whisper archive, the ggml archives and their platform link deps.
+    #
+    # The cargo manifest's dependency on xybrid-llama-sys exists ONLY so the
+    # build script can read its `links = "llama"` metadata (DEP_LLAMA_SRC /
+    # DEP_LLAMA_ROOT). There is no build script here and no Rust-level use of
+    # it, so it is deliberately absent from this dep list.
+    deps = ["//:whisper"],
+    visibility = ["//visibility:public"],
+)
+
+# Dir-basename alias so `//crates/whisper-cpp-sys` (the label all_crate_deps()
+# emits) resolves to the target above. Same -sys lib-name-override gotcha as
+# llama's: the package is `xybrid-whisper-sys` but its [lib] name is
+# `xybrid_whisper_sys`, so package-derived auto-aliasing would diverge.
+alias(
+    name = "whisper-cpp-sys",
+    actual = ":xybrid_whisper_sys",
+    visibility = ["//visibility:public"],
+)

--- a/crates/whisper-cpp-sys/build.rs
+++ b/crates/whisper-cpp-sys/build.rs
@@ -172,6 +172,11 @@ fn compile_whisper_cpp() {
 
     let mut build = cc::Build::new();
     build
+        // whisper-arch.h includes C++ headers before whisper.cpp defines this
+        // itself. Define it from the command line so Windows CRT headers expose
+        // M_PI from their first inclusion. The empty replacement matches the
+        // later source definition without producing a redefinition warning.
+        .define("_USE_MATH_DEFINES", "")
         .define("WHISPER_VERSION", format!("\"{version}\"").as_str())
         .cpp(true)
         // Upstream pins C++11 for `whisper` with a "don't bump" comment in
@@ -341,6 +346,12 @@ fn generate_bindings(whisper_dir: &Path, ggml_include: &Path, out_dir: &Path) {
         .allowlist_function("whisper_.*")
         .allowlist_type("whisper_.*")
         .allowlist_var("WHISPER_.*")
+        // This output is also committed for Bazel and compiled for every
+        // supported target. Bindgen's layout tests bake in the generator
+        // host's pointer width, so a 64-bit snapshot cannot compile for
+        // Android armv7. The #[repr(C)] declarations themselves remain
+        // target-correct because pointers and usize retain their native size.
+        .layout_tests(false)
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .unwrap_or_else(|e| fail("xybrid-whisper-sys: bindgen failed", &[format!("{e}")]));

--- a/crates/whisper-cpp-sys/src/bindings.rs
+++ b/crates/whisper-cpp-sys/src/bindings.rs
@@ -62,30 +62,12 @@ pub struct whisper_ahead {
     pub n_text_layer: ::std::os::raw::c_int,
     pub n_head: ::std::os::raw::c_int,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_ahead"][::std::mem::size_of::<whisper_ahead>() - 8usize];
-    ["Alignment of whisper_ahead"][::std::mem::align_of::<whisper_ahead>() - 4usize];
-    ["Offset of field: whisper_ahead::n_text_layer"]
-        [::std::mem::offset_of!(whisper_ahead, n_text_layer) - 0usize];
-    ["Offset of field: whisper_ahead::n_head"]
-        [::std::mem::offset_of!(whisper_ahead, n_head) - 4usize];
-};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct whisper_aheads {
     pub n_heads: usize,
     pub heads: *const whisper_ahead,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_aheads"][::std::mem::size_of::<whisper_aheads>() - 16usize];
-    ["Alignment of whisper_aheads"][::std::mem::align_of::<whisper_aheads>() - 8usize];
-    ["Offset of field: whisper_aheads::n_heads"]
-        [::std::mem::offset_of!(whisper_aheads, n_heads) - 0usize];
-    ["Offset of field: whisper_aheads::heads"]
-        [::std::mem::offset_of!(whisper_aheads, heads) - 8usize];
-};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct whisper_context_params {
@@ -98,28 +80,6 @@ pub struct whisper_context_params {
     pub dtw_aheads: whisper_aheads,
     pub dtw_mem_size: usize,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_context_params"][::std::mem::size_of::<whisper_context_params>() - 48usize];
-    ["Alignment of whisper_context_params"]
-        [::std::mem::align_of::<whisper_context_params>() - 8usize];
-    ["Offset of field: whisper_context_params::use_gpu"]
-        [::std::mem::offset_of!(whisper_context_params, use_gpu) - 0usize];
-    ["Offset of field: whisper_context_params::flash_attn"]
-        [::std::mem::offset_of!(whisper_context_params, flash_attn) - 1usize];
-    ["Offset of field: whisper_context_params::gpu_device"]
-        [::std::mem::offset_of!(whisper_context_params, gpu_device) - 4usize];
-    ["Offset of field: whisper_context_params::dtw_token_timestamps"]
-        [::std::mem::offset_of!(whisper_context_params, dtw_token_timestamps) - 8usize];
-    ["Offset of field: whisper_context_params::dtw_aheads_preset"]
-        [::std::mem::offset_of!(whisper_context_params, dtw_aheads_preset) - 12usize];
-    ["Offset of field: whisper_context_params::dtw_n_top"]
-        [::std::mem::offset_of!(whisper_context_params, dtw_n_top) - 16usize];
-    ["Offset of field: whisper_context_params::dtw_aheads"]
-        [::std::mem::offset_of!(whisper_context_params, dtw_aheads) - 24usize];
-    ["Offset of field: whisper_context_params::dtw_mem_size"]
-        [::std::mem::offset_of!(whisper_context_params, dtw_mem_size) - 40usize];
-};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct whisper_token_data {
@@ -134,31 +94,6 @@ pub struct whisper_token_data {
     pub t_dtw: i64,
     pub vlen: f32,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_token_data"][::std::mem::size_of::<whisper_token_data>() - 56usize];
-    ["Alignment of whisper_token_data"][::std::mem::align_of::<whisper_token_data>() - 8usize];
-    ["Offset of field: whisper_token_data::id"]
-        [::std::mem::offset_of!(whisper_token_data, id) - 0usize];
-    ["Offset of field: whisper_token_data::tid"]
-        [::std::mem::offset_of!(whisper_token_data, tid) - 4usize];
-    ["Offset of field: whisper_token_data::p"]
-        [::std::mem::offset_of!(whisper_token_data, p) - 8usize];
-    ["Offset of field: whisper_token_data::plog"]
-        [::std::mem::offset_of!(whisper_token_data, plog) - 12usize];
-    ["Offset of field: whisper_token_data::pt"]
-        [::std::mem::offset_of!(whisper_token_data, pt) - 16usize];
-    ["Offset of field: whisper_token_data::ptsum"]
-        [::std::mem::offset_of!(whisper_token_data, ptsum) - 20usize];
-    ["Offset of field: whisper_token_data::t0"]
-        [::std::mem::offset_of!(whisper_token_data, t0) - 24usize];
-    ["Offset of field: whisper_token_data::t1"]
-        [::std::mem::offset_of!(whisper_token_data, t1) - 32usize];
-    ["Offset of field: whisper_token_data::t_dtw"]
-        [::std::mem::offset_of!(whisper_token_data, t_dtw) - 40usize];
-    ["Offset of field: whisper_token_data::vlen"]
-        [::std::mem::offset_of!(whisper_token_data, vlen) - 48usize];
-};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct whisper_model_loader {
@@ -173,19 +108,6 @@ pub struct whisper_model_loader {
     pub eof: ::std::option::Option<unsafe extern "C" fn(ctx: *mut ::std::os::raw::c_void) -> bool>,
     pub close: ::std::option::Option<unsafe extern "C" fn(ctx: *mut ::std::os::raw::c_void)>,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_model_loader"][::std::mem::size_of::<whisper_model_loader>() - 32usize];
-    ["Alignment of whisper_model_loader"][::std::mem::align_of::<whisper_model_loader>() - 8usize];
-    ["Offset of field: whisper_model_loader::context"]
-        [::std::mem::offset_of!(whisper_model_loader, context) - 0usize];
-    ["Offset of field: whisper_model_loader::read"]
-        [::std::mem::offset_of!(whisper_model_loader, read) - 8usize];
-    ["Offset of field: whisper_model_loader::eof"]
-        [::std::mem::offset_of!(whisper_model_loader, eof) - 16usize];
-    ["Offset of field: whisper_model_loader::close"]
-        [::std::mem::offset_of!(whisper_model_loader, close) - 24usize];
-};
 pub const whisper_gretype_WHISPER_GRETYPE_END: whisper_gretype = 0;
 pub const whisper_gretype_WHISPER_GRETYPE_ALT: whisper_gretype = 1;
 pub const whisper_gretype_WHISPER_GRETYPE_RULE_REF: whisper_gretype = 2;
@@ -200,16 +122,6 @@ pub struct whisper_grammar_element {
     pub type_: whisper_gretype,
     pub value: u32,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_grammar_element"][::std::mem::size_of::<whisper_grammar_element>() - 8usize];
-    ["Alignment of whisper_grammar_element"]
-        [::std::mem::align_of::<whisper_grammar_element>() - 4usize];
-    ["Offset of field: whisper_grammar_element::type_"]
-        [::std::mem::offset_of!(whisper_grammar_element, type_) - 0usize];
-    ["Offset of field: whisper_grammar_element::value"]
-        [::std::mem::offset_of!(whisper_grammar_element, value) - 4usize];
-};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct whisper_vad_params {
@@ -220,23 +132,6 @@ pub struct whisper_vad_params {
     pub speech_pad_ms: ::std::os::raw::c_int,
     pub samples_overlap: f32,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_vad_params"][::std::mem::size_of::<whisper_vad_params>() - 24usize];
-    ["Alignment of whisper_vad_params"][::std::mem::align_of::<whisper_vad_params>() - 4usize];
-    ["Offset of field: whisper_vad_params::threshold"]
-        [::std::mem::offset_of!(whisper_vad_params, threshold) - 0usize];
-    ["Offset of field: whisper_vad_params::min_speech_duration_ms"]
-        [::std::mem::offset_of!(whisper_vad_params, min_speech_duration_ms) - 4usize];
-    ["Offset of field: whisper_vad_params::min_silence_duration_ms"]
-        [::std::mem::offset_of!(whisper_vad_params, min_silence_duration_ms) - 8usize];
-    ["Offset of field: whisper_vad_params::max_speech_duration_s"]
-        [::std::mem::offset_of!(whisper_vad_params, max_speech_duration_s) - 12usize];
-    ["Offset of field: whisper_vad_params::speech_pad_ms"]
-        [::std::mem::offset_of!(whisper_vad_params, speech_pad_ms) - 16usize];
-    ["Offset of field: whisper_vad_params::samples_overlap"]
-        [::std::mem::offset_of!(whisper_vad_params, samples_overlap) - 20usize];
-};
 extern "C" {
     pub fn whisper_version() -> *const ::std::os::raw::c_char;
 }
@@ -560,21 +455,6 @@ pub struct whisper_timings {
     pub batchd_ms: f32,
     pub prompt_ms: f32,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_timings"][::std::mem::size_of::<whisper_timings>() - 20usize];
-    ["Alignment of whisper_timings"][::std::mem::align_of::<whisper_timings>() - 4usize];
-    ["Offset of field: whisper_timings::sample_ms"]
-        [::std::mem::offset_of!(whisper_timings, sample_ms) - 0usize];
-    ["Offset of field: whisper_timings::encode_ms"]
-        [::std::mem::offset_of!(whisper_timings, encode_ms) - 4usize];
-    ["Offset of field: whisper_timings::decode_ms"]
-        [::std::mem::offset_of!(whisper_timings, decode_ms) - 8usize];
-    ["Offset of field: whisper_timings::batchd_ms"]
-        [::std::mem::offset_of!(whisper_timings, batchd_ms) - 12usize];
-    ["Offset of field: whisper_timings::prompt_ms"]
-        [::std::mem::offset_of!(whisper_timings, prompt_ms) - 16usize];
-};
 extern "C" {
     pub fn whisper_get_timings(ctx: *mut whisper_context) -> *mut whisper_timings;
 }
@@ -689,151 +569,12 @@ pub struct whisper_full_params {
 pub struct whisper_full_params__bindgen_ty_1 {
     pub best_of: ::std::os::raw::c_int,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_full_params__bindgen_ty_1"]
-        [::std::mem::size_of::<whisper_full_params__bindgen_ty_1>() - 4usize];
-    ["Alignment of whisper_full_params__bindgen_ty_1"]
-        [::std::mem::align_of::<whisper_full_params__bindgen_ty_1>() - 4usize];
-    ["Offset of field: whisper_full_params__bindgen_ty_1::best_of"]
-        [::std::mem::offset_of!(whisper_full_params__bindgen_ty_1, best_of) - 0usize];
-};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct whisper_full_params__bindgen_ty_2 {
     pub beam_size: ::std::os::raw::c_int,
     pub patience: f32,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_full_params__bindgen_ty_2"]
-        [::std::mem::size_of::<whisper_full_params__bindgen_ty_2>() - 8usize];
-    ["Alignment of whisper_full_params__bindgen_ty_2"]
-        [::std::mem::align_of::<whisper_full_params__bindgen_ty_2>() - 4usize];
-    ["Offset of field: whisper_full_params__bindgen_ty_2::beam_size"]
-        [::std::mem::offset_of!(whisper_full_params__bindgen_ty_2, beam_size) - 0usize];
-    ["Offset of field: whisper_full_params__bindgen_ty_2::patience"]
-        [::std::mem::offset_of!(whisper_full_params__bindgen_ty_2, patience) - 4usize];
-};
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_full_params"][::std::mem::size_of::<whisper_full_params>() - 304usize];
-    ["Alignment of whisper_full_params"][::std::mem::align_of::<whisper_full_params>() - 8usize];
-    ["Offset of field: whisper_full_params::strategy"]
-        [::std::mem::offset_of!(whisper_full_params, strategy) - 0usize];
-    ["Offset of field: whisper_full_params::n_threads"]
-        [::std::mem::offset_of!(whisper_full_params, n_threads) - 4usize];
-    ["Offset of field: whisper_full_params::n_max_text_ctx"]
-        [::std::mem::offset_of!(whisper_full_params, n_max_text_ctx) - 8usize];
-    ["Offset of field: whisper_full_params::offset_ms"]
-        [::std::mem::offset_of!(whisper_full_params, offset_ms) - 12usize];
-    ["Offset of field: whisper_full_params::duration_ms"]
-        [::std::mem::offset_of!(whisper_full_params, duration_ms) - 16usize];
-    ["Offset of field: whisper_full_params::translate"]
-        [::std::mem::offset_of!(whisper_full_params, translate) - 20usize];
-    ["Offset of field: whisper_full_params::no_context"]
-        [::std::mem::offset_of!(whisper_full_params, no_context) - 21usize];
-    ["Offset of field: whisper_full_params::no_timestamps"]
-        [::std::mem::offset_of!(whisper_full_params, no_timestamps) - 22usize];
-    ["Offset of field: whisper_full_params::single_segment"]
-        [::std::mem::offset_of!(whisper_full_params, single_segment) - 23usize];
-    ["Offset of field: whisper_full_params::print_special"]
-        [::std::mem::offset_of!(whisper_full_params, print_special) - 24usize];
-    ["Offset of field: whisper_full_params::print_progress"]
-        [::std::mem::offset_of!(whisper_full_params, print_progress) - 25usize];
-    ["Offset of field: whisper_full_params::print_realtime"]
-        [::std::mem::offset_of!(whisper_full_params, print_realtime) - 26usize];
-    ["Offset of field: whisper_full_params::print_timestamps"]
-        [::std::mem::offset_of!(whisper_full_params, print_timestamps) - 27usize];
-    ["Offset of field: whisper_full_params::token_timestamps"]
-        [::std::mem::offset_of!(whisper_full_params, token_timestamps) - 28usize];
-    ["Offset of field: whisper_full_params::thold_pt"]
-        [::std::mem::offset_of!(whisper_full_params, thold_pt) - 32usize];
-    ["Offset of field: whisper_full_params::thold_ptsum"]
-        [::std::mem::offset_of!(whisper_full_params, thold_ptsum) - 36usize];
-    ["Offset of field: whisper_full_params::max_len"]
-        [::std::mem::offset_of!(whisper_full_params, max_len) - 40usize];
-    ["Offset of field: whisper_full_params::split_on_word"]
-        [::std::mem::offset_of!(whisper_full_params, split_on_word) - 44usize];
-    ["Offset of field: whisper_full_params::max_tokens"]
-        [::std::mem::offset_of!(whisper_full_params, max_tokens) - 48usize];
-    ["Offset of field: whisper_full_params::debug_mode"]
-        [::std::mem::offset_of!(whisper_full_params, debug_mode) - 52usize];
-    ["Offset of field: whisper_full_params::audio_ctx"]
-        [::std::mem::offset_of!(whisper_full_params, audio_ctx) - 56usize];
-    ["Offset of field: whisper_full_params::tdrz_enable"]
-        [::std::mem::offset_of!(whisper_full_params, tdrz_enable) - 60usize];
-    ["Offset of field: whisper_full_params::suppress_regex"]
-        [::std::mem::offset_of!(whisper_full_params, suppress_regex) - 64usize];
-    ["Offset of field: whisper_full_params::initial_prompt"]
-        [::std::mem::offset_of!(whisper_full_params, initial_prompt) - 72usize];
-    ["Offset of field: whisper_full_params::carry_initial_prompt"]
-        [::std::mem::offset_of!(whisper_full_params, carry_initial_prompt) - 80usize];
-    ["Offset of field: whisper_full_params::prompt_tokens"]
-        [::std::mem::offset_of!(whisper_full_params, prompt_tokens) - 88usize];
-    ["Offset of field: whisper_full_params::prompt_n_tokens"]
-        [::std::mem::offset_of!(whisper_full_params, prompt_n_tokens) - 96usize];
-    ["Offset of field: whisper_full_params::language"]
-        [::std::mem::offset_of!(whisper_full_params, language) - 104usize];
-    ["Offset of field: whisper_full_params::detect_language"]
-        [::std::mem::offset_of!(whisper_full_params, detect_language) - 112usize];
-    ["Offset of field: whisper_full_params::suppress_blank"]
-        [::std::mem::offset_of!(whisper_full_params, suppress_blank) - 113usize];
-    ["Offset of field: whisper_full_params::suppress_nst"]
-        [::std::mem::offset_of!(whisper_full_params, suppress_nst) - 114usize];
-    ["Offset of field: whisper_full_params::temperature"]
-        [::std::mem::offset_of!(whisper_full_params, temperature) - 116usize];
-    ["Offset of field: whisper_full_params::max_initial_ts"]
-        [::std::mem::offset_of!(whisper_full_params, max_initial_ts) - 120usize];
-    ["Offset of field: whisper_full_params::length_penalty"]
-        [::std::mem::offset_of!(whisper_full_params, length_penalty) - 124usize];
-    ["Offset of field: whisper_full_params::temperature_inc"]
-        [::std::mem::offset_of!(whisper_full_params, temperature_inc) - 128usize];
-    ["Offset of field: whisper_full_params::entropy_thold"]
-        [::std::mem::offset_of!(whisper_full_params, entropy_thold) - 132usize];
-    ["Offset of field: whisper_full_params::logprob_thold"]
-        [::std::mem::offset_of!(whisper_full_params, logprob_thold) - 136usize];
-    ["Offset of field: whisper_full_params::no_speech_thold"]
-        [::std::mem::offset_of!(whisper_full_params, no_speech_thold) - 140usize];
-    ["Offset of field: whisper_full_params::greedy"]
-        [::std::mem::offset_of!(whisper_full_params, greedy) - 144usize];
-    ["Offset of field: whisper_full_params::beam_search"]
-        [::std::mem::offset_of!(whisper_full_params, beam_search) - 148usize];
-    ["Offset of field: whisper_full_params::new_segment_callback"]
-        [::std::mem::offset_of!(whisper_full_params, new_segment_callback) - 160usize];
-    ["Offset of field: whisper_full_params::new_segment_callback_user_data"]
-        [::std::mem::offset_of!(whisper_full_params, new_segment_callback_user_data) - 168usize];
-    ["Offset of field: whisper_full_params::progress_callback"]
-        [::std::mem::offset_of!(whisper_full_params, progress_callback) - 176usize];
-    ["Offset of field: whisper_full_params::progress_callback_user_data"]
-        [::std::mem::offset_of!(whisper_full_params, progress_callback_user_data) - 184usize];
-    ["Offset of field: whisper_full_params::encoder_begin_callback"]
-        [::std::mem::offset_of!(whisper_full_params, encoder_begin_callback) - 192usize];
-    ["Offset of field: whisper_full_params::encoder_begin_callback_user_data"]
-        [::std::mem::offset_of!(whisper_full_params, encoder_begin_callback_user_data) - 200usize];
-    ["Offset of field: whisper_full_params::abort_callback"]
-        [::std::mem::offset_of!(whisper_full_params, abort_callback) - 208usize];
-    ["Offset of field: whisper_full_params::abort_callback_user_data"]
-        [::std::mem::offset_of!(whisper_full_params, abort_callback_user_data) - 216usize];
-    ["Offset of field: whisper_full_params::logits_filter_callback"]
-        [::std::mem::offset_of!(whisper_full_params, logits_filter_callback) - 224usize];
-    ["Offset of field: whisper_full_params::logits_filter_callback_user_data"]
-        [::std::mem::offset_of!(whisper_full_params, logits_filter_callback_user_data) - 232usize];
-    ["Offset of field: whisper_full_params::grammar_rules"]
-        [::std::mem::offset_of!(whisper_full_params, grammar_rules) - 240usize];
-    ["Offset of field: whisper_full_params::n_grammar_rules"]
-        [::std::mem::offset_of!(whisper_full_params, n_grammar_rules) - 248usize];
-    ["Offset of field: whisper_full_params::i_start_rule"]
-        [::std::mem::offset_of!(whisper_full_params, i_start_rule) - 256usize];
-    ["Offset of field: whisper_full_params::grammar_penalty"]
-        [::std::mem::offset_of!(whisper_full_params, grammar_penalty) - 264usize];
-    ["Offset of field: whisper_full_params::vad"]
-        [::std::mem::offset_of!(whisper_full_params, vad) - 268usize];
-    ["Offset of field: whisper_full_params::vad_model_path"]
-        [::std::mem::offset_of!(whisper_full_params, vad_model_path) - 272usize];
-    ["Offset of field: whisper_full_params::vad_params"]
-        [::std::mem::offset_of!(whisper_full_params, vad_params) - 280usize];
-};
 extern "C" {
     pub fn whisper_context_default_params_by_ref() -> *mut whisper_context_params;
 }
@@ -1078,19 +819,6 @@ pub struct whisper_vad_context_params {
     pub use_gpu: bool,
     pub gpu_device: ::std::os::raw::c_int,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of whisper_vad_context_params"]
-        [::std::mem::size_of::<whisper_vad_context_params>() - 12usize];
-    ["Alignment of whisper_vad_context_params"]
-        [::std::mem::align_of::<whisper_vad_context_params>() - 4usize];
-    ["Offset of field: whisper_vad_context_params::n_threads"]
-        [::std::mem::offset_of!(whisper_vad_context_params, n_threads) - 0usize];
-    ["Offset of field: whisper_vad_context_params::use_gpu"]
-        [::std::mem::offset_of!(whisper_vad_context_params, use_gpu) - 4usize];
-    ["Offset of field: whisper_vad_context_params::gpu_device"]
-        [::std::mem::offset_of!(whisper_vad_context_params, gpu_device) - 8usize];
-};
 extern "C" {
     pub fn whisper_vad_default_context_params() -> whisper_vad_context_params;
 }

--- a/crates/xybrid-bolt/Cargo.toml
+++ b/crates/xybrid-bolt/Cargo.toml
@@ -51,3 +51,12 @@ platform-desktop = ["xybrid-sdk/platform-desktop"]
 # (and pulls `llm-llamacpp` transitively via xybrid-sdk).
 llm-llamacpp = ["xybrid-sdk/llm-llamacpp"]
 llm-llamacpp-vision = ["xybrid-sdk/llm-llamacpp-vision"]
+
+# whisper.cpp ASR forwarder, same purpose as the two above: it lets
+# measure-binary-size.sh diff `llm-llamacpp-vision` against
+# `llm-llamacpp-vision,asr-whispercpp` through this crate's real
+# staticlib/cdylib. The baseline must already carry llama.cpp, because
+# whisper.cpp links the ggml llama builds rather than its own — measuring
+# against a llama-less baseline would charge whisper for ggml, which every
+# shipped artifact already contains.
+asr-whispercpp = ["xybrid-sdk/asr-whispercpp"]

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -35,13 +35,20 @@ rust_library(
     edition = "2021",
     # Resolved from the real Cargo.lock by the @crates hub (DEP_DATA). Backend
     # accel features are gated per-platform exactly as cargo's presets unify them.
+    # asr-whispercpp is unconditional, matching cargo: every platform-* preset
+    # enables it (~0.2 MiB stripped on the Android cdylib proxy). `xybrid-whisper`
+    # is the implicit optional-dependency feature cargo derives from the
+    # `dep:xybrid-whisper` entry — the hub resolves it, so it is listed here for
+    # the same reason `xybrid-llama` / `xybrid-llama-sys` are.
     crate_features = [
+        "asr-whispercpp",
         "default",
         "llm-llamacpp",
         "ort-download",  # no-op marker (mode is per-target in Cargo.toml); kept to match the hub's resolved feature set.
         "schema",
         "xybrid-llama",
         "xybrid-llama-sys",
+        "xybrid-whisper",
     ] + select({
         "@rules_rs//rs/platforms/config:aarch64-apple-darwin": [
             "candle",
@@ -90,7 +97,12 @@ rust_library(
         ],
         "//conditions:default": [],
     }),
-    deps = all_crate_deps(normal = True),
+    # `all_crate_deps` resolves from the hub's view of Cargo.lock, which reflects
+    # the workspace's DEFAULT feature set — and `asr-whispercpp` is off by
+    # default, so the optional `xybrid-whisper` path-dep is absent from it. The
+    # feature is force-enabled above, so the dep has to be added by hand or the
+    # crate fails to compile with an unresolved `xybrid_whisper` import.
+    deps = all_crate_deps(normal = True) + ["//crates/xybrid-whisper:xybrid_whisper"],
     visibility = ["//visibility:public"],
 )
 

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -481,6 +481,8 @@ impl TemplateExecutor {
             ExecutionTemplate::Onnx { model_file } => ("onnx", model_file),
             ExecutionTemplate::CoreMl { model_file } => ("coreml", model_file),
             ExecutionTemplate::TfLite { model_file } => ("tflite", model_file),
+            #[cfg(feature = "asr-whispercpp")]
+            ExecutionTemplate::GgmlWhisper { model_file, .. } => ("whispercpp", model_file),
             _ => return false,
         };
         let model_full_path = Path::new(&self.base_path).join(model_file);

--- a/crates/xybrid-core/src/runtime_adapter/whisper_cpp/runtime.rs
+++ b/crates/xybrid-core/src/runtime_adapter/whisper_cpp/runtime.rs
@@ -179,6 +179,17 @@ impl ModelRuntime for WhisperCppRuntime {
         vec!["bin"]
     }
 
+    fn is_loaded(&self, model_path: &Path) -> bool {
+        // Same key as `load`, so the two always agree.
+        let Ok(guard) = self.model.lock() else {
+            // A poisoned lock means the context is unusable and the caller will
+            // have to reload, so "not loaded" is the honest answer.
+            return false;
+        };
+        self.loaded_path.as_deref() == Some(model_path.display().to_string().as_str())
+            && guard.is_some()
+    }
+
     fn load(&mut self, model_path: &Path) -> AdapterResult<()> {
         let key = model_path.display().to_string();
         let mut guard = lock(&self.model)?;

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -67,17 +67,24 @@ onnx-inspect = ["dep:ort", "ort/download-binaries", "ort/tls-rustls"]
 # ~1.5 MiB on the iOS static-lib proxy — noise against the ~30/160 MiB
 # baselines — so vision runs out of the box rather than being a BYO-build.
 
+# Every preset also ships `asr-whispercpp` (whisper.cpp speech recognition on
+# the ggml `llm-llamacpp-vision` already links). Measured cost is ~0.2 MiB
+# stripped on the Android cdylib proxy — roughly a third of what the vision
+# backend costs, and noise against the ~31/145 MiB baselines — so ASR runs out
+# of the box rather than being a BYO-build. On Linux/Windows it is the ONLY
+# Whisper path, since `platform-desktop` carries no Candle.
+
 # Android: Dynamic ORT loading + Candle + llama.cpp (mistral.rs has SIGILL issues on ARM)
-platform-android = ["xybrid-core/ort-dynamic", "xybrid-core/candle", "llm-llamacpp-vision"]
+platform-android = ["xybrid-core/ort-dynamic", "xybrid-core/candle", "llm-llamacpp-vision", "asr-whispercpp"]
 
 # iOS: CoreML + Metal acceleration + llama.cpp
-platform-ios = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp-vision"]
+platform-ios = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp-vision", "asr-whispercpp"]
 
 # macOS: CoreML + Metal + llama.cpp
-platform-macos = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp-vision"]
+platform-macos = ["xybrid-core/ort-download", "xybrid-core/ort-coreml", "xybrid-core/candle-metal", "xybrid-core/candle-hub", "llm-llamacpp-vision", "asr-whispercpp"]
 
 # Desktop (Linux/Windows): CPU with llama.cpp
-platform-desktop = ["xybrid-core/ort-download", "llm-llamacpp-vision"]
+platform-desktop = ["xybrid-core/ort-download", "llm-llamacpp-vision", "asr-whispercpp"]
 
 # INDIVIDUAL FEATURE FORWARDING (for custom builds)
 
@@ -100,8 +107,8 @@ llm-llamacpp = ["xybrid-core/llm-llamacpp"]
 
 # whisper.cpp speech recognition. Pulls `llm-llamacpp` transitively, because
 # whisper.cpp links the ggml that llama.cpp builds rather than a second copy.
-# Not yet in the `platform-*` presets: the per-artifact size delta is measured
-# in the platform sweep before it ships by default.
+# In every `platform-*` preset above; kept as a standalone forwarder so
+# tools/scripts/measure-binary-size.sh can build the with/without delta.
 asr-whispercpp = ["xybrid-core/asr-whispercpp"]
 llm-llamacpp-vision = ["llm-llamacpp", "xybrid-core/llm-llamacpp-vision"]
 

--- a/crates/xybrid-whisper/BUILD.bazel
+++ b/crates/xybrid-whisper/BUILD.bazel
@@ -1,0 +1,47 @@
+# Safe Rust wrapper over xybrid-whisper-sys. Builds once that crate links.
+load("@rules_rs//rs:rust_library.bzl", "rust_library")
+load("@rules_rs//rs:rust_test.bzl", "rust_test")
+
+rust_library(
+    name = "xybrid_whisper",
+    srcs = glob(["src/**/*.rs"]),
+    # Plain list, no select: unlike llama's `vision`, this crate has no
+    # per-platform feature delta — whisper.cpp's CPU path is the only one we
+    # build, on every target.
+    crate_features = ["bindings"],
+    edition = "2021",
+    deps = [
+        "//crates/whisper-cpp-sys:xybrid_whisper_sys",
+        "@crates//:thiserror",
+        "@crates//:tracing",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Inline `#[cfg(test)] mod tests` in params.rs / segment.rs. `crate = ` inherits
+# srcs, edition and deps; crate_features is a plain list here, which does
+# inherit (the loss on `crate = ` affects selects, see xybrid-llama's note).
+rust_test(
+    name = "xybrid_whisper_test",
+    crate = ":xybrid_whisper",
+)
+
+# Integration test. Opens with `#![cfg(feature = "bindings")]`, so without that
+# feature it compiles to an EMPTY binary and nothing is type-checked. It
+# self-skips when the (gitignored) GGML weights are absent, which is the case on
+# CI — so compiling it is most of the value of having it here.
+rust_test(
+    name = "transcribe_smoke",
+    srcs = ["tests/transcribe_smoke.rs"],
+    crate_features = ["bindings"],
+    edition = "2021",
+    deps = [":xybrid_whisper"],
+)
+
+# Dir-basename alias so `//crates/xybrid-whisper` (the label all_crate_deps()
+# emits for xybrid-core) resolves to the proven target above.
+alias(
+    name = "xybrid-whisper",
+    actual = ":xybrid_whisper",
+    visibility = ["//visibility:public"],
+)

--- a/tools/scripts/measure-binary-size.sh
+++ b/tools/scripts/measure-binary-size.sh
@@ -1,23 +1,21 @@
 #!/usr/bin/env bash
-# measure-binary-size.sh — size the native mtmd/vision delta on the host.
+# measure-binary-size.sh — size a native backend's contribution on the host.
 #
-# The native vision backend (`llm-llamacpp-vision`, llama.cpp's mtmd/clip) ships
-# in every `platform-*` preset as of 0.2.1. This script answers "how many bytes
-# does it add?" by building the xybrid-bolt staticlib + cdylib for the host
-# platform twice and diffing them:
+# Answers "how many bytes does this backend add?" by building the xybrid-bolt
+# staticlib + cdylib twice and diffing them:
 #
-#   baseline : --features llm-llamacpp         (llama.cpp, no mtmd)
-#   vision   : --features llm-llamacpp-vision  (adds the native mtmd backend)
+#   baseline : --features "$BASELINE_FEATURES"
+#   delta    : --features "$DELTA_FEATURES"
 #
-# The accelerators (ORT / Candle) the presets add are constant on both sides, so
-# they cancel out of the delta — the figure below is the pure mtmd cost.
+# Anything the two feature sets share (ORT, Candle, the rest of llama.cpp)
+# is constant on both sides and cancels out, so the figure printed is the
+# isolated cost of what the delta adds.
 #
 # This is a LOCAL PROXY for the per-platform shipped-artifact delta (iOS .a /
-# Android .so), not a substitute: it builds for the host triple, so the
-# mtmd/llama.cpp delta is directionally representative but absolute byte counts
-# differ per target.
+# Android .so), not a substitute: it builds for the host triple, so the number
+# is directionally representative but absolute byte counts differ per target.
 # The staticlib (.a) is the closest proxy for the shipped iOS .a; the cdylib
-# (.dylib) for the Android .so. Prefer the STRIPPED delta as the meaningful
+# (.dylib/.so) for the Android .so. Prefer the STRIPPED delta as the meaningful
 # figure. For the true shipped numbers, read the per-ABI / per-slice sizes the
 # build-android.yml / build-apple.yml jobs print.
 #
@@ -25,7 +23,10 @@
 # this is invoked explicitly — it is NOT wired into CI.
 #
 # Usage:
-#   tools/scripts/measure-binary-size.sh    # builds for the host platform
+#   tools/scripts/measure-binary-size.sh                 # native vision (mtmd)
+#   tools/scripts/measure-binary-size.sh whispercpp      # whisper.cpp ASR
+#   BASELINE_FEATURES=... DELTA_FEATURES=... REQUIRED_SYMBOL=... \
+#     LABEL="..." tools/scripts/measure-binary-size.sh   # anything else
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -34,37 +35,65 @@ LIB="libxybrid_bolt"   # crate lib name (xybrid-bolt -> underscored)
 # cdylib extension is .dylib on macOS, .so on Linux.
 SO_EXT="so"; [ "$(uname)" = "Darwin" ] && SO_EXT="dylib"
 
-# Separate target dirs: the two builds differ only by the mtmd cmake target;
-# a shared dir would let cargo reuse the wrong native objects across the flip.
+# Named presets. As of 0.2.1 every `platform-*` preset bundles
+# `llm-llamacpp-vision`, so a preset can no longer serve as a lean baseline —
+# each pair below isolates one backend against the llama build it sits on.
+case "${1:-vision}" in
+  vision)
+    : "${LABEL:=Native vision (mtmd)}"
+    : "${BASELINE_FEATURES:=llm-llamacpp}"
+    : "${DELTA_FEATURES:=llm-llamacpp-vision}"
+    : "${REQUIRED_SYMBOL:=mtmd}"
+    ;;
+  whispercpp)
+    # whisper.cpp links the ggml llama.cpp already built, so the baseline must
+    # include the llama backend — otherwise the "delta" would wrongly include
+    # ggml itself, which every shipped artifact already carries.
+    : "${LABEL:=whisper.cpp ASR}"
+    : "${BASELINE_FEATURES:=llm-llamacpp-vision}"
+    : "${DELTA_FEATURES:=llm-llamacpp-vision,asr-whispercpp}"
+    : "${REQUIRED_SYMBOL:=whisper_full}"
+    ;;
+  custom)
+    : "${LABEL:?set LABEL for a custom measurement}"
+    : "${BASELINE_FEATURES:?set BASELINE_FEATURES for a custom measurement}"
+    : "${DELTA_FEATURES:?set DELTA_FEATURES for a custom measurement}"
+    : "${REQUIRED_SYMBOL:=}"
+    ;;
+  *)
+    echo "usage: $(basename "$0") [vision|whispercpp|custom]" >&2
+    exit 2
+    ;;
+esac
+
+# Separate target dirs: the two builds differ by a native cmake/cc target, and a
+# shared dir would let cargo reuse the wrong native objects across the flip.
 BASE_TGT="$REPO_ROOT/target/size-base"
-VIS_TGT="$REPO_ROOT/target/size-vision"
+DELTA_TGT="$REPO_ROOT/target/size-delta"
 
 build () {  # $1=target-dir  $2=feature-list
   echo "==> building $PKG ($2) [release] -> $1" >&2
   CARGO_TARGET_DIR="$1" cargo build --release -p "$PKG" --features "$2"
 }
 
-# As of 0.2.1 every `platform-*` preset bundles `llm-llamacpp-vision`, so a
-# preset can no longer serve as the no-vision baseline. The mtmd delta is
-# independent of the ORT/Candle accelerators (identical on both sides), so we
-# isolate it by diffing the llama backend with vs without mtmd directly.
-build "$BASE_TGT" "llm-llamacpp"
-build "$VIS_TGT"  "llm-llamacpp-vision"
+build "$BASE_TGT"  "$BASELINE_FEATURES"
+build "$DELTA_TGT" "$DELTA_FEATURES"
 
-# Correctness guard: the vision build must actually link the native mtmd code,
-# otherwise a broken sdk->core->llama-sys/vision chain would silently report a
-# ~0 delta and look like "vision is free". `nm` on the produced staticlib is
-# robust to build caching (it inspects the artifact, not the build log).
-VIS_A="$VIS_TGT/release/$LIB.a"
-if command -v nm >/dev/null 2>&1 && [ -f "$VIS_A" ]; then
+# Correctness guard: the delta build must actually link the native code under
+# test, otherwise a broken feature chain would silently report a ~0 delta and
+# look like "this backend is free". `nm` on the produced staticlib is robust to
+# build caching (it inspects the artifact, not the build log).
+DELTA_A="$DELTA_TGT/release/$LIB.a"
+if [ -n "$REQUIRED_SYMBOL" ] && command -v nm >/dev/null 2>&1 && [ -f "$DELTA_A" ]; then
   # Use `grep -c`, NOT `grep -q`: under `set -o pipefail`, `grep -q` closes the
   # pipe on the first match, which makes the (still-running) `nm` die with
   # SIGPIPE and reports the whole pipeline as failed — a false FATAL even when
-  # mtmd IS present. `grep -c` consumes all of nm's output, so nm exits 0.
-  mtmd_syms="$(nm "$VIS_A" 2>/dev/null | grep -ci 'mtmd' || true)"
-  if [ "${mtmd_syms:-0}" -eq 0 ]; then
-    echo "FATAL: vision build linked no mtmd symbols — the llm-llamacpp-vision" >&2
-    echo "       feature chain is broken; the measured delta is meaningless." >&2
+  # the symbol IS present. `grep -c` consumes all of nm's output, so nm exits 0.
+  found="$(nm "$DELTA_A" 2>/dev/null | grep -ci "$REQUIRED_SYMBOL" || true)"
+  if [ "${found:-0}" -eq 0 ]; then
+    echo "FATAL: the delta build linked no '$REQUIRED_SYMBOL' symbols — the" >&2
+    echo "       '$DELTA_FEATURES' feature chain is broken; the measured" >&2
+    echo "       delta is meaningless." >&2
     exit 1
   fi
 fi
@@ -78,7 +107,7 @@ stripped_bytes () {
 }
 mib () { awk "BEGIN{printf \"%.1f\", $1/1048576}"; }
 
-row () {  # $1=label $2=base-file $3=vision-file
+row () {  # $1=label $2=base-file $3=delta-file
   if [ ! -f "$2" ] || [ ! -f "$3" ]; then echo "skip $1 (missing artifact)" >&2; return; fi
   local b v bs vs
   b=$(bytes "$2");           v=$(bytes "$3")
@@ -89,11 +118,13 @@ row () {  # $1=label $2=base-file $3=vision-file
 }
 
 echo
-echo "Native vision (mtmd) size delta — all figures MiB"
+echo "$LABEL size delta — all figures MiB"
+echo "  baseline: $BASELINE_FEATURES"
+echo "  delta:    $DELTA_FEATURES"
 printf '%-30s %10s %10s %9s %12s %12s %10s\n' \
-  artifact base vision delta base-strip vision-strip delta-strip
-row "$LIB.a  (staticlib ~ iOS .a)"   "$BASE_TGT/release/$LIB.a"     "$VIS_TGT/release/$LIB.a"
-row "$LIB.$SO_EXT (cdylib ~ Android .so)" "$BASE_TGT/release/$LIB.$SO_EXT" "$VIS_TGT/release/$LIB.$SO_EXT"
+  artifact base with delta base-strip with-strip delta-strip
+row "$LIB.a  (staticlib ~ iOS .a)"   "$BASE_TGT/release/$LIB.a"     "$DELTA_TGT/release/$LIB.a"
+row "$LIB.$SO_EXT (cdylib ~ Android .so)" "$BASE_TGT/release/$LIB.$SO_EXT" "$DELTA_TGT/release/$LIB.$SO_EXT"
 echo
 echo "Host: $(rustc -vV | sed -n 's/^host: //p')"
 echo "Note: host proxy, not the shipped per-platform delta (see header)."


### PR DESCRIPTION
## Summary

Follow-up to #462, which landed the whisper.cpp ASR backend behind a cargo-only feature. This wires it into **Bazel** — the build of record for every shipped native artifact — and **turns it on by default**, backed by a size measurement. Android and iOS now carry speech recognition; before this PR they could not.

**Bazel: a `cc_library`, not a second cmake target**

* `//:whisper` compiles `vendor/whisper-cpp/src/whisper.cpp` with `deps = ["//:llama"]`. This reverses the original design note, deliberately: driving whisper's own CMakeLists would configure `vendor/whisper-cpp/ggml`, which is exactly the duplicate the whole design exists to prevent. Depending on `//:llama` makes **"exactly one ggml" a property of the build graph** rather than a convention. It's also cheaper — one translation unit, no configure-time codegen, so no cmake toolchain and a remote-cacheable compile on the NDK / windows-msvc / apple lanes alike.
* The cargo build script's link-order hack (re-emitting `-lggml*` and the platform libraries after `-lwhisper`) has no Bazel equivalent — Bazel derives link order from the dep graph.
* **CI asserts the invariant** instead of trusting it: a step fails if `deps(//:whisper)` stops containing `//:llama` or starts containing `vendor/whisper-cpp/ggml`. That turns the one mistake a future whisper bump invites — *"it won't compile against the pinned ggml, so use the bundled one"* — into a red build rather than two tensor runtimes in one binary. Uses `cquery`, not `query`: the unconfigured query loads every arm of every `select` in the closure and dies resolving one of hermetic-llvm's per-arch kernel-headers repos.

**Preset adoption, backed by a measurement**

`measure-binary-size.sh` was hardcoded to the vision/mtmd delta; it now takes a named preset. The whisper one baselines against `llm-llamacpp-vision` — a llama-less baseline would charge whisper for ggml, which every artifact already carries.

| artifact | base (stripped) | with whisper | delta |
|---|---|---|---|
| `libxybrid_bolt.dylib` — cdylib, Android proxy | 31.0 MiB | 31.2 MiB | **+0.2 MiB** |
| `libxybrid_bolt.a` — staticlib, iOS proxy | 145.0 MiB | 148.4 MiB | +3.4 MiB |

The cdylib is the number to trust: a staticlib is an archive that keeps every object whether or not anything reaches it, while the cdylib has been through a real link with dead-stripping. +0.2 MiB is consistent with the design rather than surprising — whisper's library is one ~337 KB TU and ggml was already linked. The vision backend costs **0.74 MiB** on the same proxy and ships in every preset today, so this is about a third of an already-accepted cost. `asr-whispercpp` therefore joins all four cargo `platform-*` presets and core's hand-mirrored Bazel `crate_features`.

**Verified locally**

`//:whisper`, both Rust crates, `xybrid-core` with the feature on, the **macOS CLI** (480 whisper symbols in the shipped binary), and the **iOS bolt staticlib** (`whisper.o` is `platform 2` / `minos 16.0`). Android and linux are CI-only from a Mac — `//:llama`'s cmake exits 127 on the android lane here *before* whisper is reached, which reproduces with `//:llama` alone and is unrelated to this change.

**One Bazel gotcha worth a reviewer's eye:** `all_crate_deps()` resolves from the hub's view of `Cargo.lock`, i.e. the workspace's *default* feature set. An optional path-dep whose feature is off by default is absent from it even when `crate_features` force-enables that feature — so `xybrid-core` has to list `//crates/xybrid-whisper` by hand or fail with an unresolved `xybrid_whisper` import.

## Type of Change

- [x] New feature

## Checklist

- [x] Tests pass (`cargo test --workspace --features ort-download`)
- [x] Code follows project style — `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -D warnings` green
- [x] Documentation updated — every non-obvious decision commented at its site; design note in `.context/whispercpp-design.md`
- [ ] **Breaking change to artifact contents, by design**: every `platform-*` preset now links whisper.cpp (+0.2 MiB stripped). No API change — `ExecutionTemplate` stays additive and no public signature moved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native linking and default shipped binaries (single-ggml invariant is CI-guarded but still critical); preset-wide ASR increases artifact size and build surface across platforms without a public API break.
> 
> **Overview**
> Wires **whisper.cpp into Bazel** as the build of record for shipped natives, and turns **`asr-whispercpp` on in every `platform-*` preset** so mobile/desktop artifacts include ASR by default (~0.2 MiB stripped on the Android cdylib proxy per the PR’s measurement story).
> 
> **Bazel native graph:** adds `//:whisper` as a single-TU `cc_library` that depends on `//:llama` (or `//:llama_metal` when metal is enabled), deliberately **not** whisper’s CMake/bundled `ggml`. New `crates/whisper-cpp-sys` and `crates/xybrid-whisper` targets use committed bindgen output and link through `//:whisper`. **CI** builds the llama+whisper chain on RBE and **`cquery`-asserts** that `//:whisper` still depends on llama’s ggml and never pulls `vendor/whisper-cpp/ggml`.
> 
> **Cargo/Bazel parity:** `xybrid-core`’s Bazel target force-enables `asr-whispercpp` and manually adds `//crates/xybrid-whisper` because `all_crate_deps()` omits optional deps when the feature is off in the default lock view. Runtime tweaks: `is_model_loaded` for `GgmlWhisper` and `WhisperCppRuntime::is_loaded`.
> 
> **Tooling:** `measure-binary-size.sh` gains named presets (including `whispercpp` baselined on `llm-llamacpp-vision`). Cargo `build.rs` / committed bindings drop bindgen layout tests and define `_USE_MATH_DEFINES` for Windows/MinGW `M_PI`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7bf7ffa7eb520d0d6f1d4fbfbb93eb1d112fbb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->