### PR TITLE
docs: correct every claim invalidated by the Candle retirement

### DIFF
--- a/.agents/skills/test-model/SKILL.md
+++ b/.agents/skills/test-model/SKILL.md
@@ -46,7 +46,8 @@ Based on the `execution_template.type` and `metadata.task`:
 |------|-------|-----------------|---------------|
 | `text-to-speech` | `Envelope::Text("Hello world")` | Audio bytes (length > 0) | default |
 | `speech-recognition` (Onnx) | `Envelope::Audio(wav_bytes)` | Text transcription | default |
-| `speech-recognition` (SafeTensors) | `Envelope::Audio(wav_bytes)` | Text transcription | `candle,candle-metal` |
+| `speech-recognition` (GgmlWhisper) | `Envelope::Audio(wav_bytes)` | Text transcription | `asr-whispercpp` (in every `platform-*` preset) |
+| `speech-recognition` (SafeTensors) | `Envelope::Audio(wav_bytes)` | Text transcription | `candle,candle-metal` — opt-in only; no preset enables Candle |
 | `text-generation` (Gguf) | `Envelope::Text("Hello")` | Text response | `llm-llamacpp` |
 | `text-embedding` | `Envelope::Text("test sentence")` | Embedding vector (f32) | default |
 | `image_classification` | Raw image bytes | Class probabilities | default |
@@ -79,7 +80,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         metadata: HashMap::new(),
     };
 
-    let output = executor.execute(&metadata, &input)?;
+    // Third arg is an optional `&GenerationConfig` override.
+    let output = executor.execute(&metadata, &input, None)?;
     println!("Output: {:?}", output.kind);
     println!("Test passed!");
     Ok(())
@@ -134,5 +136,6 @@ Status: PASS / FAIL
 - **"file not found"**: A file listed in `files` array doesn't exist — download it or fix the path
 - **"preprocessing failed"**: Wrong preprocessing step for the model type
 - **"ONNX error"**: Model file may be corrupted or wrong format
-- **"feature not enabled"**: Add the required feature flag (e.g., `--features candle` for SafeTensors models)
+- **"SafeTensors execution requires the 'candle' feature"**: the bundle is a Candle/SafeTensors model and no `platform-*` preset enables Candle any more. Either add `--features candle` explicitly, or switch to the GGML bundle (`ExecutionTemplate::GgmlWhisper`) that runs on `asr-whispercpp` — e.g. `whisper-tiny-ggml` instead of `whisper-tiny`.
+- **"feature not enabled"**: Add the required feature flag (e.g. `--features asr-whispercpp` for GGML Whisper, `--features candle` for SafeTensors)
 - **"llm backend not available"**: Add `--features llm-llamacpp` for GGUF models

--- a/.agents/skills/xybrid-init/SKILL.md
+++ b/.agents/skills/xybrid-init/SKILL.md
@@ -62,7 +62,8 @@ Use the model card description, file extensions, and config to determine the mod
 
 **File-based detection:**
 - `.gguf` file → **LLM** (Gguf template)
-- `.safetensors` + whisper/candle architecture → **ASR** (SafeTensors template)
+- GGML Whisper weights (`ggml-*.bin`, or a `.bin` whose model card says whisper.cpp / GGML) → **ASR** (GgmlWhisper template) — the default ASR path
+- `.safetensors` + whisper architecture → **ASR** (SafeTensors template, Candle runtime) — opt-in only, needs `--features candle`; prefer the GGML bundle above
 - `.onnx` file → continue to task detection below
 - `.mlmodel` / `.mlpackage` → **CoreML** template
 - `.tflite` → **TfLite** template
@@ -104,7 +105,15 @@ Choose ONE:
 // ONNX model
 { "type": "Onnx", "model_file": "model.onnx" }
 
-// SafeTensors (Candle runtime — currently only Whisper)
+// GGML Whisper (whisper.cpp — the default ASR path, feature `asr-whispercpp`)
+// `language`: omit or null to auto-detect. `audio_ctx`: 0 = no encoder
+// truncation (the safe default — truncating is the biggest streaming speed
+// lever but too much of it makes the decoder loop, so opt in per model after
+// a quality check). `translate`: true translates to English instead of
+// transcribing in the source language.
+{ "type": "GgmlWhisper", "model_file": "model.bin", "language": "en", "audio_ctx": 0, "translate": false }
+
+// SafeTensors (Candle runtime — Whisper only; opt-in `candle` feature, in no platform preset)
 { "type": "SafeTensors", "model_file": "model.safetensors", "architecture": "whisper", "config_file": "config.json", "tokenizer_file": "tokenizer.json" }
 
 // GGUF (local LLMs via llama.cpp)

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -245,9 +245,9 @@ let result = model.run(&Envelope::text("Hello world"))?;
 # voice-assistant.yaml
 name: voice-assistant
 stages:
-  - model: whisper-tiny    # 音声 → テキスト
-  - model: qwen2.5-0.5b    # LLMで処理
-  - model: kokoro-82m      # テキスト → 音声
+  - model: whisper-tiny-ggml  # 音声 → テキスト
+  - model: qwen2.5-0.5b       # LLMで処理
+  - model: kokoro-82m         # テキスト → 音声
 ```
 
 **CLI:**
@@ -303,7 +303,8 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 
 | モデル | パラメータ数 | フォーマット | 説明 |
 |-------|--------|--------|-------------|
-| Whisper Tiny | 39M | SafeTensors | 多言語文字起こし（Candleランタイム） |
+| Whisper Tiny（`whisper-tiny-ggml`） | 39M | GGML Q5_1 | whisper.cpp による多言語文字起こし — すべてのプラットフォームプリセットに同梱 |
+| Whisper Tiny（`whisper-tiny`） | 39M | SafeTensors | 同じ重みを Candle ランタイムで実行 — `candle` フィーチャを有効にしたビルドが必要 |
 | Wav2Vec2 Base | 95M | ONNX | CTC復号による英語ASR |
 
 ### テキスト読み上げ（Text-to-Speech）

--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ Chain models together into a single multi-model inference pipeline (MMP) — bui
 # voice-assistant.yaml
 name: voice-assistant
 stages:
-  - model: whisper-tiny    # Speech → text
-  - model: qwen2.5-0.5b    # Process with LLM
-  - model: kokoro-82m      # Text → speech
+  - model: whisper-tiny-ggml  # Speech → text
+  - model: qwen2.5-0.5b       # Process with LLM
+  - model: kokoro-82m         # Text → speech
 ```
 
 **CLI:**
@@ -316,7 +316,8 @@ All models run entirely on-device. No cloud, no API keys required. Browse the fu
 
 | Model | Params | Format | Description |
 |-------|--------|--------|-------------|
-| Whisper Tiny | 39M | SafeTensors | Multilingual transcription (Candle runtime) |
+| Whisper Tiny (`whisper-tiny-ggml`) | 39M | GGML Q5_1 | Multilingual transcription on whisper.cpp — in every platform preset |
+| Whisper Tiny (`whisper-tiny`) | 39M | SafeTensors | Same weights on the Candle runtime — needs a build with the `candle` feature |
 | Wav2Vec2 Base | 95M | ONNX | English ASR with CTC decoding |
 
 ### Text-to-Speech

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -245,9 +245,9 @@ let result = model.run(&Envelope::text("国破山河在，城春草木深"))?;
 # voice-assistant.yaml
 name: voice-assistant
 stages:
