### PR TITLE
ci: serve the pinned macOS SDK from cache in every Bazel job

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -631,6 +631,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       # The toolchain smokes come first and are cheap: they pull windows.h, the
       # MSVC STL and clang's builtin headers, so a sysroot or include-order
       # regression fails here rather than 20 minutes into llama.cpp.

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -113,6 +113,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       # Build the feature-complete 3-ABI AAR with Bazel and stage its jniLibs
       # into bindings/kotlin/libs/ (the layout the verify + gate steps and the
       # Kotlin AAR expect). Replaces build-android-bolt.sh (boltffi pack +

--- a/.github/workflows/build-react-native.yml
+++ b/.github/workflows/build-react-native.yml
@@ -84,6 +84,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       # Build the xcframework with Bazel (same //bindings/apple:XybridFFI the
       # release and build-apple.yml use), then stage it + the committed bolt
       # Swift wrappers into the RN package tree, where the podspec vendors
@@ -307,6 +315,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # 1. Build the bolt .so for all ABIs and stage the AAR's jniLibs into
       #    bindings/kotlin/libs/ — the layout Gradle publishes from

--- a/.github/workflows/build-unity.yml
+++ b/.github/workflows/build-unity.yml
@@ -62,6 +62,14 @@ jobs:
           which cmake >/dev/null || brew install cmake
           which pkg-config >/dev/null || brew install pkg-config
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       # Note: arm64 only. ORT has no x86_64-apple-darwin prebuilt; Intel Macs run
       # arm64 via Rosetta 2.
       # `-c opt` is required: --config=macos-metal sets the platform + Metal but
@@ -127,6 +135,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh remote
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Build + stage Windows native (Bazel)
         run: |
@@ -195,6 +211,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh remote
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       - name: Build + stage Linux native (Bazel)
         run: |
           set -euo pipefail
@@ -255,6 +279,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh remote
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # stage_unity_native.py copies each ABI's .so into
       # Runtime/Plugins/Android/<abi>/ and bundles the vendored ORT and
@@ -335,6 +367,14 @@ jobs:
             exit 1
           fi
           echo "ORT iOS library found."
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # --config=ios already sets compilation_mode=opt (unlike macos-metal), so
       # no explicit -c opt here.

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -213,6 +213,14 @@ jobs:
           # (bazel/ort_ios_sim.bzl).
           which xz >/dev/null || brew install xz
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       - name: Build XCFramework (Bazel)
         run: bazelisk build --config=ios //bindings/apple:XybridFFI
 
@@ -269,6 +277,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # Three configs, one bazel-bin symlink — resolve every artifact via
       # cquery + cp -L immediately after its build (never reference bazel-bin
@@ -376,6 +392,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       - name: Build CLI (Bazel mixed execution, shipping mode)
         run: |
           bazelisk build --config=remote --config=macos-metal -c opt \
@@ -454,6 +478,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Build Android jniLibs (Bazel AAR on RBE)
         run: |
@@ -563,6 +595,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # Four configs, one bazel-bin symlink — resolve every artifact via
       # cquery + cp -L immediately after its build. build-android (a needs)
@@ -676,6 +716,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       # cargokit wants `<libName>.dll` + `<libName>.dll.lib` in the prebuilt
       # dir (artifacts_provider.dart), which is exactly what rustc emits for an
@@ -800,6 +848,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       - name: Build CLI (Bazel on RBE, shipping mode)
         run: |
           bazelisk build --config=remote -c opt //crates/xybrid-cli:xybrid
@@ -879,6 +935,14 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
+
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
 
       - name: Build CLI (Bazel on RBE, shipping mode)
         run: |

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -289,6 +289,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       # Bazel builds the feature-complete 3-ABI AAR; stage its jniLibs into
       # bindings/kotlin/libs/. Replaces build-android-bolt.sh.
       - name: Build Android jniLibs (Bazel AAR)

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -124,6 +124,14 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: tools/scripts/write-buildbuddy-rc.sh
 
