### PR TITLE
feat: self-host star history chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,80 @@
+name: Star history
+
+# Records the public star count once a day and redraws the README chart.
+#
+# GitHub restricted the stargazers *list* endpoint to admins and collaborators
+# on 2026-06-30, which is what broke star-history.com. The star *count* on the
+# repo object is still public, so we collect our own series instead of relying
+# on a third-party service.
+#
+# Data and charts live on the unprotected `star-history` branch, never on
+# master: master requires a reviewed PR, and a daily commit there would churn
+# the git log and re-trigger CI for nothing.
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out master for the script
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Attach the data branch as a worktree
+        run: |
+          if git fetch origin star-history:refs/remotes/origin/star-history 2>/dev/null; then
+            git worktree add data origin/star-history
+            git -C data switch -c star-history --track origin/star-history
+          else
+            # First run: start the branch with no history of its own, so the
+            # daily snapshots never interleave with the source tree.
+            echo "star-history branch not found; bootstrapping an orphan branch"
+            git worktree add --detach data
+            git -C data checkout --orphan star-history
+            git -C data rm -rf --quiet . || true
+          fi
+
+      - name: Snapshot and render
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/scripts/star-history.py \
+            --repo "${{ github.repository }}" \
+            --data data/stars.jsonl \
+            --light data/star-history.svg \
+            --dark data/star-history-dark.svg \
+            snapshot
+          python3 tools/scripts/star-history.py \
+            --repo "${{ github.repository }}" \
+            --data data/stars.jsonl \
+            --light data/star-history.svg \
+            --dark data/star-history-dark.svg \
+            render
+
+      - name: Commit if the count moved
+        working-directory: data
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add stars.jsonl star-history.svg star-history-dark.svg
+          if git diff --cached --quiet; then
+            echo "No change today."
+            exit 0
+          fi
+          stars=$(tail -n 1 stars.jsonl | sed 's/.*"stars": *\([0-9]*\).*/\1/')
+          git commit -m "chore(stars): ${stars} stars"
+          git push origin star-history

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,10 @@ claudedocs/
 bindings/kotlin/consumer-smoke/.gradle/
 bindings/kotlin/consumer-smoke/app/build/
 bindings/kotlin/consumer-smoke/app/libs/
+
+# Star history scratch (tools/scripts/star-history.py). The canonical series
+# and rendered charts live on the unprotected `star-history` branch, which the
+# README links to; these are just local run output.
+/.metrics/
+/docs/assets/star-history.svg
+/docs/assets/star-history-dark.svg

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 [deepwiki-shield]: https://deepwiki.com/badge.svg
 [deepwiki-url]: https://deepwiki.com/xybrid-ai/xybrid
 [stars-shield]: https://img.shields.io/github/stars/xybrid-ai/xybrid?style=flat-square
-[stars-url]: https://github.com/xybrid-ai/xybrid/stargazers
+[stars-url]: https://github.com/xybrid-ai/xybrid#star-history
 [twitter-shield]: https://img.shields.io/badge/Follow-%40xybrid__ai-000000?style=for-the-badge&logo=x&logoColor=white
 [twitter-url]: https://x.com/xybrid_ai
 [visitors-shield]: https://visitor-badge.laobi.icu/badge?page_id=xybrid-ai.xybrid
