### PR TITLE
feat(bazel): add a Vulkan lane to the Bazel graph

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -75,6 +75,19 @@ build:macos-metal --config=local_tools
 # (-fstack-protector, which needs a libssp hermetic-llvm's MinGW sysroot doesn't
 # ship, is disabled for windows at the toolchain level in hermetic_llvm.patch.)
 
+# Desktop Linux GPU lane: ggml's Vulkan backend ON (//:llama_vulkan). Mixed
+# execution, same model as macos-metal above — everything except the llama.cpp
+# compile still runs on RBE; that one action is pinned local because it needs
+# glslc, the Vulkan headers/loader and a host compiler on the EXEC machine, and
+# the RBE image is a bare ubuntu:22.04 that has none of them. So the runner must
+# have the SDK installed first (.github/actions/setup-vulkan-sdk).
+#
+# The resulting binary links libvulkan.so.1 dynamically, so it needs a Vulkan
+# loader (and a driver, to use the GPU) on the machine that runs it — this lane
+# is an additional artifact, never a replacement for the CPU-only linux CLI.
+build:linux-vulkan --platforms=@rules_rs//rs/platforms:x86_64-unknown-linux-gnu
+build:linux-vulkan --//:vulkan=true
+
 # --- Apple Gate 1: iOS device staticlib, built LOCALLY on a Mac (Xcode iphoneos
 # SDK via apple_support). CPU-only, Metal OFF. Mac-bound end-to-end — NEVER
 # combine with --config=remote (no Mac RBE; the iOS closure needs an iphoneos

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -488,33 +488,32 @@ jobs:
       - name: Setup Vulkan SDK
         uses: ./.github/actions/setup-vulkan-sdk
 
-      # //:llama_vulkan reads the Vulkan headers and loader from two fixed /opt
-      # paths, which this step points at whatever the runner actually has. Fixed,
-      # because a cmake cache value has to be known at analysis time — the SDK's
-      # own directory is version-stamped.
+      # //:llama_vulkan reads the Vulkan headers from a fixed /opt path, which
+      # this step points at whatever the runner actually has. Fixed, because a
+      # cmake cache value has to be known at analysis time — the SDK's own
+      # directory is version-stamped.
       #
-      # Headers are staged rather than used in place because cmake turns
-      # Vulkan_INCLUDE_DIR into a `-I`, and a `-I` outranks the toolchain
-      # sysroot: handing it /usr/include would shadow hermetic-llvm's libc
-      # headers with this runner's glibc 2.39 ones while the link still uses
-      # glibc 2.28. A directory holding only the Vulkan trees cannot do that.
-      - name: Stage the Vulkan headers and loader
+      # Staged rather than used in place because cmake turns Vulkan_INCLUDE_DIR
+      # into a `-I`, and a `-I` outranks the toolchain sysroot: handing it
+      # /usr/include would shadow hermetic-llvm's libc headers with this
+      # runner's glibc 2.39 ones while the link still uses glibc 2.28. A
+      # directory holding only the Vulkan trees cannot do that.
+      #
+      # The loader is NOT staged — it comes from //bazel/vulkan:libvulkan.so,
+      # built by our own toolchain (see bazel/vulkan/vulkan_stub.c).
+      - name: Stage the Vulkan headers
         run: |
-          sudo mkdir -p /opt/xybrid-vulkan-include /opt/xybrid-vulkan-lib
-          # Prefer the LunarG SDK: it is what the cargo Vulkan job (ci.yml)
-          # builds against, so it is the proven set, and it keeps the headers
-          # and the loader on the same version.
-          SDK="${VULKAN_SDK:-}"
-          if [ -d "${SDK:-}/include" ] && [ -e "${SDK:-}/lib/libvulkan.so" ]; then
-            INC="$SDK/include"; LIB="$SDK/lib/libvulkan.so"
-          else
+          sudo mkdir -p /opt/xybrid-vulkan-include
+          # Prefer the LunarG SDK's tree: it is what the cargo Vulkan job
+          # (ci.yml) builds against, so it is the proven header set.
+          INC="${VULKAN_SDK:+$VULKAN_SDK/include}"
+          if [ ! -d "${INC:-}" ]; then
             # No usable SDK: fall back to apt. libvulkan-dev does not depend on
             # spirv-headers, so ask for it explicitly.
             sudo apt-get install -y spirv-headers
-            INC=/usr/include; LIB=/usr/lib/x86_64-linux-gnu/libvulkan.so
+            INC=/usr/include
           fi
           echo "headers: $INC"
-          echo "loader:  $LIB"
           # vulkan/ is the obvious one; vk_video/ because vulkan_core.h includes
           # the video codec headers; spirv/ because ggml-vulkan.cpp includes
           # <spirv/unified1/spirv.hpp> for its cooperative-matrix paths.
@@ -522,8 +521,7 @@ jobs:
             test -d "$INC/$tree" || { echo "missing $INC/$tree"; exit 1; }
             sudo ln -sfn "$INC/$tree" "/opt/xybrid-vulkan-include/$tree"
           done
-          sudo ln -sfn "$LIB" /opt/xybrid-vulkan-lib/libvulkan.so
-          ls -l /opt/xybrid-vulkan-include /opt/xybrid-vulkan-lib
+          ls -l /opt/xybrid-vulkan-include
 
       - name: Configure BuildBuddy remote config
         env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -444,6 +444,109 @@ jobs:
           strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface"; exit 1; }
           echo "Metal CLI smoke: OK"
 
