### PR TITLE
ci(react-native): retry the Bazel xcframework build on repo-fetch flakes

### DIFF
--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -92,7 +92,28 @@ jobs:
         run: |
           set -euo pipefail
           REMOTE=""; [ -n "$BUILDBUDDY_API_KEY" ] && REMOTE="--config=remote-cache"
-          bazelisk build $REMOTE --config=ios //bindings/apple:XybridFFI
+
+          # Retry the whole invocation: repo fetches out of this runner
+          # intermittently fail TLS verification mid-analysis —
+          #   TLS error: (certificate_unknown) PKIX path building failed
+          #   ... downloading rules_go-v0.59.0.zip
+          # which aborts the build before a single action runs (seen on the
+          # v0.5.0 release branch; the same job had passed 40 minutes earlier).
+          # Bazel's own --experimental_repository_downloader_retries (default
+          # 5) is already exhausted by then, so only a fresh invocation, later
+          # in wall-clock time, recovers. Same shape as the emulator-install
+          # retry in build-android.yml.
+          for i in 1 2 3; do
+            if bazelisk build $REMOTE --config=ios //bindings/apple:XybridFFI; then
+              break
+            fi
+            if [ "$i" = 3 ]; then
+              echo "::error::bazel build failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::bazel build attempt $i failed; retrying in 30s"
+            sleep 30
+          done
 
           RN_IOS="bindings/react-native/ios"
           ZIP="bazel-bin/bindings/apple/XybridFFI.xcframework.zip"


### PR DESCRIPTION
Follow-up agreed during the v0.5.0 release.

`Stage iOS artifacts` failed on the release branch with:

```
TLS error: (certificate_unknown) PKIX path building failed
  ... downloading rules_go-v0.59.0.zip
ERROR: Analysis of target '//bindings/apple:XybridFFI' failed
```

- the runner could not verify github.com for ~34s, so analysis aborted before any action ran
- Bazel already retries repo downloads 5 times (`--experimental_repository_downloader_retries` defaults to 5), so its in-process retry was spent — only a fresh invocation recovers, which is what a manual `gh run rerun --failed` did (all 4 jobs then green)
- same job had passed 40 minutes earlier on the same branch and on master, so it is runner infrastructure, not a regression
- wraps the `bazelisk build` in a 3-attempt loop with 30s backoff, matching the corrupt-emulator-download retry in `build-android.yml`

Worth applying to the other macOS Bazel lanes if it recurs; kept to the one job that actually flaked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no product, security, or build-logic impact; only adds retries around an existing Bazel invocation.
> 
> **Overview**
> Wraps the `bazelisk build //bindings/apple:XybridFFI` step in `build-react-native.yml` with a **3-attempt retry loop** (30s backoff) so intermittent runner TLS failures during Bazel repo analysis no longer fail the job.
> 
> Bazel's own download retries are already exhausted by these flakes; only a fresh invocation recovers. Pattern matches the existing emulator-install retry in `build-android.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a03f78ff102eb49d66acb1d6d2d7e78b2689a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->