### PR TITLE
ci: stop three workflows from failing in every fork

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -460,10 +460,20 @@ jobs:
     timeout-minutes: 60
     env:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+    # Every build step below is secret-gated, so without RBE this job succeeds
+    # having produced nothing. Downstream jobs can't read secrets in a job-level
+    # `if`, so publish the same fork-safety signal the `bazel` job does — else a
+    # consumer sees a green producer and fails on the missing artifact.
+    outputs:
+      rbe: ${{ steps.rbe-check.outputs.rbe }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
+
+      - name: Check RBE availability
+        id: rbe-check
+        run: echo "rbe=${{ env.BUILDBUDDY_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
 
       # The Microsoft payload lands on top of the usual LLVM/rustc/NDK fetches,
       # so this job needs the headroom more than the others do.
@@ -562,7 +572,11 @@ jobs:
   bazel-windows-msvc-smoke:
     name: Bazel windows-MSVC Flutter DLL smoke (loads it on Windows)
     needs: bazel-windows-msvc
-    if: github.event_name != 'pull_request'
+    # Gate on the producer's RBE signal, not the event name: a push in a fork is
+    # not a pull_request, so the event check alone let this run against a
+    # producer that had skipped every build step, and the download failed with
+    # "Artifact not found". Matches bazel-windows-smoke / bazel-windows-bolt-smoke.
+    if: needs.bazel-windows-msvc.outputs.rbe == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -54,6 +54,12 @@ env:
 jobs:
   publish-native:
     name: Publish native (${{ matrix.target }}, ${{ matrix.feature }})
+    # Publisher only, and only from the canonical repo. A fork inherits the
+    # weekly cron but its GITHUB_TOKEN cannot write ghcr.io/xybrid-ai/*, so every
+    # row died on `response status code 403: Forbidden` after paying the full
+    # llama.cpp compile — a standing red cron in every fork, for a cache only we
+    # publish. Forks consume the slices; they never produce them.
+    if: github.repository == 'xybrid-ai/xybrid'
     permissions:
       contents: read
       packages: write   # oras login + push of the prebuilt native slice to ghcr

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -74,10 +74,17 @@ jobs:
       # So assert up front, and only for runs that should have secrets: same-repo
       # PRs, master pushes, and manual dispatches. Fork PRs fall through to the
       # skips by design.
+      #
+      # The `github.repository` test is what makes that true for pushes as well.
+      # A contributor who syncs their fork's master triggers this workflow in
+      # THEIR repo, where no secret exists — and a push is not a pull_request, so
+      # the event test alone let the assertion fire and failed every fork's
+      # Actions tab. Secrets are only ever expected in the canonical repo.
       - name: Require credentials (non-fork runs)
         if: >-
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.repository == 'xybrid-ai/xybrid' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}


### PR DESCRIPTION
Every fork of xybrid carries a standing wall of red in its Actions tab. Three workflows assume that a non-`pull_request` event implies secrets are present — false for the push a contributor triggers by syncing their fork's master, and for the crons a fork inherits. None of this gates a PR here, but it is noise a contributor cannot fix, and it buries real failures in their own fork.

**Workflow Fixes:**

* Scoped Unity Editor CI's credential assertion to the canonical repo. The assertion deliberately fires on non-`pull_request` runs so a missing secret cannot silently skip the Editor step and still report success — correct here, wrong in a fork, where the secret does not exist and never will. The per-step secret gates already handle fork PRs.
* Gated the `Bazel windows-MSVC Flutter DLL smoke` on its producer's RBE signal instead of the event name. Every build step in `bazel-windows-msvc` is secret-gated, so without RBE the producer skips its whole body, still reports success, and the consumer dies on `Artifact not found`. The producer now publishes `outputs.rbe` and the smoke gates on it — the same pattern `bazel-windows-smoke` and `bazel-windows-bolt-smoke` already use.
* Scoped `Build Natives` to this repo. Its weekly cron rides along into forks, where `GITHUB_TOKEN` cannot write `ghcr.io/xybrid-ai/*`, so every row paid a full llama.cpp compile and then died on `response status code 403: Forbidden`. Forks consume prebuilt slices; they never publish them.

**Evidence:**

* Observed on `chimbiwide/xybrid`, where master-push runs left exactly three failing workflows: `Unity Editor CI`, `Bazel`, and `Build Natives`. All three are addressed here.
* In the same Bazel run, `bazel-windows-smoke` and `bazel-windows-bolt-smoke` **skipped** cleanly while the Flutter DLL smoke **failed** — the guard those two carry is the one it was missing.

**Impact:**

* No behaviour change on master pushes, same-repo PRs, or manual dispatches — all three jobs run exactly as before.
* Verified all three files parse and that each job's resolved `if` / `outputs` are what the fix intends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow `if`/`outputs` guards only; no product build or runtime behavior changes on the main repo.
> 
> **Overview**
> Stops **standing red Actions runs in forks** by tightening when jobs assume secrets or artifacts exist. Canonical-repo master pushes, same-repo PRs, and manual dispatches behave the same as before.
> 
> **`unity-editor.yml`** — The upfront credential check now runs only when `github.repository == 'xybrid-ai/xybrid'` and the run is a same-repo PR or a non-PR event. Fork master syncs are pushes without Unity/BuildBuddy secrets; the old “non-PR ⇒ assert secrets” rule failed those runs even though downstream steps were already meant to skip on forks.
> 
> **`bazel.yml`** — `bazel-windows-msvc` exposes an `rbe` job output (BuildBuddy key present), and **`bazel-windows-msvc-smoke`** gates on `needs.bazel-windows-msvc.outputs.rbe == 'true'` instead of only `github.event_name != 'pull_request'`. Without RBE the producer still goes green while skipping uploads; the smoke job no longer downloads a missing artifact.
> 
> **`build-natives.yml`** — `publish-native` is limited to the canonical repo so inherited weekly crons in forks do not compile llama.cpp and then fail with **403** pushing to `ghcr.io/xybrid-ai/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1c1332d1426f733568d22d5ba05942af060438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->