### PR TITLE
fix(docs): stop claiming CUDA, and warn when GPU offload is a no-op

### DIFF
--- a/.github/actions/bazel-repo-cache/action.yml
+++ b/.github/actions/bazel-repo-cache/action.yml
@@ -1,75 +1,81 @@
-name: Cache Bazel repository fetches
+name: Cache the pinned macOS SDK download
 description: >
-  Persist Bazel's content-addressed repository cache across runs, so pinned
-  external archives are not re-downloaded from the network on every job.
+  Persist the one Bazel repository fetch whose upstream is broken — hermetic-llvm's
+  macOS SDK package — so jobs stop depending on hosts that refuse to serve it.
 
-# WHY THIS EXISTS. Repository fetches are client-side — remote execution and the
-# BuildBuddy action cache do nothing for them — so each job re-downloaded every
-# pinned archive, including hermetic-llvm's macOS SDK. That one comes from
-# Apple's CDN, whose pinned URL now returns 403, leaving only the
-# web.archive.org mirror hermetic-llvm lists beside it, which throttles Actions
-# IP ranges. On 2026-08-11 both refused within seconds of each other and the
-# Apple job failed in analysis having built nothing.
+# WHY THIS EXISTS. hermetic-llvm pins the macOS SDK to a swcdn.apple.com URL plus
+# one web.archive.org mirror. Apple's URL now returns 403 permanently (verified
+# off-CI, and unchanged through hermetic-llvm 0.8.17), leaving the Wayback mirror,
+# which throttles Actions IP ranges — on 2026-08-11 both refused in the same run
+# and the Apple job died in analysis having built nothing.
 #
-# @macos_sdk is reached even by jobs that target neither macOS nor iOS, because
-# @llvm//toolchain/args/macos:macos_sdk_sysroot is analyzed regardless of target
-# platform — so this is worth having on the Linux lanes too.
+# Repository fetches are client-side, so neither remote execution nor the
+# BuildBuddy action cache helps. @macos_sdk is reached even by jobs targeting
+# neither macOS nor iOS, because @llvm//toolchain/args/macos:macos_sdk_sysroot is
+# analyzed regardless of target platform — which is why a Linux lane can fail on
+# an Apple download.
 #
-# The cache is content-addressed by sha256, so a hit serves a pinned archive
-# without contacting its host at all: one successful fetch covers later runs
-# instead of re-rolling the dice. `restore-keys` carries most of the value —
-# an older cache still holds the same SDK entry when only MODULE.bazel moved.
+# WHY ONE FILE AND NOT THE WHOLE REPOSITORY CACHE. Caching every fetch works, and
+# costs 1.6 GB per lane; this repository already sits at 9.9 GB of GitHub's 10 GB
+# cache limit, so entries that size evict everyone else's caches and then get
+# evicted themselves. `path` therefore points at a single content-addressed entry
+# inside Bazel's repository cache: ~58 MB, shared by every lane through one key,
+# and the only fetch whose hosts are actually unreliable.
+#
+# Bazel verifies the sha256 from hermetic-llvm's own pin, so a restored (or
+# mirrored) file cannot substitute different content — a cache hit is exactly the
+# archive the pin demands, or the build fails.
 
 inputs:
-  key-prefix:
-    description: Cache key prefix, so lanes with different fetch sets stay separate.
+  macos-sdk-sha256:
+    description: >
+      sha256 of hermetic-llvm's pinned macOS SDK package, which is both the cache
+      key and its location inside Bazel's repository cache. Update on a
+      hermetic-llvm bump that moves the pin — a stale value only costs a miss,
+      never a wrong artifact.
     required: false
-    default: bazel-repo
+    default: edc7ce9b8f09e0c7a39aaa714f941b4c2597f333ec1ffe59a14d67eb36cdb7e7
   macos-sdk-mirror:
     description: >
