### PR TITLE
fix(core): use as_chunks for constant-size slice chunking

### DIFF
--- a/crates/xybrid-core/benches/raw_image_ingress.rs
+++ b/crates/xybrid-core/benches/raw_image_ingress.rs
@@ -27,7 +27,7 @@ fn nv12_1920x1080_frame() -> Envelope {
     let uv_bytes = y_bytes / 2;
 
     let mut pixels = vec![128_u8; y_bytes + uv_bytes];
-    for uv in pixels[y_bytes..].chunks_exact_mut(2) {
+    for uv in pixels[y_bytes..].as_chunks_mut::<2>().0 {
         uv[0] = 128;
         uv[1] = 128;
     }

--- a/crates/xybrid-core/examples/neutts_decode_tokens.rs
+++ b/crates/xybrid-core/examples/neutts_decode_tokens.rs
@@ -63,8 +63,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err("waveform.f32 size is not a multiple of 4".into());
     }
     let all: Vec<f32> = bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect();
     let total_ms = (all.len() as f32 / sample_rate as f32 * 1000.0) as usize;
     println!(

--- a/crates/xybrid-core/src/execution/preprocessing/image.rs
+++ b/crates/xybrid-core/src/execution/preprocessing/image.rs
@@ -380,7 +380,7 @@ fn rgb_bytes_to_tensor(
 
     match (channels, layout) {
         (1, _) => {
-            for (dst, pixel) in output.iter_mut().zip(rgb.chunks_exact(3)) {
+            for (dst, pixel) in output.iter_mut().zip(rgb.as_chunks::<3>().0) {
                 let red = pixel[0] as f32 * scale;
                 let green = pixel[1] as f32 * scale;
                 let blue = pixel[2] as f32 * scale;
@@ -390,14 +390,19 @@ fn rgb_bytes_to_tensor(
         (3, ImageTensorLayout::Nchw) => {
             let (red_plane, remaining) = output.split_at_mut(pixel_count);
             let (green_plane, blue_plane) = remaining.split_at_mut(pixel_count);
-            for (index, pixel) in rgb.chunks_exact(3).enumerate() {
+            for (index, pixel) in rgb.as_chunks::<3>().0.iter().enumerate() {
                 red_plane[index] = pixel[0] as f32 * scale;
                 green_plane[index] = pixel[1] as f32 * scale;
                 blue_plane[index] = pixel[2] as f32 * scale;
             }
         }
         (3, ImageTensorLayout::Nhwc) => {
-            for (dst, pixel) in output.chunks_exact_mut(3).zip(rgb.chunks_exact(3)) {
+            for (dst, pixel) in output
+                .as_chunks_mut::<3>()
+                .0
+                .iter_mut()
+                .zip(rgb.as_chunks::<3>().0)
+            {
                 for channel in 0..3 {
                     dst[channel] = pixel[channel] as f32 * scale;
                 }
@@ -2251,7 +2256,7 @@ mod tests {
 
         assert_eq!(rgb.len(), 2 * 2 * 3);
         // Every pixel shares the single chroma sample.
-        for pixel in rgb.chunks_exact(3) {
+        for pixel in rgb.as_chunks::<3>().0 {
             assert!(
                 pixel[0].abs_diff(229) <= 2,
                 "R expected ~229, got {}",

--- a/crates/xybrid-core/src/preprocessing/mel_spectrogram.rs
+++ b/crates/xybrid-core/src/preprocessing/mel_spectrogram.rs
@@ -130,9 +130,11 @@ pub fn audio_bytes_to_whisper_mel(audio_bytes: &[u8]) -> AdapterResult<ArrayD<f3
         }
 
         let samples: Vec<f32> = audio_bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| {
-                let sample = i16::from_le_bytes([chunk[0], chunk[1]]);
+                let sample = i16::from_le_bytes(*chunk);
                 sample as f32 / 32768.0
             })
             .collect();

--- a/crates/xybrid-core/src/runtime_adapter/tensor_utils.rs
+++ b/crates/xybrid-core/src/runtime_adapter/tensor_utils.rs
@@ -301,9 +301,11 @@ fn decode_audio_to_samples(audio_data: &[u8]) -> AdapterResult<Vec<f32>> {
             }
 
             let samples: Vec<f32> = audio_data
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| {
-                    let sample = i16::from_le_bytes([chunk[0], chunk[1]]);
+                    let sample = i16::from_le_bytes(*chunk);
                     sample as f32 / 32768.0
                 })
                 .collect();

--- a/crates/xybrid-core/src/tts/voice_embedding.rs
+++ b/crates/xybrid-core/src/tts/voice_embedding.rs
@@ -261,11 +261,10 @@ impl VoiceEmbeddingLoader {
         let voice_bytes = &bytes[start..end];
 
         let embedding: Vec<f32> = voice_bytes
-            .chunks_exact(4)
-            .map(|chunk| {
-                let bytes: [u8; 4] = chunk.try_into().unwrap();
-                f32::from_le_bytes(bytes)
-            })
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect();
 
         Ok(embedding)

--- a/crates/xybrid-core/tests/mobilenet_vision_parity.rs
+++ b/crates/xybrid-core/tests/mobilenet_vision_parity.rs
@@ -55,7 +55,9 @@ fn legacy_flattened_metadata(mut metadata: ModelMetadata) -> ModelMetadata {
 fn topk_pairs(envelope: Envelope) -> Vec<(usize, f32)> {
     match envelope.kind {
         EnvelopeKind::Embedding(values) => values
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| (pair[0] as usize, pair[1]))
             .collect(),
         other => panic!("expected embedding TopK output, got {other:?}"),

--- a/crates/xybrid-core/tests/whispercpp_asr.rs
+++ b/crates/xybrid-core/tests/whispercpp_asr.rs
@@ -233,7 +233,9 @@ fn streaming_language_override_reaches_whisper_transcribe_params() {
 fn decode_wav_16k_mono(bytes: &[u8]) -> Vec<f32> {
     assert!(bytes.len() > 44, "WAV shorter than its header");
     bytes[44..]
-        .chunks_exact(2)
-        .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32_768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f32::from(i16::from_le_bytes(*c)) / 32_768.0)
         .collect()
 }

--- a/crates/xybrid-whisper/tests/transcribe_smoke.rs
+++ b/crates/xybrid-whisper/tests/transcribe_smoke.rs
@@ -64,8 +64,10 @@ fn read_wav_16k_mono(path: &Path) -> Vec<f32> {
     assert_eq!(bits, 16, "fixture must be 16-bit");
 
     bytes[44..]
-        .chunks_exact(2)
-        .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32_768.0)
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|c| f32::from(i16::from_le_bytes(*c)) / 32_768.0)
         .collect()
 }
 


### PR DESCRIPTION
Unblocks CI on master and on every open PR.

## What broke

- Rust **1.98.0** shipped 2026-08-18 with a new lint, `clippy::chunks_exact_to_as_chunks`.
- CI uses `dtolnay/rust-toolchain@stable`, so runners picked it up automatically.
- With `-D warnings`, both `clippy` and `clippy (llm-llamacpp)` now fail — on this repo's own code, not on any contributor's diff.
- First casualty: #521 (external contributor), where every other job is green.

## Fix

- 13 `chunks_exact(N)` / `chunks_exact_mut(N)` call sites moved to `as_chunks::<N>()` / `as_chunks_mut::<N>()` (stable since 1.88; Bazel pins 1.92).
- Chunk items become `[T; N]`, so a `try_into().unwrap()` in the voice-embedding loader and the manual byte re-packing in both PCM decoders go away.
- No behaviour change: `as_chunks().0` yields the same complete chunks and drops the same remainder.

## Files

- `xybrid-core`: `execution/preprocessing/image.rs`, `preprocessing/mel_spectrogram.rs`, `runtime_adapter/tensor_utils.rs`, `tts/voice_embedding.rs`
- tests / bench / example: `mobilenet_vision_parity.rs`, `whispercpp_asr.rs`, `raw_image_ingress.rs`, `neutts_decode_tokens.rs`
- `xybrid-whisper`: `tests/transcribe_smoke.rs`

## Follow-up worth considering

CI tracks `stable`, so the next new clippy lint breaks master the same way. Pinning a toolchain (AGENTS.md open question #1: MSRV) would make this a scheduled bump instead of a surprise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical clippy-driven API swap with equivalent remainder semantics; no logic or data-path changes.
> 
> **Overview**
> Replaces `chunks_exact(N)` / `chunks_exact_mut(N)` with `as_chunks::<N>()` / `as_chunks_mut::<N>()` so clippy on Rust 1.98 (`clippy::chunks_exact_to_as_chunks`) no longer fails CI under `-D warnings`.
> 
> Chunk items are now `[T; N]`, which drops a `try_into().unwrap()` in the voice-embedding loader and the manual byte packing in PCM/f32 decoders. Remainder handling is unchanged (`as_chunks().0` still yields complete chunks only). No behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d23ff9b9b22b985ca8175ccd1640d34d0a798b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->