-  - model: whisper-tiny    # 语音 → 文本
-  - model: qwen2.5-0.5b    # 用 LLM 处理
-  - model: kokoro-82m      # 文本 → 语音
+  - model: whisper-tiny-ggml  # 语音 → 文本
+  - model: qwen2.5-0.5b       # 用 LLM 处理
+  - model: kokoro-82m         # 文本 → 语音
 ```
 
 **CLI:**
@@ -303,7 +303,8 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 
 | 模型 | 参数量 | 格式 | 简介 |
 |------|--------|------|------|
-| Whisper Tiny | 39M | SafeTensors | 多语言转录（Candle 运行时） |
+| Whisper Tiny（`whisper-tiny-ggml`） | 39M | GGML Q5_1 | 多语言转录，基于 whisper.cpp — 所有平台预设均已内置 |
+| Whisper Tiny（`whisper-tiny`） | 39M | SafeTensors | 相同权重，运行于 Candle — 需要启用 `candle` 特性重新构建 |
 | Wav2Vec2 Base | 95M | ONNX | 英语 ASR，CTC 解码 |
 
 ### 文本转语音

--- a/agents/skills/test-model/SKILL.md
+++ b/agents/skills/test-model/SKILL.md
@@ -41,7 +41,8 @@ Based on the `execution_template.type` and `metadata.task`:
 |------|-------|-----------------|---------------|
 | `text-to-speech` | `Envelope::Text("Hello world")` | Audio bytes (length > 0) | default |
 | `speech-recognition` (Onnx) | `Envelope::Audio(wav_bytes)` | Text transcription | default |
-| `speech-recognition` (SafeTensors) | `Envelope::Audio(wav_bytes)` | Text transcription | `candle,candle-metal` |
+| `speech-recognition` (GgmlWhisper) | `Envelope::Audio(wav_bytes)` | Text transcription | `asr-whispercpp` (in every `platform-*` preset) |
+| `speech-recognition` (SafeTensors) | `Envelope::Audio(wav_bytes)` | Text transcription | `candle,candle-metal` — opt-in only; no preset enables Candle |
 | `text-generation` (Gguf) | `Envelope::Text("Hello")` | Text response | `llm-llamacpp` |
 | `text-embedding` | `Envelope::Text("test sentence")` | Embedding vector (f32) | default |
 | `image_classification` | Raw image bytes | Class probabilities | default |
@@ -74,7 +75,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         metadata: HashMap::new(),
     };
 
-    let output = executor.execute(&metadata, &input)?;
+    // Third arg is an optional `&GenerationConfig` override.
+    let output = executor.execute(&metadata, &input, None)?;
     println!("Output: {:?}", output.kind);
     println!("Test passed!");
     Ok(())
@@ -129,5 +131,6 @@ Status: PASS / FAIL
 - **"file not found"**: A file listed in `files` array doesn't exist — download it or fix the path
 - **"preprocessing failed"**: Wrong preprocessing step for the model type
 - **"ONNX error"**: Model file may be corrupted or wrong format
-- **"feature not enabled"**: Add the required feature flag (e.g., `--features candle` for SafeTensors models)
+- **"SafeTensors execution requires the 'candle' feature"**: the bundle is a Candle/SafeTensors model and no `platform-*` preset enables Candle any more. Either add `--features candle` explicitly, or switch to the GGML bundle (`ExecutionTemplate::GgmlWhisper`) that runs on `asr-whispercpp` — e.g. `whisper-tiny-ggml` instead of `whisper-tiny`.
+- **"feature not enabled"**: Add the required feature flag (e.g. `--features asr-whispercpp` for GGML Whisper, `--features candle` for SafeTensors)
 - **"llm backend not available"**: Add `--features llm-llamacpp` for GGUF models

--- a/agents/skills/xybrid-init/SKILL.md
+++ b/agents/skills/xybrid-init/SKILL.md
@@ -57,7 +57,8 @@ Use the model card description, file extensions, and config to determine the mod
 
 **File-based detection:**
 - `.gguf` file → **LLM** (Gguf template)
-- `.safetensors` + whisper/candle architecture → **ASR** (SafeTensors template)
+- GGML Whisper weights (`ggml-*.bin`, or a `.bin` whose model card says whisper.cpp / GGML) → **ASR** (GgmlWhisper template) — the default ASR path
+- `.safetensors` + whisper architecture → **ASR** (SafeTensors template, Candle runtime) — opt-in only, needs `--features candle`; prefer the GGML bundle above
 - `.onnx` file → continue to task detection below
 - `.mlmodel` / `.mlpackage` → **CoreML** template
 - `.tflite` → **TfLite** template
@@ -99,7 +100,15 @@ Choose ONE:
 // ONNX model
 { "type": "Onnx", "model_file": "model.onnx" }
 
-// SafeTensors (Candle runtime — currently only Whisper)
+// GGML Whisper (whisper.cpp — the default ASR path, feature `asr-whispercpp`)
+// `language`: omit or null to auto-detect. `audio_ctx`: 0 = no encoder
+// truncation (the safe default — truncating is the biggest streaming speed
+// lever but too much of it makes the decoder loop, so opt in per model after
+// a quality check). `translate`: true translates to English instead of
+// transcribing in the source language.
+{ "type": "GgmlWhisper", "model_file": "model.bin", "language": "en", "audio_ctx": 0, "translate": false }
+
+// SafeTensors (Candle runtime — Whisper only; opt-in `candle` feature, in no platform preset)
 { "type": "SafeTensors", "model_file": "model.safetensors", "architecture": "whisper", "config_file": "config.json", "tokenizer_file": "tokenizer.json" }
 
 // GGUF (local LLMs via llama.cpp)

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -83,7 +83,7 @@ cd ios && pod install && cd ..
 import { Xybrid, ModelLoader } from 'react-native-xybrid';
 
 await Xybrid.initialize();
-const model = await ModelLoader.fromRegistry('whisper-tiny').load();
+const model = await ModelLoader.fromRegistry('whisper-tiny-ggml').load();
 const result = await model.run({ kind: 'audio', bytesBase64, sampleRate: 16000, channels: 1 });
 console.log(result.text);
 await model.release();

--- a/crates/xybrid-cli/README.md
+++ b/crates/xybrid-cli/README.md
@@ -35,7 +35,7 @@ xybrid models list
 xybrid run --model kokoro-82m --input-text "Hello world" --output hello.wav
 
 # Speech-to-text
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 
 # Chat with an LLM (interactive)
 xybrid repl --model smollm2-360m --stream

--- a/crates/xybrid/README.md
+++ b/crates/xybrid/README.md
@@ -13,10 +13,10 @@ xybrid = "0.2"
 
 Feature flags forward 1:1 to `xybrid-sdk`. Pick the preset that matches your target platform:
 
-- `platform-macos` — CoreML + Metal + llama.cpp
-- `platform-ios` — CoreML + Metal + llama.cpp
-- `platform-android` — Dynamic ORT + Candle + llama.cpp
-- `platform-desktop` — CPU ORT + llama.cpp (Linux/Windows)
+- `platform-macos` — CoreML + Metal + llama.cpp (vision) + whisper.cpp ASR
+- `platform-ios` — CoreML + Metal + llama.cpp (vision) + whisper.cpp ASR
+- `platform-android` — Dynamic ORT + llama.cpp (vision) + whisper.cpp ASR
+- `platform-desktop` — CPU ORT + llama.cpp (vision) + whisper.cpp ASR (Linux/Windows)
 
 For finer-grained control, enable individual features such as `ort-download`, `candle`, `llm-llamacpp`, `huggingface`, etc.
 

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -25,7 +25,7 @@ This document provides a comprehensive reference for all feature flags, platform
 | **ort-download** | Download prebuilt ONNX Runtime binaries | `ort/download-binaries`, `ort/tls-native` |
 | **ort-dynamic** | Load ONNX Runtime .so at runtime | `ort/load-dynamic` |
 | **ort-coreml** | Apple Neural Engine acceleration | `ort/coreml` |
-| **candle** | Pure Rust ML framework (Whisper) — Android-compatible | `candle-core`, `candle-nn`, `candle-transformers`, `safetensors`, `byteorder`, `num-traits` |
+| **candle** | Pure Rust ML framework — the SafeTensors Whisper path. **Opt-in only**: no `platform-*` preset enables it (`asr-whispercpp` / whisper.cpp is the shipped ASR backend). Android-compatible | `candle-core`, `candle-nn`, `candle-transformers`, `safetensors`, `byteorder`, `num-traits`, `rayon` |
 | **candle-hub** | Candle + HuggingFace Hub download support | `candle`, `hf-hub` (requires OpenSSL — **not for Android**) |
 | **candle-metal** | Candle with Metal GPU acceleration | `candle`, `candle-core/metal`, `candle-nn/metal` |
 | **candle-cuda** | Candle with CUDA GPU acceleration | `candle`, `candle-core/cuda` |
@@ -34,7 +34,8 @@ This document provides a comprehensive reference for all feature flags, platform
 | **llm-mistral-cuda** | mistral.rs with CUDA acceleration | `llm-mistral`, `mistralrs/cuda` |
 | **vision** | Image envelope primitives and image preprocessing | *(no additional dependencies; uses the always-present `image` crate)* |
 | **llm-llamacpp** | llama.cpp backend (cmake build + link) | `llama-cpp-sys/bindings`, `xybrid-llama/bindings` |
-| **llm-llamacpp-vision** | llama.cpp VLM path with `mmproj` / `mtmd` support | `llm-llamacpp`, `vision`, `llama-cpp-sys/vision`, `xybrid-llama/vision` |
+| **llm-llamacpp-vision** | Native llama multimodal (`mmproj` / `mtmd`) backend on top of `llm-llamacpp` | `llm-llamacpp`, `xybrid-llama-sys/vision`, `xybrid-llama/vision` |
+| **asr-whispercpp** | whisper.cpp speech recognition. Requires `llm-llamacpp` — whisper.cpp links the ggml that llama.cpp builds rather than a second copy | `llm-llamacpp`, `xybrid-whisper/bindings` |
 
 ### Notes
 
@@ -58,10 +59,10 @@ This document provides a comprehensive reference for all feature flags, platform
 | Feature | Description | Forwards to xybrid-core |
 |---------|-------------|-------------------------|
 | **default** | No default features | *(none)* |
-| **platform-android** | Android preset | `ort-dynamic`, `candle`, `llm-llamacpp` |
-| **platform-ios** | iOS preset | `ort-download`, `ort-coreml`, `candle-metal`, `candle-hub`, `llm-llamacpp` |
-| **platform-macos** | macOS preset | `ort-download`, `ort-coreml`, `candle-metal`, `candle-hub`, `llm-llamacpp` |
-| **platform-desktop** | Desktop (Linux/Windows) preset | `ort-download`, `llm-llamacpp` |
+| **platform-android** | Android preset | `ort-dynamic`, `llm-llamacpp-vision`, `asr-whispercpp` |
+| **platform-ios** | iOS preset | `ort-download`, `ort-coreml`, `llm-llamacpp-vision`, `asr-whispercpp` |
+| **platform-macos** | macOS preset | `ort-download`, `ort-coreml`, `llm-llamacpp-vision`, `asr-whispercpp` |
+| **platform-desktop** | Desktop (Linux/Windows) preset | `ort-download`, `llm-llamacpp-vision`, `asr-whispercpp` |
 | **ort-download** | Forward to core | `xybrid-core/ort-download` |
 | **ort-dynamic** | Forward to core | `xybrid-core/ort-dynamic` |
 | **ort-coreml** | Forward to core | `xybrid-core/ort-coreml` |
@@ -73,6 +74,7 @@ This document provides a comprehensive reference for all feature flags, platform
 | **llm-mistral-metal** | Forward to core | `xybrid-core/llm-mistral-metal` |
 | **llm-mistral-cuda** | Forward to core | `xybrid-core/llm-mistral-cuda` |
 | **llm-llamacpp** | Forward to core | `xybrid-core/llm-llamacpp` |
+| **asr-whispercpp** | Forward to core (pulls `llm-llamacpp` transitively) | `xybrid-core/asr-whispercpp` |
 | **vision** | Forward to core | `xybrid-core/vision` |
 | **llm-llamacpp-vision** | Forward to core VLM path | `xybrid-core/llm-llamacpp-vision`, `llm-llamacpp`, `vision` |
 
@@ -86,11 +88,12 @@ This document provides a comprehensive reference for all feature flags, platform
 | **huggingface** | Direct HuggingFace loading for `xybrid run --huggingface` | `xybrid-sdk/huggingface` |
 | **onnx-inspect** | ONNX metadata inspection for `xybrid init` | `xybrid-sdk/onnx-inspect` |
 | **vision** | `xybrid run --input-image` and REPL `/image` envelope construction for VLM turns | `xybrid-core/vision`, `xybrid-sdk/vision` |
-| **llm-llamacpp-vision** | llama.cpp VLM runtime plus CLI image input support | `llm-llamacpp`, `vision`, `xybrid-sdk/llm-llamacpp-vision` |
-| **platform-android** | Android release preset | `ort-dynamic`, `llm-llamacpp`, `candle`, `huggingface` |
-| **platform-ios** | iOS release preset | `ort-download`, `ort-coreml`, `candle-metal`, `candle-hub`, `llm-llamacpp`, `huggingface` |
-| **platform-macos** | macOS release preset | `ort-download`, `ort-coreml`, `candle-metal`, `candle-hub`, `llm-llamacpp`, `huggingface` |
-| **platform-desktop** | Linux/Windows release preset | `ort-download`, `llm-llamacpp`, `huggingface` |
+| **llm-llamacpp-vision** | Native llama.cpp VLM runtime for image turns | `llm-llamacpp`, `xybrid-sdk/llm-llamacpp-vision` |
+| **asr-whispercpp** | whisper.cpp speech recognition for `xybrid run --input-audio` | `xybrid-sdk/asr-whispercpp` |
+| **platform-android** | Android release preset — forwards to `xybrid-sdk/platform-android` | `ort-dynamic`, `llm-llamacpp-vision`, `asr-whispercpp`, `llm-llamacpp`, `huggingface` |
+| **platform-ios** | iOS release preset — forwards to `xybrid-sdk/platform-ios` | `ort-download`, `ort-coreml`, `llm-llamacpp-vision`, `asr-whispercpp`, `llm-llamacpp`, `huggingface` |
+| **platform-macos** | macOS release preset — forwards to `xybrid-sdk/platform-macos` | `ort-download`, `ort-coreml`, `llm-llamacpp-vision`, `asr-whispercpp`, `llm-llamacpp`, `huggingface` |
+| **platform-desktop** | Linux/Windows release preset — forwards to `xybrid-sdk/platform-desktop` | `ort-download`, `llm-llamacpp-vision`, `asr-whispercpp`, `llm-llamacpp`, `huggingface` |
 
 ---
 
@@ -98,22 +101,30 @@ This document provides a comprehensive reference for all feature flags, platform
 
 Platform presets are the **single source of truth** for platform-specific feature combinations. They are defined in `xybrid-sdk/Cargo.toml` and forwarded through the crate hierarchy.
 
-All current platform presets default to **text-only** llama.cpp support. Vision-language builds must compose the platform preset with `llm-llamacpp-vision`; use `vision` alone only when a crate needs image envelope/preprocessing types without the llama.cpp VLM runtime.
+All four platform presets ship the vision-language llama.cpp path (`llm-llamacpp-vision`, ~0.7 MiB stripped on the Android `.so` proxy / ~1.5 MiB on the iOS static-lib proxy) **and** whisper.cpp speech recognition (`asr-whispercpp`, ~0.2 MiB stripped). VLM and ASR work out of the box — there is nothing extra to compose.
 
-| Preset | Target Platform | Core Features Enabled | VLM Default | Rationale |
-|--------|-----------------|----------------------|-------------|-----------|
-| **platform-android** | Android (all ABIs) | `ort-dynamic`, `candle`, `llm-llamacpp` | Off; add `llm-llamacpp-vision` | Dynamic ORT loading for AAR distribution; Candle (CPU) for Whisper ASR; llama.cpp has runtime SIMD detection; mistral.rs causes SIGILL on devices without ARMv8.2-A FP16 |
-| **platform-ios** | iOS (arm64, simulator) | `ort-download`, `ort-coreml`, `candle-metal`, `candle-hub`, `llm-llamacpp` | Off; add `llm-llamacpp-vision` | Static ORT linking; CoreML for ANE acceleration; Metal for GPU |
-| **platform-macos** | macOS (arm64, x86_64) | `ort-download`, `ort-coreml`, `candle-metal`, `candle-hub`, `llm-llamacpp` | Off; add `llm-llamacpp-vision` | Same as iOS - unified Apple platform features |
-| **platform-desktop** | Linux, Windows | `ort-download`, `llm-llamacpp` | Off; add `llm-llamacpp-vision` | Static ORT linking; llama.cpp for LLM inference (unified across all platforms) |
+Candle is **not** in any preset. It cost ~1.3 MiB stripped on the same Android proxy and ~1.9 MiB on the Apple shape (which also links `candle-metal`), i.e. 6.5-9.5x its replacement, and on a Pixel 8 reached a first partial in 9871 ms against whisper.cpp's 2724 ms. The `candle*` features stay declared and buildable, so anyone who wants the SafeTensors path can opt in explicitly — they are simply not on by default any more.
+
+| Preset | Target Platform | Core Features Enabled | VLM Default | ASR Default | Rationale |
+|--------|-----------------|----------------------|-------------|-------------|-----------|
+| **platform-android** | Android (all ABIs) | `ort-dynamic`, `llm-llamacpp-vision`, `asr-whispercpp` | On | whisper.cpp | Dynamic ORT loading for AAR distribution; whisper.cpp for Whisper ASR on the ggml llama.cpp already links (+0.2 MiB stripped); llama.cpp has runtime SIMD detection; mistral.rs causes SIGILL on devices without ARMv8.2-A FP16 |
+| **platform-ios** | iOS (arm64, simulator) | `ort-download`, `ort-coreml`, `llm-llamacpp-vision`, `asr-whispercpp` | On | whisper.cpp | Static ORT linking; CoreML for ANE acceleration; Metal for GPU via ggml |
+| **platform-macos** | macOS (arm64, x86_64) | `ort-download`, `ort-coreml`, `llm-llamacpp-vision`, `asr-whispercpp` | On | whisper.cpp | Same as iOS - unified Apple platform features |
+| **platform-desktop** | Linux, Windows | `ort-download`, `llm-llamacpp-vision`, `asr-whispercpp` | On | whisper.cpp | Static ORT linking; llama.cpp for LLM inference and whisper.cpp for ASR (unified across all platforms) |
 
 > **Note**: The CLI (`xybrid-cli`) adds `huggingface` to all its platform presets so `xybrid run --huggingface` works in release builds. SDK/FFI presets do not include `huggingface` by default — add it individually if needed.
 
-Example VLM builds:
+The presets already carry `llm-llamacpp-vision` and `asr-whispercpp`, so a plain preset build is a VLM + ASR build:
 
 ```bash