-      Optional replacement download location for hermetic-llvm's pinned macOS SDK
-      package, as host+path with no scheme (Bazel adds https). Empty by default,
-      which changes nothing. Callers pass the MACOS_SDK_MIRROR repository variable,
-      so the mirror is turned on by setting that one variable — see the note below.
-      (No expression syntax in this description: an action manifest is evaluated as
-      a template, and `vars` does not exist in that context.)
+      Optional replacement download location for that package, as host+path with no
+      scheme (Bazel adds https). Empty by default, which changes nothing. Callers
+      pass the MACOS_SDK_MIRROR repository variable, so a mirror is turned on by
+      setting that one variable. (No expression syntax in this description: an
+      action manifest is evaluated as a template, and `vars` is not a context there.)
     required: false
     default: ""
 
 runs:
   using: composite
   steps:
-    - name: Restore the repository cache
+    # Scoped to the single content-addressed entry, which is also what gets saved
+    # at post — so a lane that fetches the SDK once publishes it for the rest.
+    # NOTE ON SCOPE: Actions caches are branch-scoped for reads. An entry saved on
+    # a pull request serves that PR only; the entry that protects everything is the
+    # one a master run saves.
+    - name: Restore the pinned macOS SDK
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
-        path: ~/.cache/bazel-repo
-        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelversion') }}
-        restore-keys: |
-          ${{ inputs.key-prefix }}-${{ runner.os }}-
+        path: ~/.cache/bazel-repo/content_addressable/sha256/${{ inputs.macos-sdk-sha256 }}
+        key: macos-sdk-${{ inputs.macos-sdk-sha256 }}
 
-    # .bazelrc try-imports this gitignored file, so one line here applies to
-    # every bazelisk invocation in the job — no per-command flag to forget.
-    - name: Point Bazel at the cached repository fetches
+    # .bazelrc try-imports this gitignored file, so one line here applies to every
+    # bazelisk invocation in the job — no per-command flag to forget.
+    - name: Point Bazel at the repository cache
       shell: bash
       run: |
         mkdir -p .context
         echo "common --repository_cache=$HOME/.cache/bazel-repo" >> .context/local.bazelrc
+        entry="$HOME/.cache/bazel-repo/content_addressable/sha256/${{ inputs.macos-sdk-sha256 }}/file"
+        if [ -f "$entry" ]; then
+          echo "macOS SDK served from cache ($(du -h "$entry" | cut -f1)) — no download needed."
+        else
+          echo "macOS SDK not cached; this job has to fetch it (see the action's notes)."
+        fi
 
-    # THE COLD-CACHE HOLE, and the one-variable switch that closes it.
-    #
-    # A cache hit needs a previous successful fetch, and right now neither host
-    # serving the pinned SDK is reliable: Apple's URL is gone for good and the
-    # Wayback mirror refuses Actions IP ranges. So a cold cache still fails.
-    #
-    # Bazel's downloader config rewrites a URL without touching anyone's pins —
-    # the sha256 in hermetic-llvm's MODULE.bazel still has to match, so a mirror
-    # cannot substitute different content. Set the repository variable
-    # MACOS_SDK_MIRROR to wherever the package is hosted (host+path, no scheme)
-    # and every lane picks it up; leave it unset and this is a no-op.
-    #
-    # Deliberately NOT a default pointing at some public mirror: that package is
-    # Apple's, and where it may be republished is a licensing decision for the
-    # repository owner, not something to hardcode here.
+    # The cold-cache hole, and the switch that closes it. Nothing is hardcoded to
+    # a default mirror on purpose: the package is Apple's, and where it may be
+    # republished is the repository owner's licensing call, not a CI detail.
     - name: Configure the macOS SDK mirror
       if: inputs.macos-sdk-mirror != ''
       shell: bash

