### PR TITLE
feat(core): implement temperature sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6310,6 +6310,7 @@ dependencies = [
  "objc2-io-kit",
  "objc2-metal",
  "ort",
+ "rand 0.9.5",
  "rayon",
  "regex",
  "rustfft",

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -72,6 +72,7 @@ sysinfo = "0.32"
 # no-ops for invocation compatibility (CI --features flags, sdk presets).
 # For CoreML acceleration: ort-coreml feature (macOS/iOS only).
 ndarray = "0.17"  # Used by ort for tensor operations (must match ort's ndarray version)
+rand = "0.9"  # Seedable sampling for generic model logits
 base64 = "0.22"  # For BPE token decoding
 mel_spec = "0.2"  # For mel spectrogram computation (audio preprocessing)
 num-complex = "0.4"  # Required by mel_spec for Complex numbers

--- a/crates/xybrid-core/src/execution/postprocessing/mod.rs
+++ b/crates/xybrid-core/src/execution/postprocessing/mod.rs
@@ -6,7 +6,7 @@
 //! | Module | Operations |
 //! |--------|-----------|
 //! | [`decode`] | `CTCDecode`, `BPEDecode`, `WhisperDecode` |
-//! | [`tensor_ops`] | `Argmax`, `Softmax`, `TopK`, `Threshold`, `MeanPool`, `Denormalize` |
+//! | [`tensor_ops`] | `Argmax`, `Softmax`, `TopK`, `TemperatureSample`, `Threshold`, `MeanPool`, `Denormalize` |
 //! | [`audio`] | `TTSAudioEncode` |
 
 pub mod audio;
@@ -59,13 +59,10 @@ pub fn apply_postprocessing_step(
         PostprocessingStep::MeanPool { dim } => tensor_ops::meanpool_step(data, *dim),
 
         PostprocessingStep::TemperatureSample {
-            temperature: _,
-            top_k: _,
-            top_p: _,
-        } => {
-            // TODO: Implement temperature sampling
-            Ok(data)
-        }
+            temperature,
+            top_k,
+            top_p,
+        } => tensor_ops::temperature_sample_step(data, *temperature, *top_k, *top_p),
 
         PostprocessingStep::Denormalize { mean, std } => {
             tensor_ops::denormalize_step(data, mean, std)
@@ -87,5 +84,27 @@ pub fn apply_postprocessing_step(
                 "CodecDecode is handled by CodecTtsStrategy, not the generic postprocessing dispatcher".into(),
             ),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{ArrayD, IxDyn};
+    use std::collections::HashMap;
+
+    #[test]
+    fn temperature_sample_dispatches_to_class_id() {
+        let tensor = ArrayD::from_shape_vec(IxDyn(&[3]), vec![0.1, 2.0, 0.5]).expect("valid shape");
+        let data = RawOutputs::TensorMap(HashMap::from([("logits".to_string(), tensor)]));
+        let step = PostprocessingStep::TemperatureSample {
+            temperature: 0.0,
+            top_k: None,
+            top_p: None,
+        };
+
+        let result = apply_postprocessing_step(&step, data, "").expect("sampling should succeed");
+
+        assert!(matches!(result, RawOutputs::ClassId(1)));
     }
 }

--- a/crates/xybrid-core/src/execution/postprocessing/tensor_ops.rs
+++ b/crates/xybrid-core/src/execution/postprocessing/tensor_ops.rs
@@ -4,6 +4,7 @@
 //! - `argmax_step`: Get class ID with highest probability
 //! - `softmax_step`: Apply softmax normalization
 //! - `topk_step`: Get top-K predictions
+//! - `temperature_sample_step`: Sample a class from filtered logits
 //! - `threshold_step`: Apply threshold to probabilities
 //! - `meanpool_step`: Mean pooling over sequence dimension
 //! - `denormalize_step`: Denormalize tensor values (inverse of Normalize preprocessing)
@@ -11,6 +12,7 @@
 use super::super::types::{ExecutorResult, RawOutputs};
 use crate::runtime_adapter::AdapterError;
 use ndarray::{ArrayD, IxDyn};
+use rand::Rng;
 use std::collections::HashMap;
 
 /// Apply argmax to get class ID with highest probability.
@@ -103,6 +105,61 @@ pub fn topk_step(data: RawOutputs, k: usize, dim: Option<usize>) -> ExecutorResu
     result_map.insert("topk".to_string(), topk_tensor);
 
     Ok(RawOutputs::TensorMap(result_map))
+}
+
+/// Sample a class ID from temperature-scaled, optionally filtered logits.
+///
+/// `temperature = 0` and `top_k = 1` use exact argmax. Positive temperatures
+/// use a production RNG for a weighted draw after top-k and top-p filters.
+///
+/// # Errors
+/// Returns [`AdapterError::InvalidInput`] for invalid parameters or logits,
+/// unsupported/empty tensors, and inputs other than a tensor map.
+pub fn temperature_sample_step(
+    data: RawOutputs,
+    temperature: f32,
+    top_k: Option<usize>,
+    top_p: Option<f32>,
+) -> ExecutorResult<RawOutputs> {
+    let mut rng = rand::rng();
+    temperature_sample_step_with_rng(data, temperature, top_k, top_p, &mut rng)
+}
+
+fn temperature_sample_step_with_rng<R: Rng + ?Sized>(
+    data: RawOutputs,
+    temperature: f32,
+    top_k: Option<usize>,
+    top_p: Option<f32>,
+    rng: &mut R,
+) -> ExecutorResult<RawOutputs> {
+    validate_sampling_params(temperature, top_k, top_p)?;
+    let tensor_map = match data {
+        RawOutputs::TensorMap(map) => map,
+        _ => {
+            return Err(AdapterError::InvalidInput(
+                "TemperatureSample requires tensor map".to_string(),
+            ))
+        }
+    };
+    let tensor = tensor_map.values().next().ok_or_else(|| {
+        AdapterError::InvalidInput("No outputs for TemperatureSample".to_string())
+    })?;
+    let logits = sampling_logits(tensor)?;
+
+    if logits.iter().any(|logit| !logit.is_finite()) {
+        return Err(AdapterError::InvalidInput(
+            "TemperatureSample requires finite logits".to_string(),
+        ));
+    }
+    if temperature == 0.0 || top_k == Some(1) {
+        return Ok(RawOutputs::ClassId(argmax_token(tensor)?));
+    }
+
+    let candidates = filtered_sampling_weights(logits, temperature, top_k, top_p);
+    Ok(RawOutputs::ClassId(sample_weighted_index(
+        &candidates,
+        rng,
+    )?))
 }
 
 /// Apply threshold to convert probabilities to binary predictions.
