### PR TITLE
feat(flutter): surface grammar, jsonSchemaToGbnf and reasoningContent in Dart

### DIFF
--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -41,6 +41,41 @@ env:
   FRB_VERSION: "2.11.1"
 
 jobs:
+  # Pure-Dart gate for the hand-written wrapper in bindings/flutter/lib.
+  #
+  # Cheap and native-free on purpose: the wrapper classes are plain Dart and
+  # the cdylib is only dlopened by `Xybrid.init()`, which no unit test calls.
+  # That means this job needs no Rust, no FRB codegen and no cargokit — it
+  # runs in ~1 minute alongside the (much slower) native build below.
+  #
+  # No `dart format --set-exit-if-changed` gate: several checked-in wrapper
+  # files predate one and would fail on untouched code. Reformat them in a
+  # dedicated pass before adding that check.
+  analyze-test-dart:
+    name: Analyze + test Dart wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Flutter SDK
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Install Dart dependencies
+        working-directory: bindings/flutter
+        run: flutter pub get
+
+      - name: Analyze
+        working-directory: bindings/flutter
+        run: flutter analyze --no-pub
+
+      - name: Test
+        working-directory: bindings/flutter
+        run: flutter test --no-pub
+
   # Linux-only on push/PR. macOS + Windows Flutter binaries are built and
   # validated in release-prep.yml (precompile-flutter-* jobs) at release time.
   # Use workflow_dispatch + test-ci.yml for ad-hoc per-platform validation.

--- a/bindings/flutter/lib/src/generation_config.dart
+++ b/bindings/flutter/lib/src/generation_config.dart
@@ -14,6 +14,16 @@
 /// // Custom
 /// GenerationConfig(maxTokens: 512, temperature: 0.5)
 /// ```
+///
+/// ## Structured output
+///
+/// ```dart
+/// // Force schema-valid JSON out of a local llama model
+/// final grammar = jsonSchemaToGbnf(
+///   schemaJson: '{"type":"object","properties":{"city":{"type":"string"}}}',
+/// );
+/// GenerationConfig(grammar: grammar)
+/// ```
 library;
 
 import 'rust/api/model.dart';
@@ -46,6 +56,15 @@ class GenerationConfig {
   /// Stop sequences. When null or empty, only EOS token stops generation.
   final List<String>? stopSequences;
 
+  /// GBNF grammar constraining generation to structured output.
+  ///
+  /// When set, the local llama backend masks every token the grammar would
+  /// reject, so the output is guaranteed to parse. Produce one from a JSON
+  /// Schema with [jsonSchemaToGbnf], or pass raw GBNF.
+  ///
+  /// Local llama backend only — other backends ignore it.
+  final String? grammar;
+
   /// Create a custom generation config.
   ///
   /// Only set fields you want to override — `null` fields use model defaults.
@@ -57,12 +76,14 @@ class GenerationConfig {
     this.topK,
     this.repetitionPenalty,
     this.stopSequences,
+    this.grammar,
   });
 
   /// Greedy decoding preset (deterministic, temperature=0).
   ///
-  /// Produces the same output every time for the same input.
-  const GenerationConfig.greedy()
+  /// Produces the same output every time for the same input. Pass [grammar]
+  /// to pair it with structured output — the usual shape for extraction.
+  const GenerationConfig.greedy({this.grammar})
       : maxTokens = null,
         temperature = 0.0,
         topP = 1.0,
@@ -74,7 +95,7 @@ class GenerationConfig {
   /// Creative generation preset (higher temperature).
   ///
   /// Produces more varied and creative output.
-  const GenerationConfig.creative()
+  const GenerationConfig.creative({this.grammar})
       : maxTokens = null,
         temperature = 0.9,
         topP = 0.95,
@@ -93,6 +114,7 @@ class GenerationConfig {
       topK: topK,
       repetitionPenalty: repetitionPenalty,
       stopSequences: stopSequences,
+      grammar: grammar,
     );
   }
 }