--- a/.github/actions/bazel-repo-cache/action.yml
+++ b/.github/actions/bazel-repo-cache/action.yml
@@ -1,0 +1,46 @@
+name: Cache Bazel repository fetches
+description: >
+  Persist Bazel's content-addressed repository cache across runs, so pinned
+  external archives are not re-downloaded from the network on every job.
+
+# WHY THIS EXISTS. Repository fetches are client-side — remote execution and the
+# BuildBuddy action cache do nothing for them — so each job re-downloaded every
+# pinned archive, including hermetic-llvm's macOS SDK. That one comes from
+# Apple's CDN, whose pinned URL now returns 403, leaving only the
+# web.archive.org mirror hermetic-llvm lists beside it, which throttles Actions
+# IP ranges. On 2026-08-11 both refused within seconds of each other and the
+# Apple job failed in analysis having built nothing.
+#
+# @macos_sdk is reached even by jobs that target neither macOS nor iOS, because
+# @llvm//toolchain/args/macos:macos_sdk_sysroot is analyzed regardless of target
+# platform — so this is worth having on the Linux lanes too.
+#
+# The cache is content-addressed by sha256, so a hit serves a pinned archive
+# without contacting its host at all: one successful fetch covers later runs
+# instead of re-rolling the dice. `restore-keys` carries most of the value —
+# an older cache still holds the same SDK entry when only MODULE.bazel moved.
+
+inputs:
+  key-prefix:
+    description: Cache key prefix, so lanes with different fetch sets stay separate.
+    required: false
+    default: bazel-repo
+
+runs:
+  using: composite
+  steps:
+    - name: Restore the repository cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/bazel-repo
+        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'MODULE.bazel.lock', '.bazelversion') }}
+        restore-keys: |
+          ${{ inputs.key-prefix }}-${{ runner.os }}-
+
+    # .bazelrc try-imports this gitignored file, so one line here applies to
+    # every bazelisk invocation in the job — no per-command flag to forget.
+    - name: Point Bazel at the cached repository fetches
+      shell: bash
+      run: |
+        mkdir -p .context
+        echo "common --repository_cache=$HOME/.cache/bazel-repo" >> .context/local.bazelrc

--- a/.github/actions/bazel-repo-cache/action.yml
+++ b/.github/actions/bazel-repo-cache/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: Cache key prefix, so lanes with different fetch sets stay separate.
     required: false
     default: bazel-repo
+  macos-sdk-mirror:
+    description: >
+      Optional replacement download location for hermetic-llvm's pinned macOS SDK
+      package, as host+path with no scheme (Bazel adds https). Empty by default,
+      which changes nothing. Pass `${{ vars.MACOS_SDK_MIRROR }}` so the mirror can
+      be turned on by setting one repository variable — see the note below.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -44,3 +52,30 @@ runs:
       run: |
         mkdir -p .context
         echo "common --repository_cache=$HOME/.cache/bazel-repo" >> .context/local.bazelrc
+
+    # THE COLD-CACHE HOLE, and the one-variable switch that closes it.
+    #
+    # A cache hit needs a previous successful fetch, and right now neither host
+    # serving the pinned SDK is reliable: Apple's URL is gone for good and the
+    # Wayback mirror refuses Actions IP ranges. So a cold cache still fails.
+    #
+    # Bazel's downloader config rewrites a URL without touching anyone's pins —
+    # the sha256 in hermetic-llvm's MODULE.bazel still has to match, so a mirror
+    # cannot substitute different content. Set the repository variable
+    # MACOS_SDK_MIRROR to wherever the package is hosted (host+path, no scheme)
+    # and every lane picks it up; leave it unset and this is a no-op.
+    #
+    # Deliberately NOT a default pointing at some public mirror: that package is
+    # Apple's, and where it may be republished is a licensing decision for the
+    # repository owner, not something to hardcode here.
+    - name: Configure the macOS SDK mirror
+      if: inputs.macos-sdk-mirror != ''
+      shell: bash
+      run: |
+        cfg="$PWD/.context/downloader.cfg"
+        # Match the pinned package by name, whatever build-id path Apple used.
+        printf 'rewrite swcdn\\.apple\\.com/.*/CLTools_macOSNMOS_SDK\\.pkg %s\n' \
+          '${{ inputs.macos-sdk-mirror }}' > "$cfg"
+        echo "common --downloader_config=$cfg" >> .context/local.bazelrc
+        echo "macOS SDK downloads rewritten to: ${{ inputs.macos-sdk-mirror }}"
+        cat "$cfg"

