### PR TITLE
feat(streaming): thread audio_ctx ASR override through streaming config

### DIFF
--- a/bindings/flutter/lib/src/rust/api/streaming.dart
+++ b/bindings/flutter/lib/src/rust/api/streaming.dart
@@ -115,14 +115,22 @@ class FfiStreamingConfig {
   /// Optional language hint (e.g. `"en"`); `None` uses the model default.
   final String? language;
 
+  /// Optional Whisper encoder context in mel frames; `None` uses the model default.
+  final int? audioCtx;
+
   const FfiStreamingConfig({
     required this.sampleRate,
     required this.vad,
     this.language,
+    this.audioCtx,
   });
 
   @override
-  int get hashCode => sampleRate.hashCode ^ vad.hashCode ^ language.hashCode;
+  int get hashCode =>
+      sampleRate.hashCode ^
+      vad.hashCode ^
+      language.hashCode ^
+      audioCtx.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -131,7 +139,8 @@ class FfiStreamingConfig {
           runtimeType == other.runtimeType &&
           sampleRate == other.sampleRate &&
           vad == other.vad &&
-          language == other.language;
+          language == other.language &&
+          audioCtx == other.audioCtx;
 }
 
 @freezed

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -3221,12 +3221,13 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   FfiStreamingConfig dco_decode_ffi_streaming_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return FfiStreamingConfig(
       sampleRate: dco_decode_u_32(arr[0]),
       vad: dco_decode_ffi_vad_mode(arr[1]),
       language: dco_decode_opt_String(arr[2]),
+      audioCtx: dco_decode_opt_box_autoadd_u_32(arr[3]),
     );
   }
 
@@ -4112,8 +4113,12 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     var var_sampleRate = sse_decode_u_32(deserializer);
     var var_vad = sse_decode_ffi_vad_mode(deserializer);
     var var_language = sse_decode_opt_String(deserializer);
+    var var_audioCtx = sse_decode_opt_box_autoadd_u_32(deserializer);
     return FfiStreamingConfig(
-        sampleRate: var_sampleRate, vad: var_vad, language: var_language);
+        sampleRate: var_sampleRate,
+        vad: var_vad,
+        language: var_language,
+        audioCtx: var_audioCtx);
   }
 
   @protected
@@ -5067,6 +5072,7 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_u_32(self.sampleRate, serializer);
     sse_encode_ffi_vad_mode(self.vad, serializer);
     sse_encode_opt_String(self.language, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.audioCtx, serializer);
   }
 
   @protected

--- a/bindings/flutter/lib/src/streaming.dart
+++ b/bindings/flutter/lib/src/streaming.dart
@@ -40,12 +40,14 @@ class XybridStreamSession {
     XybridModel model, {
     FfiVadMode vad = const FfiVadMode.off(),
     String? language,
+    int? audioCtx,
   }) async {
     final inner = await model.inner.stream(
       config: FfiStreamingConfig(
         sampleRate: 16000,
         vad: vad,
         language: language,
+        audioCtx: audioCtx,
       ),
     );
     return XybridStreamSession._(inner);

--- a/bindings/flutter/rust/src/api/streaming.rs
+++ b/bindings/flutter/rust/src/api/streaming.rs
@@ -94,6 +94,8 @@ pub struct FfiStreamingConfig {
     pub vad: FfiVadMode,
     /// Optional language hint (e.g. `"en"`); `None` uses the model default.
     pub language: Option<String>,
+    /// Optional Whisper encoder context in mel frames; `None` uses the model default.
+    pub audio_ctx: Option<u32>,
 }
 
 impl FfiStreamingConfig {
@@ -117,6 +119,7 @@ impl FfiStreamingConfig {
             enable_vad,
             vad_model_dir,
             language: self.language.clone(),
+            audio_ctx: self.audio_ctx,
             ..StreamConfig::default()
         })
     }

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -3963,10 +3963,12 @@ impl SseDecode for crate::api::streaming::FfiStreamingConfig {
         let mut var_sampleRate = <u32>::sse_decode(deserializer);
         let mut var_vad = <crate::api::streaming::FfiVadMode>::sse_decode(deserializer);
         let mut var_language = <Option<String>>::sse_decode(deserializer);
+        let mut var_audioCtx = <Option<u32>>::sse_decode(deserializer);
         return crate::api::streaming::FfiStreamingConfig {
             sample_rate: var_sampleRate,
             vad: var_vad,
             language: var_language,
+            audio_ctx: var_audioCtx,
         };
     }
 }
@@ -5208,6 +5210,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::streaming::FfiStreamingConfig
             self.sample_rate.into_into_dart().into_dart(),
             self.vad.into_into_dart().into_dart(),
             self.language.into_into_dart().into_dart(),
