### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.5.0] - 2026-08-11
+
+Speech recognition moves off Candle and onto whisper.cpp, running on the same
+ggml that llama.cpp already links — 3.6x faster to a first partial on a Pixel 8
+for 0.2 MiB of binary, and the first time Linux and Windows have local Whisper
+at all. Candle is retired from all four platform presets as a result; the
+features remain opt-in, so this removes a default, not a capability. Live
+streaming ASR lands on Flutter with warm-up windowing and a span-reconciled
+transcript, every binding gains the speculative-cloud surface that 0.4.1 shipped
+Rust-only, all bindings move to BoltFFI 0.29.3 (the Python SDK is now generated
+rather than hand-ported), and desktop Linux gets an opt-in Vulkan build of
+llama.cpp.
+
+**Upgrade notes.** Registry model id `whisper-tiny` resolves to a
+SafeTensors/Candle bundle and no longer runs on a default build — use
+`whisper-tiny-ggml`, a multilingual Q5_1 GGML bundle served as its own id, or
+build with `--features candle`. The Python SDK now requires **Python >= 3.10**
+and ships one wheel per interpreter ABI.
+
 ### Added
 
+- **whisper.cpp speech recognition on the shared ggml.** A three-layer stack
+  mirroring the llama.cpp one — `crates/whisper-cpp-sys` (raw FFI, compiled
+  with `cc` against llama's ggml headers, never whisper's bundled copy),
+  `crates/xybrid-whisper` (safe RAII handle, no `unsafe` on the public surface),
+  and a `WhisperCppRuntime` in core behind `ExecutionTemplate::GgmlWhisper`.
+  Measured on a Pixel 8 (5 s window, tiny.en Q5_1, 4 threads): 744 ms against
+  ~3.5 s for the Candle path. Note the container: whisper.cpp verifies
+  `GGML_FILE_MAGIC` and never moved to GGUF, so these are `ggml-*.bin` files
+  (#462).
+- **whisper.cpp is built by Bazel and enabled in every platform preset.**
+  `//:whisper` is a plain `cc_library` on `//:llama` rather than a second
+  `cmake()` target, so "exactly one ggml" is a property of the build graph and
+  CI fails if that stops being true. Cost on the stripped cdylib: +0.2 MiB
+  (#465).
+- **Live streaming ASR on Flutter**, with the rolling-window streaming API
+  bound through `flutter_rust_bridge` and a demo screen in the example app
+  (#453).
+- **Warm-up windows and a span-reconciled transcript for live streaming.** The
+  first chunks use growing windows (1.5 s, 3 s) instead of waiting for a full
+  5 s one, landing the first partial ~3.5 s sooner, and the accumulator tracks
+  the audio span each segment covers so overlapping windows replace rather than
+  repeat earlier text (#458).
+- **An `audio_ctx` streaming override**, threaded through core `StreamConfig`,
+  the SDK builder, and the Flutter binding, so a caller can trim the Whisper
+  encoder window without repackaging the model bundle. `None` keeps the bundle
+  default (#481).
+- **Speculative cloud, download progress, and result provenance on every
+  binding.** `ExecutionProvenance` on `InferenceResult` tells a device answer
+  from a gateway answer, `DownloadState`/`DownloadStatus` plus
+  `download_status`/`await_download`/`is_cloud_serving` expose the background
+  download, and `set_speculative_cloud` / `from_registry_speculative` /
+  `set_platform_url` reach Swift, Kotlin, Unity C#, Python, React Native, and
+  Dart. Progress is polled everywhere except Flutter, which gets a push
+  `StreamSink`: FRB sinks are safe, while boltffi's inline-closure return ABI
+  is not, so no closure crosses that boundary (#459).
 - **llama.cpp Vulkan builds for desktop Linux**: consumers can now set
   `XYBRID_LLAMA_CPP_VULKAN=1` when building `platform-desktop` to compile the
   bundled backend with `GGML_VULKAN=ON`; local LLM telemetry reports `vulkan`
@@ -28,9 +88,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Published Linux binaries are unchanged and stay CPU-only: a Vulkan build
   requires a Vulkan loader on the machine that runs it, so it belongs in a
   separate artifact rather than in place of the default one.
+- **A Device Logs guide** — where SDK logs land per platform (logcat tag
+  `xybrid`, unified-log subsystem `dev.xybrid.sdk`, host-registered logger on
+  desktop), the commands to read them, and what the telemetry-export and
+  registry-failover warnings look like (#457).
 
 ### Changed
 
+- **Candle is retired from all four platform presets.** whisper.cpp supersedes
+  it for ASR at a fraction of the cost — measured on the stripped cdylib,
+  Candle is 1.3–1.9 MiB against whisper.cpp's 0.2 MiB, 6.5–9.5x its
+  replacement — and Whisper was its only live model here. The `candle*`
+  features stay declared and buildable as an opt-in. Consequence for callers:
+  the registry id `whisper-tiny` (a SafeTensors bundle) no longer loads on a
+  default build, and fails with a message naming both the feature and the GGML
+  alternative rather than a bare `Runtime 'candle' not configured`. The demos
+  and examples point at `whisper-tiny-ggml` (#476).
+- **whisper.cpp transcription is hardened**, with three user-visible changes:
+  bracketed non-speech annotations such as `[BLANK_AUDIO]` are suppressed
+  rather than emitted as transcript text (a caller-facing opt-out is tracked in
+  #483); timestamp tokens are decoded for audio longer than 30 seconds, so a
+  padded final window no longer repeats text past the end of the real audio;
+  and unsupported `prompt` metadata returns `InvalidInput` instead of being
+  silently ignored, without echoing the prompt back. Twelve real-model
+  regression cases move off Candle onto a checksum-pinned multilingual GGML
+  model, covering WER, window boundaries, 66-second input, per-request language
+  and translation, and the two behaviours above (#484).
+- **Streaming sessions share the model's loaded executor.** Each session used
+  to build its own, reloading whisper weights from disk on every open (~2.5 s),
+  and then ran a full silent warm-up inference even when the weights were
+  already resident. `ModelHandle.executor` is now shared, `ModelRuntime` gained
+  `is_loaded`, and the warm-up returns early when the executor is already warm,
+  so second and later sessions open with no hidden compute. Unloading mid-stream
+  swaps in a fresh executor rather than pulling weights out from under a running
+  transcription (#461, #464).
 - **BoltFFI 0.25.3 → 0.29.3.** Every exported C symbol is renamed
   (`boltffi_set_api_key` → `boltffi_function_xybrid_bolt_set_api_key`), so all
   generated bindings — Swift, Kotlin, Unity C#, Python — were regenerated
@@ -49,9 +140,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distribution**: 0.29's Python target compiles a CPython extension rather than
   emitting ctypes, so the SDK requires **Python >= 3.10** and ships one wheel
   per interpreter ABI instead of a single `py3-none` wheel.
+- **Docs corrected for the Candle retirement.** Preset tables, platform
+  rationales, and every runnable example that named the now-unloadable
+  `whisper-tiny`; the `candle` feature-reference rows stay and now say
+  explicitly that they are opt-in. Also fills gaps that predate the change:
+  `asr-whispercpp` and `ExecutionTemplate::GgmlWhisper` were absent from these
+  docs despite shipping in every preset, telemetry's `backend` enum lacked
+  `whispercpp`, and the feature matrix claimed every preset is text-only when
+  they have carried the llama.cpp vision path for far longer (#479).
 
 ### Fixed
 
+- **A gateway request with no model no longer silently runs OpenAI.** Both
+  request builders fell back to `gpt-4o-mini`, so a caller who forgot to set a
+  model paid for a third-party provider and saw the resulting failure as an
+  opaque gateway 502 rather than a client bug. It is now an `InvalidInput`
+  error. The per-provider defaults stay, since there the caller has already
+  chosen the provider (#463).
+- **Swift and Kotlin SDKs register a native log sink.** `xybrid-bolt` never
+  registered a log backend, so every `log::warn!` in the SDK — telemetry send
+  failures, registry failovers — was discarded on those two SDKs, the same hole
+  #448 closed for Flutter (#452).
+- **The cargo-built CLI had no whisper.cpp on any platform.** Its manifest
+  re-listed its own backend sets instead of forwarding to the SDK presets, so
+  `asr-whispercpp` never reached it and only the Bazel-built CLI had ASR. It
+  now forwards, removing the drift class rather than this instance of it
+  (#476).
+- **`asr-whispercpp` is advertised in the registry client's backend list.** It
+  was missing from `ALL_FEATURES`, so the `backends=` header under-reported the
+  backend set for as long as the backend had existed (#476).
+- **Cross-compiling whisper.cpp gave bindgen the wrong sysroot.** A cargo
+  Android build — which is what cargokit does for Flutter — died on
+  `ggml.h:214:10: fatal error: 'stdio.h' file not found`, because libclang
+  resolves headers against the host sysroot. `xybrid-llama-sys` now emits
+  `cargo:ndk=<path>` and the whisper crate consumes it, keeping one
+  NDK-resolution implementation in the workspace; the Apple `-isysroot` and
+  simulator-triple handling come along in the same helper. CI missed it because
+  every Android lane goes through Bazel, which compiles committed bindings and
+  never runs bindgen (#468).
 - **`gen_python_bolt.py` no longer deletes the staged native artifacts.** It
   pruned every file it had not generated, so regenerating removed the compiled
   bridge and the cdylib beside it and broke `import xybrid`.
@@ -59,10 +185,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cdylib comes from the wheel `boltffi pack python` builds, so features are now
   forwarded to that build (`--cargo-arg`) instead of only to a separate
   `cargo build` whose output was discarded.
-
-### Planned
-
-- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+- **Three workflows no longer fail in every fork.** Unity Editor CI, the
+  Bazel Windows Flutter DLL smoke, and the weekly Build Natives cron each
+  assumed a non-`pull_request` event implies secrets are present, which is
+  false for a contributor syncing their fork's master and for inherited crons.
+  None of them gated anything here, but they buried real failures in forks
+  under noise a contributor cannot fix (#480).
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -425,7 +425,7 @@ dependencies = [
  "num-traits",
  "pastey 0.1.1",
  "rayon",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "v_frame",
  "y4m",
 ]
@@ -485,6 +485,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "basic-cookies"
@@ -729,13 +735,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -858,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -954,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -964,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1093,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "percent-encoding",
  "time",
@@ -1704,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fixedbitset"
@@ -1817,9 +1823,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1832,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1842,15 +1848,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1859,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1878,32 +1884,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2306,8 +2312,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
- "ureq 3.3.0",
+ "thiserror 2.0.20",
+ "ureq 3.4.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2746,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2859,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3166,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.22.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef84a52be188a1d4124bd717903fdde96ca4705f2b56adfe2d91fcc57fcb6987"
+checksum = "42d74234349a775546a83af0f0c0c0e3a73227dee4950a542cda81a47240b3e6"
 dependencies = [
  "memo-map",
  "serde",
@@ -3176,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.22.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6e279dc925840c2d9ebc1e9f85410611d01292561297463ba3e516c3ad94dd"
+checksum = "35c96d8fae7fa4743bbcf06f486ff43f81837f5e8826f8bf525dbc4c0e03be5d"
 dependencies = [
  "minijinja",
  "serde",
@@ -3656,7 +3662,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq 3.3.0",
+ "ureq 3.4.0",
 ]
 
 [[package]]
@@ -3667,7 +3673,7 @@ checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq 3.3.0",
+ "ureq 3.4.0",
 ]
 
 [[package]]
@@ -3900,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -4096,7 +4102,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4118,7 +4124,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4254,7 +4260,7 @@ dependencies = [
  "rand 0.9.5",
  "rand_chacha",
  "simd_helpers",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -4363,7 +4369,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5051,11 +5057,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5071,9 +5077,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5224,7 +5230,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -5613,11 +5619,11 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "cookie_store",
  "flate2",
  "log",
@@ -5634,11 +5640,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http 1.5.0",
  "httparse",
  "log",
@@ -5752,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5765,9 +5771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5775,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5785,9 +5791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5798,9 +5804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5820,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6218,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6232,14 +6238,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6268,7 +6274,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6337,7 +6343,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -6347,7 +6353,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6356,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6365,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6374,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6400,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-whisper"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6409,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-whisper-sys"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6418,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_bolt"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "android_logger",
  "boltffi",
@@ -6430,7 +6436,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",
@@ -6509,18 +6515,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6682,9 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.5.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "38642071c99779a96e26a6c4add471761c0bdacb7820440cffc201845c3157fd"
+let xybridFFIChecksum = "59b9d73dc2436d376399222dde6c1ea3855d24f6d0c8e020504ef5108baf700e"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.4.1"
+let sdkVersion = "0.5.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.5.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "dd434383f90b2b8825a2cfbc24f18bad203e0e9cdbf3c4bc7ed504f4c66d694f"
+let xybridFFIChecksum = "86e7c6bbe26b3d3605e10cfa5733417bf5eb03ce5822cd649196be761ce01c72"
 
 let package = Package(
     name: "Xybrid",

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.5.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "59b9d73dc2436d376399222dde6c1ea3855d24f6d0c8e020504ef5108baf700e"
+let xybridFFIChecksum = "dd434383f90b2b8825a2cfbc24f18bad203e0e9cdbf3c4bc7ed504f4c66d694f"
 
 let package = Package(
     name: "Xybrid",

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 **モデルを実行:**
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.5.0")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.4.1"
+xybrid = "0.5.0"
 ```
 
 **モデルを実行:**

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 **Run a model:**
@@ -159,7 +159,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 
@@ -177,7 +177,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.5.0")
 ]
 ```
 
@@ -216,7 +216,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.4.1"
+xybrid = "0.5.0"
 ```
 
 **Run a model:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 **运行模型：**
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.5.0")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.4.1"
+xybrid = "0.5.0"
 ```
 
 **运行模型：**

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -12,14 +12,14 @@ Add Xybrid to your Xcode project:
 
 1. In Xcode, select **File > Add Package Dependencies...**
 2. Enter: `https://github.com/xybrid-ai/xybrid`
-3. Set **Dependency Rule** to **Up to Next Major Version** → `0.4.1`
+3. Set **Dependency Rule** to **Up to Next Major Version** → `0.5.0`
 4. Select the **Xybrid** library product
 
 Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
 ]
 ```
 

--- a/bindings/apple/XybridFFI-Info.plist
+++ b/bindings/apple/XybridFFI-Info.plist
@@ -7,8 +7,8 @@
 	     CFBundlePackageType) on top of these; only the version keys must be
 	     supplied. This is the embedded static framework's Info.plist. -->
 	<key>CFBundleVersion</key>
-	<string>0.4.1</string>
+	<string>0.5.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.1</string>
+	<string>0.5.0</string>
 </dict>
 </plist>

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.5.0
+
+Live streaming speech recognition, now on the whisper.cpp backend, plus the
+speculative-cloud surface.
+
+* Added: live streaming ASR — `XybridStreamSession` with a rolling window over
+  fed audio, partial and final transcript events, and a demo screen in the
+  example app (xybrid-ai/xybrid#453)
+* Added: `XybridStreamSession.fromModel(..., audioCtx:)`, an optional Whisper
+  encoder-context override in mel frames. `null` keeps the model bundle's
+  default (xybrid-ai/xybrid#481)
+* Added: speculative cloud fallback and download visibility —
+  `fromRegistrySpeculative`, `willSpeculate`, `isCloudServing`,
+  `downloadStatus`, `downloadProgress` (a push `StreamSink` of load events),
+  `setPlatformUrl`, and `setSpeculativeCloud`. Results carry
+  `executionTarget`, so a device answer is distinguishable from a gateway one;
+  a pipeline reports its final stage's target (xybrid-ai/xybrid#459)
+* Changed: ASR runs on whisper.cpp rather than Candle — 3.6x faster to a first
+  partial on a Pixel 8, and the first partial itself arrives ~3.5 s sooner
+  thanks to warm-up windowing. **The registry id `whisper-tiny` no longer
+  loads**; use `whisper-tiny-ggml` (xybrid-ai/xybrid#462, xybrid-ai/xybrid#465,
+  xybrid-ai/xybrid#476, xybrid-ai/xybrid#458)
+* Changed: transcripts no longer contain bracketed non-speech annotations such
+  as `[BLANK_AUDIO]`, audio longer than 30 seconds no longer repeats text past
+  its end, and unsupported `prompt` metadata now returns an input error instead
+  of being ignored (xybrid-ai/xybrid#484)
+* Fixed: building the example for Android from source failed in
+  `xybrid-whisper-sys` with `'stdio.h' file not found`; bindgen now gets the
+  NDK sysroot (xybrid-ai/xybrid#468)
+
 ## 0.4.1
 
 No Dart API changes. Fixes to the iOS build and to diagnostics on both mobile

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -15,7 +15,7 @@ Or add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 <details>

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.4.1"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.5.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -12,7 +12,7 @@ Add to your `build.gradle.kts`:
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.4.1"
+version = "0.5.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xybrid"
-version = "0.4.1"
+version = "0.5.0"
 description = "Python SDK for local-first xybrid inference"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/xybrid/_bolt/__init__.py
+++ b/bindings/python/xybrid/_bolt/__init__.py
@@ -1943,7 +1943,7 @@ def telemetry_shutdown() -> None:
 
 MODULE_NAME = "xybrid_bolt"
 PACKAGE_NAME = "xybrid_bolt"
-PACKAGE_VERSION = "0.4.1"
+PACKAGE_VERSION = "0.5.0"
 
 __all__ = [
     "MODULE_NAME",

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.4.1"
+  implementation "ai.xybrid:xybrid-kotlin:0.5.0"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -42,7 +42,7 @@ Or edit `Packages/manifest.json` directly:
     }
   ],
   "dependencies": {
-    "ai.xybrid.sdk": "0.4.1"
+    "ai.xybrid.sdk": "0.5.0"
   }
 }
 ```
@@ -59,7 +59,7 @@ https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 Pin a version by appending a tag:
 
 ```
-https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.4.1
+https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.5.0
 ```
 
 (**Window → Package Manager → + → Add package from git URL**, or add it under

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/web/README.md
+++ b/bindings/web/README.md
@@ -1,6 +1,6 @@
 # @xybrid/web preview
 
-`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.4.1` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
+`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.5.0` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
 
 ## Supported now
 

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xybrid/web",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Preview browser tensor runtime for Xybrid metadata backed by LiteRT.",

--- a/crates/whisper-cpp-sys/Cargo.toml
+++ b/crates/whisper-cpp-sys/Cargo.toml
@@ -39,7 +39,7 @@ committed-bindings = ["bindings"]
 # "exactly one ggml" invariant enforceable: `links = "llama"` metadata tells
 # us where that ggml's headers and archives are, so whisper.cpp compiles and
 # links against them instead of configuring its own bundled copy.
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.1" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.5.0" }
 
 [build-dependencies]
 # whisper.cpp's library is ONE translation unit (`src/whisper.cpp`) whose only

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,11 +25,11 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.1", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.4.1", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.5.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.5.0", optional = true }
 # Safe whisper.cpp wrappers. Gated behind `asr-whispercpp`, which also pulls
 # `llm-llamacpp` — that is where the shared ggml comes from.
-xybrid-whisper = { path = "../xybrid-whisper", version = "0.4.1", optional = true }
+xybrid-whisper = { path = "../xybrid-whisper", version = "0.5.0", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.4.1" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.5.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.4.1", path = "../../macros" }
+xybrid-macros = { version = "0.5.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.4.1", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.5.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.4.1", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.5.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid-whisper/Cargo.toml
+++ b/crates/xybrid-whisper/Cargo.toml
@@ -20,6 +20,6 @@ default = []
 bindings = ["xybrid-whisper-sys/bindings"]
 
 [dependencies]
-xybrid-whisper-sys = { path = "../whisper-cpp-sys", version = "0.4.1" }
+xybrid-whisper-sys = { path = "../whisper-cpp-sys", version = "0.5.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.4.1", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.5.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -11,7 +11,7 @@ Add the Xybrid SDK from Maven Central:
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -11,7 +11,7 @@ Android SDK 通过 BoltFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支�
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/flutter.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.mdx
@@ -11,7 +11,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 ## Initialization

--- a/docs/content/docs/(integration)/sdks/flutter.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.zh.mdx
@@ -11,7 +11,7 @@ Flutter SDK（`xybrid_flutter`）通过 FFI 提供到 Xybrid Rust 核心的 Dart
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 ## 初始化

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -15,7 +15,7 @@ Add the Xybrid package via Swift Package Manager:
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -15,7 +15,7 @@ Swift SDK 处于早期访问阶段。正式版本通过 Swift Package Manager �
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/web.mdx
+++ b/docs/content/docs/(integration)/sdks/web.mdx
@@ -6,7 +6,7 @@ description: Browser SDK preview for on-device ML inference with WebAssembly and
 The Web SDK (`@xybrid/web`) runs Xybrid models directly in the browser. It has two surfaces: a tensor surface (`XybridModel`) for TfLite models and a text-generation surface (`XybridLlm`) for `.litertlm` language models. Inference executes locally through WebAssembly, with WebGPU acceleration when available — no server round-trip.
 
 <Callout type="info">
-`@xybrid/web` `0.4.1` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
+`@xybrid/web` `0.5.0` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
 </Callout>
 
 ## Try the Demo

--- a/docs/content/docs/(integration)/sdks/web.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/web.zh.mdx
@@ -6,7 +6,7 @@ description: 基于 WebAssembly 与 WebGPU 的浏览器端设备内 ML 推理 SD
 Web SDK（`@xybrid/web`）让 Xybrid 模型直接在浏览器中运行。它包含两个界面：用于 TfLite 模型的张量界面（`XybridModel`），以及用于 `.litertlm` 语言模型的文本生成界面（`XybridLlm`）。推理通过 WebAssembly 在本地执行，在可用时使用 WebGPU 加速——无需服务器往返。
 
 <Callout type="info">
-`@xybrid/web` `0.4.1` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
+`@xybrid/web` `0.5.0` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
 </Callout>
 
 ## 体验示例

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Get Xybrid running in your app with a few lines of code. Choose your SDK below.
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 ```bash
@@ -54,7 +54,7 @@ Or add to `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
 ]
 ```
 
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 
@@ -119,7 +119,7 @@ In Unity, go to **Window > Package Manager > + > Add package from git URL** and 
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.4.1` to the git URL.
+Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.5.0` to the git URL.
 
 **Run inference**
 
@@ -191,7 +191,7 @@ See the [Web SDK guide](/docs/sdks/web) for the tensor surface, registry loading
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.4.1"
+xybrid = "0.5.0"
 ```
 
 **Run inference**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -12,7 +12,7 @@ description: 几分钟内开始使用 Xybrid
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.4.1
+  xybrid_flutter: ^0.5.0
 ```
 
 ```bash
@@ -54,7 +54,7 @@ https://github.com/xybrid-ai/xybrid
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.4.1")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
 ]
 ```
 
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.4.1")
+    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
 }
 ```
 
@@ -119,7 +119,7 @@ val result = model.runAsync(envelope)
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.4.1`。
+或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.5.0`。
 
 **运行推理**
 
@@ -190,7 +190,7 @@ const llm = await XybridLlm.fromHuggingFace("litert-community/SmolLM2-135M-Instr
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.4.1"
+xybrid = "0.5.0"
 ```
 
 **运行推理**

--- a/docs/telemetry/registry.md
+++ b/docs/telemetry/registry.md
@@ -37,7 +37,7 @@ The command exits 0 in both cases — it is a status report, not an error.
 The header is a single line, semicolon-separated:
 
 ```
-X-Xybrid-Client: binding=flutter; sdk_version=0.4.1; core_version=0.4.1; platform=ios-arm64; backends=asr-whispercpp,llm-llamacpp,llm-llamacpp-vision,ort-coreml,ort-download,vision
+X-Xybrid-Client: binding=flutter; sdk_version=0.5.0; core_version=0.5.0; platform=ios-arm64; backends=asr-whispercpp,llm-llamacpp,llm-llamacpp-vision,ort-coreml,ort-download,vision
 ```
 
 | Field | Type | Description |


### PR DESCRIPTION
Release **v0.5.0**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.5.0).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.5.0`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release cut with documented breaking changes: default ASR model id no longer loads without Candle, and the Python SDK drops the universal py3-none wheel for per-ABI builds requiring Python ≥ 3.10.
> 
> **Overview**
> Cuts **v0.5.0** across the workspace, bindings, docs, and SPM checksum — a release PR that versions and documents work already landed.
> 
> **Headline for consumers:** ASR defaults move from Candle to whisper.cpp (`whisper-tiny` → `whisper-tiny-ggml`), Flutter gets live streaming ASR, speculative-cloud reaches every binding, and the Python SDK now requires **Python ≥ 3.10** (generated BoltFFI wheels per ABI).
> 
> Upgrade notes and the full Added/Changed/Fixed set live in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1095246b0290ee87b2e8be95277004a05b0357e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->