### PR TITLE
fix(release): publish the whisper crates before xybrid-core

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -175,7 +175,12 @@ jobs:
   # =========================================================================
   # Publish Rust crates to crates.io.
   #
-  # Dependency order: macros -> core -> sdk -> xybrid. Each publish waits
+  # Dependency order: every crate xybrid-core depends on must precede it, or
+  # `cargo publish -p xybrid-core` fails resolving a path dep that is not yet
+  # on the index ("no matching package named `<dep>` found"). Optional deps
+  # count — cargo resolves them at package time regardless of the feature
+  # set. Adding a crate under crates/ that xybrid-core depends on therefore
+  # means adding a publish_crate line below. Each publish waits
   # for the new version to become visible on the sparse index before moving
   # on. Idempotent: a re-run skips crates whose <name>@<version> is already
   # on crates.io.
@@ -249,6 +254,10 @@ jobs:
           publish_crate xybrid-macros
           publish_crate xybrid-llama-sys
           publish_crate xybrid-llama
+          # whisper-sys depends on llama-sys (it compiles against that crate's
+          # ggml via DEP_LLAMA_*), so it follows llama, and both precede core.
+          publish_crate xybrid-whisper-sys
+          publish_crate xybrid-whisper
           publish_crate xybrid-core
           publish_crate xybrid-sdk
           publish_crate xybrid


### PR DESCRIPTION
v0.5.0's crates.io publish failed halfway:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `xybrid-whisper` found
  required by package `xybrid-core v0.5.0`
```

- `xybrid-core` gained optional path deps on `xybrid-whisper` / `xybrid-whisper-sys` in #462, but `release-publish.yml`'s publish list still stopped at `xybrid-llama`
- optional deps are resolved at package time regardless of features, so being feature-gated does not save it
- adds `xybrid-whisper-sys` then `xybrid-whisper` before `xybrid-core` (whisper-sys compiles against llama-sys's ggml, so it follows llama)
- comment above the job now says the rule, since this is the second time a new crate broke the chain (first was the llama split, #166)

**State of v0.5.0 on crates.io:** `xybrid-macros`, `xybrid-llama-sys`, `xybrid-llama` published; `xybrid-core`, `xybrid-sdk`, `xybrid` did not. `publish_crate` skips anything already on the index, so re-dispatching `release-publish` resumes at `xybrid-whisper-sys`.

pub.dev is stranded by the same failure — `dispatch-flutter-publish` sits behind `needs: publish-crates`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the crates.io release publish order, which is release-critical infrastructure, but the change itself is a small, targeted ordering fix.
> 
> **Overview**
> Fixes the crates.io publish order so the v0.5.0 release can finish after `xybrid-core` gained optional deps on the whisper crates.
> 
> Inserts `xybrid-whisper-sys` then `xybrid-whisper` after the llama crates and before `xybrid-core` in `release-publish.yml`. Updates the job comment to state that **every** crate `xybrid-core` depends on — including optional ones — must be published first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f81eb9c8a224b37fd7a52668f4ef5312c9f2d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->