### PR TITLE
fix(whisper-sys): stop bundling a second ggml into staticlib targets

### DIFF
--- a/bindings/flutter/example/macos/Podfile.lock
+++ b/bindings/flutter/example/macos/Podfile.lock
@@ -1,0 +1,35 @@
+PODS:
+  - battery_plus (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - xybrid_flutter (0.1.0):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - battery_plus (from `Flutter/ephemeral/.symlinks/plugins/battery_plus/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - xybrid_flutter (from `Flutter/ephemeral/.symlinks/plugins/xybrid_flutter/macos`)
+
+EXTERNAL SOURCES:
+  battery_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/battery_plus/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  xybrid_flutter:
+    :path: Flutter/ephemeral/.symlinks/plugins/xybrid_flutter/macos
+
+SPEC CHECKSUMS:
+  battery_plus: 0ed4cf1e771b535a89ac7323e0855ec734cf745f
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  path_provider_foundation: 0b743cbb62d8e47eab856f09262bb8c1ddcfe6ba
+  xybrid_flutter: 6bdc9742e4ad5a35f7587b7951a37382ed03f7ca
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/bindings/flutter/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/bindings/flutter/example/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		6EC7F3B07AEF09AD421913EF /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2D48B6B9633F90CB0B327D5 /* Pods_RunnerTests.framework */; };
+		D0B272F310B6B6FB38405C57 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FC3AA5FD6729DABFE287B6F /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		27E535F4645DC85684700A53 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		2E36717ECEBE3B633C4E1BB9 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +80,14 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		370961431B5172D3289D17B9 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6A247926F363FDE8DE7224B2 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		770A9281FA021665584886CF /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		77B45DC88AFF276998D27847 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8FC3AA5FD6729DABFE287B6F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		C2D48B6B9633F90CB0B327D5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EC7F3B07AEF09AD421913EF /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0B272F310B6B6FB38405C57 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				9DA467A47E90E6F60AFDC52D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		9DA467A47E90E6F60AFDC52D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				77B45DC88AFF276998D27847 /* Pods-Runner.debug.xcconfig */,
+				27E535F4645DC85684700A53 /* Pods-Runner.release.xcconfig */,
+				6A247926F363FDE8DE7224B2 /* Pods-Runner.profile.xcconfig */,
+				370961431B5172D3289D17B9 /* Pods-RunnerTests.debug.xcconfig */,
+				2E36717ECEBE3B633C4E1BB9 /* Pods-RunnerTests.release.xcconfig */,
+				770A9281FA021665584886CF /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8FC3AA5FD6729DABFE287B6F /* Pods_Runner.framework */,
+				C2D48B6B9633F90CB0B327D5 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				DC4B78567F6EA9A854F88D25 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				FBC0257FB4FE86721E561CE2 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				638BF0F317DB44B074436597 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		638BF0F317DB44B074436597 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DC4B78567F6EA9A854F88D25 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FBC0257FB4FE86721E561CE2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 370961431B5172D3289D17B9 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2E36717ECEBE3B633C4E1BB9 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 770A9281FA021665584886CF /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/crates/whisper-cpp-sys/build.rs
+++ b/crates/whisper-cpp-sys/build.rs
@@ -206,8 +206,16 @@ fn compile_whisper_cpp() {
     // Re-emit the ggml archives AFTER it: GNU ld resolves static archives left
     // to right, and cargo emits a dependency's link flags before its
     // dependents', so xybrid-llama-sys's `-lggml` lands too early to satisfy
-    // whisper's references. Repeating an archive on the link line is free;
-    // getting the order wrong is a link failure on Linux.
+    // whisper's references. Getting the order wrong is a link failure on Linux.
+    //
+    // The `-bundle` modifier is load-bearing. Repeating an archive is free for
+    // an executable or a cdylib, because ld only pulls members that resolve a
+    // pending undefined symbol. It is NOT free for a `staticlib`: rustc bundles
+    // every member of every named archive into the output `.a`, so a plain
+    // repeat lands a second copy of all of ggml and the final link dies with
+    // ~1300 duplicate symbols. That is the Flutter macOS/iOS path.
+    // `-bundle` keeps the ordering fix while leaving the single copy that
+    // xybrid-llama-sys bundles as the only one in the archive.
     println!(
         "cargo:rustc-link-search=native={}/lib",
         llama_root.display()
@@ -217,9 +225,9 @@ fn compile_whisper_cpp() {
         llama_root.display()
     );
     println!("cargo:rustc-link-search=native={}", llama_root.display());
-    println!("cargo:rustc-link-lib=static=ggml");
-    println!("cargo:rustc-link-lib=static=ggml-base");
-    println!("cargo:rustc-link-lib=static=ggml-cpu");
+    println!("cargo:rustc-link-lib=static:-bundle=ggml");
+    println!("cargo:rustc-link-lib=static:-bundle=ggml-base");
+    println!("cargo:rustc-link-lib=static:-bundle=ggml-cpu");
     emit_platform_deps();
 }
 
@@ -249,7 +257,7 @@ fn emit_platform_deps() {
             println!("cargo:rustc-link-lib=framework=Metal");
             println!("cargo:rustc-link-lib=framework=Foundation");
             println!("cargo:rustc-link-lib=framework=MetalKit");
-            println!("cargo:rustc-link-lib=static=ggml-metal");
+            println!("cargo:rustc-link-lib=static:-bundle=ggml-metal");
         }
         // Windows link deps are handled by llama.cpp's cmake export.
         _ => {}


### PR DESCRIPTION
Found by actually running the Flutter example that shipped in #525 — `flutter build macos` fails on master.

## The failure

```
duplicate symbol '_ggml_backend_load_all_from_path' in:
    .../libxybrid_flutter_ffi.a[arm64][1190](ggml-backend-reg.cpp.o)
    .../libxybrid_flutter_ffi.a[arm64][1531](ggml-backend-reg.cpp.o)
```

**1287 duplicate symbols.** Both copies are in the *same* archive, so one Rust staticlib carries ggml twice.

## Why

`crates/whisper-cpp-sys/build.rs` deliberately re-emits `-lggml`/`-lggml-base`/`-lggml-cpu` (+`-lggml-metal` on Apple) after `-lwhisper`. **That re-emission is correct and stays** — GNU ld resolves static archives left to right, cargo emits a dependency's flags before its dependents', so llama's `-lggml` lands too early to satisfy whisper's references.

The flaw is one line of reasoning in the comment above it:

> Repeating an archive on the link line is free

True for an executable or cdylib — ld pulls only members that resolve a pending undefined symbol. **False for a `staticlib`**, where rustc bundles *every* member of *every* named archive into the output `.a`.

That asymmetry explains the blast radius exactly:

| Target | Link mode | Affected |
|---|---|---|
| Flutter macOS / iOS | staticlib | **broken** |
| Flutter Linux / Windows | cdylib | fine |
| CLI, tests | bin | fine |

And it explains why nobody noticed: the `Build Flutter` matrix is `linux` only, so macOS Flutter native has never been built in CI.

## The fix

`static=ggml` → `static:-bundle=ggml`. The flag keeps its position on the link line, so the Linux ordering fix is untouched; `-bundle` just stops rustc adding a second copy to the archive, leaving the one `xybrid-llama-sys` bundles.

Worth noting: this crate exists to prevent precisely this. Its manifest says it compiles *"against the ggml that xybrid-llama-sys already builds — never a second copy"*, and the `links = "whisper"` comment calls two-copies "the single thing this crate's design exists to prevent." It blocked a third-party second copy while creating one itself.

## Verified on macOS arm64

- `flutter build macos` on the example: **1287 duplicate symbols → 0**, builds clean
- The app **runs**: downloads `whisper-tiny-ggml` through the App Sandbox, and its live widget tree reads `Text("Whisper loaded")` (read via the Dart VM service, not inferred)
- `cargo test -p integration-tests --features asr-whispercpp --test whispercpp_integration` — **14 passed** against the real 32MB model, with whisper.cpp running on Metal, so the bin/rlib path still resolves at runtime

**Not verified locally: Linux, Android, Windows.** Those rest on CI (`Build Flutter (linux)`, `test-llm`, `test-whispercpp`, `Build Android`, Bazel). The change is link-order-neutral by construction, but I'd rather say what I did and didn't run.

## Recommendation, not included here

Add `macos` to the `Build Flutter` matrix. Without it this class of bug is invisible again the moment it returns — a staticlib-only breakage cannot be caught by a cdylib-only matrix. The cost is real (macOS runners bill at 10x and this builds llama.cpp + whisper.cpp from source), so I left the call to you rather than adding the job unilaterally.

Second commit is unrelated housekeeping: `flutter build macos` runs `pod install`, which rewrites the Runner pbxproj and writes `Podfile.lock`. `examples/flutter` already commits both; this matches that convention so contributors don't get a dirty tree on every macOS build. Both files are under `example/macos/`, which `.pubignore` excludes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native link flags for whisper/ggml, which can break staticlib (Flutter Apple) or Linux archive order if `-bundle` is wrong. Scope is small and the Linux ordering intent is preserved.
> 
> **Overview**
> Fixes Flutter macOS/iOS native builds that failed with ~1300 duplicate ggml symbols because `whisper-cpp-sys` re-emitted `static=ggml*` after whisper, and rustc packed every archive member into the Flutter `staticlib`.
> 
> Re-emission stays (GNU ld still needs ggml after whisper). The flags become `static:-bundle=ggml{,-base,-cpu,-metal}` so rustc keeps link order without stuffing a second copy of ggml into the `.a`. Bin/cdylib paths are unchanged.
> 
> Also commits CocoaPods output (`Podfile.lock` and Runner `pbxproj`) for the Flutter macOS example so `flutter build macos` does not dirty the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d449a33a6cc7c33b58b5885f602e04c50fa15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->