@@ -348,6 +405,118 @@ pub fn argmax_token(logits: &ArrayD<f32>) -> ExecutorResult<usize> {
     }
 }
 
+fn validate_sampling_params(
+    temperature: f32,
+    top_k: Option<usize>,
+    top_p: Option<f32>,
+) -> ExecutorResult<()> {
+    if !temperature.is_finite() || temperature < 0.0 {
+        return Err(AdapterError::InvalidInput(format!(
+            "TemperatureSample temperature must be finite and non-negative, got {}",
+            temperature
+        )));
+    }
+    if top_k == Some(0) {
+        return Err(AdapterError::InvalidInput(
+            "TemperatureSample top_k must be greater than zero".to_string(),
+        ));
+    }
+    if let Some(top_p) = top_p {
+        if !top_p.is_finite() || !(0.0 < top_p && top_p <= 1.0) {
+            return Err(AdapterError::InvalidInput(format!(
+                "TemperatureSample top_p must be finite and in (0, 1], got {}",
+                top_p
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn sampling_logits(tensor: &ArrayD<f32>) -> ExecutorResult<&[f32]> {
+    let shape = tensor.shape();
+    if !(1..=3).contains(&shape.len()) || shape.contains(&0) {
+        return Err(AdapterError::InvalidInput(format!(
+            "TemperatureSample expects a non-empty 1D, 2D, or 3D logits tensor, got {:?}",
+            shape
+        )));
+    }
+
+    let data = tensor.as_slice().ok_or_else(|| {
+        AdapterError::InvalidInput(
+            "TemperatureSample requires a contiguous logits tensor".to_string(),
+        )
+    })?;
+    let vocab_size = *shape.last().ok_or_else(|| {
+        AdapterError::InvalidInput("TemperatureSample received an empty tensor shape".to_string())
+    })?;
+    Ok(&data[..vocab_size])
+}
+
+fn filtered_sampling_weights(
+    logits: &[f32],
+    temperature: f32,
+    top_k: Option<usize>,
+    top_p: Option<f32>,
+) -> Vec<(usize, f64)> {
+    let max_logit = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut candidates: Vec<(usize, f64)> = logits
+        .iter()
+        .enumerate()
+        .map(|(index, &logit)| {
+            let scaled = (f64::from(logit) - f64::from(max_logit)) / f64::from(temperature);
+            (index, scaled.exp())
+        })
+        .collect();
+
+    if top_k.is_some() || top_p.is_some_and(|top_p| top_p < 1.0) {
+        candidates.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    }
+    if let Some(top_k) = top_k {
+        candidates.truncate(top_k.min(candidates.len()));
+    }
+    if let Some(top_p) = top_p.filter(|top_p| *top_p < 1.0) {
+        let total_weight: f64 = candidates.iter().map(|(_, weight)| weight).sum();
+        let cutoff = total_weight * f64::from(top_p);
+        let mut cumulative = 0.0;
+        let keep = candidates
+            .iter()
+            .position(|(_, weight)| {
+                cumulative += weight;
+                cumulative >= cutoff
+            })
+            .map_or(candidates.len(), |position| position + 1)
+            .max(1);
+        candidates.truncate(keep);
+    }
+    candidates
+}
+
+fn sample_weighted_index<R: Rng + ?Sized>(
+    candidates: &[(usize, f64)],
+    rng: &mut R,
+) -> ExecutorResult<usize> {
+    let total_weight: f64 = candidates.iter().map(|(_, weight)| weight).sum();
+    if candidates.is_empty() || !total_weight.is_finite() || total_weight <= 0.0 {
+        return Err(AdapterError::InvalidInput(
+            "TemperatureSample could not construct a probability distribution".to_string(),
+        ));
+    }
+
+    let draw = rng.random_range(0.0..total_weight);
+    let mut cumulative = 0.0;
+    for &(index, weight) in candidates {
+        cumulative += weight;
+        if draw < cumulative {
+            return Ok(index);
+        }
+    }
+    candidates.last().map(|(index, _)| *index).ok_or_else(|| {
+        AdapterError::InvalidInput(
+            "TemperatureSample could not select from an empty distribution".to_string(),
+        )
+    })
+}
+
 /// Apply softmax to a tensor along a dimension.
 fn apply_softmax(tensor: &mut ArrayD<f32>, dim: Option<usize>) -> ExecutorResult<()> {
     let shape = tensor.shape().to_vec(); // Clone shape to avoid borrow conflicts
@@ -462,6 +631,189 @@ mod tests {
     use super::*;
     use crate::execution::preprocessing::tensor::normalize_step;
     use crate::execution::types::PreprocessedData;
+    use ndarray::Array2;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    fn logits_data(logits: &[f32]) -> RawOutputs {
+        let tensor = ArrayD::from_shape_vec(IxDyn(&[logits.len()]), logits.to_vec())
+            .expect("valid logits shape");
+        RawOutputs::TensorMap(HashMap::from([("logits".to_string(), tensor)]))
+    }
+
+    fn sampled_class(result: RawOutputs) -> usize {
+        match result {
+            RawOutputs::ClassId(class_id) => class_id,
+            other => panic!("expected ClassId, got {other:?}"),
+        }
+    }
+
+    fn sample_with_seed(
+        data: RawOutputs,
+        temperature: f32,
+        top_k: Option<usize>,
+        top_p: Option<f32>,
+    ) -> ExecutorResult<RawOutputs> {
+        let mut rng = StdRng::seed_from_u64(42);
+        temperature_sample_step_with_rng(data, temperature, top_k, top_p, &mut rng)
+    }
+
+    fn assert_invalid(result: ExecutorResult<RawOutputs>) {
+        assert!(matches!(result, Err(AdapterError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn temperature_zero_returns_exact_argmax() {
+        let result = sample_with_seed(logits_data(&[0.5, 3.0, 1.0]), 0.0, None, None).unwrap();
+
+        assert_eq!(sampled_class(result), 1);
+    }
+
+    #[test]
+    fn top_k_one_returns_exact_argmax() {
+        let result =
+            sample_with_seed(logits_data(&[0.5, 3.0, 1.0]), 100.0, Some(1), Some(0.1)).unwrap();
+
+        assert_eq!(sampled_class(result), 1);
+    }
+
+    #[test]
+    fn fixed_seed_repeats_the_same_sample_sequence() {
+        let mut first_rng = StdRng::seed_from_u64(7);
+        let mut second_rng = StdRng::seed_from_u64(7);
+
+        let first: Vec<_> = (0..32)
+            .map(|_| {
+                let result = temperature_sample_step_with_rng(
+                    logits_data(&[0.0, 0.5, 1.0]),
+                    1.0,
+                    None,
+                    None,
+                    &mut first_rng,
+                )
+                .unwrap();
+                sampled_class(result)
+            })
+            .collect();
+        let second: Vec<_> = (0..32)
+            .map(|_| {
+                let result = temperature_sample_step_with_rng(
+                    logits_data(&[0.0, 0.5, 1.0]),
+                    1.0,
+                    None,
+                    None,
+                    &mut second_rng,
+                )
+                .unwrap();
+                sampled_class(result)
+            })
+            .collect();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn top_k_and_top_p_filters_compose() {
+        let candidates = filtered_sampling_weights(&[4.0, 3.0, 2.0, 1.0], 1.0, Some(3), Some(0.8));
+        let indices: Vec<_> = candidates.iter().map(|(index, _)| *index).collect();
+
+        assert_eq!(indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn top_p_always_retains_one_token() {
+        let candidates = filtered_sampling_weights(&[2.0, 1.0, 0.0], 1.0, None, Some(f32::EPSILON));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].0, 0);
+    }
+
+    #[test]
+    fn top_p_one_retains_all_tokens() {
+        let candidates = filtered_sampling_weights(&[3.0, 2.0, 1.0], 0.001, None, Some(1.0));
+        let indices: Vec<_> = candidates.iter().map(|(index, _)| *index).collect();
+
+        assert_eq!(indices, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn high_temperature_with_full_top_p_is_nearly_uniform() {
+        const SAMPLES: usize = 20_000;
+        const EXPECTED_PER_CLASS: usize = SAMPLES / 4;
+        const TOLERANCE: usize = 400;
+
+        let mut rng = StdRng::seed_from_u64(2026);
+        let mut counts = [0usize; 4];
+        for _ in 0..SAMPLES {
+            let result = temperature_sample_step_with_rng(
+                logits_data(&[0.0, 1.0, 2.0, 3.0]),
+                1_000_000.0,
+                None,
+                Some(1.0),
+                &mut rng,
+            )
+            .unwrap();
+            counts[sampled_class(result)] += 1;
+        }
+
+        for count in counts {
+            assert!(
+                count.abs_diff(EXPECTED_PER_CLASS) <= TOLERANCE,
+                "expected near-uniform counts, got {counts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn temperature_sample_rejects_invalid_parameters() {
+        for (temperature, top_k, top_p) in [
+            (-0.1, None, None),
+            (f32::NAN, None, None),
+            (f32::INFINITY, None, None),
+            (1.0, Some(0), None),
+            (1.0, None, Some(0.0)),
+            (1.0, None, Some(-0.1)),
+            (1.0, None, Some(1.1)),
+            (1.0, None, Some(f32::NAN)),
+            (1.0, None, Some(f32::INFINITY)),
+        ] {
+            assert_invalid(sample_with_seed(
+                logits_data(&[0.0, 1.0]),
+                temperature,
+                top_k,
+                top_p,
+            ));
+        }
+    }
+
+    #[test]
+    fn temperature_sample_rejects_invalid_inputs() {
+        assert_invalid(sample_with_seed(
+            RawOutputs::Text("not logits".to_string()),
+            1.0,
+            None,
+            None,
+        ));
+        assert_invalid(sample_with_seed(
+            RawOutputs::TensorMap(HashMap::new()),
+            1.0,
+            None,
+            None,
+        ));
+        assert_invalid(sample_with_seed(logits_data(&[]), 1.0, None, None));
+        assert_invalid(sample_with_seed(
+            logits_data(&[0.0, f32::NAN]),
+            1.0,
+            None,
+            None,
+        ));
+
+        let non_contiguous = Array2::from_shape_vec((2, 2), vec![0.0, 1.0, 2.0, 3.0])
+            .expect("valid shape")
+            .reversed_axes()
+            .into_dyn();
+        let data = RawOutputs::TensorMap(HashMap::from([("logits".to_string(), non_contiguous)]));
+        assert_invalid(sample_with_seed(data, 1.0, None, None));
+    }
 
     #[test]
     fn test_denormalize_step_round_trip() {

--- a/crates/xybrid-core/src/execution/postprocessing/tensor_ops.rs
+++ b/crates/xybrid-core/src/execution/postprocessing/tensor_ops.rs
@@ -141,9 +141,7 @@ fn temperature_sample_step_with_rng<R: Rng + ?Sized>(
             ))
         }
     };
-    let tensor = tensor_map.values().next().ok_or_else(|| {
-        AdapterError::InvalidInput("No outputs for TemperatureSample".to_string())
-    })?;
+    let tensor = select_logits_output(&tensor_map)?;
     let logits = sampling_logits(tensor)?;
 
     if logits.iter().any(|logit| !logit.is_finite()) {
@@ -362,8 +360,14 @@ pub fn argmax_token(logits: &ArrayD<f32>) -> ExecutorResult<usize> {
 
     // Handle 3D logits [batch, seq_len, vocab_size]
     if shape.len() == 3 {
+        if shape.contains(&0) {
+            return Err(AdapterError::InvalidInput(format!(
+                "Unexpected empty logits shape: {:?}",
+                shape
+            )));
+        }
         let vocab_size = shape[2];
-        let start_idx = 0; // First batch, first position
+        let start_idx = (shape[1] - 1) * vocab_size; // First batch, final position
         let end_idx = start_idx + vocab_size;
 
         let slice = &data[start_idx..end_idx];
@@ -402,6 +406,25 @@ pub fn argmax_token(logits: &ArrayD<f32>) -> ExecutorResult<usize> {
             "Unexpected logits shape: {:?}",
             shape
         )))
+    }
+}
+
+fn select_logits_output(tensor_map: &HashMap<String, ArrayD<f32>>) -> ExecutorResult<&ArrayD<f32>> {
+    if let Some(logits) = tensor_map.get("logits") {
+        return Ok(logits);
+    }
+
+    match tensor_map.len() {
+        0 => Err(AdapterError::InvalidInput(
+            "No outputs for TemperatureSample".to_string(),
+        )),
+        1 => tensor_map.values().next().ok_or_else(|| {
+            AdapterError::InvalidInput("No outputs for TemperatureSample".to_string())
+        }),
+        _ => Err(AdapterError::InvalidInput(
+            "TemperatureSample requires a named 'logits' output when multiple outputs are present"
+                .to_string(),
+        )),
     }
 }
 
@@ -449,7 +472,12 @@ fn sampling_logits(tensor: &ArrayD<f32>) -> ExecutorResult<&[f32]> {
     let vocab_size = *shape.last().ok_or_else(|| {
         AdapterError::InvalidInput("TemperatureSample received an empty tensor shape".to_string())
     })?;
-    Ok(&data[..vocab_size])
+    let start_idx = if shape.len() == 3 {
+        (shape[1] - 1) * vocab_size
+    } else {
+        0
+    };
+    Ok(&data[start_idx..start_idx + vocab_size])
 }
 
 fn filtered_sampling_weights(
@@ -672,6 +700,77 @@ mod tests {
     fn top_k_one_returns_exact_argmax() {
         let result =
             sample_with_seed(logits_data(&[0.5, 3.0, 1.0]), 100.0, Some(1), Some(0.1)).unwrap();
+
+        assert_eq!(sampled_class(result), 1);
+    }
+
+    #[test]
+    fn temperature_sample_argmax_uses_final_sequence_position() {
+        let tensor = ArrayD::from_shape_vec(
+            IxDyn(&[1, 2, 3]),
+            vec![1_000.0, -1_000.0, -1_000.0, -1_000.0, 1_000.0, -1_000.0],
+        )
+        .expect("valid logits shape");
+        let data = RawOutputs::TensorMap(HashMap::from([("logits".to_string(), tensor)]));
+
+        let result = sample_with_seed(data, 0.0, None, None).unwrap();
+
+        assert_eq!(sampled_class(result), 1);
+    }
+
+    #[test]
+    fn temperature_sample_weighted_draw_uses_final_sequence_position() {
+        let tensor = ArrayD::from_shape_vec(
+            IxDyn(&[1, 2, 3]),
+            vec![1_000.0, -1_000.0, -1_000.0, -1_000.0, 1_000.0, -1_000.0],
+        )
+        .expect("valid logits shape");
+        let data = RawOutputs::TensorMap(HashMap::from([("logits".to_string(), tensor)]));
+
+        let result = sample_with_seed(data, 1.0, None, None).unwrap();
+
+        assert_eq!(sampled_class(result), 1);
+    }
+
+    #[test]
+    fn temperature_sample_prefers_named_logits_output() {
+        let logits =
+            ArrayD::from_shape_vec(IxDyn(&[2]), vec![0.0, 10.0]).expect("valid logits shape");
+        let cache =
+            ArrayD::from_shape_vec(IxDyn(&[2]), vec![10.0, 0.0]).expect("valid cache shape");
+        let data = RawOutputs::TensorMap(HashMap::from([
+            ("logits".to_string(), logits),
+            ("present.0.key".to_string(), cache),
+        ]));
+
+        let result = sample_with_seed(data, 0.0, None, None).unwrap();
+
+        assert_eq!(sampled_class(result), 1);
+    }
+
+    #[test]
+    fn temperature_sample_rejects_multiple_unnamed_outputs() {
+        let first =
+            ArrayD::from_shape_vec(IxDyn(&[2]), vec![0.0, 1.0]).expect("valid output shape");
+        let second =
+            ArrayD::from_shape_vec(IxDyn(&[2]), vec![1.0, 0.0]).expect("valid output shape");
+        let data = RawOutputs::TensorMap(HashMap::from([
+            ("output_a".to_string(), first),
+            ("output_b".to_string(), second),
+        ]));
+
+        let result = sample_with_seed(data, 0.0, None, None);
+
+        assert_invalid(result);
+    }
+
+    #[test]
+    fn temperature_sample_accepts_single_unnamed_output() {
+        let tensor =
+            ArrayD::from_shape_vec(IxDyn(&[2]), vec![0.0, 1.0]).expect("valid output shape");
+        let data = RawOutputs::TensorMap(HashMap::from([("scores".to_string(), tensor)]));
+
+        let result = sample_with_seed(data, 0.0, None, None).unwrap();
 
         assert_eq!(sampled_class(result), 1);
     }

--- a/crates/xybrid-core/src/execution/template/steps.rs
+++ b/crates/xybrid-core/src/execution/template/steps.rs
@@ -727,4 +727,29 @@ mod tests {
             _ => panic!("Expected CodecDecode variant"),
         }
     }
+
+    #[test]
+    fn temperature_sample_serde_preserves_all_parameters() {
+        let json = r#"{
+            "type": "TemperatureSample",
+            "temperature": 0.7,
+            "top_k": 40,
+            "top_p": 0.9
+        }"#;
+
+        let step: PostprocessingStep = serde_json::from_str(json).unwrap();
+
+        match step {
+            PostprocessingStep::TemperatureSample {
+                temperature,
+                top_k,
+                top_p,
+            } => {
+                assert!((temperature - 0.7).abs() < f32::EPSILON);
+                assert_eq!(top_k, Some(40));
+                assert_eq!(top_p, Some(0.9));
+            }
+            _ => panic!("Expected TemperatureSample variant"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- wire `TemperatureSample` into postprocessing and validate its existing `temperature`, `top_k`, and `top_p` config
- apply stable temperature scaling, composed top-k/top-p filtering, and a weighted draw using production entropy
- keep fixed-seed RNG injection internal and cover deterministic, statistical, edge, input, dispatcher, and serde behavior

Fixes #241

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p xybrid-core --lib --features ort-download` (1,031 passed, 1 ignored)
- `cargo test --workspace --features ort-download`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Bazel note

`bazelisk test //crates/xybrid-core:xybrid-core_test --test_filter=temperature_sample` resolved dependencies and completed analysis, but no Rust test executed because the unconditional native llama.cpp build failed first. Hermetic Clang 22 rejects `CF_ENUM` declarations from Apple CoreFoundation headers while compiling vendored cpp-httplib (`-Welaborated-enum-base`). Cargo workspace validation, including the native llama/whisper paths, passes.