+            self.audio_ctx.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -5877,6 +5880,7 @@ impl SseEncode for crate::api::streaming::FfiStreamingConfig {
         <u32>::sse_encode(self.sample_rate, serializer);
         <crate::api::streaming::FfiVadMode>::sse_encode(self.vad, serializer);
         <Option<String>>::sse_encode(self.language, serializer);
+        <Option<u32>>::sse_encode(self.audio_ctx, serializer);
     }
 }
 

--- a/crates/xybrid-core/src/streaming/session.rs
+++ b/crates/xybrid-core/src/streaming/session.rs
@@ -99,6 +99,8 @@ pub struct StreamConfig {
     pub enable_partial_results: bool,
     /// Language hint (passed to model if supported)
     pub language: Option<String>,
+    /// Whisper encoder context override in mel frames; `None` uses the model default
+    pub audio_ctx: Option<u32>,
     /// VAD configuration for smart chunking
     pub vad: VadStreamConfig,
 }
@@ -110,6 +112,7 @@ impl Default for StreamConfig {
             min_chunk_secs: 1.0, // At least 1 second before processing
             enable_partial_results: true,
             language: Some("en".to_string()),
+            audio_ctx: None,
             vad: VadStreamConfig::default(),
         }
     }
@@ -130,6 +133,22 @@ impl StreamConfig {
             vad: VadStreamConfig::with_model(model_dir),
             ..Default::default()
         }
+    }
+
+    /// Create an audio envelope carrying the configured ASR overrides.
+    fn inference_envelope(&self, wav_bytes: Vec<u8>) -> Envelope {
+        let mut envelope = Envelope::new(EnvelopeKind::Audio(wav_bytes));
+        if let Some(language) = &self.language {
+            envelope
+                .metadata
+                .insert("language".to_string(), language.clone());
+        }
+        if let Some(audio_ctx) = self.audio_ctx {
+            envelope
+                .metadata
+                .insert("audio_ctx".to_string(), audio_ctx.to_string());
+        }
+        envelope
     }
 }
 
