### PR TITLE
fix(asr): harden whisper.cpp transcription

### DIFF
--- a/.github/workflows/test-whispercpp.yml
+++ b/.github/workflows/test-whispercpp.yml
@@ -1,0 +1,95 @@
+name: Test whisper.cpp
+
+# Real multilingual weights exercise behavior that compile-only lanes cannot:
+# translation, per-request language selection, long-window handling, and the
+# suppression of bracketed non-speech tokens in user-facing transcripts.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'crates/whisper-cpp-sys/**'
+      - 'crates/xybrid-whisper/**'
+      - 'crates/llama-cpp-sys/**'
+      - 'crates/xybrid-llama/**'
+      - 'crates/xybrid-core/src/runtime_adapter/whisper_cpp/**'
+      - 'crates/xybrid-core/src/audio/**'
+      - 'crates/xybrid-core/src/execution/**'
+      - 'crates/xybrid-core/Cargo.toml'
+      - 'integration-tests/**'
+      - 'vendor/llama.cpp'
+      - 'vendor/whisper-cpp'
+      - 'Cargo.lock'
+      - '.github/workflows/test-whispercpp.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'crates/whisper-cpp-sys/**'
+      - 'crates/xybrid-whisper/**'
+      - 'crates/llama-cpp-sys/**'
+      - 'crates/xybrid-llama/**'
+      - 'crates/xybrid-core/src/runtime_adapter/whisper_cpp/**'
+      - 'crates/xybrid-core/src/audio/**'
+      - 'crates/xybrid-core/src/execution/**'
+      - 'crates/xybrid-core/Cargo.toml'
+      - 'integration-tests/**'
+      - 'vendor/llama.cpp'
+      - 'vendor/whisper-cpp'
+      - 'Cargo.lock'
+      - '.github/workflows/test-whispercpp.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test-whispercpp-integration:
+    name: Test whisper.cpp (integration, real model)
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: whispercpp-integration
+
+      - name: Ensure download tooling (jq, zstd)
+        run: |
+          for tool in jq zstd; do
+            command -v "$tool" >/dev/null || brew install "$tool"
+          done
+
+      # The checksum pins the exact multilingual Q5_1 weights whose quality
+      # thresholds this suite calibrates. The registry remains convenient
+      # for download, but a mutable artifact cannot silently redefine the test.
+      - name: Cache whisper-tiny-ggml
+        id: cache-whisper-tiny-ggml
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: integration-tests/fixtures/models/whisper-tiny-ggml
+          key: whisper-tiny-ggml-${{ runner.os }}-818710568da3ca15689e31a743197b520007872ff9576237bda97bd1b469c3d7
+
+      - name: Download whisper-tiny-ggml
+        if: steps.cache-whisper-tiny-ggml.outputs.cache-hit != 'true'
+        run: ./integration-tests/download.sh whisper-tiny-ggml
+
+      - name: Verify multilingual Q5_1 weights
+        run: |
+          echo '818710568da3ca15689e31a743197b520007872ff9576237bda97bd1b469c3d7  integration-tests/fixtures/models/whisper-tiny-ggml/ggml-tiny-q5_1.bin' \
+            | shasum -a 256 -c -
+
+      - name: Test Whisper end to end
+        env:
+          XYBRID_REQUIRE_MODELS: 1
+        run: |
+          cargo test -p integration-tests --features asr-whispercpp \
+            --test whispercpp_integration -- --nocapture

--- a/crates/xybrid-core/src/runtime_adapter/whisper_cpp/runtime.rs
+++ b/crates/xybrid-core/src/runtime_adapter/whisper_cpp/runtime.rs
@@ -148,6 +148,16 @@ impl WhisperCppRuntime {
             }
         }
 
+        // whisper.cpp supports an initial prompt, but xybrid has not exposed
+        // or validated that capability yet. Reject it rather than silently
+        // claiming to honour caller input; do not echo the prompt because it
+        // may contain private user text.
+        if metadata_value(metadata, "prompt").is_some() {
+            return Err(AdapterError::InvalidInput(
+                "'prompt' is not supported by the whisper.cpp runtime".to_string(),
+            ));
+        }
+
         // Rejected rather than ignored: greedy decoding with temperature
         // fallback disabled never samples, so silently accepting a temperature
         // would misreport what ran. Mirrors the Candle runtime's contract.
@@ -356,6 +366,20 @@ mod tests {
             .params_for(&meta(&[("temperature", "hot")]))
             .expect_err("not a number");
         assert!(matches!(err, AdapterError::InvalidInput(_)), "{err:?}");
+    }
+
+    #[test]
+    fn prompt_is_rejected_without_echoing_its_contents() {
+        let runtime = WhisperCppRuntime::new();
+        let private_prompt = "PRIVATE_PROMPT_SENTINEL_7c1f";
+        let err = runtime
+            .params_for(&meta(&[("prompt", private_prompt)]))
+            .expect_err("prompt handling is not implemented");
+
+        assert!(matches!(err, AdapterError::InvalidInput(_)), "{err:?}");
+        let message = err.to_string();
+        assert!(message.contains("prompt"), "{message}");
+        assert!(!message.contains(private_prompt), "{message}");
     }
 
     #[test]

--- a/crates/xybrid-whisper/src/model.rs
+++ b/crates/xybrid-whisper/src/model.rs
@@ -17,6 +17,9 @@ use crate::segment::Segment;
 /// only padding, and decoding padding fabricates text.
 const MIN_SAMPLES: usize = 400;
 
+/// Samples in Whisper's full 30-second encoder window.
+const FULL_WINDOW_SAMPLES: usize = SAMPLE_RATE as usize * 30;
+
 /// An owning handle to a whisper.cpp context.
 ///
 /// Dropping frees the native context. Transcription takes `&mut self` because
@@ -119,13 +122,26 @@ impl WhisperModel {
 
         wparams.n_threads = i32::try_from(params.n_threads).unwrap_or(i32::MAX).max(1);
         wparams.audio_ctx = i32::try_from(params.normalized_audio_ctx()).unwrap_or(i32::MAX);
-        wparams.no_timestamps = !params.timestamps;
+        // Timestamp tokens let whisper.cpp advance to the true end of speech
+        // inside each 30 s window. They are optional for one-window live
+        // partials, but required for longer input: without them, the final
+        // short window is padded to 30 s and tiny can fill that padding with a
+        // long repetition loop. Segment spans remain an internal part of our
+        // return type either way, so enabling them here does not change the IO
+        // shape.
+        wparams.no_timestamps = !params.timestamps && pcm.len() <= FULL_WINDOW_SAMPLES;
         wparams.no_context = !params.use_context;
         wparams.translate = params.task == Task::Translate;
         wparams.print_progress = false;
         wparams.print_realtime = false;
         wparams.print_special = false;
         wparams.print_timestamps = false;
+        // Keep Whisper's non-speech vocabulary out of user-facing text. The
+        // upstream default is false, which lets bracketed annotations such as
+        // "[BLANK_AUDIO]" and "[Speaking in French]" surface as transcripts.
+        // Candle applies the equivalent suppress-token mask, so enabling
+        // whisper.cpp's built-in mask preserves that behavior across backends.
+        wparams.suppress_nst = true;
         // Disable temperature fallback. A fallback re-runs the whole window at
         // a higher temperature, which on a live path turns one slow window into
         // several — the measured 2.7 s outlier behind an otherwise 0.7 s

--- a/crates/xybrid-whisper/src/params.rs
+++ b/crates/xybrid-whisper/src/params.rs
@@ -54,8 +54,10 @@ pub struct TranscribeParams {
     /// the rest of the runtime uses rather than the core count — whisper is
     /// memory-bandwidth-bound, and oversubscription measurably slows it down.
     pub n_threads: u32,
-    /// Emit per-segment timestamps. Off for live partials, on for final
-    /// transcripts that need alignment.
+    /// Request timestamp-token decoding. Off for one-window live partials, on
+    /// for final transcripts that need alignment. Inputs longer than Whisper's
+    /// 30-second encoder window enable timestamp tokens internally so the
+    /// decoder can stop at the real end of a padded final window.
     pub timestamps: bool,
     /// Condition each window on the previous window's text. Improves coherence
     /// on continuous speech but can propagate an early mistake through the rest

--- a/integration-tests/BUILD.bazel
+++ b/integration-tests/BUILD.bazel
@@ -72,6 +72,7 @@ _E2E_TESTS = {
     "reasoning_budget": ["llm-llamacpp"],
     "reasoning_capture": ["llm-llamacpp"],
     "tts_integration": [],
+    "whispercpp_integration": ["asr-whispercpp"],
 }
 
 # local_llm is absent on purpose: it is gated on `llm-mistral`, and xybrid-core's
@@ -79,7 +80,9 @@ _E2E_TESTS = {
 # be satisfied here the way llm-llamacpp can. whisper_candle_integration is
 # absent for the same reason — it is gated on `candle`, which xybrid-core's
 # crate_features above do not enable. It runs under cargo, in the Test Candle
-# workflow.
+# workflow. whisper.cpp is included because core's Bazel target enables it;
+# the real weights remain a cargo-only CI download, while this target proves
+# the test and skip path compile in the Bazel graph.
 
 [
     rust_test(

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -12,6 +12,10 @@ default = []
 # CI turns it on in the Test Candle workflow.
 candle = ["xybrid-core/candle"]
 
+# whisper.cpp ASR backend — gates tests/whispercpp_integration.rs. The real
+# multilingual model is downloaded only by the dedicated model-test workflow.
+asr-whispercpp = ["xybrid-core/asr-whispercpp"]
+
 # Local LLM inference
 llm-mistral = ["xybrid-core/llm-mistral"]              # mistral.rs (CPU)
 llm-mistral-metal = ["xybrid-core/llm-mistral-metal"]  # mistral.rs + Metal (macOS)

--- a/integration-tests/download.sh
+++ b/integration-tests/download.sh
@@ -62,10 +62,10 @@ check_models() {
         # Check for model.onnx or model_metadata.json
         if [ -d "$model_dir" ] && { [ -f "$model_dir/model_metadata.json" ] || [ -f "$model_dir/model.onnx" ]; }; then
             echo -e "  ${GREEN}✓${NC} $model [$source]"
-            ((present++))
+            present=$((present + 1))
         else
             echo -e "  ${RED}✗${NC} $model [$source] (missing)"
-            ((missing++))
+            missing=$((missing + 1))
         fi
     done
 
@@ -98,10 +98,26 @@ validate_file() {
     return 0
 }
 
+# Portable SHA-256 for registry passthrough files. Linux images provide
+# sha256sum; macOS provides shasum.
+sha256_file() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | cut -d' ' -f1
+    else
+        echo "No SHA-256 tool found (need sha256sum or shasum)" >&2
+        return 1
+    fi
+}
+
 # Detect current platform
 detect_platform() {
-    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
-    local arch=$(uname -m)
+    local os
+    local arch
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    arch=$(uname -m)
 
     case "$os" in
         darwin)
@@ -184,13 +200,21 @@ download_from_registry() {
     local download_url
     local file_name
     local size_bytes
+    local passthrough
+    local expected_sha256
     download_url=$(echo "$resolve_response" | jq -r '.resolved.download_url // empty')
     file_name=$(echo "$resolve_response" | jq -r '.resolved.file // empty')
     size_bytes=$(echo "$resolve_response" | jq -r '.resolved.size_bytes // 0')
+    passthrough=$(echo "$resolve_response" | jq -r '.resolved.passthrough // false')
+    expected_sha256=$(echo "$resolve_response" | jq -r '.resolved.sha256 // empty')
 
     if [ -z "$download_url" ]; then
         echo -e "${RED}✗ No download URL found for $model_name${NC}"
         echo "  Response: $resolve_response"
+        return 1
+    fi
+    if [ -z "$file_name" ] || [ "$(basename "$file_name")" != "$file_name" ]; then
+        echo -e "${RED}✗ Registry returned an invalid file name: $file_name${NC}"
         return 1
     fi
 
@@ -199,11 +223,54 @@ download_from_registry() {
 
     mkdir -p "$model_dir"
 
-    # Download the bundle
+    # Download the bundle or raw passthrough model.
     local bundle_file="$model_dir/$file_name"
     echo "  Downloading..."
 
     if curl -L -# -f -o "$bundle_file" "$download_url"; then
+        if [ "$passthrough" = "true" ]; then
+            if ! validate_file "$bundle_file" "$size_bytes"; then
+                echo -e "${RED}✗ Downloaded passthrough file is invalid${NC}"
+                rm -rf "$model_dir"
+                return 1
+            fi
+
+            local actual_size
+            actual_size=$(wc -c < "$bundle_file" | tr -d ' ')
+            if [ "$size_bytes" -gt 0 ] && [ "$actual_size" -ne "$size_bytes" ]; then
+                echo -e "${RED}✗ Size mismatch for $file_name${NC}"
+                echo "  Expected: $size_bytes bytes"
+                echo "  Actual:   $actual_size bytes"
+                rm -rf "$model_dir"
+                return 1
+            fi
+
+            if [ -n "$expected_sha256" ]; then
+                local actual_sha256
+                actual_sha256=$(sha256_file "$bundle_file") || {
+                    rm -rf "$model_dir"
+                    return 1
+                }
+                if [ "$actual_sha256" != "$expected_sha256" ]; then
+                    echo -e "${RED}✗ SHA-256 mismatch for $file_name${NC}"
+                    echo "  Expected: $expected_sha256"
+                    echo "  Actual:   $actual_sha256"
+                    rm -rf "$model_dir"
+                    return 1
+                fi
+            fi
+
+            if ! echo "$resolve_response" | jq -e '.resolved.model_metadata | type == "object"' >/dev/null; then
+                echo -e "${RED}✗ Passthrough response is missing model metadata${NC}"
+                rm -rf "$model_dir"
+                return 1
+            fi
+            echo "$resolve_response" | jq '.resolved.model_metadata' > "$model_dir/model_metadata.json"
+            chmod -R u+rw "$model_dir" 2>/dev/null || true
+            echo -e "${GREEN}✓ $model_name downloaded successfully${NC}"
+            return 0
+        fi
+
         echo "  Extracting bundle..."
 
         # Detect archive type by magic bytes

--- a/integration-tests/fixtures/models/models.json
+++ b/integration-tests/fixtures/models/models.json
@@ -20,6 +20,13 @@
       "size_mb": 150,
       "task": "speech-recognition"
     },
+    "whisper-tiny-ggml": {
+      "description": "Whisper tiny multilingual GGML Q5_1 for ASR via whisper.cpp",
+      "source": "registry",
+      "size_mb": 31,
+      "task": "speech-recognition",
+      "feature_gate": "asr-whispercpp"
+    },
     "whisper-ggml-tiny-en": {
       "description": "Whisper tiny.en, GGML Q5_1 - fast English ASR via whisper.cpp on the shared ggml",
       "source": "url",

--- a/integration-tests/tests/whispercpp_integration.rs
+++ b/integration-tests/tests/whispercpp_integration.rs
@@ -1,0 +1,476 @@
+//! End-to-end Whisper regression coverage through the whisper.cpp runtime.
+//!
+//! This carries the behavior checks that previously existed only for Candle:
+//! short and boundary-length audio, multi-window transcription, per-request
+//! language and task handling, translation, and non-speech-token suppression.
+//! Every inference goes through [`ModelRuntime`] with an [`Envelope`], matching
+//! the executor's production path.
+//!
+//! Run with:
+//!   cargo test -p integration-tests --features asr-whispercpp \
+//!     --test whispercpp_integration -- --nocapture
+//!
+//! Download the model first:
+//!   ./integration-tests/download.sh whisper-tiny-ggml
+
+#![cfg(feature = "asr-whispercpp")]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use integration_tests::fixtures;
+use xybrid_core::audio::{decode_wav_audio, samples_to_wav};
+use xybrid_core::execution::{ExecutionTemplate, ModelMetadata};
+use xybrid_core::ir::{Envelope, EnvelopeKind};
+use xybrid_core::runtime_adapter::whisper_cpp::WhisperCppRuntime;
+use xybrid_core::runtime_adapter::{AdapterError, ModelRuntime};
+
+const MODEL: &str = "whisper-tiny-ggml";
+const MODEL_OVERRIDE_ENV: &str = "XYBRID_WHISPER_TEST_MODEL";
+const SAMPLE_RATE: u32 = 16_000;
+const JFK_CLIP: &str = "jfk.wav";
+const FRENCH_CLIP: &str = "mls-fr-1-8s.wav";
+const JFK_TRANSCRIPT: &str = "And so my fellow Americans, ask not what your country can do for \
+                              you, ask what you can do for your country.";
+const MAX_WER: f64 = 0.10;
+
+/// Serializes real-model cases so the test harness cannot create a dozen
+/// ~150 MB whisper contexts and CPU-heavy inference calls at once.
+static MODEL_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug)]
+struct FixtureModel {
+    path: PathBuf,
+    language: Option<String>,
+    audio_ctx: u32,
+    translate: bool,
+}
+
+fn serial_model_test() -> MutexGuard<'static, ()> {
+    match MODEL_TEST_LOCK.lock() {
+        Ok(guard) => guard,
+        // This lock carries no model state; it only limits concurrency. A
+        // previous assertion poisoning it does not make the next test unsafe.
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// A loaded multilingual whisper.cpp runtime, or `None` when the model is not
+/// downloaded and model fixtures are optional.
+fn whisper_runtime() -> Option<WhisperCppRuntime> {
+    let fixture = fixture_model()?;
+    let mut runtime = WhisperCppRuntime::new().with_defaults(
+        fixture.language,
+        fixture.audio_ctx,
+        fixture.translate,
+    );
+    runtime
+        .load(&fixture.path)
+        .unwrap_or_else(|e| panic!("loading {}: {e}", fixture.path.display()));
+    Some(runtime)
+}
+
+fn fixture_model() -> Option<FixtureModel> {
+    if let Some(path) = std::env::var_os(MODEL_OVERRIDE_ENV) {
+        let path = PathBuf::from(path);
+        assert!(
+            path.is_file(),
+            "{MODEL_OVERRIDE_ENV} points at a missing model: {}",
+            path.display()
+        );
+        return Some(FixtureModel {
+            path,
+            language: None,
+            audio_ctx: 0,
+            translate: false,
+        });
+    }
+
+    let model_dir = fixtures::model_for_test(MODEL)?;
+    let fixture = read_bundle_config(&model_dir);
+    if fixture.path.is_file() {
+        return Some(fixture);
+    }
+
+    if std::env::var_os(fixtures::REQUIRE_MODELS_ENV).is_some() {
+        panic!(
+            "{MODEL} model payload not found at {}. Run: ./integration-tests/download.sh {MODEL}",
+            fixture.path.display()
+        );
+    }
+    None
+}
+
+fn read_bundle_config(model_dir: &Path) -> FixtureModel {
+    let metadata_path = model_dir.join("model_metadata.json");
+    let json = std::fs::read_to_string(&metadata_path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", metadata_path.display()));
+    let metadata: ModelMetadata = serde_json::from_str(&json)
+        .unwrap_or_else(|e| panic!("parsing {}: {e}", metadata_path.display()));
+
+    let ExecutionTemplate::GgmlWhisper {
+        model_file,
+        language,
+        audio_ctx,
+        translate,
+    } = metadata.execution_template
+    else {
+        panic!(
+            "{MODEL} must use ExecutionTemplate::GgmlWhisper, got {:?}",
+            metadata.execution_template
+        );
+    };
+
+    FixtureModel {
+        path: model_dir.join(model_file),
+        language,
+        audio_ctx,
+        translate,
+    }
+}
+
+fn skip_notice() {
+    eprintln!("Skipping: {MODEL} not downloaded. Run: ./integration-tests/download.sh {MODEL}");
+}
+
+fn read_pcm(name: &str) -> Vec<f32> {
+    let path = fixtures::input_dir().join(name);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    decode_wav_audio(&bytes, SAMPLE_RATE, 1)
+        .unwrap_or_else(|e| panic!("decoding {}: {e}", path.display()))
+}
+
+fn looped(pcm: &[f32], samples: usize) -> Vec<f32> {
+    assert!(!pcm.is_empty(), "cannot loop empty audio");
+    pcm.iter().copied().cycle().take(samples).collect()
+}
+
+fn transcript_repeated(times: usize) -> String {
+    vec![JFK_TRANSCRIPT; times].join(" ")
+}
+
+fn transcribe(
+    runtime: &mut WhisperCppRuntime,
+    pcm: &[f32],
+    metadata: &[(&str, &str)],
+) -> Result<String, AdapterError> {
+    let envelope = Envelope {
+        kind: EnvelopeKind::Audio(samples_to_wav(pcm, SAMPLE_RATE)),
+        metadata: metadata
+            .iter()
+            .map(|&(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+    };
+
+    match runtime.execute(&envelope)?.kind {
+        EnvelopeKind::Text(text) => Ok(text),
+        other => panic!("expected text output, got {other:?}"),
+    }
+}
+
+fn transcribed(runtime: &mut WhisperCppRuntime, pcm: &[f32], metadata: &[(&str, &str)]) -> String {
+    transcribe(runtime, pcm, metadata).unwrap_or_else(|e| {
+        panic!(
+            "transcribing {} samples ({:.2} s) with {metadata:?} failed: {e}",
+            pcm.len(),
+            pcm.len() as f64 / f64::from(SAMPLE_RATE),
+        )
+    })
+}
+
+fn words(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(|word| {
+            word.chars()
+                .filter(|c| c.is_alphanumeric() || *c == '\'')
+                .flat_map(char::to_lowercase)
+                .collect::<String>()
+        })
+        .filter(|word| !word.is_empty())
+        .collect()
+}
+
+fn wer(reference: &str, hypothesis: &str) -> f64 {
+    let reference = words(reference);
+    let hypothesis = words(hypothesis);
+    if reference.is_empty() {
+        return if hypothesis.is_empty() { 0.0 } else { 1.0 };
+    }
+
+    let mut previous: Vec<usize> = (0..=hypothesis.len()).collect();
+    let mut current = vec![0usize; hypothesis.len() + 1];
+    for (i, reference_word) in reference.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, hypothesis_word) in hypothesis.iter().enumerate() {
+            let substitute = previous[j] + usize::from(reference_word != hypothesis_word);
+            let delete = previous[j + 1] + 1;
+            let insert = current[j] + 1;
+            current[j + 1] = substitute.min(delete).min(insert);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[hypothesis.len()] as f64 / reference.len() as f64
+}
+
+fn assert_wer_within_budget(label: &str, reference: &str, text: &str) {
+    let measured = wer(reference, text);
+    println!("{label}: WER {measured:.3}\n  {text:?}");
+    assert!(
+        measured <= MAX_WER,
+        "{label}: WER {measured:.3} exceeds the {MAX_WER} budget\n  got:      \
+         {text:?}\n  expected: {reference:?}"
+    );
+}
+
+fn assert_transcribed_something(label: &str, text: &str) {
+    println!("{label}: {text:?}");
+    assert!(
+        !words(text).is_empty(),
+        "{label}: expected a transcript, got {text:?}"
+    );
+}
+
+fn assert_no_hallucinated_annotation(label: &str, text: &str) {
+    assert!(
+        !text.contains('[') && !text.contains('('),
+        "{label}: transcript carries a bracketed non-speech annotation: {text:?}"
+    );
+}
+
+const ENGLISH_FUNCTION_WORDS: &[&str] = &[
+    "the", "and", "of", "to", "in", "is", "was", "were", "that", "this", "it", "he", "she", "you",
+    "i", "we", "they", "his", "her", "their", "my", "for", "with", "not", "but", "have", "had",
+    "said", "when", "what", "which", "who", "will", "would", "there", "from", "as", "so", "if",
+    "do", "did", "does", "be", "been", "at", "by",
+];
+
+fn english_word_rate(text: &str) -> f64 {
+    let words = words(text);
+    if words.is_empty() {
+        return 0.0;
+    }
+    let hits = words
+        .iter()
+        .filter(|word| ENGLISH_FUNCTION_WORDS.contains(&word.as_str()))
+        .count();
+    hits as f64 / words.len() as f64
+}
+
+#[test]
+fn sub_second_audio_emits_no_annotation_token() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(JFK_CLIP);
+    let text = transcribed(&mut runtime, &pcm[..SAMPLE_RATE as usize * 3 / 10], &[]);
+    println!("0.3 s slice: {text:?}");
+    assert_no_hallucinated_annotation("0.3 s slice", &text);
+}
+
+#[test]
+fn forced_language_mismatch_emits_no_annotation_token() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(FRENCH_CLIP);
+    let text = transcribed(&mut runtime, &pcm, &[("language", "en")]);
+    println!("French audio forced to language=en: {text:?}");
+    assert_no_hallucinated_annotation("French audio forced to language=en", &text);
+}
+
+#[test]
+fn transcribes_five_second_slice() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(JFK_CLIP);
+    let text = transcribed(&mut runtime, &pcm[..5 * SAMPLE_RATE as usize], &[]);
+    assert_transcribed_something("5 s slice", &text);
+}
+
+#[test]
+fn transcribes_full_clip_within_wer_budget() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(JFK_CLIP);
+    assert_eq!(pcm.len(), 176_000, "jfk.wav should be 11.0 s at 16 kHz");
+    let text = transcribed(&mut runtime, &pcm, &[]);
+    assert_wer_within_budget("11 s clip", JFK_TRANSCRIPT, &text);
+}
+
+#[test]
+fn transcribes_exactly_240159_samples() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = looped(&read_pcm(JFK_CLIP), 240_159);
+    let text = transcribed(&mut runtime, &pcm, &[]);
+    assert_transcribed_something("240_159 samples (15.0099 s)", &text);
+}
+
+#[test]
+fn transcribes_exactly_240160_samples() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = looped(&read_pcm(JFK_CLIP), 240_160);
+    let text = transcribed(&mut runtime, &pcm, &[]);
+    assert_transcribed_something("240_160 samples (15.01 s)", &text);
+    assert_no_hallucinated_annotation("240_160 samples (15.01 s)", &text);
+}
+
+#[test]
+fn transcribes_exactly_thirty_seconds() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = looped(&read_pcm(JFK_CLIP), 480_000);
+    let text = transcribed(&mut runtime, &pcm, &[]);
+    assert_transcribed_something("480_000 samples (30.00 s)", &text);
+    assert_no_hallucinated_annotation("480_000 samples (30.00 s)", &text);
+}
+
+#[test]
+fn transcribes_sixty_six_seconds_without_dropping_audio() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let jfk = read_pcm(JFK_CLIP);
+    let pcm = looped(&jfk, jfk.len() * 6);
+    assert_eq!(pcm.len(), 1_056_000, "six 11 s copies at 16 kHz");
+    let text = transcribed(&mut runtime, &pcm, &[]);
+    assert_wer_within_budget("66 s clip", &transcript_repeated(6), &text);
+}
+
+#[test]
+fn language_metadata_applies_per_request_not_per_load() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(FRENCH_CLIP);
+    let english_first = transcribed(&mut runtime, &pcm, &[("language", "en")]);
+    let french_first = transcribed(&mut runtime, &pcm, &[("language", "fr")]);
+    let english_second = transcribed(&mut runtime, &pcm, &[("language", "en")]);
+    let french_second = transcribed(&mut runtime, &pcm, &[("language", "fr")]);
+
+    assert_transcribed_something("language=fr", &french_first);
+    assert_ne!(
+        english_first.trim(),
+        french_first.trim(),
+        "language=fr decoded identically to language=en, so the metadata did nothing"
+    );
+    assert_eq!(
+        english_first, english_second,
+        "language=en changed after an intervening language=fr request"
+    );
+    assert_eq!(
+        french_first, french_second,
+        "language=fr changed after an intervening language=en request"
+    );
+    assert_no_hallucinated_annotation("language=en", &english_first);
+}
+
+#[test]
+fn translate_task_returns_english_for_french_audio() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(FRENCH_CLIP);
+    let french = transcribed(
+        &mut runtime,
+        &pcm,
+        &[("language", "fr"), ("task", "transcribe")],
+    );
+    let translated = transcribed(
+        &mut runtime,
+        &pcm,
+        &[("language", "fr"), ("task", "translate")],
+    );
+
+    let french_rate = english_word_rate(&french);
+    let translated_rate = english_word_rate(&translated);
+    println!("transcribe (fr): rate {french_rate:.3} {french:?}");
+    println!("translate  (en): rate {translated_rate:.3} {translated:?}");
+    assert!(
+        translated_rate > french_rate,
+        "task=translate should read as English: {translated_rate:.3} vs {french_rate:.3}\n  \
+         translate: {translated:?}\n  transcribe: {french:?}"
+    );
+}
+
+#[test]
+fn translate_without_language_returns_english_for_french_audio() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let pcm = read_pcm(FRENCH_CLIP);
+    let french = transcribed(&mut runtime, &pcm, &[("language", "fr")]);
+    let translated = transcribed(&mut runtime, &pcm, &[("task", "translate")]);
+
+    let french_rate = english_word_rate(&french);
+    let translated_rate = english_word_rate(&translated);
+    println!("transcribe (fr):          rate {french_rate:.3} {french:?}");
+    println!("translate  (no language): rate {translated_rate:.3} {translated:?}");
+    assert!(
+        translated_rate > french_rate,
+        "task=translate without a language should read as English: {translated_rate:.3} vs \
+         {french_rate:.3}\n  translate: {translated:?}\n  transcribe: {french:?}"
+    );
+}
+
+#[test]
+fn rejects_prompt_metadata_without_exposing_it() {
+    let private_prompt = "PRIVATE_PROMPT_SENTINEL_7c1f";
+    let pcm = vec![0.0; SAMPLE_RATE as usize];
+    let mut runtime = WhisperCppRuntime::new();
+    let error = transcribe(&mut runtime, &pcm, &[("prompt", private_prompt)])
+        .expect_err("prompt is unsupported and must be rejected");
+
+    assert!(
+        matches!(error, AdapterError::InvalidInput(_)),
+        "expected InvalidInput, got {error:?}"
+    );
+    assert!(
+        error.to_string().contains("prompt"),
+        "error should name the rejected parameter: {error}"
+    );
+    assert!(
+        !error.to_string().contains(private_prompt),
+        "error must not expose the rejected prompt: {error}"
+    );
+}


### PR DESCRIPTION
## Summary

This pull request hardens whisper.cpp transcription by suppressing bracketed non-speech tokens, enabling timestamp-token decoding for audio longer than 30 seconds, and rejecting unsupported prompt metadata without echoing its contents. It also moves the load-bearing Candle ASR coverage onto whisper.cpp using a checksum-pinned multilingual model so these behaviors remain tested as the old backend is retired.

**Runtime Behavior:**

* Enabled whisper.cpp's non-speech-token mask so annotations such as `[BLANK_AUDIO]` do not appear as transcripts; a caller-facing opt-out is tracked in #483.
* Enabled timestamp tokens for multi-window input, preventing a padded final window from repeating text after the real audio ends.
* Changed unsupported `prompt` metadata from a silent no-op to a privacy-safe `InvalidInput` error.

**Regression Coverage and CI:**

* Ported 12 real-model cases covering short audio, exact boundary lengths, 66-second input, WER, per-request language selection, translation, non-speech-token suppression, and prompt rejection.
* Added a macOS workflow that downloads and verifies the multilingual GGML Q5_1 model before running the suite.
* Extended the integration-test downloader to support raw registry passthrough artifacts with exact size, SHA-256, filename, and metadata checks.
* Added the whisper.cpp test feature and Bazel target, including a clean skip path when downloaded weights are absent.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter default transcript text and long-audio decoding for all whisper.cpp users; rejecting `prompt` may surface errors where input was previously ignored, though behavior is covered by new integration tests.
> 
> **Overview**
> **whisper.cpp transcription** now turns on non-speech-token suppression so bracketed annotations do not appear in user transcripts, forces timestamp-token decoding for PCM longer than 30 seconds (even when callers leave `timestamps` off) to avoid repetition on padded final windows, and returns **`InvalidInput`** for unsupported `prompt` metadata without echoing the prompt.
> 
> **Regression coverage** adds a large `whispercpp_integration` suite (WER, boundaries, 66s audio, per-request language/task, translation, annotation checks) behind the new **`asr-whispercpp`** feature, plus a **macOS GitHub workflow** that caches/downloads **`whisper-tiny-ggml`**, verifies a pinned SHA-256, and runs the suite with **`XYBRID_REQUIRE_MODELS=1`**.
> 
> **Tooling** registers the GGML fixture in **`models.json`**, wires the test into **Bazel**, and extends **`download.sh`** for registry **passthrough** downloads (size/SHA-256/metadata validation) with small shell portability fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469da909e9ceae57ad547844d1918c9cb5d70db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->