-cargo build -p xybrid-cli --features platform-macos,llm-llamacpp-vision
-cargo check -p xybrid-sdk --features platform-desktop,llm-llamacpp-vision
+cargo build -p xybrid-cli --features platform-macos
+cargo check -p xybrid-sdk --features platform-desktop
+```
+
+To opt back into the Candle SafeTensors path on top of a preset:
+
+```bash
+cargo check -p xybrid-sdk --features platform-macos,candle-metal
 ```
 
 ### Why llm-mistral is NOT on Android
@@ -133,7 +144,8 @@ The following types and modules are conditionally compiled based on feature flag
 | Module | Condition | Description |
 |--------|-----------|-------------|
 | `coreml` | `target_os = "macos" OR target_os = "ios" OR test` | CoreML runtime adapter |
-| `candle` | `feature = "candle"` | Candle (pure Rust) runtime adapter |
+| `candle` | `feature = "candle"` | Candle (pure Rust) runtime adapter — opt-in, not in any preset |
+| `whisper_cpp` | `feature = "asr-whispercpp"` | whisper.cpp ASR runtime adapter (shares llama.cpp's ggml) |
 | `llm` | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | Shared LLM types and adapter |
 | `mistral` | `feature = "llm-mistral"` | MistralBackend implementation |
 | `llama_cpp` | `feature = "llm-llamacpp"` | LlamaCppBackend implementation |
@@ -145,6 +157,8 @@ The following types and modules are conditionally compiled based on feature flag
 | `LlmRuntimeAdapter` import | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | LLM adapter import |
 | `llm_adapter_cache` field | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | Cached LLM adapter in TemplateExecutor |
 | `ExecutionTemplate::Gguf` handling | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | GGUF model execution path |
+| `ExecutionTemplate::GgmlWhisper` handling | `feature = "asr-whispercpp"` | GGML Whisper (whisper.cpp) execution path. Fields: `model_file`, `language` (`null` = auto-detect), `audio_ctx` (`0` = no truncation), `translate`. Without the feature the arm errors `GGML Whisper execution requires the 'asr-whispercpp' feature` |
+| `ExecutionTemplate::SafeTensors` handling | `feature = "candle"` | Candle SafeTensors path. Without the feature the arm errors `SafeTensors execution requires the 'candle' feature…` and points at a GGML bundle instead |
 | `execute_streaming()` full impl | `feature = "llm-mistral" OR feature = "llm-llamacpp"` | Streaming with callback |
 | `execute_streaming()` stub | `NOT (llm-mistral OR llm-llamacpp)` | Falls back to regular execution |
 | `execute_streaming_with_context()` | Same as above | Streaming with conversation context |
@@ -158,6 +172,7 @@ The following types and modules are conditionally compiled based on feature flag
 | `ONNXMobileRuntimeAdapter` | `target_os = "android" OR test` |
 | `CoreMLRuntimeAdapter` | `target_os = "macos" OR target_os = "ios" OR test` |
 | `CandleBackend`, `CandleRuntimeAdapter` | `feature = "candle"` |
+| `WhisperCppRuntime` | `feature = "asr-whispercpp"` |
 | `ChatMessage`, `GenerationConfig`, `GenerationOutput`, `LlmBackend`, `LlmConfig`, `LlmResult`, `LlmRuntimeAdapter` | `feature = "llm-mistral" OR feature = "llm-llamacpp"` |
 | `MistralBackend` | `feature = "llm-mistral"` |
 | `LlamaCppBackend` | `feature = "llm-llamacpp"` |

--- a/docs/FEATURE_MATRIX.zh.md
+++ b/docs/FEATURE_MATRIX.zh.md
@@ -25,7 +25,8 @@
 | **ort-download** | 下载预编译的 ONNX Runtime 二进制文件 | `ort/download-binaries`、`ort/tls-native` |
 | **ort-dynamic** | 在运行时加载 ONNX Runtime 的 .so | `ort/load-dynamic` |
 | **ort-coreml** | Apple Neural Engine 加速 | `ort/coreml` |
-| **candle** | 纯 Rust ML 框架（Whisper）— 兼容 Android | `candle-core`、`candle-nn`、`candle-transformers`、`safetensors`、`byteorder`、`num-traits` |
+| **candle** | 纯 Rust ML 框架 — SafeTensors Whisper 路径。**仅可显式启用**，自 whisper.cpp 取代其 ASR 角色后已从所有平台预设中移除 | `candle-core`、`candle-nn`、`candle-transformers`、`safetensors`、`byteorder`、`num-traits` |
+| **asr-whispercpp** | whisper.cpp 语音识别，运行在 llama.cpp 已链接的 ggml 上。需要 `llm-llamacpp` —— ggml 正是由它提供 | `xybrid-whisper`、`xybrid-whisper-sys` |
 | **candle-hub** | Candle + HuggingFace Hub 下载支持 | `candle`、`hf-hub`（需要 OpenSSL — **不适用于 Android**） |
 | **candle-metal** | 带 Metal 显卡加速的 Candle | `candle`、`candle-core/metal`、`candle-nn/metal` |
 | **candle-cuda** | 带 CUDA 显卡加速的 Candle | `candle`、`candle-core/cuda` |
@@ -57,10 +58,10 @@
 | Feature | 说明 | 转发到 xybrid-core |
 |---------|-------------|-------------------------|
 | **default** | 无默认特性 | *（无）* |
-| **platform-android** | Android 预设 | `ort-dynamic`、`candle`、`llm-llamacpp` |
-| **platform-ios** | iOS 预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` |
-| **platform-macos** | macOS 预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` |
-| **platform-desktop** | 桌面（Linux/Windows）预设 | `ort-download`、`llm-llamacpp` |
+| **platform-android** | Android 预设 | `ort-dynamic`、`llm-llamacpp-vision`、`asr-whispercpp` |
+| **platform-ios** | iOS 预设 | `ort-download`、`ort-coreml`、`llm-llamacpp-vision`、`asr-whispercpp` |
+| **platform-macos** | macOS 预设 | `ort-download`、`ort-coreml`、`llm-llamacpp-vision`、`asr-whispercpp` |
+| **platform-desktop** | 桌面（Linux/Windows）预设 | `ort-download`、`llm-llamacpp-vision`、`asr-whispercpp` |
 | **ort-download** | 转发到 core | `xybrid-core/ort-download` |
 | **ort-dynamic** | 转发到 core | `xybrid-core/ort-dynamic` |
 | **ort-coreml** | 转发到 core | `xybrid-core/ort-coreml` |
@@ -86,10 +87,10 @@
 | **onnx-inspect** | 为 `xybrid init` 提供 ONNX 元数据检查 | `xybrid-sdk/onnx-inspect` |
 | **vision** | 为 VLM 对话提供 `xybrid run --input-image` 和 REPL `/image` 的 Envelope 构建 | `xybrid-core/vision`、`xybrid-sdk/vision` |
 | **llm-llamacpp-vision** | llama.cpp VLM 运行时以及 CLI 图像输入支持 | `llm-llamacpp`、`vision`、`xybrid-sdk/llm-llamacpp-vision` |
-| **platform-android** | Android 发布预设 | `ort-dynamic`、`llm-llamacpp`、`candle`、`huggingface` |
-| **platform-ios** | iOS 发布预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp`、`huggingface` |
-| **platform-macos** | macOS 发布预设 | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp`、`huggingface` |
-| **platform-desktop** | Linux/Windows 发布预设 | `ort-download`、`llm-llamacpp`、`huggingface` |
+| **platform-android** | Android 发布预设 — 转发到 `xybrid-sdk/platform-android` | `ort-dynamic`、`llm-llamacpp-vision`、`asr-whispercpp`、`llm-llamacpp`、`huggingface` |
+| **platform-ios** | iOS 发布预设 — 转发到 `xybrid-sdk/platform-ios` | `ort-download`、`ort-coreml`、`llm-llamacpp-vision`、`asr-whispercpp`、`llm-llamacpp`、`huggingface` |
+| **platform-macos** | macOS 发布预设 — 转发到 `xybrid-sdk/platform-macos` | `ort-download`、`ort-coreml`、`llm-llamacpp-vision`、`asr-whispercpp`、`llm-llamacpp`、`huggingface` |
+| **platform-desktop** | Linux/Windows 发布预设 — 转发到 `xybrid-sdk/platform-desktop` | `ort-download`、`llm-llamacpp-vision`、`asr-whispercpp`、`llm-llamacpp`、`huggingface` |
 
 ---
 
@@ -97,14 +98,16 @@
 
 平台预设是平台专属特性组合的**单一事实来源**。它们定义在 `xybrid-sdk/Cargo.toml` 中，并通过 crate 层级向下转发。
 
-当前所有平台预设默认仅提供**纯文本**的 llama.cpp 支持。视觉语言构建必须将平台预设与 `llm-llamacpp-vision` 组合；仅当某个 crate 需要图像 Envelope/预处理类型而不需要 llama.cpp VLM 运行时时，才单独使用 `vision`。
+四个平台预设均已包含视觉语言 llama.cpp 路径（`llm-llamacpp-vision`）与 whisper.cpp 语音识别（`asr-whispercpp`，在 Android `.so` 代理上约 0.2 MiB，已 strip）。VLM 与 ASR 开箱即用，无需额外组合。
 
-| 预设 | 目标平台 | 启用的 Core 特性 | VLM 默认 | 理由 |
-|--------|-----------------|----------------------|-------------|-----------|
-| **platform-android** | Android（所有 ABI） | `ort-dynamic`、`candle`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 用于 AAR 分发的动态 ORT 加载；用于 Whisper ASR 的 Candle（CPU）；llama.cpp 具备运行时 SIMD 检测；mistral.rs 在不具备 ARMv8.2-A FP16 的设备上会导致 SIGILL |
-| **platform-ios** | iOS（arm64、模拟器） | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 静态 ORT 链接；用于 ANE 加速的 CoreML；用于 GPU 的 Metal |
-| **platform-macos** | macOS（arm64、x86_64） | `ort-download`、`ort-coreml`、`candle-metal`、`candle-hub`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 与 iOS 相同 — 统一的 Apple 平台特性 |
-| **platform-desktop** | Linux、Windows | `ort-download`、`llm-llamacpp` | 关闭；添加 `llm-llamacpp-vision` | 静态 ORT 链接；用于 LLM 推理的 llama.cpp（所有平台统一） |
+Candle **不在**任何预设中。在同一 Android 代理上它约占 1.3 MiB（Apple 形态因额外链接 `candle-metal` 约占 1.9 MiB），即其替代方案的 6.5–9.5 倍；在 Pixel 8 上首个部分结果需 9871 ms，而 whisper.cpp 为 2724 ms。`candle*` 特性仍然保留且可编译，需要 SafeTensors 路径的用户可显式启用 —— 只是不再默认开启。
+
+| 预设 | 目标平台 | 启用的 Core 特性 | VLM 默认 | ASR 默认 | 理由 |
+|--------|-----------------|----------------------|-------------|-------------|-----------|
+| **platform-android** | Android（所有 ABI） | `ort-dynamic`、`llm-llamacpp-vision`、`asr-whispercpp` | 开启 | whisper.cpp | 用于 AAR 分发的动态 ORT 加载；Whisper ASR 由 whisper.cpp 承担，复用 llama.cpp 已链接的 ggml（strip 后约 0.2 MiB）；llama.cpp 具备运行时 SIMD 检测；mistral.rs 在不具备 ARMv8.2-A FP16 的设备上会导致 SIGILL |
+| **platform-ios** | iOS（arm64、模拟器） | `ort-download`、`ort-coreml`、`llm-llamacpp-vision`、`asr-whispercpp` | 开启 | whisper.cpp | 静态 ORT 链接；用于 ANE 加速的 CoreML；经由 ggml 使用 Metal |
+| **platform-macos** | macOS（arm64、x86_64） | `ort-download`、`ort-coreml`、`llm-llamacpp-vision`、`asr-whispercpp` | 开启 | whisper.cpp | 与 iOS 相同 — 统一的 Apple 平台特性 |
+| **platform-desktop** | Linux、Windows | `ort-download`、`llm-llamacpp-vision`、`asr-whispercpp` | 开启 | whisper.cpp | 静态 ORT 链接；LLM 推理用 llama.cpp，ASR 用 whisper.cpp（所有平台统一） |
 
 > **注意**：CLI（`xybrid-cli`）会为其所有平台预设添加 `huggingface`，使 `xybrid run --huggingface` 在发布构建中可用。SDK/FFI 预设默认不包含 `huggingface` — 如有需要请单独添加。
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -62,10 +62,10 @@ The prebuilt binaries from the install script already include the correct featur
 | Feature | Description |
 |---------|-------------|
 | **Platform presets** | |
-| `platform-macos` | ONNX download + CoreML + Metal + text-only llama.cpp |
-| `platform-ios` | ONNX download + CoreML + Metal + text-only llama.cpp |
-| `platform-android` | ONNX dynamic + text-only llama.cpp |
-| `platform-desktop` | ONNX download + text-only llama.cpp |
+| `platform-macos` | ONNX download + CoreML + Metal + llama.cpp with vision + whisper.cpp ASR |
+| `platform-ios` | ONNX download + CoreML + Metal + llama.cpp with vision + whisper.cpp ASR |
+| `platform-android` | ONNX dynamic + llama.cpp with vision + whisper.cpp ASR |
+| `platform-desktop` | ONNX download + llama.cpp with vision + whisper.cpp ASR |
 | **Individual flags** | |
 | `ort-download` | Download prebuilt ONNX Runtime binaries |
 | `ort-dynamic` | Load ONNX Runtime .so at runtime |
@@ -129,8 +129,12 @@ xybrid run --model kokoro-82m --input-text "Hello world" --output hello.wav
 ### Speech-to-Text
 
 ```bash
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 ```
+
+`whisper-tiny-ggml` is the GGML bundle that runs on whisper.cpp, which every
+platform preset ships. The older `whisper-tiny` id serves the SafeTensors
+bundle and needs a build with `--features candle`.
 
 ### Chat with an LLM
 
@@ -191,7 +195,7 @@ Chain models together with a YAML file:
 # voice-assistant.yaml
 name: voice-assistant
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
   - model: smollm2-360m
   - model: kokoro-82m
 ```

