### PR TITLE
perf(asr): enable Metal on Apple silicon

### DIFF
--- a/crates/xybrid-core/src/execution/template/metadata.rs
+++ b/crates/xybrid-core/src/execution/template/metadata.rs
@@ -810,10 +810,27 @@ pub fn span_kind_from_template(template: &ExecutionTemplate) -> &'static str {
                 "cpu"
             }
         }
-        // whisper.cpp is loaded with `use_gpu = false` in the safe wrapper, so
-        // unlike the GGUF arms above there is no Metal case to branch on.
-        ExecutionTemplate::GgmlWhisper { .. }
-        | ExecutionTemplate::Onnx { .. }
+        ExecutionTemplate::GgmlWhisper { .. } => {
+            // The safe wrapper requests Metal only on Apple-silicon macOS.
+            // Keep the outer span aligned with that platform default.
+            #[cfg(all(
+                feature = "asr-whispercpp",
+                target_os = "macos",
+                target_arch = "aarch64"
+            ))]
+            {
+                "gpu"
+            }
+            #[cfg(not(all(
+                feature = "asr-whispercpp",
+                target_os = "macos",
+                target_arch = "aarch64"
+            )))]
+            {
+                "cpu"
+            }
+        }
+        ExecutionTemplate::Onnx { .. }
         | ExecutionTemplate::TfLite { .. }
         | ExecutionTemplate::LiteRtLm { .. }
         | ExecutionTemplate::ModelGraph { .. } => "cpu",
@@ -827,6 +844,35 @@ pub fn span_kind_from_template(template: &ExecutionTemplate) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ggml_whisper_template() -> ExecutionTemplate {
+        ExecutionTemplate::GgmlWhisper {
+            model_file: "ggml-tiny-q5_1.bin".into(),
+            language: None,
+            audio_ctx: 0,
+            translate: false,
+        }
+    }
+
+    #[cfg(all(
+        feature = "asr-whispercpp",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn ggml_whisper_uses_gpu_span_on_apple_silicon_macos() {
+        assert_eq!(span_kind_from_template(&ggml_whisper_template()), "gpu");
+    }
+
+    #[cfg(not(all(
+        feature = "asr-whispercpp",
+        target_os = "macos",
+        target_arch = "aarch64"
+    )))]
+    #[test]
+    fn ggml_whisper_uses_cpu_span_without_macos_metal() {
+        assert_eq!(span_kind_from_template(&ggml_whisper_template()), "cpu");
+    }
 
     #[test]
     fn test_onnx_serialization() {

--- a/crates/xybrid-whisper/BUILD.bazel
+++ b/crates/xybrid-whisper/BUILD.bazel
@@ -6,8 +6,9 @@ rust_library(
     name = "xybrid_whisper",
     srcs = glob(["src/**/*.rs"]),
     # Plain list, no select: unlike llama's `vision`, this crate has no
-    # per-platform feature delta — whisper.cpp's CPU path is the only one we
-    # build, on every target.
+    # per-platform Rust feature delta. The wrapper requests the Metal backend
+    # via a target cfg on Apple-silicon macOS; //:whisper already selects the
+    # matching ggml implementation through the top-level build config.
     crate_features = ["bindings"],
     edition = "2021",
     deps = [

--- a/crates/xybrid-whisper/src/model.rs
+++ b/crates/xybrid-whisper/src/model.rs
@@ -20,6 +20,21 @@ const MIN_SAMPLES: usize = 400;
 /// Samples in Whisper's full 30-second encoder window.
 const FULL_WINDOW_SAMPLES: usize = SAMPLE_RATE as usize * 30;
 
+/// Whether new contexts request GPU offload on this target.
+///
+/// Metal was 2.7–7.8x faster in end-to-end ASR benchmarks on an M1 Pro, with
+/// no word-level regressions in the release cases. Other targets remain on the
+/// CPU path until they are measured independently.
+const DEFAULT_USE_GPU: bool = cfg!(all(target_os = "macos", target_arch = "aarch64"));
+
+fn default_context_params() -> sys::whisper_context_params {
+    // SAFETY: `whisper_context_default_params` is a pure value constructor
+    // with no preconditions.
+    let mut params = unsafe { sys::whisper_context_default_params() };
+    params.use_gpu = DEFAULT_USE_GPU;
+    params
+}
+
 /// An owning handle to a whisper.cpp context.
 ///
 /// Dropping frees the native context. Transcription takes `&mut self` because
@@ -56,12 +71,7 @@ impl WhisperModel {
         let c_path = CString::new(path_str)
             .map_err(|_| WhisperError::InvalidInput("model path contains a null byte".into()))?;
 
-        // SAFETY: `whisper_context_default_params` is a pure value constructor
-        // with no preconditions.
-        let mut cparams = unsafe { sys::whisper_context_default_params() };
-        // GPU offload is a per-platform decision xybrid-core makes; the wrapper
-        // stays on the CPU path that every target supports.
-        cparams.use_gpu = false;
+        let cparams = default_context_params();
 
         // SAFETY: `c_path` is a valid null-terminated string that outlives the
         // call, and `cparams` is a by-value POD struct. A null return is the
@@ -262,5 +272,22 @@ impl std::fmt::Debug for WhisperModel {
             .field("multilingual", &self.multilingual)
             .field("sample_rate", &SAMPLE_RATE)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_context_params;
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    fn apple_silicon_macos_requests_gpu_by_default() {
+        assert!(default_context_params().use_gpu);
+    }
+
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[test]
+    fn other_targets_keep_gpu_disabled_by_default() {
+        assert!(!default_context_params().use_gpu);
     }
 }


### PR DESCRIPTION
## Summary

This pull request enables whisper.cpp GPU offload by default on Apple-silicon macOS after benchmarks showed 2.7–7.8x faster inference on an M1 Pro without word-level regressions. Other targets remain on CPU until independently measured, and `GgmlWhisper` telemetry now reports the matching GPU or CPU span kind.

**Runtime and Telemetry Changes:**

* Configure whisper.cpp context parameters to request Metal only on `aarch64-apple-darwin`.
* Align outer execution-span telemetry and Bazel documentation with the target-specific backend selection.

**Verification:**

* Add target-aware wrapper and telemetry regression tests.
* Validate 12 real-model cases on Metal, the Bazel `macos-metal` targets, workspace formatting, Clippy, and the full workspace test suite.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (performance improvement)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default ASR execution backend on Apple silicon from CPU to Metal, which can affect runtime behavior and stability even with reported benchmark coverage. Telemetry labeling also changes for that path.
> 
> **Overview**
> Enables **Metal GPU offload by default** for whisper.cpp ASR on Apple-silicon macOS (`aarch64`), after benchmarks showed large speedups with no word-level regressions. Other targets stay on CPU.
> 
> `WhisperModel::load` now sets `use_gpu` from a target cfg instead of always forcing CPU. Outer `GgmlWhisper` execution-span telemetry is updated to report `gpu` on the same Apple-silicon + `asr-whispercpp` path, with matching regression tests and Bazel comment cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e37d9e70661b58af0ebe138795d71731f27c5fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->