--- a/.github/actions/bazel-repo-cache/action.yml
+++ b/.github/actions/bazel-repo-cache/action.yml
@@ -29,8 +29,10 @@ inputs:
     description: >
       Optional replacement download location for hermetic-llvm's pinned macOS SDK
       package, as host+path with no scheme (Bazel adds https). Empty by default,
-      which changes nothing. Pass `${{ vars.MACOS_SDK_MIRROR }}` so the mirror can
-      be turned on by setting one repository variable — see the note below.
+      which changes nothing. Callers pass the MACOS_SDK_MIRROR repository variable,
+      so the mirror is turned on by setting that one variable — see the note below.
+      (No expression syntax in this description: an action manifest is evaluated as
+      a template, and `vars` does not exist in that context.)
     required: false
     default: ""
 
@@ -71,11 +73,16 @@ runs:
     - name: Configure the macOS SDK mirror
       if: inputs.macos-sdk-mirror != ''
       shell: bash
+      # Via env, not interpolated into the script: an input reaching a shell
+      # command directly is the standard Actions injection shape, even when the
+      # value comes from a repository variable an admin set.
+      env:
+        MIRROR: ${{ inputs.macos-sdk-mirror }}
       run: |
         cfg="$PWD/.context/downloader.cfg"
         # Match the pinned package by name, whatever build-id path Apple used.
         printf 'rewrite swcdn\\.apple\\.com/.*/CLTools_macOSNMOS_SDK\\.pkg %s\n' \
-          '${{ inputs.macos-sdk-mirror }}' > "$cfg"
+          "$MIRROR" > "$cfg"
         echo "common --downloader_config=$cfg" >> .context/local.bazelrc
-        echo "macOS SDK downloads rewritten to: ${{ inputs.macos-sdk-mirror }}"
+        echo "macOS SDK downloads rewritten to: $MIRROR"
         cat "$cfg"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -129,6 +129,7 @@ jobs:
         uses: ./.github/actions/bazel-repo-cache
         with:
           key-prefix: bazel-repo-linux
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # .bazelrc try-imports this gitignored file; in CI it's materialized from
       # the secret. Absent secret (forks) → no :remote config → RBE steps skip.
@@ -415,6 +416,7 @@ jobs:
         uses: ./.github/actions/bazel-repo-cache
         with:
           key-prefix: bazel-repo-macos-metal
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Configure BuildBuddy remote config
         env:
@@ -545,6 +547,7 @@ jobs:
         uses: ./.github/actions/bazel-repo-cache
         with:
           key-prefix: bazel-repo-linux
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Configure BuildBuddy remote config
         env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -122,6 +122,14 @@ jobs:
       # r27 as a normal Bazel repository input (rules_android_ndk.patch +
       # XYBRID_NDK_URL/SHA256 in the committed .bazelrc).
 
+      # Keeps pinned archives — notably hermetic-llvm's macOS SDK, whose Apple
+      # CDN URL now 403s — out of the per-run network path. @macos_sdk is
+      # analyzed even here, where nothing targets Apple.
+      - name: Cache Bazel repository fetches
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          key-prefix: bazel-repo-linux
+
       # .bazelrc try-imports this gitignored file; in CI it's materialized from
       # the secret. Absent secret (forks) → no :remote config → RBE steps skip.
       - name: Configure BuildBuddy remote config
@@ -401,6 +409,13 @@ jobs:
           which cmake >/dev/null || brew install cmake
           which pkg-config >/dev/null || brew install pkg-config
 
+      # Keeps pinned archives — notably hermetic-llvm's macOS SDK, whose
+      # Apple CDN URL now 403s — out of the per-run network path.
+      - name: Cache Bazel repository fetches
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          key-prefix: bazel-repo-macos-metal
+
       - name: Configure BuildBuddy remote config
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -522,6 +537,14 @@ jobs:
             sudo ln -sfn "$INC/$tree" "/opt/xybrid-vulkan-include/$tree"
           done
           ls -l /opt/xybrid-vulkan-include