--- a/docs/INSTALLATION.zh.md
+++ b/docs/INSTALLATION.zh.md
@@ -62,10 +62,10 @@ cargo install --git https://github.com/xybrid-ai/xybrid xybrid-cli --features pl
 | Feature | 说明 |
 |---------|-------------|
 | **平台预设** | |
-| `platform-macos` | ONNX 下载 + CoreML + Metal + 纯文本输入llama.cpp |
-| `platform-ios` | ONNX 下载 + CoreML + Metal + 纯文本输入llama.cpp |
-| `platform-android` | ONNX 动态加载 + 纯文本输入llama.cpp |
-| `platform-desktop` | ONNX 下载 + 纯文本输入llama.cpp |
+| `platform-macos` | ONNX 下载 + CoreML + Metal + 支持视觉的 llama.cpp + whisper.cpp 语音识别 |
+| `platform-ios` | ONNX 下载 + CoreML + Metal + 支持视觉的 llama.cpp + whisper.cpp 语音识别 |
+| `platform-android` | ONNX 动态加载 + 支持视觉的 llama.cpp + whisper.cpp 语音识别 |
+| `platform-desktop` | ONNX 下载 + 支持视觉的 llama.cpp + whisper.cpp 语音识别 |
 | **独立标志** | |
 | `ort-download` | 下载预编译的 ONNX Runtime 二进制文件 |
 | `ort-dynamic` | 在运行时加载 ONNX Runtime 的 .so |