+  # The desktop-Linux GPU lane: the CLI with ggml's Vulkan backend linked in.
+  #
+  # #307 gave the CARGO build a Vulkan opt-in (XYBRID_LLAMA_CPP_VULKAN=1), but
+  # the shipped Linux CLI comes from Bazel, which sets the cmake defines itself
+  # and never reads that variable — so this job is what makes a distributed
+  # binary able to use a GPU.
+  #
+  # Mixed execution, like bazel-macos-metal: the Rust graph compiles on RBE and
+  # only //:llama_vulkan runs here, because ggml's Vulkan build needs glslc, the
+  # Vulkan headers/loader and a host compiler on the machine running cmake, and
+  # the RBE image is a bare ubuntu:22.04 that has none of them. Hence the SDK
+  # install step below.
+  #
+  # Runs on PRs (unlike the metal/MSVC lanes): this lane is new, and llama.cpp
+  # with GGML_VULKAN=ON is exactly the compile most likely to break on an
+  # upstream bump. The build steps stay RBE-gated, so a fork PR — which has no
+  # secret and would otherwise compile the entire graph on the runner — only
+  # pays for the analysis phase.
+  bazel-linux-vulkan:
+    name: Bazel linux Vulkan lane
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: true
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
+      # glslc + libvulkan-dev, which is where //:llama_vulkan's pinned
+      # Vulkan_LIBRARY / Vulkan_GLSLC_EXECUTABLE point. Shared with ci.yml's
+      # cargo Vulkan job.
+      - name: Setup Vulkan SDK
+        uses: ./.github/actions/setup-vulkan-sdk
+
+      # cmake turns Vulkan_INCLUDE_DIR into a `-I` on ggml-vulkan's TUs, and a
+      # `-I` outranks the toolchain sysroot — so handing it /usr/include would
+      # shadow hermetic-llvm's libc headers with this runner's glibc 2.39 ones
+      # while the link still uses glibc 2.28. Stage a directory carrying ONLY
+      # the Vulkan headers so that cannot happen; //:llama_vulkan hardcodes this
+      # path, because a cache_entries value has to be known at analysis time —
+      # hence a fixed directory rather than the SDK's versioned $VULKAN_SDK.
+      - name: Stage a Vulkan-only include dir
+        run: |
+          sudo mkdir -p /opt/xybrid-vulkan-include
+          # vk_video/ too: vulkan_core.h includes the video codec headers.
+          for tree in vulkan vk_video; do
+            test -d "/usr/include/$tree" || { echo "missing /usr/include/$tree"; exit 1; }
+            sudo ln -sfn "/usr/include/$tree" "/opt/xybrid-vulkan-include/$tree"
+          done
+          ls -l /opt/xybrid-vulkan-include
+
+      - name: Configure BuildBuddy remote config
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Fork-safe structural gate: the flag, the config_settings and the
+      # //:llama_vulkan selects have to resolve even with no secret present.
+      - name: Analyze the Vulkan lane (no build)
+        run: |
+          bazelisk build --nobuild --config=linux-vulkan -c opt \
+            //crates/xybrid-cli:xybrid //:llama_vulkan
+
+      - name: Build the Vulkan CLI (mixed execution)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          bazelisk build --config=remote --config=linux-vulkan -c opt \
+            //crates/xybrid-cli:xybrid
+
+      # What a green build does NOT prove: that Vulkan is actually USED. The
+      # runner has a loader but no GPU, so llama.cpp falls back to CPU at
+      # runtime. This asserts the parts that are checkable here — the backend
+      # is compiled in, the loader is a real link dependency, and the feature
+      # set still matches the CPU lane.
+      - name: Smoke the Vulkan CLI (run + backend + loader + features)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: |
+          BIN=$(tools/scripts/bazel-output.sh //crates/xybrid-cli:xybrid --config=remote --config=linux-vulkan -c opt)
+          echo "resolved Vulkan CLI: $BIN"
+          file "$BIN"
+          "$BIN" --help >/dev/null
+          test "$(nm "$BIN" | grep -c 'ggml_backend_vk')" -gt 0 || { echo "MISSING Vulkan backend symbols"; exit 1; }
+          readelf -d "$BIN" | grep -q 'libvulkan\.so\.1' || { echo "NOT linked against the Vulkan loader"; exit 1; }
+          test "$(nm "$BIN" | grep -c ' mtmd_')" -gt 0 || { echo "MISSING vision (mtmd) symbols"; exit 1; }
+          strings "$BIN" | grep -q 'huggingface\.co' || { echo "MISSING huggingface support"; exit 1; }
+          # Same floor the CPU lane holds. This is the guard on the Vulkan
+          # include path: if ggml-vulkan's TUs ever pick up the runner's glibc
+          # headers instead of the hermetic sysroot's, the floor jumps here.
+          MAX_GLIBC=$(strings "$BIN" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu | tail -1)
+          echo "glibc floor: $MAX_GLIBC"
+          [ "$(printf '%s\n' "$MAX_GLIBC" GLIBC_2.31 | sort -V | tail -1)" = "GLIBC_2.31" ] || { echo "glibc floor regressed above 2.31: $MAX_GLIBC"; exit 1; }
+          echo "Vulkan CLI smoke: OK ✅"
+
   # The windows-MSVC lane — NON-SHIPPING proof, like the windows-gnu bolt DLL
   # above. Everything compiles on Linux RBE workers; the runner only fetches
   # repositories and inspects outputs.

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -488,35 +488,42 @@ jobs:
       - name: Setup Vulkan SDK
         uses: ./.github/actions/setup-vulkan-sdk
 
-      # cmake turns Vulkan_INCLUDE_DIR into a `-I` on ggml-vulkan's TUs, and a
-      # `-I` outranks the toolchain sysroot — so handing it /usr/include would
-      # shadow hermetic-llvm's libc headers with this runner's glibc 2.39 ones
-      # while the link still uses glibc 2.28. Stage a directory carrying ONLY
-      # the Vulkan headers so that cannot happen; //:llama_vulkan hardcodes this
-      # path, because a cache_entries value has to be known at analysis time —
-      # hence a fixed directory rather than the SDK's versioned $VULKAN_SDK.
-      - name: Stage a Vulkan-only include dir
+      # //:llama_vulkan reads the Vulkan headers and loader from two fixed /opt
+      # paths, which this step points at whatever the runner actually has. Fixed,
+      # because a cmake cache value has to be known at analysis time — the SDK's
+      # own directory is version-stamped.
+      #
+      # Headers are staged rather than used in place because cmake turns
+      # Vulkan_INCLUDE_DIR into a `-I`, and a `-I` outranks the toolchain
+      # sysroot: handing it /usr/include would shadow hermetic-llvm's libc
+      # headers with this runner's glibc 2.39 ones while the link still uses
+      # glibc 2.28. A directory holding only the Vulkan trees cannot do that.
+      - name: Stage the Vulkan headers and loader
         run: |
-          sudo mkdir -p /opt/xybrid-vulkan-include
-          # Prefer the LunarG SDK's include tree: it is what the cargo Vulkan
-          # job (ci.yml) compiles against, so it is the proven set, and it
-          # carries every tree ggml reaches for in one place.
-          SRC="${VULKAN_SDK:+$VULKAN_SDK/include}"
-          if [ ! -d "${SRC:-}" ]; then
-            # No SDK env: fall back to apt. libvulkan-dev does not depend on
+          sudo mkdir -p /opt/xybrid-vulkan-include /opt/xybrid-vulkan-lib
+          # Prefer the LunarG SDK: it is what the cargo Vulkan job (ci.yml)
+          # builds against, so it is the proven set, and it keeps the headers
+          # and the loader on the same version.
+          SDK="${VULKAN_SDK:-}"
+          if [ -d "${SDK:-}/include" ] && [ -e "${SDK:-}/lib/libvulkan.so" ]; then
+            INC="$SDK/include"; LIB="$SDK/lib/libvulkan.so"
+          else
+            # No usable SDK: fall back to apt. libvulkan-dev does not depend on
             # spirv-headers, so ask for it explicitly.
             sudo apt-get install -y spirv-headers
-            SRC=/usr/include
+            INC=/usr/include; LIB=/usr/lib/x86_64-linux-gnu/libvulkan.so
           fi
-          echo "include source: $SRC"
+          echo "headers: $INC"
+          echo "loader:  $LIB"
           # vulkan/ is the obvious one; vk_video/ because vulkan_core.h includes
           # the video codec headers; spirv/ because ggml-vulkan.cpp includes
           # <spirv/unified1/spirv.hpp> for its cooperative-matrix paths.
           for tree in vulkan vk_video spirv; do
-            test -d "$SRC/$tree" || { echo "missing $SRC/$tree"; exit 1; }
-            sudo ln -sfn "$SRC/$tree" "/opt/xybrid-vulkan-include/$tree"
+            test -d "$INC/$tree" || { echo "missing $INC/$tree"; exit 1; }
+            sudo ln -sfn "$INC/$tree" "/opt/xybrid-vulkan-include/$tree"
           done
-          ls -l /opt/xybrid-vulkan-include
+          sudo ln -sfn "$LIB" /opt/xybrid-vulkan-lib/libvulkan.so
+          ls -l /opt/xybrid-vulkan-include /opt/xybrid-vulkan-lib
 
       - name: Configure BuildBuddy remote config
         env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -498,10 +498,23 @@ jobs:
       - name: Stage a Vulkan-only include dir
         run: |
           sudo mkdir -p /opt/xybrid-vulkan-include
-          # vk_video/ too: vulkan_core.h includes the video codec headers.
-          for tree in vulkan vk_video; do
-            test -d "/usr/include/$tree" || { echo "missing /usr/include/$tree"; exit 1; }
-            sudo ln -sfn "/usr/include/$tree" "/opt/xybrid-vulkan-include/$tree"
+          # Prefer the LunarG SDK's include tree: it is what the cargo Vulkan
+          # job (ci.yml) compiles against, so it is the proven set, and it
+          # carries every tree ggml reaches for in one place.
+          SRC="${VULKAN_SDK:+$VULKAN_SDK/include}"
+          if [ ! -d "${SRC:-}" ]; then
+            # No SDK env: fall back to apt. libvulkan-dev does not depend on
+            # spirv-headers, so ask for it explicitly.
+            sudo apt-get install -y spirv-headers
+            SRC=/usr/include
+          fi
+          echo "include source: $SRC"
+          # vulkan/ is the obvious one; vk_video/ because vulkan_core.h includes
+          # the video codec headers; spirv/ because ggml-vulkan.cpp includes
+          # <spirv/unified1/spirv.hpp> for its cooperative-matrix paths.
+          for tree in vulkan vk_video spirv; do
+            test -d "$SRC/$tree" || { echo "missing $SRC/$tree"; exit 1; }
+            sudo ln -sfn "$SRC/$tree" "/opt/xybrid-vulkan-include/$tree"
           done
           ls -l /opt/xybrid-vulkan-include
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -158,13 +158,34 @@ _METAL_CMAKE_FLAGS = {
 # holding ONLY the vulkan trees, and the smoke asserts the floor.
 _VULKAN_INCLUDE_DIR = "/opt/xybrid-vulkan-include"
 
+# THE LOADER, same staging trick for a different reason. The exec machine's
+# libvulkan.so is built against ITS glibc, so linking it against hermetic-llvm's
+# 2.28 sysroot leaves the loader's own imports unresolved — lld rejects it under
+# its default --no-allow-shlib-undefined:
+#
+#   ld.lld: error: undefined reference: __isoc23_sscanf@GLIBC_2.38
+#   >>> referenced by /usr/lib/x86_64-linux-gnu/libvulkan.so
+#
+# Those symbols are the LOADER's business, resolved on the machine that runs the
+# binary by the same glibc that ships its libvulkan — not ours to satisfy at
+# link time. `--allow-shlib-undefined` (below) says exactly that. It relaxes the
+# check only for symbols a shared library needs, never for undefined symbols in
+# our own objects, and the smoke still asserts OUR glibc floor.
+#
+# A path under /opt, not the real one, so the CI job can point it at the SDK's
+# loader (matching the headers it stages) or apt's, without this file caring.
+_VULKAN_LIBRARY = "/opt/xybrid-vulkan-lib/libvulkan.so"
+
 _VULKAN_CMAKE_FLAGS = {
     "GGML_VULKAN": "ON",
     "Vulkan_INCLUDE_DIR": _VULKAN_INCLUDE_DIR,
-    # The loader and glslc are binaries, not headers — taking those straight
-    # from the apt payload carries no include-path hazard.
-    "Vulkan_LIBRARY": "/usr/lib/x86_64-linux-gnu/libvulkan.so",
+    "Vulkan_LIBRARY": _VULKAN_LIBRARY,
+    # glslc is executed, never linked, so it has neither hazard.
     "Vulkan_GLSLC_EXECUTABLE": "/usr/bin/glslc",
+    # For llama.cpp's throwaway tool executables, which link ggml-vulkan and so
+    # drag the loader in. (A `-Wl,` flag is position-independent, unlike the
+    # libraries that have to ride on CMAKE_CXX_STANDARD_LIBRARIES.)
+    "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined",
 }
 
 # The static C++ runtime archives the linux and windows-gnu lanes hand to cmake

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -158,34 +158,29 @@ _METAL_CMAKE_FLAGS = {
 # holding ONLY the vulkan trees, and the smoke asserts the floor.
 _VULKAN_INCLUDE_DIR = "/opt/xybrid-vulkan-include"
 
-# THE LOADER, same staging trick for a different reason. The exec machine's
-# libvulkan.so is built against ITS glibc, so linking it against hermetic-llvm's
-# 2.28 sysroot leaves the loader's own imports unresolved — lld rejects it under
-# its default --no-allow-shlib-undefined:
+# THE LOADER is NOT taken from the exec machine, for two independent reasons
+# (both learned the hard way in CI):
 #
-#   ld.lld: error: undefined reference: __isoc23_sscanf@GLIBC_2.38
-#   >>> referenced by /usr/lib/x86_64-linux-gnu/libvulkan.so
+#   1. Its libvulkan.so is built against ITS glibc, so resolving it against
+#      hermetic-llvm's 2.28 sysroot leaves the loader's own imports undefined —
+#      `ld.lld: error: undefined reference: __isoc23_sscanf@GLIBC_2.38`.
+#   2. A host path is not an action input, so it is simply absent when the
+#      final Rust link runs on a remote worker.
 #
-# Those symbols are the LOADER's business, resolved on the machine that runs the
-# binary by the same glibc that ships its libvulkan — not ours to satisfy at
-# link time. `--allow-shlib-undefined` (below) says exactly that. It relaxes the
-# check only for symbols a shared library needs, never for undefined symbols in
-# our own objects, and the smoke still asserts OUR glibc floor.
-#
-# A path under /opt, not the real one, so the CI job can point it at the SDK's
-# loader (matching the headers it stages) or apt's, without this file caring.
-_VULKAN_LIBRARY = "/opt/xybrid-vulkan-lib/libvulkan.so"
+# //bazel/vulkan:libvulkan.so is a link-time stub built by our own toolchain,
+# carrying the real SONAME so the binary still binds to the machine's real
+# loader at runtime. See bazel/vulkan/vulkan_stub.c for the full reasoning.
+# `data` + `$(execpath)` is the same shape the linux/windows arms already use
+# for the static C++ runtime archives.
+_VULKAN_LIBRARY = "$$EXT_BUILD_ROOT/$(execpath //bazel/vulkan:libvulkan.so)"
 
 _VULKAN_CMAKE_FLAGS = {
     "GGML_VULKAN": "ON",
     "Vulkan_INCLUDE_DIR": _VULKAN_INCLUDE_DIR,
     "Vulkan_LIBRARY": _VULKAN_LIBRARY,
-    # glslc is executed, never linked, so it has neither hazard.
+    # glslc is executed, never linked or included, so it has neither hazard and
+    # comes straight from the exec machine.
     "Vulkan_GLSLC_EXECUTABLE": "/usr/bin/glslc",
-    # For llama.cpp's throwaway tool executables, which link ggml-vulkan and so
-    # drag the loader in. (A `-Wl,` flag is position-independent, unlike the
-    # libraries that have to ride on CMAKE_CXX_STANDARD_LIBRARIES.)
-    "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined",
 }
 
 # The static C++ runtime archives the linux and windows-gnu lanes hand to cmake
@@ -540,7 +535,9 @@ cmake(
     # runner's gcc (for vulkan-shaders-gen) live.
     env = {"PATH": "/usr/local/bin:/usr/bin:/bin"},
     cache_entries = _LINUX_LLAMA | _VULKAN_CMAKE_FLAGS,
-    data = _STATIC_CXX_RUNTIME_LIBS,
+    # The C++ runtime archives the linux arm needs, plus the loader stub that
+    # _VULKAN_CMAKE_FLAGS references by $(execpath).
+    data = _STATIC_CXX_RUNTIME_LIBS + ["//bazel/vulkan:libvulkan.so"],
     lib_source = ":llama_src",
     out_static_libs = [
         "libmtmd.a",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,28 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# The desktop-Linux GPU lane toggle — the Bazel half of the Vulkan chapter
+# (#307 turned GGML_VULKAN on for CARGO builds via XYBRID_LLAMA_CPP_VULKAN;
+# the shipped Linux CLI comes from Bazel, which never reads that env var).
+# Same shape as --//:metal above: identical Rust features on both lanes, the
+# flag flips only llama.cpp's GGML_VULKAN, and the flipped compile lives in a
+# separate target (//:llama_vulkan) that must run on a machine carrying the
+# Vulkan SDK (see build:linux-vulkan).
+#
+# --//:metal=true --//:vulkan=true together is meaningless (darwin vs linux)
+# and Bazel reports it as an ambiguous select match naming both settings, which
+# is a clear enough failure to not be worth a config_setting_group guard.
+bool_flag(
+    name = "vulkan",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "vulkan_enabled",
+    flag_values = {":vulkan": "true"},
+    visibility = ["//visibility:public"],
+)
+
 # Host platform for Linux hosts (CI runners): rules_rs' experimental toolchains
 # need an explicit host platform carrying a libc constraint on Linux. Activated
 # by `common:linux` in .bazelrc (auto-applied via --enable_platform_specific_config).
@@ -112,6 +134,71 @@ _LLAMA_LIBS = [
 _METAL_CMAKE_FLAGS = {
     "GGML_METAL": "ON",
     "GGML_ACCELERATE": "ON",
+}
+
+# ggml's Vulkan backend, used by the Linux GPU lane (//:llama_vulkan).
+#
+# The three Vulkan_* pins matter as much as GGML_VULKAN itself. ggml's
+# ggml-vulkan/CMakeLists.txt opens with
+# `find_package(Vulkan COMPONENTS glslc REQUIRED)`, and under the hermetic
+# toolchain CMAKE_SYSROOT points at hermetic-llvm's sysroot — so FindVulkan's
+# find_path/find_library would search that sysroot and miss the SDK payload the
+# exec machine has under /usr. A pre-set cache variable short-circuits find_*
+# entirely, and cache_entries is exactly `-D<var>=<value>`, so pinning the three
+# results FindVulkan would otherwise compute makes discovery a non-issue.
+#
+# INCLUDE DIR: deliberately NOT /usr/include, even though that is where
+# `apt-get install libvulkan-dev` puts vulkan/ (and where FindVulkan would land).
+# cmake turns Vulkan_INCLUDE_DIRS into a `-I` on ggml-vulkan's TUs, and a `-I`
+# is searched BEFORE the toolchain's sysroot — so /usr/include would shadow
+# hermetic-llvm's libc headers for those files. Compiling against the runner's
+# glibc 2.39 headers while linking hermetic glibc 2.28 is how you get symbols
+# like `__isoc23_sscanf` (a 2.38+ header redirect) into the binary and the
+# glibc floor silently rises. The Vulkan CI job instead stages a directory
+# holding ONLY the vulkan trees, and the smoke asserts the floor.
+_VULKAN_INCLUDE_DIR = "/opt/xybrid-vulkan-include"
+
+_VULKAN_CMAKE_FLAGS = {
+    "GGML_VULKAN": "ON",
+    "Vulkan_INCLUDE_DIR": _VULKAN_INCLUDE_DIR,
+    # The loader and glslc are binaries, not headers — taking those straight
+    # from the apt payload carries no include-path hazard.
+    "Vulkan_LIBRARY": "/usr/lib/x86_64-linux-gnu/libvulkan.so",
+    "Vulkan_GLSLC_EXECUTABLE": "/usr/bin/glslc",
+}
+
+# The static C++ runtime archives the linux and windows-gnu lanes hand to cmake
+# (see CMAKE_CXX_STANDARD_LIBRARIES below). cfg=target — the same labels resolve
+# per-platform — unlike build_data's exec-config host tools.
+_STATIC_CXX_RUNTIME_LIBS = [
+    "@llvm//runtimes/libcxx:libcxx.static",
+    "@llvm//runtimes/libcxx:libcxxabi.static",
+    "@llvm//runtimes/libunwind:libunwind.static",
+]
+
+# Desktop-linux config, shared by the CPU lane (//:llama's linux arm) and the
+# GPU lane (//:llama_vulkan).
+#
+# VISION (Flip 1): TOOLS+COMMON=ON unlock tools/ -> libmtmd, mirroring the
+# android arms — the shipped cargo CLI is built with platform-desktop =
+# vision+huggingface, so the Bazel artifact must match. The tool EXECUTABLES
+# need a C++ runtime: the hermetic toolchain links C++ via staged inputs
+# (-nostdlib++), which rfcc's cmake doesn't replicate — hand the static
+# libc++/abi/unwind archives to the exe links via CMAKE_CXX_STANDARD_LIBRARIES
+# (lands AFTER objects, unlike EXE_LINKER_FLAGS). The tools themselves are
+# discarded; only the static libs ship. GGML_LLAMAFILE stays default-ON
+# (android-only off).
+#
+# PIC so these static libs also link into a -shared consumer (the Flutter
+# cdylib, //bindings/flutter/rust): stb_image's __thread globals otherwise emit
+# R_X86_64_TPOFF32, illegal in a shared lib. Harmless for the CLI exe
+# (macOS/arm64 is PIC by default, Android via the NDK, so only the linux GNU arm
+# needs this explicitly).
+_LINUX_LLAMA = _LLAMA_CACHE_ENTRIES | {
+    "LLAMA_BUILD_TOOLS": "ON",
+    "LLAMA_BUILD_COMMON": "ON",
+    "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
+    "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
 }
 
 _DARWIN_LLAMA = _LLAMA_CACHE_ENTRIES | {
@@ -233,26 +320,11 @@ cmake(
         # _GNU_SOURCE instead of _DARWIN_C_SOURCE (u_int/u_char vanish from the
         # SDK headers). Metal stays OFF (base entries): CPU-only is the lane
         # that can leave the Mac; Metal needs Xcode.
-        # Desktop-linux VISION (Flip 1): TOOLS+COMMON=ON unlock tools/ -> libmtmd,
-        # mirroring the android arms — the shipped cargo CLI is built with
-        # platform-desktop = vision+huggingface, so the Bazel artifact must match.
-        # The tool EXECUTABLES need a C++ runtime: the hermetic toolchain links
-        # C++ via staged inputs (-nostdlib++), which rfcc's cmake doesn't
-        # replicate — hand the static libc++/abi/unwind archives to the exe
-        # links via CMAKE_CXX_STANDARD_LIBRARIES (lands AFTER objects, unlike
-        # EXE_LINKER_FLAGS). The tools themselves are discarded; only the
-        # static libs ship. GGML_LLAMAFILE stays default-ON (android-only off).
-        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": _LLAMA_CACHE_ENTRIES | {
-            "LLAMA_BUILD_TOOLS": "ON",
-            "LLAMA_BUILD_COMMON": "ON",
-            "CMAKE_CXX_STANDARD_LIBRARIES": "$$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxx.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libcxx:libcxxabi.static) $$EXT_BUILD_ROOT/$(execpath @llvm//runtimes/libunwind:libunwind.static)",
-            # PIC so these static libs also link into a -shared consumer (the
-            # Flutter cdylib, //bindings/flutter/rust): stb_image's __thread
-            # globals otherwise emit R_X86_64_TPOFF32, illegal in a shared lib.
-            # Harmless for the CLI exe (macOS/arm64 is PIC by default, Android via
-            # the NDK, so only the linux GNU arm needs this explicitly).
-            "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
-        },
+        # Desktop-linux CPU lane — see _LINUX_LLAMA above for what it carries
+        # (vision, the static C++ runtime for the throwaway tool exes, PIC).
+        # The GPU lane is the same dict plus _VULKAN_CMAKE_FLAGS, in the
+        # separate //:llama_vulkan target below.
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": _LINUX_LLAMA,
         # darwin CPU lane (RBE): _DARWIN_LLAMA + the SDK's -lc++ for the tool
         # exes (resolves against the sysroot's libc++.tbd stubs; the tools are
         # discarded). NOT the hermetic static libcxx: compiling hermetic-llvm's
@@ -304,16 +376,8 @@ cmake(
     # deliberately absent: darwin-target libcxx-from-source is broken (see the
     # darwin arm comment) — both darwin lanes use the SDK's -lc++.
     data = select({
-        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": [
-            "@llvm//runtimes/libcxx:libcxx.static",
-            "@llvm//runtimes/libcxx:libcxxabi.static",
-            "@llvm//runtimes/libunwind:libunwind.static",
-        ],
-        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": [
-            "@llvm//runtimes/libcxx:libcxx.static",
-            "@llvm//runtimes/libcxx:libcxxabi.static",
-            "@llvm//runtimes/libunwind:libunwind.static",
-        ],
+        "@rules_rs//rs/platforms/config:x86_64-unknown-linux-gnu": _STATIC_CXX_RUNTIME_LIBS,
+        "@rules_rs//rs/platforms/config:x86_64-pc-windows-gnu": _STATIC_CXX_RUNTIME_LIBS,
         "//conditions:default": [],
     }),
     lib_source = ":llama_src",
@@ -423,6 +487,56 @@ cmake(
     visibility = ["//visibility:public"],
 )
 
+# The desktop-Linux GPU lane: llama with ggml's Vulkan backend. A SEPARATE
+# target for the same two reasons //:llama_metal is separate — //:llama keeps
+# byte-stable action keys on every existing lane, and this one can be pinned
+# LOCAL while the rest of the graph still executes on RBE.
+#
+# WHY LOCAL. The RBE exec image is bare `ubuntu:22.04` (hermetic-llvm's
+# rbe.bzl exec_properties), which carries no glslc, no Vulkan headers and no
+# host compiler. ggml's Vulkan build needs all three on the EXEC machine:
+#
+#   1. `find_package(Vulkan COMPONENTS glslc REQUIRED)` — headers + loader +
+#      the glslc binary (pinned via _VULKAN_CMAKE_FLAGS rather than searched).
+#   2. `vulkan-shaders-gen`, a nested CMake ExternalProject built for the HOST
+#      and then run to compile the .comp shaders. Under rfcc CMAKE_SYSTEM_NAME
+#      is toolchain-set, so cmake takes its CMAKE_CROSSCOMPILING branch and
+#      `detect_host_compiler()` looks for gcc/clang on PATH.
+#
+# So the exec machine is the GitHub runner with .github/actions/setup-vulkan-sdk
+# applied (apt: glslc + libvulkan-dev), not an RBE worker. `no-remote-exec`
+# pins the spawn; unlike //:llama_metal no exec_compatible_with is needed —
+# both the runner and the RBE exec platform are linux/x86_64, so the tools
+# resolved for either platform run here.
+#
+# Not hermetic, by the same reasoning as //:llama_metal's Xcode dependency: a
+# hermetic lane would have to ship glslc (no shaderc/glslang module exists in
+# the BCR today), the Vulkan headers and a host cc as action inputs. Worth
+# doing only if this needs to build on RBE.
+cmake(
+    name = "llama_vulkan",
+    # rfcc sanitizes PATH; /usr/bin is where the apt payload's glslc and the
+    # runner's gcc (for vulkan-shaders-gen) live.
+    env = {"PATH": "/usr/local/bin:/usr/bin:/bin"},
+    cache_entries = _LINUX_LLAMA | _VULKAN_CMAKE_FLAGS,
+    data = _STATIC_CXX_RUNTIME_LIBS,
+    lib_source = ":llama_src",
+    out_static_libs = [
+        "libmtmd.a",
+        # ggml's Vulkan backend is its own archive (ggml_add_backend_library),
+        # linked alongside the rest exactly like cargo does it (build.rs:725).
+        "libggml-vulkan.a",
+    ] + _LLAMA_LIBS,
+    # "manual" for the same reason as //:llama_metal: keep `bazel build //...`
+    # on a machine with no Vulkan SDK from analyzing/building this. Explicit
+    # requests and the transitive path (llama-cpp-sys' --//:vulkan select) work.
+    tags = [
+        "manual",
+        "no-remote-exec",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # whisper.cpp, built on the ggml //:llama already produced.
 #
 # A plain cc_library, NOT a second rules_foreign_cc cmake() target. Two reasons,
@@ -443,10 +557,10 @@ cmake(
 # `src/parakeet.cpp` is deliberately not compiled: a second architecture behind
 # its own header, worth nothing until there is a Parakeet model story.
 #
-# The `//:metal_enabled` select mirrors //crates/llama-cpp-sys:wrapper_cc — on
-# that lane ggml comes from //:llama_metal instead, and linking whisper against
-# the CPU llama there would reintroduce the duplicate this target exists to
-# avoid.
+# The GPU-lane selects mirror //crates/llama-cpp-sys:wrapper_cc — on those lanes
+# ggml comes from //:llama_metal / //:llama_vulkan instead, and linking whisper
+# against the CPU llama there would reintroduce the duplicate this target exists
+# to avoid.
 cc_library(
     name = "whisper",
     srcs = ["vendor/whisper-cpp/src/whisper.cpp"],
@@ -484,6 +598,7 @@ cc_library(
     ],
     deps = select({
         "//:metal_enabled": ["//:llama_metal"],
+        "//:vulkan_enabled": ["//:llama_vulkan"],
         "//conditions:default": ["//:llama"],
     }),
     visibility = ["//visibility:public"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiler as a nested CMake project whose paths exceed Windows' 260-character
   limit under cargo's `OUT_DIR`, so the build fails wherever the repo is
   checked out. Every other target rejects the variable with a clear error.
+- **A Vulkan lane on the Bazel graph** (`--config=linux-vulkan`). The Linux CLI
+  builds from Bazel, which writes llama.cpp's cmake defines itself and never
+  reads `XYBRID_LLAMA_CPP_VULKAN` — so the environment variable above reaches
+  cargo builds only. The new `--//:vulkan` flag selects `//:llama_vulkan`,
+  mirroring how `--//:metal` selects `//:llama_metal`, and a CI job builds and
+  smokes the resulting CLI (Vulkan backend symbols present, `libvulkan.so.1` a
+  real link dependency). That target runs on the local machine rather than a
+  remote worker, because ggml's Vulkan build needs `glslc`, the Vulkan headers
+  and a host compiler where cmake runs, and the remote image has none of them.
+  Published Linux binaries are unchanged and stay CPU-only: a Vulkan build
+  requires a Vulkan loader on the machine that runs it, so it belongs in a
+  separate artifact rather than in place of the default one.
 
 ### Changed
 

--- a/bazel/vulkan/BUILD.bazel
+++ b/bazel/vulkan/BUILD.bazel
@@ -1,0 +1,21 @@
+# The Vulkan loader, as far as the LINKER is concerned — see vulkan_stub.c for
+# why the exec machine's real libvulkan.so cannot play that role under a
+# hermetic toolchain, and why binding to the real one at runtime still works.
+#
+# Used by //:llama_vulkan (as cmake's Vulkan_LIBRARY, which
+# `find_package(Vulkan REQUIRED)` insists on and llama.cpp's throwaway tool
+# executables actually link) and by //crates/llama-cpp-sys:wrapper_cc (which
+# carries it into the final Rust link).
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "libvulkan.so",
+    srcs = ["vulkan_stub.c"],
+    # The SONAME is the entire mechanism: it is what lands in the produced
+    # binary's DT_NEEDED, so the dynamic loader resolves these symbols against
+    # whatever real libvulkan.so.1 the machine has. Without it the linker would
+    # record this build path instead.
+    linkopts = ["-Wl,-soname,libvulkan.so.1"],
+    linkshared = True,
+    visibility = ["//visibility:public"],
+)

--- a/bazel/vulkan/vulkan_stub.c
+++ b/bazel/vulkan/vulkan_stub.c
@@ -1,0 +1,45 @@
+// Link-time stub for the Vulkan loader. NEVER shipped, never called.
+//
+// ggml's Vulkan backend routes almost everything through vulkan-hpp's dynamic
+// dispatcher, so the static archives leave exactly three loader symbols
+// undefined (grep ggml-vulkan.cpp for `vk[A-Z]`):
+//
+//   vkGetInstanceProcAddr          bootstraps the dispatcher
+//   vkGetPhysicalDeviceFeatures2   queried before the dispatcher covers it
+//   vkCmdCopyBuffer                one direct command call
+//
+// The obvious way to satisfy them is to link the exec machine's libvulkan.so,
+// and that does not work here: it is built against ITS glibc, so resolving it
+// against hermetic-llvm's 2.28 sysroot leaves the loader's own imports
+// undefined (`__isoc23_sscanf@GLIBC_2.38`), and a host path is not an action
+// input, so it is simply absent when the link runs on a remote worker.
+//
+// A stub compiled by our own toolchain fixes both. It carries the real
+// library's SONAME (libvulkan.so.1, set in BUILD.bazel), so the produced binary
+// records that in DT_NEEDED and the dynamic loader binds these calls to the
+// machine's REAL Vulkan loader at startup. The stub bodies below exist only to
+// give the linker something to resolve against; nothing ever executes them.
+//
+// Adding a fourth direct call upstream fails the link with the missing symbol
+// named, which is the diagnostic we want — so this list stays honest rather
+// than padded with entry points we do not use.
+
+void *vkGetInstanceProcAddr(void *instance, const char *name) {
+  (void)instance;
+  (void)name;
+  return 0;
+}
+
+void vkGetPhysicalDeviceFeatures2(void *physical_device, void *features) {
+  (void)physical_device;
+  (void)features;
+}
+
+void vkCmdCopyBuffer(void *command_buffer, void *src, void *dst,
+                     unsigned int region_count, const void *regions) {
+  (void)command_buffer;
+  (void)src;
+  (void)dst;
+  (void)region_count;
+  (void)regions;
+}

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -40,20 +40,27 @@ cc_library(
     # Metal lane: the frameworks cargo's build.rs emits on apple (build.rs:
     # 675-680). The Rust crates' #[link] attrs already pull Metal/Foundation/
     # Accelerate; MetalKit exists ONLY here — ggml-metal.m needs it.
-    # Vulkan lane: the loader, which ggml-vulkan.cpp calls directly
-    # (vkGetInstanceProcAddr bootstraps vulkan-hpp's dynamic dispatcher, so the
-    # static archive still leaves that one symbol undefined). Cargo does this as
+    # Vulkan lane: three loader symbols ggml-vulkan.cpp calls directly, which
+    # the static archives leave undefined (everything else goes through
+    # vulkan-hpp's dynamic dispatcher). Cargo satisfies them with
     # `rustc-link-lib=vulkan` + a $VULKAN_SDK/lib search path (build.rs:760,773);
-    # here it is an ABSOLUTE path on purpose — `-L/usr/lib/x86_64-linux-gnu`
-    # would put the host's libraries on the search path for EVERY other -l on
-    # the link (-lm, -lpthread, …), where they would outrank hermetic-llvm's
-    # sysroot and raise the glibc floor. A bare path pulls in exactly one file,
-    # and libvulkan.so's SONAME still lands in DT_NEEDED as libvulkan.so.1.
-    # The /opt path is staged by the CI job — see //:llama_vulkan.
+    # here they come from //bazel/vulkan:libvulkan.so, a stub built by our own
+    # toolchain, because the exec machine's real loader neither links against
+    # the hermetic sysroot nor exists on a remote worker (bazel/vulkan/
+    # vulkan_stub.c has the full story). The stub carries the real SONAME, so
+    # DT_NEEDED still says libvulkan.so.1 and the machine's real loader is what
+    # actually binds at runtime.
     #
-    # NOTE that DT_NEEDED makes the loader a hard runtime dependency of the
+    # `additional_linker_inputs` + `$(execpath)` rather than a bare path: that
+    # is what makes the file an input to the link action wherever it runs.
+    #
+    # NOTE that DT_NEEDED makes a Vulkan loader a hard runtime dependency of the
     # produced binary — which is why the lane is opt-in and would ship as its
     # own artifact, never as the default Linux CLI.
+    additional_linker_inputs = select({
+        "//:vulkan_enabled": ["//bazel/vulkan:libvulkan.so"],
+        "//conditions:default": [],
+    }),
     linkopts = select({
         "//:metal_enabled": [
             "-framework Accelerate",
@@ -62,10 +69,7 @@ cc_library(
             "-framework Foundation",
         ],
         "//:vulkan_enabled": [
-            "/opt/xybrid-vulkan-lib/libvulkan.so",
-            # The loader's own glibc imports are resolved by the machine that
-            # runs the binary, not by our sysroot — see //:llama_vulkan.
-            "-Wl,--allow-shlib-undefined",
+            "$(execpath //bazel/vulkan:libvulkan.so)",
         ],
         "//conditions:default": [],
     }),

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
     # the link (-lm, -lpthread, …), where they would outrank hermetic-llvm's
     # sysroot and raise the glibc floor. A bare path pulls in exactly one file,
     # and libvulkan.so's SONAME still lands in DT_NEEDED as libvulkan.so.1.
+    # The /opt path is staged by the CI job — see //:llama_vulkan.
     #
     # NOTE that DT_NEEDED makes the loader a hard runtime dependency of the
     # produced binary — which is why the lane is opt-in and would ship as its
@@ -61,7 +62,10 @@ cc_library(
             "-framework Foundation",
         ],
         "//:vulkan_enabled": [
-            "/usr/lib/x86_64-linux-gnu/libvulkan.so",
+            "/opt/xybrid-vulkan-lib/libvulkan.so",
+            # The loader's own glibc imports are resolved by the machine that
+            # runs the binary, not by our sysroot — see //:llama_vulkan.
+            "-Wl,--allow-shlib-undefined",
         ],
         "//conditions:default": [],
     }),

--- a/crates/llama-cpp-sys/BUILD.bazel
+++ b/crates/llama-cpp-sys/BUILD.bazel
@@ -40,6 +40,19 @@ cc_library(
     # Metal lane: the frameworks cargo's build.rs emits on apple (build.rs:
     # 675-680). The Rust crates' #[link] attrs already pull Metal/Foundation/
     # Accelerate; MetalKit exists ONLY here — ggml-metal.m needs it.
+    # Vulkan lane: the loader, which ggml-vulkan.cpp calls directly
+    # (vkGetInstanceProcAddr bootstraps vulkan-hpp's dynamic dispatcher, so the
+    # static archive still leaves that one symbol undefined). Cargo does this as
+    # `rustc-link-lib=vulkan` + a $VULKAN_SDK/lib search path (build.rs:760,773);
+    # here it is an ABSOLUTE path on purpose — `-L/usr/lib/x86_64-linux-gnu`
+    # would put the host's libraries on the search path for EVERY other -l on
+    # the link (-lm, -lpthread, …), where they would outrank hermetic-llvm's
+    # sysroot and raise the glibc floor. A bare path pulls in exactly one file,
+    # and libvulkan.so's SONAME still lands in DT_NEEDED as libvulkan.so.1.
+    #
+    # NOTE that DT_NEEDED makes the loader a hard runtime dependency of the
+    # produced binary — which is why the lane is opt-in and would ship as its
+    # own artifact, never as the default Linux CLI.
     linkopts = select({
         "//:metal_enabled": [
             "-framework Accelerate",
@@ -47,13 +60,17 @@ cc_library(
             "-framework MetalKit",
             "-framework Foundation",
         ],
+        "//:vulkan_enabled": [
+            "/usr/lib/x86_64-linux-gnu/libvulkan.so",
+        ],
         "//conditions:default": [],
     }),
     deps = select({
         # --//:metal=true swaps in the Metal llama (a separate, local-pinned
-        # target — see //:llama_metal). Everything above this select is
-        # identical between the lanes by design.
+        # target — see //:llama_metal), --//:vulkan=true the Vulkan one.
+        # Everything above these selects is identical between the lanes by design.
         "//:metal_enabled": ["//:llama_metal"],
+        "//:vulkan_enabled": ["//:llama_vulkan"],
         "//conditions:default": ["//:llama"],
     }),
 )
@@ -75,6 +92,7 @@ rust_library(
     edition = "2021",
     deps = [":wrapper_cc"] + select({
         "//:metal_enabled": ["//:llama_metal"],
+        "//:vulkan_enabled": ["//:llama_vulkan"],
         "//conditions:default": ["//:llama"],
     }),
     visibility = ["//visibility:public"],

--- a/crates/xybrid-core/BUILD.bazel
+++ b/crates/xybrid-core/BUILD.bazel
@@ -86,6 +86,17 @@ rust_library(
         ],
         "//conditions:default": [],
     }),
+    # Vulkan lane (--//:vulkan=true): `local_execution_provider` decides between
+    # "vulkan" and "cpu" with `option_env!("XYBRID_LLAMA_CPP_VULKAN")`
+    # (runtime_adapter/llm.rs) — a rustc-time lookup, which cargo satisfies from
+    # the shell and Bazel has to set explicitly. Without it a Vulkan-linked
+    # binary reports "cpu" on every inference span. Costs this rlib and its
+    # reverse deps their own cache entries on that lane; the llama.cpp compile,
+    # which is the expensive half, is untouched.
+    rustc_env = select({
+        "//:vulkan_enabled": {"XYBRID_LLAMA_CPP_VULKAN": "1"},
+        "//conditions:default": {},
+    }),
     # `all_crate_deps` resolves from the hub's view of Cargo.lock, which reflects
     # the workspace's DEFAULT feature set — and `asr-whispercpp` is off by
     # default, so the optional `xybrid-whisper` path-dep is absent from it. The

--- a/docs/FEATURE_MATRIX.md
+++ b/docs/FEATURE_MATRIX.md
@@ -59,6 +59,12 @@ This document provides a comprehensive reference for all feature flags, platform
   CMake project, and under cargo's `OUT_DIR` the paths MSBuild generates for it
   exceed the 260-character `MAX_PATH` limit. Every other target rejects the
   variable at build time.
+- Bazel has its own Vulkan switch, `--config=linux-vulkan` (which sets
+  `--//:vulkan=true`), because Bazel writes llama.cpp's cmake defines directly
+  and never reads `XYBRID_LLAMA_CPP_VULKAN`. It selects `//:llama_vulkan`, a
+  locally-executed target — the exec machine needs `glslc`, the Vulkan headers
+  and the loader. This is the lane that matters for shipped Linux artifacts,
+  since the CLI builds from Bazel; the published binaries are still CPU-only.
 
 ---
 
@@ -222,6 +228,7 @@ These are the canonical feature combinations CI must run to gate a release. Any 
 | Default-features workspace clippy | `cargo clippy --workspace -- -D warnings` | Default `ort-download` shape; vendored crates compile cleanly with nothing else enabled. |
 | Vision umbrella workspace clippy | `cargo clippy --workspace --features llm-llamacpp-vision --tests --examples -- -D warnings` | The full VLM path through llama.cpp `mtmd`, including vision tests/examples that gate on `llm-llamacpp-vision`. |
 | llama.cpp Vulkan check | `XYBRID_LLAMA_CPP_VULKAN=1 cargo check -p xybrid-sdk --features platform-desktop` | Linux CI installs the Vulkan SDK/loader first, then verifies the opt-in llama.cpp Vulkan build. |
+| Bazel Vulkan lane | `bazel build --config=remote --config=linux-vulkan -c opt //crates/xybrid-cli:xybrid` | The same backend on the Bazel graph — the lane shipped artifacts would come from. Links and smokes the CLI, so unlike the `cargo check` row above it also proves the loader link. |
 | **`--all-features` is forbidden.** | — | See conflict table above. |
 
 ### Platform preset matrix

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -70,8 +70,35 @@ FileTracker generates for it exceed Windows' 260-character `MAX_PATH`, leaving
 about 17 characters for the repository root. It fails from any realistic
 checkout location, so it is gated off rather than shipped broken.
 
-The prebuilt binaries use the release platform configuration. The Vulkan
-environment variable only affects binaries you compile yourself.
+Under Bazel the knob is a build flag, not an environment variable — Bazel sets
+llama.cpp's cmake defines itself and never reads `XYBRID_LLAMA_CPP_VULKAN`:
+
+```bash
+bazel build --config=remote --config=linux-vulkan -c opt //crates/xybrid-cli:xybrid
+```
+
+That config needs the Vulkan SDK on the machine driving the build — ggml
+compiles its GLSL shaders with a nested `vulkan-shaders-gen` project, so
+`//:llama_vulkan` is pinned to local execution while the rest of the graph still
+builds remotely. Two things to set up first:
+
+```bash
+sudo apt-get install glslc libvulkan-dev
+
+# A Vulkan-only include dir. //:llama_vulkan points cmake here instead of at
+# /usr/include, so that a `-I` for the Vulkan headers cannot shadow the
+# hermetic toolchain's libc headers.
+sudo mkdir -p /opt/xybrid-vulkan-include
+sudo ln -sfn /usr/include/vulkan   /opt/xybrid-vulkan-include/vulkan
+sudo ln -sfn /usr/include/vk_video /opt/xybrid-vulkan-include/vk_video
+```
+
+A Vulkan build links `libvulkan.so.1` dynamically, so the machine that *runs*
+it needs a Vulkan loader too, and a driver to reach the GPU.
+
+The prebuilt binaries use the release platform configuration, which is CPU-only
+on Linux — no Vulkan asset is published yet. Both Vulkan paths above affect
+only binaries you compile yourself.
 
 <details>
 <summary>All available feature flags</summary>

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -85,16 +85,18 @@ builds remotely. Two things to set up first:
 ```bash
 sudo apt-get install glslc libvulkan-dev spirv-headers
 
-# //:llama_vulkan reads the headers and the loader from two fixed paths. The
-# headers are staged rather than used in place so that cmake's `-I` for them
-# cannot shadow the hermetic toolchain's libc headers. Use $VULKAN_SDK/include
-# and $VULKAN_SDK/lib instead if you have the LunarG SDK.
-sudo mkdir -p /opt/xybrid-vulkan-include /opt/xybrid-vulkan-lib
+# //:llama_vulkan reads the Vulkan headers from a fixed path, staged rather
+# than used in place so that cmake's `-I` for them cannot shadow the hermetic
+# toolchain's libc headers. Use $VULKAN_SDK/include if you have the LunarG SDK.
+sudo mkdir -p /opt/xybrid-vulkan-include
 for tree in vulkan vk_video spirv; do
   sudo ln -sfn "/usr/include/$tree" "/opt/xybrid-vulkan-include/$tree"
 done
-sudo ln -sfn /usr/lib/x86_64-linux-gnu/libvulkan.so /opt/xybrid-vulkan-lib/libvulkan.so
 ```
+
+The loader is not taken from your system at build time: `//bazel/vulkan` builds a
+link-time stub carrying the real `libvulkan.so.1` SONAME, so the binary binds to
+whatever Vulkan loader the machine running it has.
 
 A Vulkan build links `libvulkan.so.1` dynamically, so the machine that *runs*
 it needs a Vulkan loader too, and a driver to reach the GPU.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -83,14 +83,16 @@ compiles its GLSL shaders with a nested `vulkan-shaders-gen` project, so
 builds remotely. Two things to set up first:
 
 ```bash
-sudo apt-get install glslc libvulkan-dev
+sudo apt-get install glslc libvulkan-dev spirv-headers
 
 # A Vulkan-only include dir. //:llama_vulkan points cmake here instead of at
 # /usr/include, so that a `-I` for the Vulkan headers cannot shadow the
-# hermetic toolchain's libc headers.
+# hermetic toolchain's libc headers. Point these at $VULKAN_SDK/include instead
+# if you have the LunarG SDK installed.
 sudo mkdir -p /opt/xybrid-vulkan-include
-sudo ln -sfn /usr/include/vulkan   /opt/xybrid-vulkan-include/vulkan
-sudo ln -sfn /usr/include/vk_video /opt/xybrid-vulkan-include/vk_video
+for tree in vulkan vk_video spirv; do
+  sudo ln -sfn "/usr/include/$tree" "/opt/xybrid-vulkan-include/$tree"
+done
 ```
 
 A Vulkan build links `libvulkan.so.1` dynamically, so the machine that *runs*

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -85,14 +85,15 @@ builds remotely. Two things to set up first:
 ```bash
 sudo apt-get install glslc libvulkan-dev spirv-headers
 
-# A Vulkan-only include dir. //:llama_vulkan points cmake here instead of at
-# /usr/include, so that a `-I` for the Vulkan headers cannot shadow the
-# hermetic toolchain's libc headers. Point these at $VULKAN_SDK/include instead
-# if you have the LunarG SDK installed.
-sudo mkdir -p /opt/xybrid-vulkan-include
+# //:llama_vulkan reads the headers and the loader from two fixed paths. The
+# headers are staged rather than used in place so that cmake's `-I` for them
+# cannot shadow the hermetic toolchain's libc headers. Use $VULKAN_SDK/include
+# and $VULKAN_SDK/lib instead if you have the LunarG SDK.
+sudo mkdir -p /opt/xybrid-vulkan-include /opt/xybrid-vulkan-lib
 for tree in vulkan vk_video spirv; do
   sudo ln -sfn "/usr/include/$tree" "/opt/xybrid-vulkan-include/$tree"
 done
+sudo ln -sfn /usr/lib/x86_64-linux-gnu/libvulkan.so /opt/xybrid-vulkan-lib/libvulkan.so
 ```
 
 A Vulkan build links `libvulkan.so.1` dynamically, so the machine that *runs*


### PR DESCRIPTION
## Summary

This pull request gives the Bazel graph a Vulkan lane, so a Linux build can actually use the GPU. #307 added a Vulkan opt-in for cargo builds (`XYBRID_LLAMA_CPP_VULKAN=1`), but the Linux CLI ships from Bazel, which writes llama.cpp's cmake defines itself and never reads that variable — distributed binaries were unaffected by it.

**Build Configuration:**

* Added `--//:vulkan` (config `linux-vulkan`), selecting a separate `//:llama_vulkan` cmake target exactly as `--//:metal` selects `//:llama_metal`, so `//:llama` keeps byte-stable action keys on every existing lane.
* Extracted the desktop-linux cmake config to `_LINUX_LLAMA`, now shared by the CPU and GPU lanes instead of duplicated.
* Added Vulkan arms to `//:whisper` and both `llama-cpp-sys` selects, so the single-ggml invariant holds on the new lane too.
* Pinned the Vulkan compile to local execution. The RBE exec image is a bare `ubuntu:22.04` (hermetic-llvm's `rbe.bzl`) with no `glslc`, no Vulkan headers and no host compiler — and ggml needs all three: `find_package(Vulkan COMPONENTS glslc REQUIRED)` plus a nested `vulkan-shaders-gen` project built with the host cc. A hermetic lane would have to ship `glslc` as an action input; the BCR publishes `vulkan_headers` but neither `shaderc` nor `glslang`.

**Three details worth review attention:**

* `Vulkan_INCLUDE_DIR` points at a staged Vulkan-only directory, never `/usr/include`. cmake turns it into a `-I` that outranks the toolchain sysroot, so ggml-vulkan's TUs would compile against the runner's glibc headers while linking the hermetic one — silently raising the glibc floor. Same reason the loader is linked by absolute path rather than `-L /usr/lib/… -lvulkan`, which would put host libraries on the search path for every other `-l`.
* FindVulkan's three results are pinned as cache entries, so discovery never runs and cannot search the wrong sysroot.
* **The loader is a stub we build, never the host's** (`//bazel/vulkan`). Linking the exec machine's `libvulkan.so` fails twice over: it is built against *its* glibc, so it leaves its own imports unresolved against our 2.28 sysroot, and a host path is not a build input, so it is absent when the Rust link runs on a remote worker. ggml routes almost everything through vulkan-hpp's dynamic dispatcher, so only three loader symbols are referenced directly — the stub defines those and carries the real `libvulkan.so.1` SONAME, so the produced binary still binds to the machine's real loader at runtime and the stub never executes. A fourth direct call added upstream fails the link naming the missing symbol.
* `xybrid-core` gets `XYBRID_LLAMA_CPP_VULKAN=1` in its rustc env on this lane, or `local_execution_provider` — an `option_env!` read — would report `cpu` for a Vulkan-linked binary.

**CI:**

* New `bazel-linux-vulkan` job builds and smokes the CLI: Vulkan backend symbols present, `libvulkan.so.1` a real link dependency, vision + huggingface intact, and the glibc floor held (that last one is the guard on the include-path decision above). Fork PRs pay only for the analysis phase.

**Impact:**

* Published binaries are unchanged and stay CPU-only. A Vulkan build hard-requires a Vulkan loader at runtime — ggml-vulkan calls `vkGetInstanceProcAddr` directly, so `DT_NEEDED` carries `libvulkan.so.1` — so it belongs in an additional release asset rather than in place of the default CLI. That release row is deliberately **not** wired here.
* Windows Vulkan is still out. The `MAX_PATH` wall that blocked it for cargo does disappear under Bazel (Windows is cross-built on Linux workers through rules_foreign_cc, MSBuild never runs), but a Windows target still needs Windows Vulkan headers and an import library, which apt cannot provide.

## Type of Change

- [x] New feature
- [x] Documentation

## Checklist

- [x] BUILD files and the workflow parse clean; no Rust source changed
- [x] Documentation updated (`docs/INSTALLATION.md`, `docs/FEATURE_MATRIX.md`, `CHANGELOG.md`)
- [x] No breaking changes — existing lanes keep their action keys, published artifacts unchanged
- [x] The new lane is verified in CI: `Bazel linux Vulkan lane` passes in 17m22s, and the smoke confirms Vulkan backend symbols, `libvulkan.so.1` in `DT_NEEDED`, vision + huggingface, and a **glibc floor of 2.28** — below the CPU lane's 2.31 ceiling, which is the proof that the staged include directory kept the runner's libc headers out of the build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial Bazel/cmake/linker changes and a new CI lane that depends on host Vulkan tooling and header staging; runtime still needs a system Vulkan loader, but default release artifacts are unchanged.
> 
> **Overview**
> Adds a **Bazel-only Linux GPU path** (`--config=linux-vulkan` / `--//:vulkan=true`) so the shipped Linux CLI can link ggml’s Vulkan backend—cargo’s `XYBRID_LLAMA_CPP_VULKAN` env var does not apply to Bazel builds.
> 
> The lane mirrors **Metal**: a separate `//:llama_vulkan` cmake target (Vulkan cmake pins + `libggml-vulkan.a`) runs **locally** on the CI runner while the Rust graph still uses RBE; desktop Linux cmake config is factored into `_LINUX_LLAMA` shared with the CPU `//:llama` arm. **`//bazel/vulkan:libvulkan.so`** is a hermetic link stub (real `libvulkan.so.1` SONAME) wired through `llama-cpp-sys`, `//:whisper`, and `xybrid-core`’s `rustc_env` so telemetry reports `vulkan` instead of `cpu`.
> 
> **CI** adds `bazel-linux-vulkan` on relevant PRs: Vulkan SDK setup, staged headers at `/opt/xybrid-vulkan-include`, analyze/build/smoke (backend symbols, `DT_NEEDED` on `libvulkan.so.1`, vision/huggingface, glibc floor). **Published Linux binaries stay CPU-only**; docs/changelog describe the opt-in artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c994033142a04544f84790ba417fc6f74bd0544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