+      # Serve hermetic-llvm's pinned macOS SDK from cache: Apple's URL 403s
+      # permanently and its only mirror throttles Actions runners. Analyzed on
+      # every target platform, not just Apple ones — see the action.
+      - name: Cache the pinned macOS SDK
+        uses: ./.github/actions/bazel-repo-cache
+        with:
+          macos-sdk-mirror: ${{ vars.MACOS_SDK_MIRROR }}
+
       # The Linux bolt cdylib is not built anywhere else in CI — bazel.yml builds
       # the windows one for the Unity DLL proof, and the linux CLI, but never
       # this. Only the toplevel .so is downloaded (--remote_download_toplevel).


### PR DESCRIPTION
## Summary

This pull request finishes the mitigation #485 started, extending it to the nineteen Bazel jobs it left out — including all eight `release-prep` jobs, which meant the workflow that cuts a release still depended on a download that returns 403 for everyone. hermetic-llvm pins the macOS SDK to a `swcdn.apple.com` URL that is now permanently dead, with a single `web.archive.org` mirror behind it that throttles Actions runners; #489 answered the same class of failure with retries, and the two compose — a retry helps a transient refusal, the cache removes the fetch.

**Coverage:**

* Added the `bazel-repo-cache` step to every remaining job that runs `bazelisk`: `build-android`, both `build-react-native` jobs, all five `build-unity` jobs, `test-ci`, `unity-editor`, `bazel.yml`'s windows-MSVC lane, and all eight `release-prep` jobs.
* Costs the cache budget nothing per lane — one shared key holding one ~54 MB content-addressed entry, not a per-lane copy of every fetch. Bazel still verifies hermetic-llvm's sha256, so a restored file cannot be different content.
* `@macos_sdk` is analyzed regardless of target platform, which is why Linux, Android and Windows jobs are in scope rather than just the Apple ones.

**Two notes on how this was applied, one of which nearly shipped a silent no-op:**

* A job counts as a Bazel job only when `bazelisk` appears in a **script line**. My first pass matched a *comment* mentioning bazelisk in `release-prep`'s checkout step and inserted the cache **before checkout** — which would have written `.context/local.bazelrc` into a workspace `git` then replaced, doing nothing at all. A validation pass now asserts every job orders `checkout → cache → bazelisk`.
* Insertion goes above each step's own comment block, so no existing comment ends up documenting the wrong step.

**Impact:**

* No build logic changes — 152 added lines, all of them the same step plus its comment. Jobs behave identically on a cache miss.
* Still a mitigation, not a cure: a cold cache depends on that throttling mirror answering. The `MACOS_SDK_MIRROR` repository variable added in #485 closes the gap whenever a mirror is authorized; unset, it stays a no-op.

## Type of Change

- [x] Bug fix
- [x] Other: CI resilience

## Checklist

- [x] `actionlint` clean across all workflows
- [x] Every `bazelisk` job asserted to order `checkout → cache → bazelisk`
- [x] No trailing whitespace introduced
- [x] No Rust or build-logic changes, so no test surface moves
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow edits that add an existing cache action; no application, auth, or build-logic changes.
> 
> **Overview**
> Finishes the #485 mitigation by adding the shared `bazel-repo-cache` step to the remaining Bazel jobs that still fetched hermetic-llvm's pinned macOS SDK from a permanently 403ing Apple URL (with a throttling Wayback mirror).
> 
> Coverage now includes `bazel.yml`'s windows-MSVC lane, `build-android`, both `build-react-native` Bazel jobs, all five `build-unity` jobs, `test-ci`, `unity-editor`, and all eight `release-prep` Bazel jobs. Linux/Android/Windows lanes are included because `@macos_sdk` is analyzed on every target platform.
> 
> No build logic changes — jobs behave the same on a cache miss, and Bazel still verifies the pinned sha256.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395555c375a4f4170b409f57b9ef0559ef1513fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->