@@ -460,7 +460,10 @@ We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guideline
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xybrid-ai/xybrid&type=date&legend=bottom-right)](https://www.star-history.com/#xybrid-ai/xybrid&type=date&legend=bottom-right)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/xybrid-ai/xybrid/star-history/star-history-dark.svg">
+  <img alt="Star history for xybrid-ai/xybrid" src="https://raw.githubusercontent.com/xybrid-ai/xybrid/star-history/star-history.svg">
+</picture>
 
 ## License
 

--- a/tools/scripts/star-history.py
+++ b/tools/scripts/star-history.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Self-hosted star history: snapshot, backfill and render, with no third party.
+
+GitHub restricted the stargazers *list* endpoint to admins and collaborators on
+2026-06-30, which broke star-history.com and every service built on it. The star
+*count* (``stargazers_count`` on the repo object) is still public, and the list
+still works for people who administer the repo -- so we collect it ourselves.
+
+Subcommands:
+
+``backfill``
+    Walk the full stargazer list (needs admin/collaborator rights) and rebuild
+    the true historical curve from each ``starred_at`` timestamp. Run once.
+
+``snapshot``
+    Append today's public star count. Runs daily in CI, needs no special rights.
+
+``render``
+    Turn the collected series into committed SVG charts (light + dark).
+
+Data lives in a JSON Lines file, one ``{"date": ..., "stars": ...}`` per day,
+sorted, with one entry per date. Rendering never touches the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_FILE = REPO_ROOT / ".metrics" / "stars.jsonl"
+LIGHT_SVG = REPO_ROOT / "docs" / "assets" / "star-history.svg"
+DARK_SVG = REPO_ROOT / "docs" / "assets" / "star-history-dark.svg"
+DEFAULT_REPO = "xybrid-ai/xybrid"
+
+# Chart geometry, in SVG user units.
+WIDTH, HEIGHT = 800, 360
+MARGIN_LEFT, MARGIN_RIGHT = 62, 24
+MARGIN_TOP, MARGIN_BOTTOM = 46, 44
+PLOT_WIDTH = WIDTH - MARGIN_LEFT - MARGIN_RIGHT
+PLOT_HEIGHT = HEIGHT - MARGIN_TOP - MARGIN_BOTTOM
+
+Y_TICKS = 5
+X_TICKS = 6
+
+THEMES = {
+    "light": {
+        "bg": "#ffffff",
+        "grid": "#e5e7eb",
+        "axis": "#d0d7de",
+        "text": "#57606a",
+        "title": "#1f2328",
+        "line": "#dfb317",
+        "fill": "#dfb317",
+        "fill_opacity": "0.14",
+    },
+    "dark": {
+        "bg": "#0d1117",
+        "grid": "#21262d",
+        "axis": "#30363d",
+        "text": "#8b949e",
+        "title": "#e6edf3",
+        "line": "#e3b341",
+        "fill": "#e3b341",
+        "fill_opacity": "0.16",
+    },
+}
+
+
+# --------------------------------------------------------------------------- #
+# data access
+# --------------------------------------------------------------------------- #
+
+
+def gh(*args: str) -> str:
+    """Run `gh` and return stdout, failing loudly with gh's own stderr."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        sys.exit(f"gh {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def load_series(path: Path) -> list[tuple[date, int]]:
+    if not path.exists():
+        return []
+    by_date: dict[date, int] = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        record = json.loads(line)
+        # Later entries for the same day win; CI may snapshot more than once.
+        by_date[date.fromisoformat(record["date"])] = int(record["stars"])
+    return sorted(by_date.items())
+
+
+def save_series(path: Path, series: list[tuple[date, int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({"date": day.isoformat(), "stars": stars})
+        for day, stars in series
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# subcommands
+# --------------------------------------------------------------------------- #
+
+
+def cmd_backfill(args: argparse.Namespace) -> None:
+    """Reconstruct the real curve from starred_at timestamps.
+
+    Requires admin or collaborator rights on the repo: since 2026-06-30 the
+    stargazers list 401s unauthenticated and 404s for everyone else.
+    """
+    raw = gh(
+        "api",
+        "-H",
+        "Accept: application/vnd.github.star+json",
+        "--paginate",
+        f"repos/{args.repo}/stargazers",
+        "--jq",
+        ".[].starred_at",
+    )
+    stamps = [line.strip() for line in raw.splitlines() if line.strip()]
+    if not stamps:
+        sys.exit(
+            "No stargazers returned. Either the repo has none, or your token "
+            "lacks admin/collaborator rights on it."
+        )
+
+    # GitHub caps the list at 40k stargazers. Past that, the early history is
+    # unrecoverable and the curve would start mid-air -- say so rather than
+    # silently drawing a wrong shape.
+    if len(stamps) >= 40_000:
+        print(
+            f"warning: hit GitHub's 40k stargazer cap; history before "
+            f"{stamps[0][:10]} is not retrievable",
+            file=sys.stderr,
+        )
+
+    days = sorted(date.fromisoformat(stamp[:10]) for stamp in stamps)
+    running, series = 0, []
+    current = days[0]
+    index = 0
+    # Emit one cumulative point per calendar day, including flat days, so the
+    # x-axis is real time rather than "days something happened".
+    while current <= days[-1]:
+        while index < len(days) and days[index] == current:
+            running += 1
+            index += 1
+        series.append((current, running))
+        current = date.fromordinal(current.toordinal() + 1)
+
+    save_series(args.data, series)
+    print(
+        f"backfilled {len(series)} days, {series[0][0]} to {series[-1][0]}, "
+        f"{series[-1][1]} stars -> {args.data}"
+    )
+
+
+def cmd_snapshot(args: argparse.Namespace) -> None:
+    """Append today's star count from the still-public repo endpoint."""
+    stars = int(gh("api", f"repos/{args.repo}", "--jq", ".stargazers_count").strip())
+    today = datetime.now(timezone.utc).date()
+
+    series = load_series(args.data)
+    merged = dict(series)
+    if merged.get(today) == stars:
+        print(f"no change: {stars} stars on {today}")
+        return
+    merged[today] = stars
+    save_series(args.data, sorted(merged.items()))
+    print(f"recorded {stars} stars on {today}")
+
+
+def cmd_render(args: argparse.Namespace) -> None:
+    series = load_series(args.data)
+    if len(series) < 2:
+        sys.exit(f"need at least 2 data points to draw a chart, found {len(series)}")
+
+    args.light.parent.mkdir(parents=True, exist_ok=True)
+    args.light.write_text(render_svg(series, args.repo, THEMES["light"]))
+    args.dark.parent.mkdir(parents=True, exist_ok=True)
+    args.dark.write_text(render_svg(series, args.repo, THEMES["dark"]))
+    print(f"rendered {len(series)} points -> {args.light} and {args.dark}")
+
+
+# --------------------------------------------------------------------------- #
+# rendering
+# --------------------------------------------------------------------------- #
+
+
+def nice_ceiling(value: int) -> int:
+    """Round up to a readable axis maximum (100, 250, 500, 1000, ...)."""
+    if value <= 10:
+        return 10
+    magnitude = 10 ** (len(str(value)) - 1)
+    for step in (1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10):
+        candidate = int(magnitude * step)
+        if candidate >= value:
+            return candidate
+    return magnitude * 10
+
+
+def human(value: int) -> str:
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M".replace(".0M", "M")
+    if value >= 1_000:
+        return f"{value / 1_000:.1f}k".replace(".0k", "k")
+    return str(value)
+
+
+def render_svg(
+    series: list[tuple[date, int]], repo: str, theme: dict[str, str]
+) -> str:
+    first_day, last_day = series[0][0], series[-1][0]
+    span_days = max((last_day - first_day).days, 1)
+    y_max = nice_ceiling(series[-1][1])
+
+    def x_of(day: date) -> float:
+        return MARGIN_LEFT + PLOT_WIDTH * ((day - first_day).days / span_days)
+
+    def y_of(stars: int) -> float:
+        return MARGIN_TOP + PLOT_HEIGHT * (1 - stars / y_max)
+
+    points = [(x_of(day), y_of(stars)) for day, stars in series]
+    line = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+    baseline = MARGIN_TOP + PLOT_HEIGHT
+    area = (
+        f"{points[0][0]:.1f},{baseline:.1f} "
+        + line
+        + f" {points[-1][0]:.1f},{baseline:.1f}"
+    )
+
+    parts: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" '
+        f'height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" '
+        f'font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">',
+        f'<rect width="{WIDTH}" height="{HEIGHT}" fill="{theme["bg"]}"/>',
+        f'<text x="{MARGIN_LEFT}" y="26" font-size="15" font-weight="600" '
+        f'fill="{theme["title"]}">{repo}</text>',
+        f'<text x="{WIDTH - MARGIN_RIGHT}" y="26" font-size="13" '
+        f'text-anchor="end" fill="{theme["text"]}">'
+        f'{series[-1][1]} stars &#183; {first_day} to {last_day}</text>',
+    ]
+
+    # Horizontal gridlines and y labels.
+    for tick in range(Y_TICKS + 1):
+        value = round(y_max * tick / Y_TICKS)
+        y = y_of(value)
+        parts.append(
+            f'<line x1="{MARGIN_LEFT}" y1="{y:.1f}" x2="{MARGIN_LEFT + PLOT_WIDTH}" '
+            f'y2="{y:.1f}" stroke="{theme["grid"]}" stroke-width="1"/>'
+        )
+        parts.append(
+            f'<text x="{MARGIN_LEFT - 10}" y="{y + 4:.1f}" font-size="11" '
+            f'text-anchor="end" fill="{theme["text"]}">{human(value)}</text>'
+        )
+
+    # Date labels along the bottom.
+    for tick in range(X_TICKS):
+        offset = round(span_days * tick / (X_TICKS - 1))
+        day = date.fromordinal(first_day.toordinal() + offset)
+        x = x_of(day)
+        anchor = "start" if tick == 0 else "end" if tick == X_TICKS - 1 else "middle"
+        parts.append(
+            f'<text x="{x:.1f}" y="{baseline + 20:.1f}" font-size="11" '
+            f'text-anchor="{anchor}" fill="{theme["text"]}">'
+            f'{day.strftime("%b %d")}</text>'
+        )
+
+    parts.append(
+        f'<polygon points="{area}" fill="{theme["fill"]}" '
+        f'fill-opacity="{theme["fill_opacity"]}"/>'
+    )
+    parts.append(
+        f'<polyline points="{line}" fill="none" stroke="{theme["line"]}" '
+        f'stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>'
+    )
+    parts.append(
+        f'<circle cx="{points[-1][0]:.1f}" cy="{points[-1][1]:.1f}" r="4" '
+        f'fill="{theme["line"]}"/>'
+    )
+    parts.append(
+        f'<line x1="{MARGIN_LEFT}" y1="{baseline:.1f}" '
+        f'x2="{MARGIN_LEFT + PLOT_WIDTH}" y2="{baseline:.1f}" '
+        f'stroke="{theme["axis"]}" stroke-width="1"/>'
+    )
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--data", type=Path, default=DATA_FILE)
+    parser.add_argument("--light", type=Path, default=LIGHT_SVG)
+    parser.add_argument("--dark", type=Path, default=DARK_SVG)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("backfill", help="rebuild history from starred_at (admin only)")
+    sub.add_parser("snapshot", help="append today's public star count")
+    sub.add_parser("render", help="draw the committed SVG charts")
+
+    args = parser.parse_args()
+    {"backfill": cmd_backfill, "snapshot": cmd_snapshot, "render": cmd_render}[
+        args.command
+    ](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the broken third-party star-history chart with a self-hosted SVG chart
- record the public star count daily using the repository-scoped GitHub Actions token
- link the Stars badge to the working README chart

## Validation
- `python3 -m py_compile tools/scripts/star-history.py`
- `git diff --check`
- workflow YAML parsed successfully
- verified both public chart URLs return HTTP 200

The `star-history` branch has been seeded with 187 days of backfilled data through 411 stars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CI-only automation with scoped `GITHUB_TOKEN` writes to a dedicated branch; no runtime or product code paths change.
> 
> **Overview**
> Replaces the broken **star-history.com** embed with a **self-hosted** light/dark SVG chart, fed by a daily public `stargazers_count` snapshot instead of the restricted stargazers list API.
> 
> Adds **`tools/scripts/star-history.py`** (`backfill` / `snapshot` / `render`) and a scheduled **`.github/workflows/star-history.yml`** job that updates **`stars.jsonl`** and SVGs on a dedicated **`star-history`** branch (via git worktree) so master stays review-only. The README **Star History** section and **Stars** badge now point at that chart; **`.gitignore`** excludes local `.metrics/` and `docs/assets` chart copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0725ba75e68da6e1d67b8272f2c6faa5e7302f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->