--- a/bindings/flutter/lib/src/result.dart
+++ b/bindings/flutter/lib/src/result.dart
@@ -98,6 +98,16 @@ class XybridResult {
   /// Returns null if the model doesn't produce text output.
   String? get text => _inner.text;
 
+  /// The model's chain-of-thought / reasoning, if it emitted any.
+  ///
+  /// Reasoning models wrap their scratchpad in `<think>` blocks. [text]
+  /// always excludes those; this getter is where they surface, so you can
+  /// show or hide the reasoning independently of the answer.
+  ///
+  /// Returns null when the model emitted no reasoning, or the backend
+  /// doesn't surface one.
+  String? get reasoningContent => _inner.reasoningContent;
+
   /// Audio bytes output (for TTS models).
   ///
   /// Returns raw PCM audio bytes (16-bit signed, little-endian).

--- a/bindings/flutter/lib/xybrid.dart
+++ b/bindings/flutter/lib/xybrid.dart
@@ -98,8 +98,10 @@ export 'src/pipeline.dart' show XybridPipeline;
 export 'src/result.dart'
     show XybridInferenceMetrics, XybridResult, XybridStageLatency;
 // Speculative cloud: the download snapshot hosts poll while the gateway
-// answers, and the provenance of a finished run.
-export 'src/rust/api/model.dart' show FfiDownloadState, FfiDownloadStatus;
+// answers, and the provenance of a finished run. `jsonSchemaToGbnf` turns a
+// JSON Schema into the grammar `GenerationConfig.grammar` expects.
+export 'src/rust/api/model.dart'
+    show FfiDownloadState, FfiDownloadStatus, jsonSchemaToGbnf;
 export 'src/rust/api/result.dart' show FfiExecutionTarget;
 export 'src/run_options.dart' show AbortPolicy, AbortSignal, RunOptions;
 export 'src/streaming.dart'

--- a/bindings/flutter/test/generation_config_test.dart
+++ b/bindings/flutter/test/generation_config_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xybrid_flutter/xybrid_flutter.dart';
+
+const _grammar = 'root ::= "{" ws "\\"city\\"" ws ":" ws string ws "}"';
+
+void main() {
+  test('grammar defaults to null so generation stays unconstrained', () {
+    const config = GenerationConfig();
+
+    expect(config.grammar, isNull);
+    expect(config.toFfi().grammar, isNull);
+  });
+
+  test('grammar reaches the FFI config', () {
+    const config = GenerationConfig(grammar: _grammar);
+
+    expect(config.toFfi().grammar, _grammar);
+  });
+
+  test('greedy preset accepts a grammar without losing its sampling values',
+      () {
+    const config = GenerationConfig.greedy(grammar: _grammar);
+    final ffi = config.toFfi();
+
+    expect(ffi.grammar, _grammar);
+    expect(ffi.temperature, 0.0);
+    expect(ffi.topP, 1.0);
+    expect(ffi.topK, 0);
+  });
+
+  test('creative preset accepts a grammar', () {
+    const config = GenerationConfig.creative(grammar: _grammar);
+    final ffi = config.toFfi();
+
+    expect(ffi.grammar, _grammar);
+    expect(ffi.temperature, 0.9);
+  });
+
+  test('presets leave grammar null when none is given', () {
+    expect(const GenerationConfig.greedy().toFfi().grammar, isNull);
+    expect(const GenerationConfig.creative().toFfi().grammar, isNull);
+  });
+
+  test('every other field still crosses unchanged', () {
+    const config = GenerationConfig(
+      maxTokens: 512,
+      temperature: 0.5,
+      topP: 0.8,
+      minP: 0.02,
+      topK: 20,
+      repetitionPenalty: 1.2,
+      stopSequences: ['<|end|>'],
+      grammar: _grammar,
+    );
+    final ffi = config.toFfi();
+
+    expect(ffi.maxTokens, 512);
+    expect(ffi.temperature, 0.5);
+    expect(ffi.topP, 0.8);
+    expect(ffi.minP, 0.02);
+    expect(ffi.topK, 20);
+    expect(ffi.repetitionPenalty, 1.2);
+    expect(ffi.stopSequences, ['<|end|>']);
+    expect(ffi.grammar, _grammar);
+  });
+
+  test('jsonSchemaToGbnf is exported from the public surface', () {
+    expect(jsonSchemaToGbnf, isA<Function>());
+  });
+}

--- a/bindings/flutter/test/result_test.dart
+++ b/bindings/flutter/test/result_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xybrid_flutter/src/rust/api/result.dart';
+import 'package:xybrid_flutter/xybrid_flutter.dart';
+
+const _metrics = FfiInferenceMetrics(totalMs: 10, stageLatenciesMs: []);
+
+FfiResult _ffiResult({String? text, String? reasoningContent}) => FfiResult(
+      success: true,
+      text: text,
+      reasoningContent: reasoningContent,
+      latencyMs: 10,
+      executionTarget: FfiExecutionTarget.local,
+      metrics: _metrics,
+    );
+
+void main() {
+  test('reasoning content surfaces separately from the answer', () {
+    final result = XybridResult.fromFfi(
+      _ffiResult(text: 'Paris', reasoningContent: 'The capital of France is…'),
+    );
+
+    expect(result.text, 'Paris');
+    expect(result.reasoningContent, 'The capital of France is…');
+  });
+
+  test('reasoning content is null when the model emitted none', () {
+    final result = XybridResult.fromFfi(_ffiResult(text: 'Paris'));
+
+    expect(result.text, 'Paris');
+    expect(result.reasoningContent, isNull);
+  });
+}


### PR DESCRIPTION
Closes #507

Both features already shipped in Rust and reached the FRB-generated Dart layer. They stopped at the hand-written wrapper, so no Flutter app could use them.

## Changes

- `GenerationConfig.grammar` + passthrough in `toFfi()`
- `GenerationConfig.greedy()` / `.creative()` now take an optional `grammar`, so the usual extraction shape is one call
- `jsonSchemaToGbnf` re-exported from the public surface
- `XybridResult.reasoningContent`
- New Dart tests for all of it

## Also

Wires a Dart analyze + test job into `build-flutter.yml`. The unit tests under `bindings/flutter/test` never ran in CI — the tests this issue asks for would have been dead weight.

The job needs no Rust, no FRB codegen, no cargokit: the cdylib is only dlopened by `Xybrid.init()`, which no unit test calls. ~1 minute.

No `dart format --set-exit-if-changed` gate — several checked-in wrapper files predate one and would fail on untouched code. Worth a dedicated reformat pass later.

## Usage

```dart
final grammar = jsonSchemaToGbnf(schemaJson: mySchema);
final result = await model.run(
  envelope,
  generationConfig: GenerationConfig.greedy(grammar: grammar),
);
print(result.text);              // schema-valid JSON
print(result.reasoningContent);  // <think> blocks, if any
```

## Test

`flutter test` — 19/19 pass. `flutter analyze` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Dart API and CI coverage only; no changes to native inference, auth, or data handling.
> 
> **Overview**
> Exposes Rust/FRB capabilities that were already generated but missing from the hand-written Flutter API: **structured generation** via `GenerationConfig.grammar` (including optional `grammar` on `greedy()` / `creative()` and `toFfi()` passthrough), **`jsonSchemaToGbnf`** on the public `xybrid.dart` export, and **`XybridResult.reasoningContent`** separate from answer `text`.
> 
> Adds a fast **`analyze-test-dart`** job in `build-flutter.yml` that runs `flutter analyze` and `flutter test` on `bindings/flutter` without Rust/FRB/cargokit, plus unit tests covering grammar FFI mapping and reasoning content wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbda2056c2b4e897fc4789126e25bddec82b351b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->