@@ -588,7 +607,7 @@ impl StreamSession {
         let sample_rate = self.buffer.config().sample_rate;
         let silence = vec![0.0f32; (sample_rate as usize) / 2];
         let wav_bytes = samples_to_wav(&silence, sample_rate);
-        let envelope = Envelope::new(EnvelopeKind::Audio(wav_bytes));
+        let envelope = self.config.inference_envelope(wav_bytes);
 
         executor
             .execute(&self.metadata, &envelope, None)
@@ -765,8 +784,8 @@ impl StreamSession {
         // Convert samples to WAV bytes
         let wav_bytes = samples_to_wav(&chunk.samples, self.buffer.config().sample_rate);
 
-        // Create envelope with audio data
-        let envelope = Envelope::new(EnvelopeKind::Audio(wav_bytes));
+        // Create envelope with audio data and per-session ASR overrides.
+        let envelope = self.config.inference_envelope(wav_bytes);
 
         // Execute through TemplateExecutor (handles ONNX, Candle, etc.)
         let output = self
@@ -833,6 +852,41 @@ mod tests {
         let config = StreamConfig::default();
         assert_eq!(config.buffer_config.sample_rate, 16000);
         assert!(config.enable_partial_results);
+        assert_eq!(config.audio_ctx, None);
+    }
+
+    #[test]
+    fn configured_asr_overrides_are_added_to_the_inference_envelope() {
+        let config = StreamConfig {
+            language: Some("fr".to_string()),
+            audio_ctx: Some(500),
+            ..Default::default()
+        };
+
+        let envelope = config.inference_envelope(vec![1, 2, 3]);
+
+        assert_eq!(
+            envelope.metadata.get("language").map(String::as_str),
+            Some("fr")
+        );
+        assert_eq!(
+            envelope.metadata.get("audio_ctx").map(String::as_str),
+            Some("500")
+        );
+    }
+
+    #[test]
+    fn absent_asr_overrides_leave_bundle_defaults_in_control() {
+        let config = StreamConfig {
+            language: None,
+            audio_ctx: None,
+            ..Default::default()
+        };
+
+        let envelope = config.inference_envelope(vec![1, 2, 3]);
+
+        assert!(!envelope.metadata.contains_key("language"));
+        assert!(!envelope.metadata.contains_key("audio_ctx"));
     }
 
     fn secs(s: f64) -> Duration {

--- a/crates/xybrid-core/tests/whispercpp_asr.rs
+++ b/crates/xybrid-core/tests/whispercpp_asr.rs
@@ -194,6 +194,41 @@ fn live_streaming_produces_a_growing_transcript() {
     );
 }
 
+#[test]
+fn streaming_language_override_reaches_whisper_transcribe_params() {
+    let Some((dir, _metadata)) = bundle_if_available() else {
+        eprintln!("skipping: whisper GGML fixture weights not present");
+        return;
+    };
+    let Some(wav) = jfk_wav() else {
+        eprintln!("skipping: jfk.wav fixture not present");
+        return;
+    };
+
+    // The fixture is English-only. Asking the streaming API for Japanese can
+    // only produce this error after StreamConfig reaches TranscribeParams;
+    // falling back to the bundle's `en` would transcribe successfully.
+    let config = StreamConfig {
+        language: Some("ja".to_string()),
+        ..Default::default()
+    };
+    let mut session =
+        StreamSession::new(&dir, config).expect("GgmlWhisper bundle opens as a streaming session");
+    let pcm = decode_wav_16k_mono(&wav);
+
+    let err = pcm
+        .chunks(8_000)
+        .find_map(|slice| session.feed(slice).err())
+        .or_else(|| session.flush().err())
+        .expect("an .en model cannot honour a Japanese streaming request");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("ja") || message.to_lowercase().contains("language"),
+        "error should name the rejected language, got: {message}"
+    );
+}
+
 /// Decode the committed 16 kHz mono 16-bit fixture into float samples.
 fn decode_wav_16k_mono(bytes: &[u8]) -> Vec<f32> {
     assert!(bytes.len() > 44, "WAV shorter than its header");

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -795,6 +795,8 @@ pub struct StreamConfig {
     pub vad_threshold: f32,
     /// Language hint for ASR
     pub language: Option<String>,
+    /// Whisper encoder context override in mel frames; `None` uses the model default
+    pub audio_ctx: Option<u32>,
     /// Path to VAD model (uses default if None)
     pub vad_model_dir: Option<String>,
 }
@@ -805,6 +807,7 @@ impl Default for StreamConfig {
             enable_vad: false,
             vad_threshold: 0.5,
             language: Some("en".to_string()),
+            audio_ctx: None,
             vad_model_dir: None,
         }
     }
@@ -822,6 +825,12 @@ impl StreamConfig {
     /// Set language hint.
     pub fn language(mut self, lang: impl Into<String>) -> Self {
         self.language = Some(lang.into());
+        self
+    }
+
+    /// Override Whisper's encoder context in mel frames.
+    pub fn audio_ctx(mut self, audio_ctx: u32) -> Self {
+        self.audio_ctx = Some(audio_ctx);
         self
     }
 
@@ -4239,6 +4248,7 @@ impl XybridModel {
                 ..Default::default()
             },
             language: config.language,
+            audio_ctx: config.audio_ctx,
             ..Default::default()
         };
 
@@ -5065,13 +5075,18 @@ mod tests {
         let config = StreamConfig::default();
         assert!(!config.enable_vad);
         assert_eq!(config.language, Some("en".to_string()));
+        assert_eq!(config.audio_ctx, None);
     }
 
     #[test]
     fn test_stream_config_with_vad() {
-        let config = StreamConfig::with_vad().language("fr").vad_threshold(0.7);
+        let config = StreamConfig::with_vad()
+            .language("fr")
+            .audio_ctx(500)
+            .vad_threshold(0.7);
         assert!(config.enable_vad);
         assert_eq!(config.language, Some("fr".to_string()));
+        assert_eq!(config.audio_ctx, Some(500));
         assert_eq!(config.vad_threshold, 0.7);
     }
 


### PR DESCRIPTION
## Summary

Threads an optional `audio_ctx` ASR override (Whisper encoder context, in mel frames) through every streaming layer — core `StreamConfig`, the SDK builder, and the Flutter `flutter_rust_bridge` binding — so callers can trim the encoder window without patching the model bundle. A new `StreamConfig::inference_envelope` helper stamps the per-session `language` and `audio_ctx` overrides onto the inference `Envelope`, replacing the two ad-hoc `Envelope::new` call sites so both the flush and chunk paths honour them. `None` leaves the model bundle defaults untouched.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live ASR inference metadata on every streaming chunk; behavior is additive when unset, but wrong `audio_ctx` values could affect transcription quality or errors.
> 
> **Overview**
> Adds an optional **`audio_ctx`** (Whisper encoder context in mel frames) on streaming config from core through the SDK and Flutter FFI, including **`XybridStreamSession.fromModel(..., audioCtx:)`**.
> 
> Streaming inference no longer builds bare audio envelopes: **`StreamConfig::inference_envelope`** attaches per-session **`language`** and **`audio_ctx`** metadata when set, and warm-up plus chunk/flush paths use it so overrides reach Whisper transcribe params; **`None`** keeps bundle defaults.
> 
> FRB/Dart codecs for **`FfiStreamingConfig`** grow a fourth field. Tests cover envelope metadata and that a streaming language override is honored end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469468890d1021b007559624c9f3fb8bad9b531b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->