@@ -129,8 +129,11 @@ xybrid run --model kokoro-82m --input-text "Hello world" --output hello.wav
 ### 语音识别 (STT)
 
 ```bash
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 ```
+
+`whisper-tiny-ggml` 是运行在 whisper.cpp 上的 GGML 模型包，所有平台预设都已内置。
+旧的 `whisper-tiny` 对应 SafeTensors 模型包，需要使用 `--features candle` 重新构建才能运行。
 
 ### 与LLM对话
 
@@ -190,7 +193,7 @@ xybrid run --model-file ./my-model.gguf --input-text "Hello!"
 # voice-assistant.yaml
 name: voice-assistant
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
   - model: smollm2-360m
   - model: kokoro-82m
 ```

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -60,7 +60,7 @@ Without a key, telemetry is disabled and the first inference logs a one-shot hin
 ### From Registry
 
 ```kotlin
-val model = Xybrid.model("whisper-tiny").load()
+val model = Xybrid.model("whisper-tiny-ggml").load()
 ```
 
 ### From Local Bundle

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -51,7 +51,7 @@ Xybrid.init(this, apiKey = BuildConfig.XYBRID_API_KEY)
 ### 从注册表
 
 ```kotlin
-val model = Xybrid.model("whisper-tiny").load()
+val model = Xybrid.model("whisper-tiny-ggml").load()
 ```
 
 ### 从本地 Bundle

--- a/docs/content/docs/(integration)/sdks/flutter.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.mdx
@@ -70,7 +70,7 @@ final wavBytes = result.audioAsWav(sampleRate: 24000);
 ## Speech-to-Text
 
 ```dart
