### PR TITLE
perf(asr): cache detected language across stream windows

### DIFF
--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -917,6 +917,27 @@ impl TemplateExecutor {
         let raw_outputs = RawOutputs::from_envelope(&result_envelope)?;
         let result = self.run_postprocessing(metadata, raw_outputs)?;
 
+        // `RawOutputs` intentionally carries only model payloads, so the
+        // postprocessing round-trip above rebuilds the envelope. Preserve the
+        // whisper.cpp language signal explicitly: StreamSession needs it to
+        // avoid auto-detecting again on every rolling window.
+        #[cfg(feature = "asr-whispercpp")]
+        let result = {
+            let mut result = result;
+            if runtime_type == "whispercpp" {
+                if let Some(language) = result_envelope
+                    .metadata
+                    .get(Envelope::DETECTED_LANGUAGE_METADATA_KEY)
+                {
+                    result.metadata.insert(
+                        Envelope::DETECTED_LANGUAGE_METADATA_KEY.to_string(),
+                        language.clone(),
+                    );
+                }
+            }
+            result
+        };
+
         info!(
             target: "xybrid_core",
             "Model execution complete: {} -> {}",

--- a/crates/xybrid-core/src/ir/envelope.rs
+++ b/crates/xybrid-core/src/ir/envelope.rs
@@ -1172,6 +1172,8 @@ impl Envelope {
     /// Metadata key carrying the parsed tool calls (JSON array of gateway
     /// `ToolCall`) on an LLM response envelope whose request offered tools.
     pub const TOOL_CALLS_METADATA_KEY: &'static str = "tool_calls";
+    /// Metadata key carrying an ASR runtime's auto-detected language code.
+    pub const DETECTED_LANGUAGE_METADATA_KEY: &'static str = "detected_language";
 
     /// Creates a new envelope with the specified kind and empty metadata.
     ///

--- a/crates/xybrid-core/src/runtime_adapter/whisper_cpp/runtime.rs
+++ b/crates/xybrid-core/src/runtime_adapter/whisper_cpp/runtime.rs
@@ -20,6 +20,14 @@ use crate::runtime_adapter::{AdapterError, AdapterResult, ModelRuntime};
 /// it is the default here for the same reason `candle::device` caps its pool.
 const DEFAULT_THREADS: u32 = 4;
 
+/// One completed whisper.cpp request, including data needed by stream-level
+/// orchestration but not repeated in the user-facing text payload.
+#[derive(Debug)]
+struct Transcription {
+    segments: Vec<Segment>,
+    detected_language: Option<String>,
+}
+
 /// whisper.cpp-backed model runtime.
 ///
 /// Holds at most one loaded model. Unlike [`crate::runtime_adapter::candle`]'s
@@ -98,8 +106,8 @@ impl WhisperCppRuntime {
         pcm: &[f32],
         params: &TranscribeParams,
     ) -> AdapterResult<String> {
-        let segments = self.transcribe_pcm_segments(pcm, params)?;
-        Ok(Segment::join(&segments))
+        let transcription = self.transcribe_pcm_result(pcm, params)?;
+        Ok(Segment::join(&transcription.segments))
     }
 
     /// Transcribe and keep the per-segment spans, which the streaming
@@ -113,11 +121,26 @@ impl WhisperCppRuntime {
         pcm: &[f32],
         params: &TranscribeParams,
     ) -> AdapterResult<Vec<Segment>> {
+        Ok(self.transcribe_pcm_result(pcm, params)?.segments)
+    }
+
+    /// Transcribe once and retain the auto-detected language while the model
+    /// lock still protects the result that produced it.
+    fn transcribe_pcm_result(
+        &mut self,
+        pcm: &[f32],
+        params: &TranscribeParams,
+    ) -> AdapterResult<Transcription> {
         let mut guard = lock(&self.model)?;
         let model = guard.as_mut().ok_or_else(|| {
             AdapterError::ModelNotLoaded("No whisper.cpp model loaded".to_string())
         })?;
-        model.transcribe(pcm, params).map_err(native_error)
+        let segments = model.transcribe(pcm, params).map_err(native_error)?;
+        let detected_language = model.detected_language().map(str::to_owned);
+        Ok(Transcription {
+            segments,
+            detected_language,
+        })
     }
 
     /// The parameters this runtime would use for a request carrying
@@ -235,8 +258,16 @@ impl ModelRuntime for WhisperCppRuntime {
         let samples = decode_wav_audio(bytes, SAMPLE_RATE, 1)
             .map_err(|e| AdapterError::InvalidInput(format!("Audio decode failed: {e}")))?;
 
-        let text = self.transcribe_pcm(&samples, &params)?;
-        Ok(Envelope::new(EnvelopeKind::Text(text)))
+        let transcription = self.transcribe_pcm_result(&samples, &params)?;
+        let text = Segment::join(&transcription.segments);
+        let mut output = Envelope::new(EnvelopeKind::Text(text));
+        if let Some(language) = transcription.detected_language {
+            output.metadata.insert(
+                Envelope::DETECTED_LANGUAGE_METADATA_KEY.to_string(),
+                language,
+            );
+        }
+        Ok(output)
     }
 }
 

--- a/crates/xybrid-core/src/streaming/session.rs
+++ b/crates/xybrid-core/src/streaming/session.rs
@@ -97,7 +97,11 @@ pub struct StreamConfig {
     pub min_chunk_secs: f32,
     /// Enable partial results during streaming
     pub enable_partial_results: bool,
-    /// Language hint (passed to model if supported)
+    /// Language hint passed to the model when supported.
+    ///
+    /// When absent, a reporting ASR runtime may auto-detect from the first
+    /// full audio window; [`StreamSession`] reuses that language for later
+    /// windows until the session is reset.
     pub language: Option<String>,
     /// Whisper encoder context override in mel frames; `None` uses the model default
     pub audio_ctx: Option<u32>,
@@ -135,13 +139,15 @@ impl StreamConfig {
         }
     }
 
-    /// Create an audio envelope carrying the configured ASR overrides.
-    fn inference_envelope(&self, wav_bytes: Vec<u8>) -> Envelope {
+    /// Create an audio envelope carrying the effective ASR overrides.
+    fn inference_envelope(&self, wav_bytes: Vec<u8>, detected_language: Option<&str>) -> Envelope {
         let mut envelope = Envelope::new(EnvelopeKind::Audio(wav_bytes));
-        if let Some(language) = &self.language {
+        // A caller override always wins. Otherwise, reuse the language the ASR
+        // runtime auto-detected on this session's first successful window.
+        if let Some(language) = self.language.as_deref().or(detected_language) {
             envelope
                 .metadata
-                .insert("language".to_string(), language.clone());
+                .insert("language".to_string(), language.to_string());
         }
         if let Some(audio_ctx) = self.audio_ctx {
             envelope
@@ -365,6 +371,8 @@ pub struct StreamSession {
     executor: Arc<Mutex<TemplateExecutor>>,
     /// Configuration
     config: StreamConfig,
+    /// Language auto-detected for this stream, reused by later windows.
+    detected_language: Option<String>,
     /// Audio buffer
     buffer: AudioBuffer,
     /// Transcript accumulator
@@ -472,6 +480,7 @@ impl StreamSession {
                         metadata,
                         executor,
                         config,
+                        detected_language: None,
                         buffer,
                         transcript: TranscriptAccumulator::new(),
                         state: StreamState::Idle,
@@ -507,6 +516,7 @@ impl StreamSession {
             metadata,
             executor,
             config,
+            detected_language: None,
             buffer,
             transcript: TranscriptAccumulator::new(),
             state: StreamState::Idle,
@@ -607,7 +617,7 @@ impl StreamSession {
         let sample_rate = self.buffer.config().sample_rate;
         let silence = vec![0.0f32; (sample_rate as usize) / 2];
         let wav_bytes = samples_to_wav(&silence, sample_rate);
-        let envelope = self.config.inference_envelope(wav_bytes);
+        let envelope = self.config.inference_envelope(wav_bytes, None);
 
         executor
             .execute(&self.metadata, &envelope, None)
@@ -713,6 +723,7 @@ impl StreamSession {
         self.transcript.reset();
         self.state = StreamState::Idle;
         self.last_error = None;
+        self.detected_language = None;
         // Reset VAD state
         if let Some(ref mut vad) = self.vad {
             vad.reset();
@@ -729,6 +740,15 @@ impl StreamSession {
     /// Get current session state.
     pub fn state(&self) -> StreamState {
         self.state
+    }
+
+    /// Return the language auto-detected for the current stream.
+    ///
+    /// This remains `None` when the caller configured an explicit language or
+    /// the active ASR runtime does not report language detection.
+    #[must_use]
+    pub fn detected_language(&self) -> Option<&str> {
+        self.detected_language.as_deref()
     }
 
     /// Get buffer statistics.
@@ -785,7 +805,9 @@ impl StreamSession {
         let wav_bytes = samples_to_wav(&chunk.samples, self.buffer.config().sample_rate);
 
         // Create envelope with audio data and per-session ASR overrides.
-        let envelope = self.config.inference_envelope(wav_bytes);
+        let envelope = self
+            .config
+            .inference_envelope(wav_bytes, self.detected_language.as_deref());
 
         // Execute through TemplateExecutor (handles ONNX, Candle, etc.)
         let output = self
@@ -804,6 +826,25 @@ impl StreamSession {
                 ));
             }
         };
+
+        // Short warm-up windows are deliberately excluded. The committed
+        // French fixture is misidentified from its first 1.5 s but correctly
+        // identified from the full 5 s window; caching the early guess would
+        // make every later transcript consistently wrong. Explicit session
+        // configuration takes precedence forever, and the first full-window
+        // detection remains stable until `reset` starts a new stream.
+        if self.config.language.is_none()
+            && self.detected_language.is_none()
+            && !self.buffer.config().is_warmup_chunk(chunk.sequence)
+        {
+            self.detected_language = output
+                .metadata
+                .get(Envelope::DETECTED_LANGUAGE_METADATA_KEY)
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|language| !language.is_empty())
+                .map(str::to_owned);
+        }
 
         // Reconcile into the transcript (replaces re-covered spans, dedupes
         // the overlap seam).
@@ -863,7 +904,7 @@ mod tests {
             ..Default::default()
         };
 
-        let envelope = config.inference_envelope(vec![1, 2, 3]);
+        let envelope = config.inference_envelope(vec![1, 2, 3], Some("de"));
 
         assert_eq!(
             envelope.metadata.get("language").map(String::as_str),
@@ -883,10 +924,40 @@ mod tests {
             ..Default::default()
         };
 
-        let envelope = config.inference_envelope(vec![1, 2, 3]);
+        let envelope = config.inference_envelope(vec![1, 2, 3], None);
 
         assert!(!envelope.metadata.contains_key("language"));
         assert!(!envelope.metadata.contains_key("audio_ctx"));
+    }
+
+    #[test]
+    fn detected_language_is_reused_when_no_override_is_configured() {
+        let config = StreamConfig {
+            language: None,
+            ..Default::default()
+        };
+
+        let envelope = config.inference_envelope(vec![1, 2, 3], Some("fr"));
+
+        assert_eq!(
+            envelope.metadata.get("language").map(String::as_str),
+            Some("fr")
+        );
+    }
+
+    #[test]
+    fn configured_language_takes_precedence_over_detected_language() {
+        let config = StreamConfig {
+            language: Some("en".to_string()),
+            ..Default::default()
+        };
+
+        let envelope = config.inference_envelope(vec![1, 2, 3], Some("fr"));
+
+        assert_eq!(
+            envelope.metadata.get("language").map(String::as_str),
+            Some("en")
+        );
     }
 
     fn secs(s: f64) -> Duration {

--- a/crates/xybrid-whisper/src/model.rs
+++ b/crates/xybrid-whisper/src/model.rs
@@ -43,6 +43,7 @@ fn default_context_params() -> sys::whisper_context_params {
 pub struct WhisperModel {
     ctx: NonNull<sys::whisper_context>,
     multilingual: bool,
+    last_detected_language: Option<String>,
 }
 
 // SAFETY: a `whisper_context` owns only heap allocations reachable through the
@@ -84,7 +85,11 @@ impl WhisperModel {
         // SAFETY: `ctx` was just checked non-null and is a live context.
         let multilingual = unsafe { sys::whisper_is_multilingual(ctx.as_ptr()) } != 0;
 
-        Ok(Self { ctx, multilingual })
+        Ok(Self {
+            ctx,
+            multilingual,
+            last_detected_language: None,
+        })
     }
 
     /// Whether this model's vocabulary carries language tokens beyond English.
@@ -93,10 +98,22 @@ impl WhisperModel {
         self.multilingual
     }
 
+    /// Return the language auto-detected by the most recent successful transcription.
+    ///
+    /// Returns `None` before the first transcription, when the caller supplied
+    /// an explicit language, or when whisper.cpp did not report a valid
+    /// language code.
+    #[must_use]
+    pub fn detected_language(&self) -> Option<&str> {
+        self.last_detected_language.as_deref()
+    }
+
     /// Transcribe 16 kHz mono PCM in `[-1.0, 1.0]`.
     ///
     /// Returns one [`Segment`] per text span whisper emitted. Callers wanting
-    /// the plain string can [`Segment::join`] them.
+    /// the plain string can [`Segment::join`] them. When `params.language` is
+    /// absent, [`WhisperModel::detected_language`] exposes the selected code
+    /// after this call succeeds.
     ///
     /// # Errors
     ///
@@ -114,6 +131,10 @@ impl WhisperModel {
         pcm: &[f32],
         params: &TranscribeParams,
     ) -> WhisperResult<Vec<Segment>> {
+        // A failed or explicitly-languaged request must not expose a stale
+        // auto-detection from an earlier transcription.
+        self.last_detected_language = None;
+
         if pcm.len() < MIN_SAMPLES {
             return Err(WhisperError::AudioTooShort {
                 samples: pcm.len(),
@@ -176,7 +197,35 @@ impl WhisperModel {
             return Err(WhisperError::InferenceFailed { code });
         }
 
-        self.collect_segments()
+        let segments = self.collect_segments()?;
+        if params.language.is_none() {
+            self.last_detected_language = self.read_detected_language();
+        }
+        Ok(segments)
+    }
+
+    /// Read the language selected by the preceding auto-detecting inference.
+    fn read_detected_language(&self) -> Option<String> {
+        // SAFETY: `self.ctx` is live and `whisper_full_lang_id` only reads the
+        // state populated by the preceding successful `whisper_full` call.
+        let id = unsafe { sys::whisper_full_lang_id(self.ctx.as_ptr()) };
+        if id < 0 {
+            return None;
+        }
+
+        // SAFETY: `whisper_lang_str` returns either null or a pointer to a
+        // process-lifetime, null-terminated language-code string owned by
+        // whisper.cpp. We check for null before reading and copy the result.
+        let language_ptr = unsafe { sys::whisper_lang_str(id) };
+        if language_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: checked non-null above; whisper.cpp guarantees null
+        // termination for its static language-code strings.
+        unsafe { CStr::from_ptr(language_ptr) }
+            .to_str()
+            .ok()
+            .map(str::to_owned)
     }
 
     /// Map a caller-supplied language code to a C string whisper accepts,
@@ -270,6 +319,7 @@ impl std::fmt::Debug for WhisperModel {
         // leaks address-space layout into logs.
         f.debug_struct("WhisperModel")
             .field("multilingual", &self.multilingual)
+            .field("last_detected_language", &self.last_detected_language)
             .field("sample_rate", &SAMPLE_RATE)
             .finish()
     }

--- a/integration-tests/tests/whispercpp_integration.rs
+++ b/integration-tests/tests/whispercpp_integration.rs
@@ -24,6 +24,7 @@ use xybrid_core::execution::{ExecutionTemplate, ModelMetadata};
 use xybrid_core::ir::{Envelope, EnvelopeKind};
 use xybrid_core::runtime_adapter::whisper_cpp::WhisperCppRuntime;
 use xybrid_core::runtime_adapter::{AdapterError, ModelRuntime};
+use xybrid_core::streaming::{StreamConfig, StreamSession};
 
 const MODEL: &str = "whisper-tiny-ggml";
 const MODEL_OVERRIDE_ENV: &str = "XYBRID_WHISPER_TEST_MODEL";
@@ -149,11 +150,11 @@ fn transcript_repeated(times: usize) -> String {
     vec![JFK_TRANSCRIPT; times].join(" ")
 }
 
-fn transcribe(
+fn execute(
     runtime: &mut WhisperCppRuntime,
     pcm: &[f32],
     metadata: &[(&str, &str)],
-) -> Result<String, AdapterError> {
+) -> Result<Envelope, AdapterError> {
     let envelope = Envelope {
         kind: EnvelopeKind::Audio(samples_to_wav(pcm, SAMPLE_RATE)),
         metadata: metadata
@@ -162,7 +163,15 @@ fn transcribe(
             .collect(),
     };
 
-    match runtime.execute(&envelope)?.kind {
+    runtime.execute(&envelope)
+}
+
+fn transcribe(
+    runtime: &mut WhisperCppRuntime,
+    pcm: &[f32],
+    metadata: &[(&str, &str)],
+) -> Result<String, AdapterError> {
+    match execute(runtime, pcm, metadata)?.kind {
         EnvelopeKind::Text(text) => Ok(text),
         other => panic!("expected text output, got {other:?}"),
     }
@@ -397,6 +406,72 @@ fn language_metadata_applies_per_request_not_per_load() {
         "language=fr changed after an intervening language=en request"
     );
     assert_no_hallucinated_annotation("language=en", &english_first);
+}
+
+#[test]
+fn auto_detected_language_is_reported_for_stream_reuse() {
+    let _serial = serial_model_test();
+    let Some(mut runtime) = whisper_runtime() else {
+        skip_notice();
+        return;
+    };
+
+    let french = read_pcm(FRENCH_CLIP);
+    let pcm = &french[..5 * SAMPLE_RATE as usize];
+
+    let auto_output = execute(&mut runtime, pcm, &[]).expect("auto-detecting transcription");
+    let detected = auto_output
+        .metadata
+        .get(Envelope::DETECTED_LANGUAGE_METADATA_KEY)
+        .expect("an auto-detecting request reports its language");
+    assert_eq!(detected, "fr");
+
+    let hinted_output = execute(&mut runtime, pcm, &[("language", detected)])
+        .expect("transcription with the detected language as a hint");
+
+    assert!(
+        !hinted_output
+            .metadata
+            .contains_key(Envelope::DETECTED_LANGUAGE_METADATA_KEY),
+        "an explicit language should not be reported as auto-detected"
+    );
+    assert_eq!(
+        auto_output.kind, hinted_output.kind,
+        "reusing the detected language must preserve the transcript"
+    );
+}
+
+#[test]
+fn streaming_caches_auto_detection_until_reset() {
+    let _serial = serial_model_test();
+    let Some(model_dir) = fixtures::model_for_test(MODEL) else {
+        skip_notice();
+        return;
+    };
+    let model_path = model_dir.join("ggml-tiny-q5_1.bin");
+    if !model_path.is_file() {
+        skip_notice();
+        return;
+    }
+
+    let config = StreamConfig {
+        language: None,
+        ..Default::default()
+    };
+    let mut session = StreamSession::new(&model_dir, config)
+        .expect("multilingual Whisper bundle opens as a streaming session");
+    let pcm = read_pcm(FRENCH_CLIP);
+
+    // The 8 s fixture crosses the 1.5 s and 3 s warm-up windows, then reaches
+    // the first full 5 s window that is allowed to seed the cache.
+    session.feed(&pcm).expect("first streaming window succeeds");
+    assert_eq!(session.detected_language(), Some("fr"));
+    session
+        .flush()
+        .expect("remaining audio uses the cached hint");
+
+    session.reset();
+    assert_eq!(session.detected_language(), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This pull request caches whisper.cpp's auto-detected language after the first full streaming window and reuses it for subsequent windows, eliminating repeated detection while preserving explicit language overrides.

**Streaming behavior:**

* Ignores short warm-up windows when seeding the cache, clears the cached value on reset, and exposes it for session-level observability.
* Carries the detected-language signal from the native wrapper through runtime metadata and executor post-processing.

**Validation:**

* Adds unit and real-model integration coverage for metadata reporting, hint reuse, warm-up handling, and reset behavior; all Rust and supported macOS Metal Bazel checks pass.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (performance optimization)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches streaming ASR language handling and the whisper.cpp execution path; a bad cache seed could lock an entire session onto the wrong language, though warm-up exclusion and override precedence mitigate that.
> 
> **Overview**
> Caches whisper.cpp's auto-detected language after the first full streaming window and reuses it on later windows, so rolling ASR no longer re-detects language every chunk.
> 
> The detected code now flows from the native wrapper through runtime envelope metadata (`detected_language`), and the executor preserves it across postprocessing for whisper.cpp. `StreamSession` seeds the cache only from non-warm-up windows, always prefers an explicit `language` override, clears the cache on `reset`, and exposes `detected_language()` for observability.
> 
> Adds unit and real-model integration coverage for metadata reporting, hint reuse, warm-up exclusion, and reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a8ee9625aaff51d8c67b28d88fdea7535949c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->