+
+      # Keeps pinned archives — notably hermetic-llvm's macOS SDK, whose Apple
+      # CDN URL now 403s — out of the per-run network path. Shares the linux
+      # lane's key prefix: same fetch set, so whichever runs first warms the other.
+      - name: Cache Bazel repository fetches
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          key-prefix: bazel-repo-linux
 
       - name: Configure BuildBuddy remote config
         env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -122,13 +122,11 @@ jobs:
       # r27 as a normal Bazel repository input (rules_android_ndk.patch +
       # XYBRID_NDK_URL/SHA256 in the committed .bazelrc).
 
-      # Keeps pinned archives — notably hermetic-llvm's macOS SDK, whose Apple
-      # CDN URL now 403s — out of the per-run network path. @macos_sdk is
-      # analyzed even here, where nothing targets Apple.
-      - name: Cache Bazel repository fetches
+      # Yes, on a Linux lane: @macos_sdk is analyzed regardless of target
+      # platform, and its Apple URL 403s permanently now — see the action.
+      - name: Cache the pinned macOS SDK
         uses: ./.github/actions/bazel-repo-cache
         with:
-          key-prefix: bazel-repo-linux
           macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # .bazelrc try-imports this gitignored file; in CI it's materialized from
@@ -410,12 +408,11 @@ jobs:
           which cmake >/dev/null || brew install cmake
           which pkg-config >/dev/null || brew install pkg-config
 
-      # Keeps pinned archives — notably hermetic-llvm's macOS SDK, whose
-      # Apple CDN URL now 403s — out of the per-run network path.
-      - name: Cache Bazel repository fetches
+      # Apple's pinned SDK URL 403s permanently now; this serves it from cache
+      # instead — see the action.
+      - name: Cache the pinned macOS SDK
         uses: ./.github/actions/bazel-repo-cache
         with:
-          key-prefix: bazel-repo-macos-metal
           macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Configure BuildBuddy remote config
@@ -540,13 +537,11 @@ jobs:
           done
           ls -l /opt/xybrid-vulkan-include
 
-      # Keeps pinned archives — notably hermetic-llvm's macOS SDK, whose Apple
-      # CDN URL now 403s — out of the per-run network path. Shares the linux
-      # lane's key prefix: same fetch set, so whichever runs first warms the other.
-      - name: Cache Bazel repository fetches
+      # One shared cache entry across every lane — see the action for why this
+      # download in particular needs it.
+      - name: Cache the pinned macOS SDK
         uses: ./.github/actions/bazel-repo-cache
         with:
-          key-prefix: bazel-repo-linux
           macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Configure BuildBuddy remote config

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -91,6 +91,7 @@ jobs:
         uses: ./.github/actions/bazel-repo-cache
         with:
           key-prefix: bazel-repo-apple
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Build XCFramework (Bazel)
         run: bazelisk build --config=ios //bindings/apple:XybridFFI

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -85,6 +85,13 @@ jobs:
           which pkg-config >/dev/null || brew install pkg-config
           which xz >/dev/null || brew install xz   # decodes the fetched sim ORT slice
 
+      # Without this the macOS SDK is re-fetched from Apple's CDN every run, and
+      # that pinned URL now 403s — see the action for the full failure mode.
+      - name: Cache Bazel repository fetches
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          key-prefix: bazel-repo-apple
+
       - name: Build XCFramework (Bazel)
         run: bazelisk build --config=ios //bindings/apple:XybridFFI
 

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -87,10 +87,9 @@ jobs:
 
       # Without this the macOS SDK is re-fetched from Apple's CDN every run, and
       # that pinned URL now 403s — see the action for the full failure mode.
-      - name: Cache Bazel repository fetches
+      - name: Cache the pinned macOS SDK
         uses: ./.github/actions/bazel-repo-cache
         with:
