### PR TITLE
docs(zh): resync the Chinese Android, iOS, and Kotlin SDK pages

### DIFF
--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -34,6 +34,8 @@ if (result.success) {
 }
 ```
 
+`Xybrid.init(context)` 还会注册 `BatteryManager` 以及（在 API 29+ 上）`PowerManager.OnThermalStatusChangedListener` 观察者，将读数转发给路由引擎。
+
 ## 初始化
 
 无论是否鉴权，推理都完全在本地运行。传入 `apiKey` 即可点亮[控制台](https://dashboard.xybrid.dev)——这一次调用会启动遥测导出器，你的 `model.run(...)` 调用便会自动上报执行轨迹：

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -41,6 +41,8 @@ if result.success {
 }
 ```
 
+在 iOS 上，`Xybrid.initialize()` 会启用 `UIDevice` 电池监测并订阅 `UIDevice.batteryLevelDidChangeNotification`，将读数转发给路由引擎。Apple 平台上的温度状态则直接在 `xybrid-core` 中从 `NSProcessInfo.thermalState` 获取。
+
 ## 初始化
 
 无论是否鉴权，推理都完全在本地运行。传入 `apiKey` 即可点亮[控制台](https://dashboard.xybrid.dev)——这一次调用会启动遥测导出器，你的 `model.run(...)` 调用便会自动上报执行轨迹：
@@ -178,10 +180,15 @@ SDK 提供便捷短别名：
 
 | 别名 | 完整类型 |
 |-------|-----------|
-| `ModelLoader` | 显式加载模型的具体类型 |
 | `Model` | `XybridModel` |
 | `Envelope` | `XybridEnvelope` |
 | `Result` | `XybridResult` |
+| `VoiceInfo` | `XybridVoiceInfo` |
+| `GenerationConfig` | `XybridGenerationConfig` |
+| `XybridSDKError` | `XybridError` |
+
+`ModelLoader` 是廉价的模型引用。通过 `Xybrid.model(...)` 构造，
+再在推理前显式调用 `load()`。
 
 ---
 

--- a/docs/content/docs/(integration)/sdks/kotlin.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/kotlin.zh.mdx
@@ -88,12 +88,18 @@ SDK 提供与完整限定名对应的短别名：
 |-------|-----------|
 | `ModelLoader` | `XybridModelLoader` |
 | `Model` | `XybridModel` |
-| `Envelope` | `XybridEnvelope` |
 | `Result` | `XybridResult` |
-| `XybridError` | `XybridException` |
+| `VoiceInfo` | `XybridVoiceInfo` |
+| `GenerationConfig` | `XybridGenerationConfig` |
+| `XybridException` | `XybridError` |
 
-`Xybrid.model(id)` 是注册表模型的简写。本地来源使用
-`ModelSource.bundle(...)` 或 `ModelSource.directory(...)`。这些调用只返回
-未加载的 `ModelLoader`；调用 `load()` 才会执行解析、下载和加载。
+`Envelope` 不是别名——它是带工厂方法的 `object`
+（`Envelope.text(...)`、`Envelope.image(...)`、`Envelope.userMessage(...)`），返回 `XybridEnvelope`。
+
+`Xybrid.model(id)` 是注册表模型的简写，也可以传入类型化的
+`ModelSource.bundle(...)`、`ModelSource.directory(...)` 或
+`ModelSource.huggingFace(...)`。这些调用只返回未加载的 `ModelLoader`；
+调用挂起函数 `load()` 才会执行加载。Java 调用方或已在工作线程上的调用方
+可以使用显式阻塞的 `loadBlocking()`。
 
 完整 API 参考请见 [Android SDK 指南](/zh/docs/sdks/android)。


### PR DESCRIPTION
Salvages the still-valid half of #433.

## Why #433 can't be merged as-is

- #433 was written against the state after #412 removed `XybridModelLoader`.
- #451 ("restore explicit model loading facades", merged 2026-08-05, two days later) put the loader back — *"the formerly deprecated loader is now canonical"*.
- #451 also resynced every `.zh.mdx` loading example. All five files in #433 already match the English pages today.
- So #433's loader edits would now **regress** the docs: they'd teach `XybridModel("id")` and state that `ModelLoader` doesn't exist, when `Xybrid.model(id).load()` is the documented path and `XybridModelLoader` is alive at `bindings/kotlin/.../Xybrid.kt:226`.

## What was still genuinely missing

Three real gaps where the Chinese pages lag the English ones:

- **android.zh.mdx / ios.zh.mdx** — the `BatteryManager` + thermal-observer note and the `UIDevice` battery-monitoring note exist in `android.mdx` / `ios.mdx` but never landed in the translations.
- **ios.zh.mdx** — alias table missing `VoiceInfo`, `GenerationConfig`, `XybridSDKError`; `ModelLoader` sat in the table instead of the prose below it.
- **kotlin.zh.mdx** — listed `Envelope` as a typealias (it's an `object` with factory methods), had the `XybridException` / `XybridError` row **reversed**, missed `VoiceInfo` and `GenerationConfig`, and the prose omitted `ModelSource.huggingFace(...)` and `loadBlocking()`.

Verified against the English pages and the actual SDK sources (`bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt`, `bindings/apple/Sources/Xybrid/Xybrid.swift`).

## Credit

The Chinese prose for both battery notes is chimbiwide's, lifted from #433, and they're the one who spotted the `Envelope` and reversed-alias problems. Co-authored accordingly.

`quickstart.zh.mdx` and `vision-models.zh.mdx` needed no changes — already in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only translation updates; no runtime, API, or security changes.
> 
> **Overview**
> Brings the Chinese Android, iOS, and Kotlin SDK docs in line with the English pages without changing loader examples.
> 
> Adds the missing battery/thermal observer notes on Android (`BatteryManager` / `PowerManager`) and iOS (`UIDevice` / `NSProcessInfo.thermalState`).
> 
> Updates type-alias tables: iOS gains `VoiceInfo`, `GenerationConfig`, and `XybridSDKError`, with `ModelLoader` explained in prose. Kotlin no longer treats `Envelope` as an alias, corrects the `XybridException`/`XybridError` mapping, and documents `ModelSource.huggingFace(...)` plus `loadBlocking()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c212d04996cdc346ee811a2c4d31634f01c804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->