### PR TITLE
fix(asr): give bindgen the Android sysroot for whisper.cpp

### DIFF
--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -638,6 +638,13 @@ fn emit_link_and_wrapper(
     // This is what keeps exactly one ggml in the binary.
     println!("cargo:root={}", dst.display());
     println!("cargo:src={}", llama_cpp_dir.display());
+    // The resolved NDK, so a dependent's bindgen can point libclang at the
+    // same sysroot. Without it, a cross-build's libclang resolves headers
+    // against the HOST sysroot and fails on `<stdio.h>`. Emitted only when the
+    // detection above actually found one, so its absence is meaningful.
+    if let Some(ndk) = ctx.android_ndk_path() {
+        println!("cargo:ndk={ndk}");
+    }
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());

--- a/crates/whisper-cpp-sys/build.rs
+++ b/crates/whisper-cpp-sys/build.rs
@@ -159,7 +159,10 @@ fn compile_whisper_cpp() {
         );
     }
 
-    generate_bindings(&whisper_dir, &ggml_include, &out_dir);
+    // Forwarded by xybrid-llama-sys (`links = "llama"`) once it has resolved an
+    // NDK. Absent on non-Android builds, which is exactly when it is unused.
+    let ndk_root = env::var("DEP_LLAMA_NDK").ok();
+    generate_bindings(&whisper_dir, &ggml_include, &out_dir, ndk_root.as_deref());
 
     let source = whisper_dir.join("src").join("whisper.cpp");
     assert_no_bundled_ggml(&whisper_dir, &source);