-final model = await Xybrid.model('whisper-tiny').load();
+final model = await Xybrid.model('whisper-tiny-ggml').load();
 final envelope = XybridEnvelope.audio(bytes: audioBytes, sampleRate: 16000);
 final result = await model.run(envelope);
 print(result.text); // "Hello, how are you?"

--- a/docs/content/docs/(integration)/sdks/flutter.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.zh.mdx
@@ -68,7 +68,7 @@ final wavBytes = result.audioAsWav(sampleRate: 24000);
 ## 语音转文字
 
 ```dart
-final model = await Xybrid.model('whisper-tiny').load();
+final model = await Xybrid.model('whisper-tiny-ggml').load();
 final envelope = XybridEnvelope.audio(bytes: audioBytes, sampleRate: 16000);
 final result = await model.run(envelope);
 print(result.text); // "Hello, how are you?"

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -68,7 +68,7 @@ Without a key, telemetry is disabled and the first inference logs a one-shot hin
 ### From Registry
 
 ```swift
-let model = try await Xybrid.model("whisper-tiny").load()
+let model = try await Xybrid.model("whisper-tiny-ggml").load()
 ```
 
 ### From Local Bundle

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -60,7 +60,7 @@ Xybrid.initialize(
 ### 从注册表
 
 ```swift