-          key-prefix: bazel-repo-apple
           macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Build XCFramework (Bazel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Published Linux binaries are unchanged and stay CPU-only: a Vulkan build
   requires a Vulkan loader on the machine that runs it, so it belongs in a
   separate artifact rather than in place of the default one.
+- **A warning when a GPU offload request cannot be honored.** `gpu_layers`
+  defaults to 99 and llama.cpp keeps every layer on the CPU when no GPU backend
+  was compiled in, so until now the only symptom of a CPU-only build on a
+  machine with an idle GPU was that inference ran slowly. Model load now logs
+  this once, pointing at the platform's GPU build options.
+
+### Fixed
+
+- **The READMEs claimed CUDA acceleration on Linux and Windows, which no build
+  provides.** `GGML_CUDA` is `OFF` on every target in both the cargo and Bazel
+  paths, `llm-mistral-cuda` is a marker feature whose backing crate is commented
+  out of the workspace, and Candle — the one component with a real CUDA path —
+  was retired from the platform presets. The hardware-acceleration table now
+  reads CPU for Linux (with Vulkan as a build-time opt-in) and CPU for Windows,
+  in all three translations.
 
 ### Changed
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -395,7 +395,7 @@ claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
 | 埋め込み | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | マルチモデルパイプライン（MMP） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | モデルのダウンロードとキャッシュ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| ハードウェアアクセラレーション | Metal, ANE | CPU | Metal, ANE | CUDA, Vulkan | CUDA |
+| ハードウェアアクセラレーション | Metal, ANE | CPU | Metal, ANE | CPU、オプトインのVulkan | CPU |
 
 **SDK MMP サポート:** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
@@ -407,7 +407,7 @@ claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
 - **オフライン対応** — 初回のモデルダウンロード後はインターネット不要。
 - **クロスプラットフォーム** — iOS、Android、macOS、Linux、Windowsで統一されたAPI。
 - **マルチモデルパイプライン（MMP）** — モデルを連鎖（ASR → LLM → TTS）して1回の呼び出しで実行。
-- **ハードウェアアクセラレーション** — Apple Neural Engine、Metal、CUDAに加え、Linux向けllama.cppビルドではVulkanをオプトイン可能。
+- **ハードウェアアクセラレーション** — Appleプラットフォームでは Apple Neural Engine と Metal、Linux向けllama.cppビルドでは Vulkan をオプトイン可能。Android と Windows は現時点ではCPU実行で、配布済みのLinuxバイナリもCPUのみ（Vulkanはビルド時のオプトイン — [インストール](docs/INSTALLATION.md#platform-features) を参照）。
 
 ### 比較
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 | Embeddings | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | Multi-Model Pipelines (MMP) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Model Download & Caching | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Hardware Acceleration | Metal, ANE | CPU | Metal, ANE | CUDA, Vulkan | CUDA |
+| Hardware Acceleration | Metal, ANE | CPU | Metal, ANE | CPU, opt-in Vulkan | CPU |
 
 **SDK MMP support:** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
@@ -430,7 +430,7 @@ CLI today (`xybrid repl` ships built-in `web_search` + your own via
 - **Offline capable** — No internet required after initial model download.
 - **Cross-platform** — One API across iOS, Android, macOS, Linux, and Windows.
 - **Multi-model pipelines (MMP)** — Chain models together (ASR → LLM → TTS) in a single call.
-- **Hardware acceleration** — Apple Neural Engine, Metal, CUDA, plus opt-in Vulkan for Linux llama.cpp builds.
+- **Hardware acceleration** — Apple Neural Engine and Metal on Apple platforms; opt-in Vulkan for Linux llama.cpp builds. Android and Windows run on CPU today, and prebuilt Linux binaries are CPU-only (Vulkan is a build-time opt-in — see [installation](docs/INSTALLATION.md#platform-features)).
 
 ### How it compares
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -396,7 +396,7 @@ Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚�
 | 嵌入模型 | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | 多模型流水线（MMP） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 模型下载与缓存 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 硬件加速 | Metal, ANE | CPU | Metal, ANE | CUDA, Vulkan | CUDA |
+| 硬件加速 | Metal, ANE | CPU | Metal, ANE | CPU，可选 Vulkan | CPU |
 
 **SDK MMP 支持：** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
@@ -408,7 +408,7 @@ Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚�
 - **离线可用** — 初次模型下载后无需互联网。
 - **跨平台** — iOS、Android、macOS、Linux 和 Windows 使用统一的 API。
 - **多模型流水线（MMP）** — 在单次调用中链接多个模型（ASR → LLM → TTS）。
-- **硬件加速** — 支持 Apple Neural Engine、Metal、CUDA，以及 Linux llama.cpp 构建可选的 Vulkan。
+- **硬件加速** — Apple 平台支持 Apple Neural Engine 与 Metal；Linux 的 llama.cpp 构建可选启用 Vulkan。Android 与 Windows 目前使用 CPU，预编译的 Linux 二进制也仅为 CPU（Vulkan 需在构建时启用 — 参见[安装说明](docs/INSTALLATION.md#platform-features)）。
 
 ### 与其他方案对比
 

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -34,7 +34,8 @@ pub use xybrid_llama::{
 };
 
 use crate::runtime_adapter::llm::{
-    ChatMessage, GenerationConfig, GenerationOutput, LlmBackend, LlmConfig, LlmResult, PartialToken,
+    local_execution_provider, ChatMessage, GenerationConfig, GenerationOutput, LlmBackend,
+    LlmConfig, LlmResult, PartialToken,
 };
 use crate::runtime_adapter::llm_telemetry::{StreamingTelemetry, StreamingTelemetryFields};
 use crate::runtime_adapter::streaming_postprocess::{
@@ -680,6 +681,37 @@ fn text_tokens_without_terminal_eog(output_tokens: &[i32], ended_on_eog: bool) -
     }
 }
 
+/// Whether a GPU offload request cannot be honored by this build at all.
+///
+/// `gpu_layers` defaults to 99 (`types::default_gpu_layers`) and llama.cpp
+/// keeps every layer on the CPU when no GPU backend was compiled in, so an
+/// honored request and an impossible one look identical from the outside.
+fn gpu_layers_are_a_no_op(gpu_layers: i32) -> bool {
+    gpu_layers > 0 && local_execution_provider("llama-cpp") == "cpu"
+}
+
+/// Say once, at load, that a GPU offload request will not happen.
+///
+/// The silence is the bug this exists to fix: without it the only symptom of a
+/// CPU-only build on a machine with an idle GPU is that inference is slow.
+/// Once per process, not per load — the answer is fixed at compile time.
+fn warn_if_gpu_layers_are_a_no_op(gpu_layers: i32) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+
+    if !gpu_layers_are_a_no_op(gpu_layers) {
+        return;
+    }
+
+    WARNED.call_once(|| {
+        log::warn!(
+            target: "xybrid_core",
+            "gpu_layers={gpu_layers} requested, but this build has no llama.cpp GPU backend \
+             compiled in — every layer runs on the CPU. See docs/INSTALLATION.md for the GPU \
+             build options on this platform."
+        );
+    });
+}
+
 fn generation_would_overflow_context(
     prefix_len: usize,
     prompt_tokens: usize,
@@ -789,6 +821,8 @@ impl LlmBackend for LlamaCppBackend {
 
             gguf_files[0].path().to_string_lossy().to_string()
         };
+
+        warn_if_gpu_layers_are_a_no_op(config.gpu_layers);
 
         // Load model
         let model = xybrid_llama::LlamaModel::load(&gguf_path, config.gpu_layers).map_err(|e| {
@@ -1678,6 +1712,22 @@ mod tests {
         assert_eq!(text_tokens_without_terminal_eog(&tokens, false), &[1, 2, 3]);
         let empty: [i32; 0] = [];
         assert_eq!(text_tokens_without_terminal_eog(&empty, false), &empty[..]);
+    }
+
+    #[test]
+    fn no_gpu_offload_request_is_never_a_no_op() {
+        // Nothing was asked for, so there is nothing to warn about — whatever
+        // backend this build has.
+        assert!(!gpu_layers_are_a_no_op(0));
+        assert!(!gpu_layers_are_a_no_op(-1));
+    }
+
+    #[test]
+    fn gpu_offload_request_is_a_no_op_exactly_when_the_build_is_cpu_only() {
+        // Tracks the build, not a hardcoded expectation: on a Metal or Vulkan
+        // build the request is honored, on a CPU-only one it is not.
+        let cpu_only = local_execution_provider("llama-cpp") == "cpu";
+        assert_eq!(gpu_layers_are_a_no_op(99), cpu_only);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This pull request fixes two halves of the same problem: the project advertised GPU acceleration it never builds, and gave no signal at runtime when a GPU request could not be honored. Both are the same failure mode as the one #307 and #482 were about — a machine with an idle GPU running slowly, with nothing anywhere saying why.

**Documentation Corrections:**

* Corrected the hardware-acceleration row in all three READMEs, which listed **CUDA** for Linux and Windows. Nothing in the project builds it: `GGML_CUDA` is `OFF` on every target in both the cargo and Bazel paths, `llm-mistral-cuda` is a marker feature whose backing crate is commented out of the workspace, and Candle — the one component with a real CUDA path — was retired from the platform presets in #476. The row now reads CPU for Windows and CPU with an opt-in Vulkan for Linux.
* Updated the feature bullet in each README to say that prebuilt Linux binaries are CPU-only and Vulkan is a build-time opt-in, linking to the installation docs, rather than implying the published binaries are accelerated.

**Runtime Diagnostics:**

* Model load now warns once when a GPU offload request cannot be honored. `gpu_layers` defaults to 99, and llama.cpp silently keeps every layer on the CPU when no GPU backend was compiled in — so an honored request and an impossible one were indistinguishable from the outside, and slow inference was the only symptom. The warning names the requested value and points at the platform's GPU build options.
* Split the check as a testable predicate (`gpu_layers_are_a_no_op`) rather than inlining it, so the two new tests assert against what the build actually is instead of hardcoding an expectation — on an Apple build they confirm a Metal build *does* honor the request, and on a CPU-only build they confirm it does not.

**Impact:**

* No behavior change beyond one log line; no public API change. The warning fires once per process, since the answer is fixed at compile time.
* Nothing here ships Vulkan to users — published Linux binaries remain CPU-only, which is now what the docs say. Whether to publish a separate Vulkan release asset is still an open decision.

## Type of Change

- [x] Bug fix
- [x] Documentation

## Checklist

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p xybrid-core --features llm-llamacpp --all-targets` clean
- [x] Both new tests pass (`cargo test -p xybrid-core --features llm-llamacpp --lib -- gpu_offload`)
- [x] Documentation updated (three READMEs + `CHANGELOG.md`)
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and docs changes are isolated; runtime adds only a diagnostic log with no API or inference behavior change beyond visibility.
> 
> **Overview**
> Adds a **composite GitHub Action** (`.github/actions/bazel-repo-cache`) that restores a single sha256-keyed entry for hermetic-llvm’s pinned **macOS SDK** in Bazel’s repository cache, wires `--repository_cache` via `.context/local.bazelrc`, and optionally rewrites Apple CDN downloads through **`vars.MACOS_SDK_MIRROR`**. That step is hooked into the main **Linux Bazel** job, **macOS Metal**, **Linux Vulkan**, and **`build-apple`** workflows so analysis no longer depends on Apple 403s or throttled mirrors.
> 
> **Documentation** in all three READMEs and **`CHANGELOG.md`** stops claiming **CUDA** on Linux/Windows; tables and bullets now say **CPU** (Linux **opt-in Vulkan** only) and that published Linux binaries stay CPU-only.
> 
> **Runtime:** on llama.cpp model load, when `gpu_layers > 0` but the build’s `local_execution_provider` is CPU-only, the core logs a **once-per-process** warning pointing at GPU build options; small unit tests cover the predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca9b0f4b7486e82b5011ec22750ce4c432d037e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->