@@ -334,8 +337,13 @@ fn assert_no_bundled_ggml(whisper_dir: &Path, source: &Path) {
 /// already plain C behind `extern "C"`, so unlike the llama.cpp side there is
 /// no first-party `_c` shim to declare — `wrapper.h` only sets the include
 /// order up for bindgen.
-fn generate_bindings(whisper_dir: &Path, ggml_include: &Path, out_dir: &Path) {
-    let bindings = bindgen::Builder::default()
+fn generate_bindings(
+    whisper_dir: &Path,
+    ggml_include: &Path,
+    out_dir: &Path,
+    ndk_root: Option<&str>,
+) {
+    let builder = bindgen::Builder::default()
         .header("wrapper.h")
         .clang_arg(format!("-I{}", whisper_dir.join("include").display()))
         .clang_arg(format!("-I{}", ggml_include.display()))
@@ -352,7 +360,9 @@ fn generate_bindings(whisper_dir: &Path, ggml_include: &Path, out_dir: &Path) {
         // Android armv7. The #[repr(C)] declarations themselves remain
         // target-correct because pointers and usize retain their native size.
         .layout_tests(false)
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
+
+    let bindings = with_cross_compile_sysroot(builder, ndk_root)
         .generate()
         .unwrap_or_else(|e| fail("xybrid-whisper-sys: bindgen failed", &[format!("{e}")]));
 
@@ -364,6 +374,83 @@ fn generate_bindings(whisper_dir: &Path, ggml_include: &Path, out_dir: &Path) {
                 &[format!("{e}")],
             )
         });
+}
+
+/// Point libclang at the target's sysroot.
+///
+/// bindgen drives libclang, which resolves `<stdio.h>` (reached through
+/// `ggml.h`) against its OWN sysroot — the host's. On any cross-build that is
+/// the wrong one, and the parse fails with `fatal error: 'stdio.h' file not
+/// found` before a single binding is emitted.
+///
+/// This mirrors the same block in `crates/llama-cpp-sys/build.rs`; the two must
+/// stay in sync. The NDK path is not re-detected here — it arrives as
+/// `DEP_LLAMA_NDK` from that crate's `links = "llama"` metadata, so there is
+/// exactly one NDK-resolution implementation in the workspace.
+fn with_cross_compile_sysroot(
+    mut builder: bindgen::Builder,
+    ndk_root: Option<&str>,
+) -> bindgen::Builder {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target = env::var("TARGET").unwrap_or_default();
+
+    // clang 21+ rejects Rust's `-sim` simulator triples verbatim and wants the
+    // canonical `<arch>-apple-<os>-simulator` form (`arm64` is clang's spelling
+    // of `aarch64`). Device and other triples pass through unchanged.
+    let clang_target = match target.strip_suffix("-sim") {
+        Some(base) => format!("{}-simulator", base.replace("aarch64", "arm64")),
+        None => target.clone(),
+    };
+    builder = builder.clang_arg(format!("--target={clang_target}"));
+
+    if target_os == "macos" || target_os == "ios" {
+        let sdk = if target_os == "ios" {
+            if target.contains("sim") {
+                "iphonesimulator"
+            } else {
+                "iphoneos"
+            }
+        } else {
+            "macosx"
+        };
+        if let Ok(out) = process::Command::new("xcrun")
+            .args(["--show-sdk-path", "--sdk", sdk])
+            .output()
+        {
+            if out.status.success() {
+                let sdk_path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !sdk_path.is_empty() {
+                    builder = builder.clang_arg(format!("-isysroot{sdk_path}"));
+                }
+            }
+        }
+    } else if target_os == "android" {
+        let Some(ndk) = ndk_root else {
+            fail(
+                "xybrid-whisper-sys: no Android NDK for bindgen",
+                &[
+                    "DEP_LLAMA_NDK is unset, so libclang would resolve <stdio.h>".into(),
+                    "against the host sysroot and fail to parse ggml.h.".into(),
+                    String::new(),
+                    "xybrid-llama-sys emits this once it has detected the NDK;".into(),
+                    "set ANDROID_NDK_HOME if its detection is not finding one.".into(),
+                ],
+            );
+        };
+        let host_tag = if cfg!(target_os = "macos") {
+            "darwin-x86_64"
+        } else if cfg!(target_os = "linux") {
+            "linux-x86_64"
+        } else {
+            "windows-x86_64"
+        };
+        let sysroot = format!("{ndk}/toolchains/llvm/prebuilt/{host_tag}/sysroot");
+        if Path::new(&sysroot).is_dir() {
+            builder = builder.clang_arg(format!("--sysroot={sysroot}"));
+        }
+    }
+
+    builder
 }
 
 /// Clone the pinned commit into `$OUT_DIR` for consumers that don't ship the

--- a/examples/flutter/lib/screens/live_asr_demo_screen.dart
+++ b/examples/flutter/lib/screens/live_asr_demo_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:xybrid_example/ui.dart';
 import 'package:xybrid_example/utils/recorder.dart';
 import 'package:xybrid_flutter/xybrid.dart';
@@ -21,11 +23,38 @@ class LiveAsrScreen extends StatefulWidget {
 /// High-level screen phases.
 enum _Phase { idle, loadingModel, loadError, ready, listening, finalizing }
 
+/// Which ASR engine runs the rolling window.
+///
+/// Both transcribe Whisper; they differ in weight format and therefore in cost.
+/// Candle runs F32 safetensors and always feeds the encoder a full 30 s window;
+/// whisper.cpp runs quantized GGML weights on the ggml the local LLM backend
+/// already links, and can truncate the encoder to the audio actually present.
+enum _Backend {
+  /// `whisper-tiny` from the registry — F32 safetensors via Candle.
+  candle('Candle (F32 safetensors)', 'whisper-tiny'),
+
+  /// A GGML bundle side-loaded onto the device — quantized, via whisper.cpp.
+  ///
+  /// Not served by the registry yet, so it is loaded from the app's external
+  /// files directory. Push it with:
+  ///
+  /// ```text
+  /// adb push integration-tests/fixtures/models/whisper-ggml-tiny-en \
+  ///   /sdcard/Android/data/com.example.xybrid_example/files/
+  /// ```
+  whisperCpp('whisper.cpp (Q5_1 GGML)', 'whisper-ggml-tiny-en');
+
+  const _Backend(this.label, this.id);
+
+  final String label;
+  final String id;
+}
+
 class _LiveAsrScreenState extends State<LiveAsrScreen> {
   final _recorder = XybridRecorder();
 
-  /// ASR model loaded from the registry (backend auto-detected by the engine).
-  static const _modelId = 'whisper-tiny';
+  /// Which engine the loaded model runs on.
+  _Backend _backend = _Backend.whisperCpp;
 
   _Phase _phase = _Phase.idle;
   double? _loadProgress;
@@ -46,6 +75,28 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
   /// Chunks seen this session, for a bit of live feedback.
   int _chunks = 0;
 
+  /// When the microphone started feeding the engine — the origin for the
+  /// first-partial latency below.
+  DateTime? _streamStartedAt;
+
+  /// When the previous partial arrived, so each new one yields a cadence.
+  DateTime? _lastPartialAt;
+
+  /// Milliseconds from stream start to the first partial transcript.
+  int? _firstPartialMs;
+
+  /// Gaps between consecutive partials, in milliseconds.
+  final List<int> _cadencesMs = [];
+
+  /// Median cadence, which is more honest than a mean here: the first steady
+  /// window after the warm-up ones is systematically slower and would drag an
+  /// average that a user never experiences.
+  int? get _medianCadenceMs {
+    if (_cadencesMs.isEmpty) return null;
+    final sorted = [..._cadencesMs]..sort();
+    return sorted[sorted.length ~/ 2];
+  }
+
   @override
   void dispose() {
     _loadSub?.cancel();
@@ -56,14 +107,29 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
 
   // ── Model loading ──────────────────────────────────────────────────────
 
-  void _loadModel() {
+  Future<void> _loadModel(_Backend backend) async {
     setState(() {
+      _backend = backend;
       _phase = _Phase.loadingModel;
       _loadProgress = null;
       _errorMessage = '';
     });
 
-    final loader = XybridModelLoader.fromRegistry(_modelId);
+    final XybridModelLoader loader;
+    try {
+      loader = switch (backend) {
+        _Backend.candle => XybridModelLoader.fromRegistry(backend.id),
+        // Side-loaded bundle: a directory holding model.bin +
+        // model_metadata.json, whose `GgmlWhisper` template routes the engine
+        // to whisper.cpp.
+        _Backend.whisperCpp => XybridModelLoader.fromDirectory(
+          await _sideloadedBundlePath(backend.id),
+        ),
+      };
+    } catch (e) {
+      _showLoadError(e);
+      return;
+    }
     _loadSub = loader.loadWithProgress().listen(
       (event) async {
         if (!mounted) return;
@@ -87,6 +153,24 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
       },
       onError: _showLoadError,
     );
+  }
+
+  /// Resolve the side-loaded bundle directory, failing with an actionable
+  /// message rather than a bare `PathNotFound` when it has not been pushed.
+  Future<String> _sideloadedBundlePath(String id) async {
+    final base = await getExternalStorageDirectory();
+    if (base == null) {
+      throw StateError('No external files directory on this device');
+    }
+    final dir = Directory('${base.path}/$id');
+    if (!dir.existsSync()) {
+      throw StateError(
+        'Bundle not found at ${dir.path}.\n\n'
+        'Push it first:\n'
+        '  adb push integration-tests/fixtures/models/$id ${base.path}/',
+      );
+    }
+    return dir.path;
   }
 
   void _showLoadError(Object error) {
@@ -121,6 +205,8 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
 
       // Listen for partials *before* feeding any audio.
       _partialSub = session.partials.listen((partial) {
+        final now = DateTime.now();
+        _recordPartialTiming(now);
         if (!mounted) return;
         setState(() {
           _liveText = partial.text;
@@ -130,6 +216,10 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
 
       // Pipe microphone PCM (already f32 mono 16 kHz) straight into the engine.
       await _recorder.startStreaming(onSamples: session.feed);
+      _streamStartedAt = DateTime.now();
+      _lastPartialAt = null;
+      _firstPartialMs = null;
+      _cadencesMs.clear();
 
       setState(() {
         _session = session;
@@ -149,6 +239,25 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
         ).showSnackBar(SnackBar(content: Text('Failed to start: $e')));
       }
     }
+  }
+
+  /// Record first-partial latency and inter-partial cadence.
+  ///
+  /// Also logged to the console with a grep-able prefix so a run can be
+  /// measured over `adb logcat` without reading the screen.
+  void _recordPartialTiming(DateTime now) {
+    final startedAt = _streamStartedAt;
+    if (startedAt == null) return;
+
+    if (_firstPartialMs == null) {
+      _firstPartialMs = now.difference(startedAt).inMilliseconds;
+      debugPrint('[ASRPERF] backend=${_backend.id} first_partial_ms=$_firstPartialMs');
+    } else if (_lastPartialAt != null) {
+      final cadence = now.difference(_lastPartialAt!).inMilliseconds;
+      _cadencesMs.add(cadence);
+      debugPrint('[ASRPERF] backend=${_backend.id} cadence_ms=$cadence');
+    }
+    _lastPartialAt = now;
   }
 
   Future<void> _stop() async {
@@ -194,10 +303,12 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
           _Phase.loadingModel => _LoadingView(progress: _loadProgress),
           _Phase.loadError => ErrorCard(
             errorMessage: _errorMessage,
-            onRetry: _loadModel,
+            onRetry: () => _loadModel(_backend),
           ),
           _ => _ActiveView(
-            modelId: _modelId,
+            modelId: _backend.label,
+            firstPartialMs: _firstPartialMs,
+            medianCadenceMs: _medianCadenceMs,
             listening: _phase == _Phase.listening,
             finalizing: _phase == _Phase.finalizing,
             liveText: _liveText,
@@ -215,7 +326,7 @@ class _LiveAsrScreenState extends State<LiveAsrScreen> {
 class _IdleView extends StatelessWidget {
   const _IdleView({required this.onLoad});
 
-  final VoidCallback onLoad;
+  final ValueChanged<_Backend> onLoad;
 
   @override
   Widget build(BuildContext context) {
@@ -231,11 +342,16 @@ class _IdleView extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
-          FilledButton.icon(
-            onPressed: onLoad,
-            icon: const Icon(Icons.download),
-            label: const Text('Load ASR model'),
-          ),
+          // One button per engine: the point of this screen is the comparison,
+          // so make it a choice rather than a build-time constant.
+          for (final backend in _Backend.values) ...[
+            FilledButton.icon(
+              onPressed: () => onLoad(backend),
+              icon: const Icon(Icons.download),
+              label: Text(backend.label),
+            ),
+            const SizedBox(height: 12),
+          ],
         ],
       ),
     );
@@ -269,6 +385,8 @@ class _LoadingView extends StatelessWidget {
 class _ActiveView extends StatelessWidget {
   const _ActiveView({
     required this.modelId,
+    required this.firstPartialMs,
+    required this.medianCadenceMs,
     required this.listening,
     required this.finalizing,
     required this.liveText,
@@ -279,6 +397,14 @@ class _ActiveView extends StatelessWidget {
   });
 
   final String modelId;
+
+  /// Milliseconds from stream start to the first partial — the number a user
+  /// actually feels when they start speaking.
+  final int? firstPartialMs;
+
+  /// Median gap between partials once the stream is running.
+  final int? medianCadenceMs;
+
   final bool listening;
   final bool finalizing;
   final String liveText;
@@ -309,6 +435,16 @@ class _ActiveView extends StatelessWidget {
                       ? 'Listening ($chunks chunks)'
                       : 'Ready',
                 ),
+                if (firstPartialMs != null)
+                  InfoRow(
+                    label: 'First partial',
+                    value: '${(firstPartialMs! / 1000).toStringAsFixed(1)} s',
+                  ),
+                if (medianCadenceMs != null)
+                  InfoRow(
+                    label: 'Cadence (median)',
+                    value: '${(medianCadenceMs! / 1000).toStringAsFixed(1)} s',
+                  ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary

This pull request fixes a build regression that made the Flutter example app impossible to build for Android from source, and turns the live ASR demo into a side-by-side comparison of the two Whisper engines so the whisper.cpp win can be measured on a real device rather than asserted.

The regression came from #462: `xybrid-whisper-sys` mirrored `xybrid-llama-sys`'s `cc` compile but not its bindgen setup. bindgen drives libclang, which resolves headers against its **own** sysroot — the host's — so on any cross-build, parsing `whisper.h` (which reaches `<stdio.h>` through `ggml.h`) fails before a single binding is emitted:

```
ggml.h:214:10: fatal error: 'stdio.h' file not found
```

CI never caught it because every CI Android lane goes through Bazel, which compiles the **committed** bindings and never runs bindgen. Only a cargo Android build reaches that code — which is exactly what cargokit does for Flutter, so the first person to build the example app hit it.

**Cross-compile sysroot plumbing:**

* `xybrid-llama-sys` now emits `cargo:ndk=<path>` alongside its existing `root` / `src` metadata, and `xybrid-whisper-sys` consumes it as `DEP_LLAMA_NDK`. Rather than duplicating the NDK env-var search across two `-sys` crates, there is exactly one NDK-resolution implementation in the workspace and the answer is forwarded through the `links = "llama"` channel already used for the ggml headers and archives.
* The whisper crate gains the same `with_cross_compile_sysroot` helper llama has: the Android `--sysroot`, the Apple `-isysroot` resolved via `xcrun`, and the clang-21 `-sim` triple translation. iOS cargo builds are covered by the same change.
* Missing NDK on an Android target now fails with an actionable message naming `DEP_LLAMA_NDK` and `ANDROID_NDK_HOME`, instead of a header error that points nowhere near the cause.

**Live ASR demo — a comparison instead of one hardcoded model:**

* The screen had `whisper-tiny` as a `static const`. It now offers both engines as buttons — Candle (registry, F32 safetensors) and whisper.cpp (side-loaded Q5_1 GGML via `XybridModelLoader.fromDirectory`) — so switching backends is a tap rather than a rebuild.
* Reports first-partial latency and median cadence, both on the card and as grep-able `[ASRPERF]` log lines so a run can be measured over `adb logcat`. Median rather than mean: the first steady window after the warm-up ones is systematically slower and would drag an average toward a number no user experiences.
* The side-loaded path fails with a "push it first" message naming the exact `adb push` command, rather than a bare `PathNotFound`.

**Measured on a Pixel 8** (same session, release build, `[ASRPERF]` capture):

| | first partial | cadence (median) |
|---|---|---|
| Candle (F32 safetensors) | 9871 ms | 4669 ms |
| whisper.cpp (Q5_1 GGML), run 1 | **2724 ms** | 4561 ms |
| whisper.cpp (Q5_1 GGML), run 2 | **2718 ms** | 3230 ms |

**3.6x on first partial** — the metric a user feels — reproducible to within 6 ms across two runs. The Candle figure independently reproduces the 9.7 s baseline recorded in #453, so the comparison is anchored rather than self-reported.

**Cadence is unchanged, and that is correct rather than disappointing.** The rolling window is 5 s with 0.5 s overlap, so a new window arrives roughly every 4.5 s of wall clock no matter how fast inference is — once a backend beats realtime, cadence is bounded by audio arrival, not compute. Candle sat at ~3.5 s of compute per 5 s window (RTF ~0.7, no headroom); whisper.cpp is far below that. Removing the fixed 1.5 s wait before the first warm-up window can exist puts the compute difference at `(9871-1500)/(2724-1500)` = **~6.8x**, consistent with the 4.7x measured on the standalone bench. It is not an order of magnitude.

## Type of Change

- [x] Bug fix
- [x] Other: example-app instrumentation

## Checklist

- [x] Tests pass (`cargo test --workspace --features ort-download`)
- [x] Code follows project style — `cargo fmt --all --check` green; `flutter analyze` clean on the changed screen
- [x] Documentation updated — device measurements and the two device-lab gotchas recorded in `.context/whispercpp-design.md`
- [x] No breaking changes — build-script and example-app only; no public API or FFI surface touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to `-sys` build scripts and the Flutter example screen; no public Rust API or FFI surface changes, though bindgen/sysroot logic must stay aligned with `llama-cpp-sys`.
> 
> **Overview**
> Fixes **cargo Android builds** of `whisper-cpp-sys` where bindgen/libclang parsed `ggml.h` against the **host** sysroot and died on missing `<stdio.h>` (Flutter/cargokit path; Bazel’s committed bindings never ran bindgen).
> 
> **Build plumbing:** `llama-cpp-sys` now emits `cargo:ndk=…` (→ `DEP_LLAMA_NDK`) when an NDK is resolved; `whisper-cpp-sys` feeds that into a new **`with_cross_compile_sysroot`** on bindgen (Android `--sysroot`, Apple `-isysroot` via `xcrun`, clang `-sim` triple fix). Android without NDK fails with a message pointing at `DEP_LLAMA_NDK` / `ANDROID_NDK_HOME`.
> 
> **Flutter live ASR demo:** Replaces a single registry `whisper-tiny` load with **Candle (registry F32)** vs **whisper.cpp (side-loaded Q5_1 GGML)** buttons, actionable `adb push` errors for missing bundles, and on-screen plus **`[ASRPERF]`** log metrics for **first-partial latency** and **median inter-partial cadence**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c39a996a04e5d225e07d40572b3363b4723da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->