-let model = try await Xybrid.model("whisper-tiny").load()
+let model = try await Xybrid.model("whisper-tiny-ggml").load()
 ```
 
 ### 从本地 Bundle

--- a/docs/content/docs/cli/index.mdx
+++ b/docs/content/docs/cli/index.mdx
@@ -64,7 +64,7 @@ xybrid models list
 xybrid run --model kokoro-82m --input-text "Hello from Xybrid!" -o hello.wav
 
 # Speech-to-text
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 
 # Chat with a local LLM (streaming)
 xybrid repl --model qwen2.5-0.5b-instruct --stream

--- a/docs/content/docs/cli/index.zh.mdx
+++ b/docs/content/docs/cli/index.zh.mdx
@@ -64,7 +64,7 @@ xybrid models list
 xybrid run --model kokoro-82m --input-text "Hello from Xybrid!" -o hello.wav
 
 # 语音识别
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 
 # 与本地 LLM 对话（流式输出）
 xybrid repl --model qwen2.5-0.5b-instruct --stream

--- a/docs/content/docs/concepts/hybrid-execution.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.mdx
@@ -17,7 +17,7 @@ Each stage has a `target`:
 
 ```yaml
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
     target: device
 
   - model: gpt-4o-mini

--- a/docs/content/docs/concepts/hybrid-execution.zh.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.zh.mdx
@@ -17,7 +17,7 @@ Xybrid 是一个*混合*运行时：每个流水线阶段都可以在设备端�
 
 ```yaml
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
     target: device
 
   - model: gpt-4o-mini

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -242,7 +242,7 @@ xybrid models list
 xybrid run --model kokoro-82m --input-text "Hello from Xybrid!" --output hello.wav
 
 # Run speech-to-text
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 ```
 
 **Expected output:**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -241,7 +241,7 @@ xybrid models list
 xybrid run --model kokoro-82m --input-text "Hello from Xybrid!" --output hello.wav
 
 # 运行语音转文字
-xybrid run --model whisper-tiny --input-audio recording.wav
+xybrid run --model whisper-tiny-ggml --input-audio recording.wav
 ```
 
 **预期输出：**

--- a/docs/sdk/API_REFERENCE.md
+++ b/docs/sdk/API_REFERENCE.md
@@ -46,7 +46,7 @@ SDKs may prefix or adjust casing:
 All SDKs follow the same three-step pattern:
 
 ```
-1. Describe a Model →  Xybrid.model("whisper-tiny")
+1. Describe a Model →  Xybrid.model("whisper-tiny-ggml")
 2. Load the Model   →  await loader.load()
 3. Run Inference    →  await model.run(envelope: input)
 ```
@@ -847,7 +847,7 @@ The optional `voiceId` and `speed` parameters work seamlessly in pipelines:
 final pipeline = XybridPipeline.fromYaml('''
 name: voice-assistant
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
   - model: llama-3-8b
   - model: kokoro-82m
 ''');
@@ -863,7 +863,7 @@ For pipeline-level voice configuration, use stage config in YAML:
 ```yaml
 name: voice-assistant
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
   - model: llama-3-8b
   - model: kokoro-82m
     config:

--- a/docs/sdk/telemetry.md
+++ b/docs/sdk/telemetry.md
@@ -221,7 +221,7 @@ Inference events (`ModelComplete`, `PipelineComplete`) carry per-call attributio
 
 | field | type | events | values | source |
 |---|---|---|---|---|
-| `backend` | string | inference | `llamacpp` \| `mlx` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint (GGUF requires the hint; SafeTensors defaults to `candle` and accepts `mlx` to override on Apple Silicon); `cloud` for the cloud adapter |
+| `backend` | string | inference | `llamacpp` \| `whispercpp` \| `mlx` \| `mistralrs` \| `ort` \| `candle` \| `cloud` | `ExecutionTemplate` variant + `metadata.backend` hint. `GgmlWhisper` → `whispercpp` unconditionally (the template fixes the runtime, so no hint is consulted); `Gguf` / `VisionLanguage` → the hint when it normalises to `mistralrs`, else `llamacpp`; `SafeTensors` → `candle` (a deferred `mlx` hint does **not** override it); `Onnx` → `ort`; `cloud` for the cloud adapter |
 | `provider` | string | inference (cloud only) | `openai` \| `anthropic` \| `google` \| `elevenlabs` \| `openrouter` \| `custom` | Cloud `IntegrationProvider` resolved from envelope metadata |
 | `task` | string | inference | `chat` \| `vlm` \| `asr` \| `tts` \| `embedding` \| `image-gen` \| `ocr` \| `rerank` \| `classify` (open string for forward-compat) | `ModelMetadata.metadata["task"]` from `model_metadata.json` |
 | `quantization` | string | inference | `q4_0` \| `q4_k_m` \| `q5_k_m` \| `q8_0` \| `fp16` \| `fp32` (open string — common GGUF labels) | `ModelMetadata.metadata["quantization"]` first; falls back to GGUF filename inference; absent (not empty) when unknown |

--- a/docs/telemetry/registry.md
+++ b/docs/telemetry/registry.md
@@ -37,7 +37,7 @@ The command exits 0 in both cases — it is a status report, not an error.
 The header is a single line, semicolon-separated:
 
 ```
-X-Xybrid-Client: binding=flutter; sdk_version=0.1.0-beta12; core_version=0.1.0-beta12; platform=ios-arm64; backends=candle-metal,llm-llamacpp,ort-coreml,ort-download
+X-Xybrid-Client: binding=flutter; sdk_version=0.4.1; core_version=0.4.1; platform=ios-arm64; backends=asr-whispercpp,llm-llamacpp,llm-llamacpp-vision,ort-coreml,ort-download,vision
 ```
 
 | Field | Type | Description |
@@ -46,7 +46,7 @@ X-Xybrid-Client: binding=flutter; sdk_version=0.1.0-beta12; core_version=0.1.0-b
 | `sdk_version` | semver-ish string | `xybrid-sdk` package version, baked in at compile time via `CARGO_PKG_VERSION`. |
 | `core_version` | semver-ish string | `xybrid-core` package version, baked in via the same mechanism. Usually equal to `sdk_version` but reported independently so version skews surface. |
 | `platform` | enum string | Compile-time target triple summary. See the table below. |
