### PR TITLE
feat(tts): add Piper per-model inference

### DIFF
--- a/crates/xybrid-cli/src/commands/init.rs
+++ b/crates/xybrid-cli/src/commands/init.rs
@@ -61,6 +61,9 @@ pub(crate) fn handle_init_command(dir: &str, flags: InitFlags) -> Result<()> {
         println!();
     }
 
+    #[cfg(not(feature = "onnx-inspect"))]
+    warn_if_onnx_without_inspection(&dir_path);
+
     // Run inspection and generation
     let result = metadata_gen::inspect_and_generate(
         &dir_path,
@@ -175,6 +178,24 @@ pub(crate) fn handle_init_command(dir: &str, flags: InitFlags) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Warn when this build cannot inspect ONNX graphs but the directory holds
+/// `.onnx` models, so degraded task detection is visible instead of silent
+/// (without `onnx-inspect`, detection falls back to filename heuristics and
+/// often emits `task: "unknown"` with empty preprocessing).
+#[cfg(not(feature = "onnx-inspect"))]
+fn warn_if_onnx_without_inspection(dir: &Path) {
+    let has_onnx = metadata_gen::list_model_files_pub(dir)
+        .iter()
+        .any(|f| f.ends_with(".onnx"));
+    if has_onnx {
+        eprintln!(
+            "{} this build lacks ONNX graph inspection; task detection is degraded. \
+             Rebuild with `--features onnx-inspect`.",
+            "warning:".yellow().bold()
+        );
+    }
 }
 
 /// Print a human-readable summary of the generated metadata.

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -127,6 +127,7 @@ schema = ["dep:schemars"]
 # consumers can depend on `xybrid-core/test-util` now and stay correct once
 # the `testing` module is gated behind this feature (audit 4a).
 test-util = []
+espeak = []
 
 # ONNX Runtime — the static-vs-dynamic mode is decided per-target by the
 # [target.'cfg(...)'] ort dependency sections, NOT by these features. The two

--- a/crates/xybrid-core/examples/tts_piper.rs
+++ b/crates/xybrid-core/examples/tts_piper.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use xybrid_core::execution::{ModelMetadata, TemplateExecutor};
+use xybrid_core::ir::{Envelope, EnvelopeKind};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let model_dir = PathBuf::from(
+        args.next()
+            .ok_or("usage: tts_piper MODEL_DIR [VOICE_ID] [TEXT] [OUTPUT]")?,
+    );
+    let metadata: ModelMetadata = serde_json::from_str(&std::fs::read_to_string(
+        model_dir.join("model_metadata.json"),
+    )?)?;
+    let voice_id = args.next().unwrap_or_else(|| {
+        metadata
+            .voices
+            .as_ref()
+            .map(|voices| voices.default.clone())
+            .unwrap_or_default()
+    });
+    let text = args
+        .next()
+        .unwrap_or_else(|| "The quick brown fox jumps over the lazy dog.".to_string());
+    let output_path = PathBuf::from(args.next().unwrap_or_else(|| "piper.wav".to_string()));
+
+    let mut envelope_metadata = HashMap::new();
+    envelope_metadata.insert("voice_id".to_string(), voice_id);
+    let envelope = Envelope::with_metadata(EnvelopeKind::Text(text), envelope_metadata);
+    let mut executor = TemplateExecutor::with_base_path(
+        model_dir
+            .to_str()
+            .ok_or("model directory must be valid UTF-8")?,
+    );
+    let output = executor.execute(&metadata, &envelope, None)?;
+    let pcm = output.audio_bytes().ok_or("TTS did not return audio")?;
+    write_wav(&output_path, pcm, 22_050)?;
+    println!("wrote {}", output_path.display());
+    Ok(())
+}
+
+fn write_wav(path: &std::path::Path, pcm: &[u8], sample_rate: u32) -> std::io::Result<()> {
+    use std::io::Write;
+    let data_len = u32::try_from(pcm.len()).unwrap_or(u32::MAX);
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(b"RIFF")?;
+    file.write_all(&36u32.saturating_add(data_len).to_le_bytes())?;
+    file.write_all(b"WAVEfmt ")?;
+    file.write_all(&16u32.to_le_bytes())?;
+    file.write_all(&1u16.to_le_bytes())?;
+    file.write_all(&1u16.to_le_bytes())?;
+    file.write_all(&sample_rate.to_le_bytes())?;
+    file.write_all(&(sample_rate * 2).to_le_bytes())?;
+    file.write_all(&2u16.to_le_bytes())?;
+    file.write_all(&16u16.to_le_bytes())?;
+    file.write_all(b"data")?;
+    file.write_all(&data_len.to_le_bytes())?;
+    file.write_all(pcm)
+}

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -39,7 +39,7 @@ use crate::ir::{Envelope, MessageRole};
 use crate::runtime_adapter::{AdapterError, ModelRuntime};
 use crate::tracing as xybrid_trace;
 use ndarray::ArrayD;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -175,6 +175,7 @@ use crate::runtime_adapter::{MultimodalChatMessage, MultimodalMessagePart, Visio
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 use crate::runtime_adapter::llm::LlmRuntimeAdapter;
 
+use super::modes::tts::PiperInferenceConfig;
 use super::modes::{
     execute_autoregressive_stage, execute_bert_inference, execute_single_shot_stage,
     execute_tts_inference, execute_whisper_decoder_stage,
@@ -248,10 +249,8 @@ pub struct TemplateExecutor {
     /// This ensures the struct has consistent fields regardless of features.
     #[cfg(not(any(feature = "llm-mistral", feature = "llm-llamacpp")))]
     llm_adapter_cache: Option<()>,
-    /// Cached ONNX session for the TTS path (see [`TtsSessionCache`]). Lives for
-    /// the executor's lifetime — i.e. the TTS model's load — and drops on unload,
-    /// exactly like `llm_adapter_cache`; no separate eviction needed.
-    tts_session_cache: Option<TtsSessionCache>,
+    tts_session_cache: VecDeque<TtsSessionCache>,
+    tts_session_capacity: usize,
     /// Optional embedding-style vision encoders keyed by metadata `vision_encoder.file`.
     ///
     /// llama.cpp VLMs do not use this registry: they consume raw ordered
@@ -311,7 +310,12 @@ impl TemplateExecutor {
             runtimes,
             base_path: base_path.into(),
             llm_adapter_cache: None,
-            tts_session_cache: None,
+            tts_session_cache: VecDeque::new(),
+            tts_session_capacity: std::env::var("XYBRID_TTS_VOICE_SESSIONS")
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .filter(|value| *value > 0)
+                .unwrap_or(4),
             vision_encoders: HashMap::new(),
         }
     }
@@ -839,7 +843,10 @@ impl TemplateExecutor {
         );
         if is_tts {
             debug!(target: "xybrid_core", "TTS detected, calling execute_tts_chunked");
-            return self.execute_tts_chunked(metadata, input, &model_full_path);
+            let voice_model = TtsVoiceLoader::new(&self.base_path)
+                .resolve_voice_model_path(metadata, input)?
+                .unwrap_or(model_full_path);
+            return self.execute_tts_chunked(metadata, input, &voice_model);
         }
 
         // Run Preprocessing for non-TTS models
@@ -2841,27 +2848,30 @@ impl TemplateExecutor {
     /// default options, so path + file identity is a sufficient key.
     fn tts_session(&mut self, model_path: &Path) -> ExecutorResult<Arc<ONNXSession>> {
         let identity = tts_file_identity(model_path);
-        if let Some(cache) = &self.tts_session_cache {
-            // Reuse only when the path matches AND the file identity is both
-            // readable and unchanged — an unreadable identity (`None`) forces a
-            // rebuild rather than trusting a possibly-stale session.
-            if cache.model_path == model_path
-                && identity.is_some()
-                && cache.file_identity == identity
-            {
-                return Ok(Arc::clone(&cache.session));
+        if let Some(position) = self.tts_session_cache.iter().position(|cache| {
+            cache.model_path == model_path && identity.is_some() && cache.file_identity == identity
+        }) {
+            if let Some(cache) = self.tts_session_cache.remove(position) {
+                let session = Arc::clone(&cache.session);
+                self.tts_session_cache.push_back(cache);
+                return Ok(session);
             }
         }
+        self.tts_session_cache
+            .retain(|cache| cache.model_path != model_path);
         let session = Arc::new(OnnxSessionFactory::create_session(
             model_path,
             ExecutionProviderKind::Cpu,
             SessionOptions::default(),
         )?);
-        self.tts_session_cache = Some(TtsSessionCache {
+        self.tts_session_cache.push_back(TtsSessionCache {
             model_path: model_path.to_path_buf(),
             file_identity: identity,
             session: Arc::clone(&session),
         });
+        while self.tts_session_cache.len() > self.tts_session_capacity {
+            self.tts_session_cache.pop_front();
+        }
         Ok(session)
     }
 
@@ -2919,13 +2929,21 @@ impl TemplateExecutor {
         // identical for every chunk, so load it once here.
         let session = self.tts_session(model_path)?;
         let speed = extract_tts_speed(input);
+        let piper = PiperInferenceConfig::from_model_path(model_path);
         let voice_embedding = TtsVoiceLoader::new(&self.base_path).load(metadata, input)?;
 
         let mut audio_chunks: Vec<Vec<f32>> = Vec::new();
         for (i, chunk) in chunks.iter().enumerate() {
             debug!(target: "xybrid_core", "TTS: Processing chunk {}/{}: {} chars", i + 1, chunks.len(), chunk.len());
-            let chunk_audio =
-                self.synthesize_chunk(&session, metadata, input, chunk, &voice_embedding, speed)?;
+            let chunk_audio = self.synthesize_chunk(
+                &session,
+                metadata,
+                input,
+                chunk,
+                &voice_embedding,
+                speed,
+                piper,
+            )?;
             // Inference always yields a waveform; guard the degenerate empty case
             // so it can't enter the crossfade (matches the pre-refactor skip).
             if chunk_audio.is_empty() {
@@ -2964,6 +2982,7 @@ impl TemplateExecutor {
         // the graph load + Level-3 optimization (the dominant short-TTS latency).
         let session = self.tts_session(model_path)?;
         let speed = extract_tts_speed(input);
+        let piper = PiperInferenceConfig::from_model_path(model_path);
         let voice_embedding = TtsVoiceLoader::new(&self.base_path).load(metadata, input)?;
         let text = match &input.kind {
             crate::ir::EnvelopeKind::Text(t) => t.clone(),
@@ -2976,8 +2995,15 @@ impl TemplateExecutor {
 
         // The whole (short) text is one chunk; the synthesis body is shared with
         // the chunked/streaming paths via synthesize_chunk.
-        let audio =
-            self.synthesize_chunk(&session, metadata, input, &text, &voice_embedding, speed)?;
+        let audio = self.synthesize_chunk(
+            &session,
+            metadata,
+            input,
+            &text,
+            &voice_embedding,
+            speed,
+            piper,
+        )?;
 
         // Wrap the already-trimmed waveform for postprocessing (mirrors the
         // chunked path's single-tensor map keyed by the model's output name).
@@ -3007,6 +3033,7 @@ impl TemplateExecutor {
         chunk: &str,
         voice_embedding: &[f32],
         speed: f32,
+        piper: PiperInferenceConfig,
     ) -> ExecutorResult<Vec<f32>> {
         let chunk_input = Envelope {
             kind: crate::ir::EnvelopeKind::Text(chunk.to_string()),
@@ -3017,7 +3044,7 @@ impl TemplateExecutor {
             .as_phoneme_ids()
             .ok_or_else(|| AdapterError::InvalidInput("Expected phoneme IDs".to_string()))?;
         let raw_outputs =
-            execute_tts_inference(session, phoneme_ids, voice_embedding.to_vec(), speed)?;
+            execute_tts_inference(session, phoneme_ids, voice_embedding.to_vec(), speed, piper)?;
         let mut audio: Vec<f32> = raw_outputs
             .values()
             .next()
@@ -3106,12 +3133,17 @@ impl TemplateExecutor {
             return Ok(());
         }
 
-        let model_path = self.tts_model_path(metadata)?;
+        let model_path =
+            match TtsVoiceLoader::new(&self.base_path).resolve_voice_model_path(metadata, input)? {
+                Some(path) => path,
+                None => self.tts_model_path(metadata)?,
+            };
         let sample_rate = Self::tts_output_sample_rate(metadata);
         let fade_samples = (sample_rate as usize * 5) / 1000; // ~5ms edge fade
         let chunks = super::text_chunking::chunk_text_for_tts(&text, max_tts_chars);
         let session = self.tts_session(&model_path)?;
         let speed = extract_tts_speed(input);
+        let piper = PiperInferenceConfig::from_model_path(&model_path);
         let voice_embedding = TtsVoiceLoader::new(&self.base_path).load(metadata, input)?;
         let output_name = session
             .output_names()
@@ -3121,8 +3153,15 @@ impl TemplateExecutor {
 
         for (i, chunk) in chunks.iter().enumerate() {
             debug!(target: "xybrid_core", "TTS stream: chunk {}/{} ({} chars)", i + 1, chunks.len(), chunk.len());
-            let chunk_audio =
-                self.synthesize_chunk(&session, metadata, input, chunk, &voice_embedding, speed)?;
+            let chunk_audio = self.synthesize_chunk(
+                &session,
+                metadata,
+                input,
+                chunk,
+                &voice_embedding,
+                speed,
+                piper,
+            )?;
             if chunk_audio.is_empty() {
                 continue; // degenerate empty inference output — skip (pre-refactor behavior)
             }
@@ -5333,6 +5372,7 @@ mod tests {
                 add_padding: true,
                 normalize_text: false,
                 silence_tokens: None,
+                id_style: Default::default(),
             },
         );
         assert!(TemplateExecutor::is_tts_model(&metadata));
@@ -5370,6 +5410,7 @@ mod tests {
                 add_padding: true,
                 normalize_text: false,
                 silence_tokens: None,
+                id_style: Default::default(),
             });
         assert!(TemplateExecutor::is_tts_model(&metadata));
     }

--- a/crates/xybrid-core/src/execution/modes/tts.rs
+++ b/crates/xybrid-core/src/execution/modes/tts.rs
@@ -29,6 +29,7 @@ pub fn execute_tts_inference(
     phoneme_ids: &[i64],
     voice_embedding: Vec<f32>,
     speed: f32,
+    piper: PiperInferenceConfig,
 ) -> ExecutorResult<HashMap<String, ArrayD<f32>>> {
     let input_names = session.input_names();
     let input_shapes = session.input_shapes();
@@ -44,7 +45,7 @@ pub fn execute_tts_inference(
         let dtype = input_dtypes.get(i).and_then(|d| *d);
         let shape = input_shapes.get(i).map(|s| s.as_slice()).unwrap_or(&[]);
 
-        match classify_tts_input(dtype, shape) {
+        match classify_tts_input(input_name, dtype, shape) {
             TtsInputKind::Tokens => {
                 let arr =
                     Array2::<i64>::from_shape_vec((batch_size, seq_len), phoneme_ids.to_vec())
@@ -95,6 +96,37 @@ pub fn execute_tts_inference(
                     .into();
                 value_inputs.insert(input_name.clone(), val);
             }
+            TtsInputKind::InputLengths => {
+                let val: Value = Value::from_array(Array1::from_vec(vec![seq_len as i64]))
+                    .map_err(|e| {
+                        AdapterError::InvalidInput(format!(
+                            "Failed to create input length value: {e}"
+                        ))
+                    })?
+                    .into();
+                value_inputs.insert(input_name.clone(), val);
+            }
+            TtsInputKind::Scales => {
+                let scales = vec![piper.noise_scale, piper.length_scale / speed, piper.noise_w];
+                let val: Value = Value::from_array(Array1::from_vec(scales))
+                    .map_err(|e| {
+                        AdapterError::InvalidInput(format!(
+                            "Failed to create Piper scales value: {e}"
+                        ))
+                    })?
+                    .into();
+                value_inputs.insert(input_name.clone(), val);
+            }
+            TtsInputKind::SpeakerId => {
+                let val: Value = Value::from_array(Array1::from_vec(vec![piper.speaker_id]))
+                    .map_err(|e| {
+                        AdapterError::InvalidInput(format!(
+                            "Failed to create Piper speaker value: {e}"
+                        ))
+                    })?
+                    .into();
+                value_inputs.insert(input_name.clone(), val);
+            }
             TtsInputKind::Unknown => {
                 // Not classified — will trigger the mismatch error below
             }
@@ -121,7 +153,8 @@ pub fn execute_tts_inference(
 
         return Err(AdapterError::InvalidInput(format!(
             "TTS model has unexpected inputs. Expected patterns: \
-             int64 [1, N] (tokens), f32 [1, 256] (voice embedding), f32 [1] (speed). \
+             int64 [1, N] (tokens), Piper input_lengths/scales/sid, \
+             f32 [1, 256] (voice embedding), or f32 [1] (speed). \
              Found: [{}]",
             found.join(", ")
         )));
@@ -138,6 +171,9 @@ enum TtsInputKind {
     VoiceEmbedding,
     /// f32 [1] — speed multiplier
     Speed,
+    InputLengths,
+    Scales,
+    SpeakerId,
     /// Unrecognized input pattern
     Unknown,
 }
@@ -148,7 +184,14 @@ enum TtsInputKind {
 /// - int64 with 2D shape [1, N] (N fixed or dynamic) → Tokens
 /// - f32 with 2D shape [1, 256] → VoiceEmbedding
 /// - f32 with 1D shape [1] (or dynamic [N]) → Speed
-fn classify_tts_input(dtype: Option<TensorElementType>, shape: &[i64]) -> TtsInputKind {
+fn classify_tts_input(name: &str, dtype: Option<TensorElementType>, shape: &[i64]) -> TtsInputKind {
+    match (name, dtype) {
+        ("input", Some(TensorElementType::Int64)) => return TtsInputKind::Tokens,
+        ("input_lengths", Some(TensorElementType::Int64)) => return TtsInputKind::InputLengths,
+        ("scales", Some(TensorElementType::Float32)) => return TtsInputKind::Scales,
+        ("sid", Some(TensorElementType::Int64)) => return TtsInputKind::SpeakerId,
+        _ => {}
+    }
     match dtype {
         Some(TensorElementType::Int64) if shape.len() == 2 && (shape[0] == 1 || shape[0] == -1) => {
             return TtsInputKind::Tokens;
@@ -169,4 +212,90 @@ fn classify_tts_input(dtype: Option<TensorElementType>, shape: &[i64]) -> TtsInp
         _ => {}
     }
     TtsInputKind::Unknown
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+pub struct PiperInferenceConfig {
+    #[serde(default = "default_noise_scale")]
+    pub noise_scale: f32,
+    #[serde(default = "default_length_scale")]
+    pub length_scale: f32,
+    #[serde(default = "default_noise_w")]
+    pub noise_w: f32,
+    #[serde(skip)]
+    pub speaker_id: i64,
+}
+
+impl Default for PiperInferenceConfig {
+    fn default() -> Self {
+        Self {
+            noise_scale: default_noise_scale(),
+            length_scale: default_length_scale(),
+            noise_w: default_noise_w(),
+            speaker_id: 0,
+        }
+    }
+}
+
+impl PiperInferenceConfig {
+    pub fn from_model_path(model_path: &std::path::Path) -> Self {
+        #[derive(serde::Deserialize)]
+        struct VoiceConfig {
+            #[serde(default)]
+            inference: PiperInferenceConfig,
+        }
+        let path = model_path.with_extension("onnx.json");
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|value| serde_json::from_str::<VoiceConfig>(&value).ok())
+            .map(|config| config.inference)
+            .unwrap_or_default()
+    }
+}
+
+fn default_noise_scale() -> f32 {
+    0.667
+}
+fn default_length_scale() -> f32 {
+    1.0
+}
+fn default_noise_w() -> f32 {
+    0.8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_piper_inputs_by_name() {
+        assert!(matches!(
+            classify_tts_input("input", Some(TensorElementType::Int64), &[1, -1]),
+            TtsInputKind::Tokens
+        ));
+        assert!(matches!(
+            classify_tts_input("input_lengths", Some(TensorElementType::Int64), &[1]),
+            TtsInputKind::InputLengths
+        ));
+        assert!(matches!(
+            classify_tts_input("scales", Some(TensorElementType::Float32), &[3]),
+            TtsInputKind::Scales
+        ));
+        assert!(matches!(
+            classify_tts_input("sid", Some(TensorElementType::Int64), &[1]),
+            TtsInputKind::SpeakerId
+        ));
+    }
+
+    #[test]
+    fn preserves_shape_fallback_for_embedding_tts() {
+        assert!(matches!(
+            classify_tts_input("style", Some(TensorElementType::Float32), &[1, 256]),
+            TtsInputKind::VoiceEmbedding
+        ));
+        assert!(matches!(
+            classify_tts_input("speed", Some(TensorElementType::Float32), &[1]),
+            TtsInputKind::Speed
+        ));
+    }
 }

--- a/crates/xybrid-core/src/execution/preprocessing/backends/espeak.rs
+++ b/crates/xybrid-core/src/execution/preprocessing/backends/espeak.rs
@@ -44,7 +44,7 @@ impl EspeakBackend {
     /// The CLI emits one line per sentence; we want a single flat IPA string.
     fn run_espeak(&self, text: &str) -> ExecutorResult<String> {
         let output = Command::new("espeak-ng")
-            .args(["--ipa", "-q", "-v", &self.language])
+            .args(["--ipa=3", "-q", "-v", &self.language])
             .arg(text)
             .output()
             .map_err(|e| {
@@ -69,7 +69,7 @@ impl EspeakBackend {
 
 impl PhonemizerBackend for EspeakBackend {
     fn phonemize(&self, text: &str, tokens_map: &HashMap<char, i64>) -> ExecutorResult<String> {
-        let phonemes = self.run_espeak(text)?;
+        let phonemes = self.phonemize_raw(text)?;
 
         // Filter to only characters in vocabulary
         let filtered: String = phonemes

--- a/crates/xybrid-core/src/execution/preprocessing/mod.rs
+++ b/crates/xybrid-core/src/execution/preprocessing/mod.rs
@@ -86,6 +86,7 @@ pub fn apply_preprocessing_step(
             add_padding,
             normalize_text,
             silence_tokens,
+            id_style,
         } => {
             let tokens_path = resolve_file_path(base_path, tokens_file);
             let dict_path = dict_file.as_ref().map(|p| resolve_file_path(base_path, p));
@@ -98,6 +99,7 @@ pub fn apply_preprocessing_step(
                 *add_padding,
                 *normalize_text,
                 silence_tokens.unwrap_or(0),
+                *id_style,
             )
         }
 

--- a/crates/xybrid-core/src/execution/preprocessing/text.rs
+++ b/crates/xybrid-core/src/execution/preprocessing/text.rs
@@ -5,8 +5,9 @@
 //! - `phonemize_step`: Convert text to phonemes for TTS models
 
 use super::super::types::{ExecutorResult, PreprocessedData};
-use crate::execution::template::{PhonemizerBackend, TokenizerType};
+use crate::execution::template::{PhonemeIdStyle, PhonemizerBackend, TokenizerType};
 use crate::runtime_adapter::AdapterError;
+use unicode_normalization::UnicodeNormalization;
 
 /// Tokenize text input for NLP models.
 ///
@@ -107,6 +108,7 @@ pub fn phonemize_step(
     add_padding: bool,
     normalize_text: bool,
     silence_tokens: u8,
+    id_style: PhonemeIdStyle,
 ) -> ExecutorResult<PreprocessedData> {
     use crate::phonemizer::load_tokens_map;
 
@@ -143,10 +145,34 @@ pub fn phonemize_step(
     let backend_impl = backend.create(base_path, dict_path, language);
     let phonemes = backend_impl.phonemize(&processed_text, &tokens_map)?;
 
-    // Convert phonemes to token IDs
-    let mut ids: Vec<i64> = Vec::new();
+    let ids = phoneme_ids(
+        &phonemes,
+        &tokens_map,
+        add_padding,
+        silence_tokens,
+        id_style,
+    );
 
-    if add_padding {
+    // Return as PhonemeIds for use by TTS models
+    Ok(PreprocessedData::PhonemeIds {
+        ids,
+        phonemes,
+        original_text: text,
+    })
+}
+
+fn phoneme_ids(
+    phonemes: &str,
+    tokens_map: &std::collections::HashMap<char, i64>,
+    add_padding: bool,
+    silence_tokens: u8,
+    id_style: PhonemeIdStyle,
+) -> Vec<i64> {
+    let mut ids = Vec::new();
+
+    if matches!(id_style, PhonemeIdStyle::Piper) {
+        ids.extend([1, 0]);
+    } else if add_padding {
         ids.push(0); // Start padding token
     }
 
@@ -158,28 +184,36 @@ pub fn phonemize_step(
         ));
     }
 
-    for c in phonemes.chars() {
+    let characters: Vec<char> = if matches!(id_style, PhonemeIdStyle::Piper) {
+        phonemes.nfd().collect()
+    } else {
+        phonemes.chars().collect()
+    };
+    for c in characters {
         if let Some(&id) = tokens_map.get(&c) {
             ids.push(id);
+            if matches!(id_style, PhonemeIdStyle::Piper) {
+                ids.push(0);
+            }
         } else if c == ' ' {
             // Space character - check if it has a mapping
             if let Some(&id) = tokens_map.get(&' ') {
                 ids.push(id);
+                if matches!(id_style, PhonemeIdStyle::Piper) {
+                    ids.push(0);
+                }
             }
         }
         // Skip unknown characters silently
     }
 
-    if add_padding {
+    if matches!(id_style, PhonemeIdStyle::Piper) {
+        ids.push(2);
+    } else if add_padding {
         ids.push(0); // End padding token
     }
 
-    // Return as PhonemeIds for use by TTS models
-    Ok(PreprocessedData::PhonemeIds {
-        ids,
-        phonemes,
-        original_text: text,
-    })
+    ids
 }
 
 /// Normalize text for TTS processing.
@@ -788,6 +822,7 @@ mod tests {
             true, // add_padding
             true, // normalize_text
             0,    // silence_tokens
+            PhonemeIdStyle::Standard,
         )
         .unwrap();
 
@@ -958,6 +993,15 @@ mod tests {
         assert!(normalize_text_for_tts("100 percent").contains("one hundred"));
     }
 
+    #[test]
+    fn piper_id_style_adds_bos_pad_interleaving_and_eos() {
+        let tokens = std::collections::HashMap::from([('a', 10), ('b', 11)]);
+        assert_eq!(
+            phoneme_ids("ab", &tokens, false, 0, PhonemeIdStyle::Piper),
+            vec![1, 0, 10, 0, 11, 0, 2]
+        );
+    }
+
     /// Helper: run phonemize_step with a specific backend and normalize_text flag.
     /// Returns (phonemes, ids) if fixtures are available, None otherwise.
     fn run_phonemize_step_with_backend(
@@ -988,6 +1032,7 @@ mod tests {
             true,
             normalize_text,
             0, // silence_tokens
+            PhonemeIdStyle::Standard,
         )
         .unwrap();
 

--- a/crates/xybrid-core/src/execution/template/mod.rs
+++ b/crates/xybrid-core/src/execution/template/mod.rs
@@ -23,7 +23,7 @@ pub use metadata::{VisionEncoderConfig, VisionPreprocessingPreset};
 // Re-export step types
 pub use steps::{
     ImageNormalizePreset, ImageResizeMode, ImageTensorLayout, InterpolationMethod, MelScaleType,
-    PhonemizerBackend, PostprocessingStep, PreprocessingStep, TokenizerType,
+    PhonemeIdStyle, PhonemizerBackend, PostprocessingStep, PreprocessingStep, TokenizerType,
 };
 
 // Re-export voice types

--- a/crates/xybrid-core/src/execution/template/steps.rs
+++ b/crates/xybrid-core/src/execution/template/steps.rs
@@ -248,7 +248,23 @@ pub enum PreprocessingStep {
         /// Uses token ID 30 (Kokoro silence token).
         #[serde(default)]
         silence_tokens: Option<u8>,
+
+        /// Token framing used after phonemization.
+        #[serde(default)]
+        id_style: PhonemeIdStyle,
     },
+}
+
+/// How phonemes are framed as model input IDs.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum PhonemeIdStyle {
+    /// Map each phoneme directly, with optional outer padding.
+    #[default]
+    Standard,
+    /// Piper framing: BOS, pad, each phoneme followed by pad, then EOS.
+    Piper,
 }
 
 impl PreprocessingStep {

--- a/crates/xybrid-core/src/execution/voice_loader.rs
+++ b/crates/xybrid-core/src/execution/voice_loader.rs
@@ -219,6 +219,13 @@ impl<S: VoiceEmbeddingSource> TtsVoiceLoader<S> {
         input: &Envelope,
         token_count: Option<usize>,
     ) -> ExecutorResult<Vec<f32>> {
+        if matches!(
+            metadata.voices.as_ref().map(|voices| &voices.format),
+            Some(VoiceFormat::PerModel { .. })
+        ) {
+            self.resolve_voice_model_path(metadata, input)?;
+            return Ok(Vec::new());
+        }
         // Step 1: Resolve voice file path
         let voice_path = match self.resolve_voice_path(metadata)? {
             Some(path) => path,
@@ -262,6 +269,31 @@ impl<S: VoiceEmbeddingSource> TtsVoiceLoader<S> {
         } else {
             self.load_legacy(&voice_path, voice_id)
         }
+    }
+
+    pub(crate) fn resolve_voice_model_path(
+        &self,
+        metadata: &ModelMetadata,
+        input: &Envelope,
+    ) -> ExecutorResult<Option<PathBuf>> {
+        let Some(voice_config) = &metadata.voices else {
+            return Ok(None);
+        };
+        let VoiceFormat::PerModel { voice_dir, pattern } = &voice_config.format else {
+            return Ok(None);
+        };
+        if !pattern.contains("{voice_id}") {
+            return Err(AdapterError::InvalidInput(
+                "Per-model voice pattern must contain {voice_id}".to_string(),
+            ));
+        }
+        let voice =
+            self.resolve_voice_info(voice_config, metadata, input.metadata.get("voice_id"))?;
+        Ok(Some(
+            self.base_path
+                .join(voice_dir)
+                .join(pattern.replace("{voice_id}", &voice.id)),
+        ))
     }
 
     /// Resolve the voice file path from metadata or legacy auto-detection.
@@ -767,6 +799,37 @@ mod tests {
         let path = loader.resolve_voice_path(&metadata).unwrap();
         assert!(path.is_some());
         assert!(path.unwrap().ends_with("voices.bin"));
+    }
+
+    #[test]
+    fn test_resolve_per_model_voice_path() {
+        let source = MockVoiceSource::new();
+        let loader = TtsVoiceLoader::with_source("/models/tts", source);
+        let mut metadata = create_test_metadata_with_voices();
+        metadata.voices.as_mut().expect("voices").format = VoiceFormat::PerModel {
+            voice_dir: "voices".to_string(),
+            pattern: "{voice_id}.onnx".to_string(),
+        };
+        let input = create_test_envelope_with_voice("voice_b");
+        assert_eq!(
+            loader
+                .resolve_voice_model_path(&metadata, &input)
+                .expect("path"),
+            Some(PathBuf::from("/models/tts/voices/voice_b.onnx"))
+        );
+    }
+
+    #[test]
+    fn test_per_model_voice_rejects_unknown_catalog_id() {
+        let source = MockVoiceSource::new();
+        let loader = TtsVoiceLoader::with_source("/models/tts", source);
+        let mut metadata = create_test_metadata_with_voices();
+        metadata.voices.as_mut().expect("voices").format = VoiceFormat::PerModel {
+            voice_dir: "voices".to_string(),
+            pattern: "{voice_id}.onnx".to_string(),
+        };
+        let input = create_test_envelope_with_voice("../outside");
+        assert!(loader.resolve_voice_model_path(&metadata, &input).is_err());
     }
 
     #[test]

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -50,6 +50,7 @@ default = []
 # never reference `xybrid_core::testing`. Forwards to `xybrid-core/test-util`
 # so the gate stays consistent if core later moves `testing` behind it.
 test-util = ["xybrid-core/test-util"]
+espeak = ["xybrid-core/espeak"]
 
 # HuggingFace Hub integration (download models directly from HF repos)
 huggingface = ["dep:hf-hub"]

--- a/crates/xybrid-sdk/src/metadata_gen.rs
+++ b/crates/xybrid-sdk/src/metadata_gen.rs
@@ -15,7 +15,11 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use xybrid_core::execution::{
-    template::GenerationParams, ExecutionTemplate, ModelMetadata, VisionEncoderConfig,
+    template::{
+        GenerationParams, PhonemeIdStyle, VoiceConfig, VoiceFormat, VoiceInfo,
+        VoiceSelectionStrategy,
+    },
+    ExecutionTemplate, ModelMetadata, PreprocessingStep, VisionEncoderConfig,
     VisionPreprocessingPreset,
 };
 
@@ -56,7 +60,19 @@ pub fn inspect_and_generate(
     let model_card = parse_hf_model_card(&dir.join("README.md"));
 
     // 2. Scan for model files
-    let model_files = detect_model_files(dir);
+    let mut model_files = detect_model_files(dir);
+    if model_files.is_empty() {
+        model_files = detect_model_files(&dir.join("voices"))
+            .into_iter()
+            .map(|mut file| {
+                file.filename = Path::new("voices")
+                    .join(file.filename)
+                    .to_string_lossy()
+                    .into_owned();
+                file
+            })
+            .collect();
+    }
 
     if model_files.is_empty() {
         return Err(SdkError::load(format!(
@@ -99,7 +115,23 @@ pub fn inspect_and_generate(
     };
 
     // 7. List all non-hidden files in directory (excluding README.md, model_metadata.json)
-    let all_files = list_model_files(dir);
+    let mut all_files = list_model_files(dir);
+    if model_files
+        .iter()
+        .any(|file| Path::new(&file.filename).parent() == Some(Path::new("voices")))
+    {
+        all_files.extend(
+            list_model_files(&dir.join("voices"))
+                .into_iter()
+                .map(|file| {
+                    Path::new("voices")
+                        .join(file)
+                        .to_string_lossy()
+                        .into_owned()
+                }),
+        );
+        all_files.sort();
+    }
 
     // 8. Build metadata from collected info
     let metadata = build_metadata(
@@ -1283,6 +1315,7 @@ fn build_onnx_metadata(
                     add_padding: true,
                     normalize_text: false,
                     silence_tokens: None,
+                    id_style: Default::default(),
                 });
                 postprocessing.push(PostprocessingStep::TTSAudioEncode {
                     sample_rate: 24000,
@@ -1396,6 +1429,9 @@ fn build_onnx_metadata(
         .and_then(|c| c.model_name.clone())
         .unwrap_or_else(|| format!("{} (auto-generated)", model_id));
 
+    let voices = task_inference
+        .and_then(|inference| piper_voice_config(primary, all_files, &inference.preprocessing));
+
     ModelMetadata {
         model_id: model_id.to_string(),
         version: "1.0".to_string(),
@@ -1408,10 +1444,90 @@ fn build_onnx_metadata(
         vision_encoder: None,
         description: Some(description),
         metadata: metadata_map,
-        voices: None,
+        voices,
         max_chunk_chars: None,
         trim_trailing_samples: None,
     }
+}
+
+fn piper_voice_config(
+    primary: &ModelFileInfo,
+    all_files: &[String],
+    preprocessing: &[PreprocessingStep],
+) -> Option<VoiceConfig> {
+    if !preprocessing.iter().any(|step| {
+        matches!(
+            step,
+            PreprocessingStep::Phonemize {
+                id_style: PhonemeIdStyle::Piper,
+                ..
+            }
+        )
+    }) {
+        return None;
+    }
+
+    let primary_path = Path::new(&primary.filename);
+    let parent = primary_path.parent().unwrap_or_else(|| Path::new(""));
+    let default = primary_path.file_stem()?.to_str()?.to_string();
+    let mut ids: Vec<String> = all_files
+        .iter()
+        .map(Path::new)
+        .filter(|path| path.parent().unwrap_or_else(|| Path::new("")) == parent)
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("onnx"))
+        .filter_map(|path| path.file_stem()?.to_str().map(str::to_string))
+        .collect();
+    if ids.is_empty() {
+        ids.push(default.clone());
+    }
+    ids.sort();
+    ids.dedup();
+
+    let catalog = ids
+        .into_iter()
+        .map(|id| {
+            let short_name = id
+                .strip_prefix("en_US-")
+                .unwrap_or(&id)
+                .strip_suffix("-medium")
+                .unwrap_or(&id);
+            let name = short_name
+                .split(['-', '_'])
+                .filter(|part| !part.is_empty())
+                .map(|part| {
+                    let mut chars = part.chars();
+                    chars
+                        .next()
+                        .map(|first| first.to_uppercase().chain(chars).collect::<String>())
+                        .unwrap_or_default()
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            VoiceInfo {
+                id,
+                name,
+                gender: None,
+                language: Some("en-US".to_string()),
+                style: Some("medium".to_string()),
+                index: None,
+                preview_url: None,
+            }
+        })
+        .collect();
+
+    Some(VoiceConfig {
+        format: VoiceFormat::PerModel {
+            voice_dir: if parent.as_os_str().is_empty() {
+                ".".to_string()
+            } else {
+                parent.to_string_lossy().into_owned()
+            },
+            pattern: "{voice_id}.onnx".to_string(),
+        },
+        default,
+        catalog,
+        selection_strategy: VoiceSelectionStrategy::default(),
+    })
 }
 
 fn build_safetensors_metadata(
@@ -1527,7 +1643,7 @@ pub(crate) fn infer_task_from_tensors(
     files: &SupportingFileInfo,
     hf_card: Option<&HfModelCard>,
 ) -> TaskInference {
-    use xybrid_core::execution::template::TokenizerType;
+    use xybrid_core::execution::template::{PhonemeIdStyle, PhonemizerBackend, TokenizerType};
     use xybrid_core::execution::{PostprocessingStep, PreprocessingStep};
 
     // Helper: choose tokenizer file
@@ -1587,9 +1703,35 @@ pub(crate) fn infer_task_from_tensors(
     let has_tokens = input_names.contains(&"tokens");
     let has_style = input_names.contains(&"style");
     let has_speed = input_names.contains(&"speed");
+    let is_piper = input_names.contains(&"input")
+        && input_names.contains(&"input_lengths")
+        && input_names.contains(&"scales");
     let has_pixel_values = input_names.contains(&"pixel_values");
     let has_input_features =
         input_names.contains(&"input_features") || input_names.contains(&"input_values");
+
+    if is_piper {
+        return TaskInference {
+            task: "text-to-speech".to_string(),
+            preprocessing: vec![PreprocessingStep::Phonemize {
+                tokens_file: "tokens.txt".to_string(),
+                dict_file: None,
+                backend: PhonemizerBackend::EspeakNG,
+                language: Some("en".to_string()),
+                add_padding: false,
+                normalize_text: false,
+                silence_tokens: None,
+                id_style: PhonemeIdStyle::Piper,
+            }],
+            postprocessing: vec![PostprocessingStep::TTSAudioEncode {
+                sample_rate: 22050,
+                apply_postprocessing: false,
+                trim_trailing_silence: false,
+            }],
+            confidence: Confidence::High,
+            alternatives: Vec::new(),
+        };
+    }
 
     // TTS pattern: tokens + style + speed
     if has_tokens && has_style && has_speed {
@@ -1603,6 +1745,7 @@ pub(crate) fn infer_task_from_tensors(
                 add_padding: true,
                 normalize_text: false,
                 silence_tokens: None,
+                id_style: Default::default(),
             }],
             postprocessing: vec![PostprocessingStep::TTSAudioEncode {
                 sample_rate: 24000,
@@ -1716,6 +1859,7 @@ fn infer_from_pipeline_tag(
                 add_padding: true,
                 normalize_text: false,
                 silence_tokens: None,
+                id_style: Default::default(),
             }],
             postprocessing: vec![PostprocessingStep::TTSAudioEncode {
                 sample_rate: 24000,
@@ -1932,6 +2076,7 @@ fn infer_from_output_shapes(
                         add_padding: true,
                         normalize_text: false,
                         silence_tokens: None,
+                        id_style: Default::default(),
                     }],
                     postprocessing: vec![PostprocessingStep::TTSAudioEncode {
                         sample_rate: 24000,
@@ -2769,6 +2914,73 @@ mod tests {
         assert!(matches!(
             result.postprocessing[0],
             xybrid_core::execution::PostprocessingStep::TTSAudioEncode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_infer_piper_inputs() {
+        let onnx = OnnxInfo {
+            inputs: vec![
+                TensorInfo {
+                    name: "input".into(),
+                    shape: vec![1, -1],
+                    dtype: "Int64".into(),
+                },
+                TensorInfo {
+                    name: "input_lengths".into(),
+                    shape: vec![1],
+                    dtype: "Int64".into(),
+                },
+                TensorInfo {
+                    name: "scales".into(),
+                    shape: vec![3],
+                    dtype: "Float32".into(),
+                },
+            ],
+            outputs: vec![TensorInfo {
+                name: "output".into(),
+                shape: vec![1, 1, -1],
+                dtype: "Float32".into(),
+            }],
+        };
+        let result = infer_task_from_tensors(&onnx, &SupportingFileInfo::default(), None);
+        assert_eq!(result.task, "text-to-speech");
+        assert!(matches!(
+            result.preprocessing[0],
+            xybrid_core::execution::PreprocessingStep::Phonemize {
+                backend: xybrid_core::execution::template::PhonemizerBackend::EspeakNG,
+                id_style: xybrid_core::execution::template::PhonemeIdStyle::Piper,
+                ..
+            }
+        ));
+        assert!(matches!(
+            result.postprocessing[0],
+            xybrid_core::execution::PostprocessingStep::TTSAudioEncode {
+                sample_rate: 22_050,
+                ..
+            }
+        ));
+
+        let primary = ModelFileInfo {
+            filename: "voices/en_US-kristin-medium.onnx".to_string(),
+            format: ModelFormat::Onnx,
+            size_bytes: 1,
+        };
+        let files = vec![
+            "tokens.txt".to_string(),
+            "voices/en_US-bryce-medium.onnx".to_string(),
+            "voices/en_US-kristin-medium.onnx".to_string(),
+        ];
+        let voices =
+            piper_voice_config(&primary, &files, &result.preprocessing).expect("Piper voices");
+        assert_eq!(voices.default, "en_US-kristin-medium");
+        assert_eq!(voices.catalog.len(), 2);
+        assert!(matches!(
+            voices.format,
+            VoiceFormat::PerModel {
+                ref voice_dir,
+                ref pattern
+            } if voice_dir == "voices" && pattern == "{voice_id}.onnx"
         ));
     }
 

--- a/docs/sdk/MODEL_METADATA.md
+++ b/docs/sdk/MODEL_METADATA.md
@@ -217,7 +217,8 @@ Converts text to phoneme token IDs for TTS models.
   "language": null,
   "add_padding": true,
   "normalize_text": false,
-  "silence_tokens": null
+  "silence_tokens": null,
+  "id_style": "standard"
 }
 ```
 
@@ -230,6 +231,7 @@ Converts text to phoneme token IDs for TTS models.
 | `add_padding` | boolean | `true` | Add padding tokens at start/end |
 | `normalize_text` | boolean | `false` | Apply text cleanup before phonemization |
 | `silence_tokens` | integer | `null` | Silence tokens to prepend (smooths plosives) |
+| `id_style` | string | `"standard"` | `"piper"` adds BOS 1, pad 0 interleaving, and EOS 2 |
 
 **Phonemizer backends**:
 
@@ -463,6 +465,14 @@ TTS models can include a `voices` section to define available voices.
 | `embedded` | All voices in a single binary file | Kokoro, KittenTTS |
 | `per_model` | Each voice is a separate model file | Piper |
 | `cloning` | Voice cloning from reference audio | (future) |
+
+For `per_model`, set `voice_dir` and a `pattern` containing `{voice_id}`.
+The selected catalog ID is substituted into that pattern and its ONNX session
+is loaded through the bounded `XYBRID_TTS_VOICE_SESSIONS` cache (default 4).
+
+Piper VITS graphs use the named inputs `input`, `input_lengths`, and `scales`,
+plus optional `sid`. `scales` is `[noise_scale, length_scale / speed, noise_w]`;
+the three defaults are read from the selected voice's adjacent `.onnx.json`.
 
 ### Voice Loaders (for `embedded` format)
 

--- a/docs/sdk/MODEL_METADATA.md
+++ b/docs/sdk/MODEL_METADATA.md
@@ -239,8 +239,15 @@ Converts text to phoneme token IDs for TTS models.
 |---------|-------------|-------|
 | `MisakiDictionary` | None (pure Rust) | **Recommended.** Bundled dictionaries + rule-based G2P fallback |
 | `CmuDictionary` | None (pure Rust) | Legacy ARPABET-based, English only |
-| `EspeakNG` | `espeak-ng` system install | Multi-language support |
+| `EspeakNG` | `espeak-ng` binary on `PATH` | Multi-language; desktop/server only (see below) |
 | `OpenPhonemizer` | ONNX model (~59MB) | Dictionary + neural G2P fallback |
+
+`EspeakNG` shells out to the `espeak-ng` executable at inference time — it is
+not linked or bundled. That makes it desktop/server-only: iOS and Android
+cannot spawn system binaries, so models that declare this backend (Piper
+voices, for example) do not run on mobile. There is no load-time check; a
+missing binary surfaces as an inference error with install instructions
+(`brew install espeak-ng` on macOS, `apt-get install espeak-ng` on Linux).
 
 **Input**: `Envelope::Text(string)` → **Output**: Token IDs (i64)
 

--- a/docs/sdk/model_metadata.schema.json
+++ b/docs/sdk/model_metadata.schema.json
@@ -434,6 +434,43 @@
           ]
         },
         {
+          "description": "GGML-format Whisper speech recognition, executed by whisper.cpp on the\nsame ggml the local LLM backend already links.\n\nDistinct from [`ExecutionTemplate::SafeTensors`] with\n`architecture: \"whisper\"`, which routes to the pure-Rust Candle\nimplementation. Both transcribe; they differ in weight format (GGML\nquantized vs F32 safetensors) and therefore in cost, which is the whole\nreason this variant exists.",
+          "type": "object",
+          "properties": {
+            "audio_ctx": {
+              "description": "Encoder context in mel frames, where 1500 covers the full 30 s\nwindow. `0` (the default) means no truncation.\n\nTruncating is the largest single speed lever for live streaming,\nbut truncating too far makes the decoder emit repetition loops.\nMeasured on a Pixel 8 with `tiny.en` Q5_1: 500 is safe for a 5 s\nwindow and 2.8x faster than full context; 250 degenerates. So a\nmodel opts in here after its own quality check rather than\ninheriting a fast-but-fragile default.",
+              "type": "integer",
+              "format": "uint32",
+              "default": 0,
+              "minimum": 0
+            },
+            "language": {
+              "description": "Language code to force (e.g. `\"en\"`). Absent means auto-detect.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "model_file": {
+              "description": "Path to the GGML model file (relative to bundle root), e.g.\n`ggml-base.en-q5_1.bin`.",
+              "type": "string"
+            },
+            "translate": {
+              "description": "Translate into English instead of transcribing in the source\nlanguage.",
+              "type": "boolean",
+              "default": false
+            },
+            "type": {
+              "type": "string",
+              "const": "GgmlWhisper"
+            }
+          },
+          "required": [
+            "type",
+            "model_file"
+          ]
+        },
+        {
           "description": "Vision-language model execution for image+text LLM inputs.",
           "type": "object",
           "properties": {
@@ -638,6 +675,21 @@
           "description": "HTK mel scale (used by older implementations, mel-spec library).\n\nFormula: `mel = 2595 * log10(1 + freq / 700)`",
           "type": "string",
           "const": "htk"
+        }
+      ]
+    },
+    "PhonemeIdStyle": {
+      "description": "How phonemes are framed as model input IDs.",
+      "oneOf": [
+        {
+          "description": "Map each phoneme directly, with optional outer padding.",
+          "type": "string",
+          "const": "standard"
+        },
+        {
+          "description": "Piper framing: BOS, pad, each phoneme followed by pad, then EOS.",
+          "type": "string",
+          "const": "piper"
         }
       ]
     },
@@ -1448,6 +1500,11 @@
                 "null"
               ],
               "default": null
+            },
+            "id_style": {
+              "description": "Token framing used after phonemization.",
+              "$ref": "#/$defs/PhonemeIdStyle",
+              "default": "standard"
             },
             "language": {
               "description": "Language code for espeak-ng (e.g., \"en-us\", \"en-gb\")\nOnly used when backend is EspeakNG",


### PR DESCRIPTION
## Summary

- support Piper VITS ONNX inputs by name: `input`, `input_lengths`, `scales`, and optional `sid`
- add Piper phoneme ID framing and align the espeak-ng backend with Piper's IPA mode
- implement `VoiceFormat::PerModel` model selection with an LRU session cache bounded by `XYBRID_TTS_VOICE_SESSIONS` (default 4)
- read per-voice inference defaults from the adjacent `.onnx.json` and map API speed through Piper's length scale
- teach metadata generation to recognize Piper graphs and nested voice models
- document the metadata contract, regenerate the schema, and add a runnable Piper example

## Why

This is the runtime prerequisite for the `piper-en-us` Phase 1 model package and Sonix serving work. Piper uses one ONNX graph per voice and a different input/framing contract from the existing embedding-based TTS models.

## Validation

- `cargo test -p xybrid-core --lib`: 1008 passed, 1 ignored
- xybrid-sdk metadata tests: 35 passed
- `cargo clippy -p xybrid-core --lib -- -D warnings`
- `cargo clippy -p xybrid-sdk --lib -- -D warnings`
- real Piper ONNX inference produced valid 22,050 Hz mono audio
- output duration fell within the official Piper CLI's stochastic run distribution

## Review notes

- Piper/VITS inference is stochastic, so parity is assessed by the audio contract, sample rate, and duration distribution rather than byte identity.
- This PR does not bump or publish crate versions. Releases must go through the repository's `release/v<version>` workflow.