-| `backends` | comma-separated list | Alphabetical list of enabled runtime feature flags from `xybrid_core::features::enabled()`. May be empty (`backends=`) if no backends are compiled in. |
+| `backends` | comma-separated list | Alphabetical list of enabled runtime feature flags from `xybrid_core::features::enabled()`. Never empty: `vision` is reported unconditionally because the vision pipeline is always compiled in. |
 
 ### `binding` values
 
@@ -80,15 +80,18 @@ Source: `xybrid_sdk::current_platform()` (`crates/xybrid-sdk/src/platform.rs`). 
 
 | Value | Cargo feature | Notes |
 |-------|---------------|-------|
-| `candle-cuda` | `candle-cuda` | Candle backend with CUDA acceleration |
-| `candle-metal` | `candle-metal` | Candle backend with Metal acceleration |
+| `asr-whispercpp` | `asr-whispercpp` | whisper.cpp speech recognition; in every `platform-*` preset. Pulls `llm-llamacpp` transitively — whisper.cpp links the ggml that llama.cpp builds |
+| `candle-cuda` | `candle-cuda` | Candle backend with CUDA acceleration. Opt-in only — no `platform-*` preset enables it |
+| `candle-metal` | `candle-metal` | Candle backend with Metal acceleration. Opt-in only — no `platform-*` preset enables it |
 | `espeak` | `espeak` | espeak-ng phonemizer (multi-language TTS) |
 | `llm-llamacpp` | `llm-llamacpp` | llama.cpp backend (universal LLM runtime) |
+| `llm-llamacpp-vision` | `llm-llamacpp-vision` | Native llama multimodal (mtmd) VLM backend layered on `llm-llamacpp`; in every `platform-*` preset |
 | `llm-mistral` | `llm-mistral` | mistral.rs backend |
 | `ort-coreml` | `ort-coreml` | ONNX Runtime with CoreML execution provider |
 | `ort-cuda` | `ort-cuda` | ONNX Runtime with CUDA execution provider |
 | `ort-download` | `ort-download` | ONNX Runtime resolved via prebuilt downloads |
 | `ort-dynamic` | `ort-dynamic` | ONNX Runtime loaded dynamically at runtime (Android) |
+| `vision` | _(none — always on)_ | Vision envelopes + preprocessing pipeline; compiled in unconditionally, so this value appears on every build |
 
 Source: `xybrid_core::features::enabled()` (`crates/xybrid-core/src/features.rs`). The list is computed once per process from `cfg!(feature = "...")` checks and cached.
 

--- a/examples/flutter/README.md
+++ b/examples/flutter/README.md
@@ -110,7 +110,7 @@ try {
 
 ```dart
 try {
-  final loader = XybridModelLoader.fromRegistry(modelId: 'whisper-tiny');
+  final loader = XybridModelLoader.fromRegistry(modelId: 'whisper-tiny-ggml');
   final model = await loader.load();
   print('Loaded: ${model.modelId}');
 } catch (e) {
@@ -163,7 +163,7 @@ print('Transcription: ${result.text}');
 const yaml = '''
 name: voice-assistant
 stages:
-  - model: whisper-tiny
+  - model: whisper-tiny-ggml
   - model: llama-3-8b
   - model: kokoro-82m
 ''';


### PR DESCRIPTION
## Summary

This pull request brings the documentation in line with #476, which retired Candle from all four platform presets and shipped whisper.cpp ASR in their place. The docs still described the old world — preset tables listing `candle*`, "Candle (CPU) for Whisper ASR" as a platform rationale, and copy-pasteable examples loading model id `whisper-tiny`, which no longer runs on a default build. Docs only; no code changes.

**Three categories, kept distinct** — conflating them is how a docs pass makes things worse rather than better:

* **False now** — preset tables and per-platform rationales claiming Candle ships. Corrected to the real preset contents (`llm-llamacpp-vision`, `asr-whispercpp`).
* **Still true** — the `candle` feature-reference rows. Those features exist and still build; they are opt-in. Kept, and now say so explicitly rather than being deleted.
* **Misleading** — runnable examples naming `whisper-tiny`. Retargeted to `whisper-tiny-ggml`. Prose that names `whisper-tiny` *as the SafeTensors/Candle path* is accurate and was left alone.

**Gaps filled, not just staleness removed:**

* `asr-whispercpp` and `ExecutionTemplate::GgmlWhisper` were absent from these docs entirely, despite shipping in every preset.
* `docs/sdk/telemetry.md`'s `backend` enum lacked `whispercpp`, even though `features.rs` now emits it in the client header.
* Two falsehoods that **predate** the retirement: `FEATURE_MATRIX` claimed all presets are "text-only" with `VLM Default: Off`, but they have carried `llm-llamacpp-vision` since well before #476.

**Coverage notes, because the first sweep missed things:**

* `docs/content/**/*.mdx` — the whole docs **site** — was invisible to a grep scoped to `*.md`. Twelve runnable references there (quickstart, `cli/index`, the four SDK integration pages, hybrid-execution) plus their `.zh` twins.
* `.agents/skills/` is a byte-identical mirror of `agents/skills/` modulo five frontmatter lines, so every skill edit lands twice. Verified back in sync afterwards.
* Sample console output showing `whisper-tiny@1.2` in the CLI trace/run reference pages is deliberately left alone — illustrative logs, not commands.

Translations (`.zh`, `.zh-CN`, `.ja-JP`) are corrected in their own register rather than having English pasted into a translated table; feature names stay untranslated as those files already do.

## Verification

No preset row lists `candle`; no runnable reference anywhere points at the unrunnable id; every edited markdown table has uniform columns. Four tables that a naive pipe-count flags as ragged are escaped `\|` inside cells and are byte-identical to before this change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor

## Checklist

- [x] Tests pass — not applicable, documentation only; no code touched (`git status` shows `.md`/`.mdx` exclusively)
- [x] Code follows project style — no code changed
- [x] Documentation updated — that is the entire change
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and MDX only; no runtime or build logic changed. Residual doc drift (e.g. INSTALLATION VLM section still saying presets are text-only) may remain outside this diff.
> 
> **Overview**
> Documentation-only update so guides match **#476**: platform presets ship **whisper.cpp** (`asr-whispercpp`) and **VLM** (`llm-llamacpp-vision`), while **Candle** is opt-in and no longer in any `platform-*` preset.
> 
> **Platform & features** — `FEATURE_MATRIX` (EN/ZH), `INSTALLATION`, and crate READMEs now list preset contents as `llm-llamacpp-vision` + `asr-whispercpp` (not `candle*`), document `GgmlWhisper` / `asr-whispercpp`, and fix stale claims that presets were text-only with VLM off.
> 
> **Default ASR model id** — Runnable examples across READMEs (EN/JA/ZH), CLI/docs site, SDK integration pages, React Native, Flutter example, and API reference switch STT/MMP samples from `whisper-tiny` to **`whisper-tiny-ggml`**, with prose that `whisper-tiny` remains the SafeTensors/Candle bundle requiring `--features candle`.
> 
> **Agent skills** — `test-model` and `xybrid-init` (mirrored under `.agents/skills/`) prefer GGML Whisper, document `TemplateExecutor::execute(..., None)`, and expand troubleshooting for missing `candle` / `asr-whispercpp`.
> 
> **Telemetry** — Registry client header and inference `backend` enum docs add **`whispercpp`** and updated preset backend lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93b0cadcb7d6e608ec20c65d791728ba7a3f19d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->