### PR TITLE
fix(natives): windows tar paths + darwin cross-arch OpenSSL

### DIFF
--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -659,6 +659,12 @@ fn build_from_source(
         )
         .define("LLAMA_BUILD_SERVER", "OFF")
         .define("LLAMA_CURL", "OFF")
+        // Default-ON upstream, but never let vendored cpp-httplib pick up a
+        // host OpenSSL: we only ship the static archives, so tool-binary TLS
+        // is dead weight — and on the arm64 macOS runners cross-building
+        // x86_64 it finds the arm64 homebrew libcrypto and the vision tools
+        // fail to link ("symbol(s) not found for architecture x86_64").
+        .define("LLAMA_OPENSSL", "OFF")
         .define("GGML_OPENMP", "OFF");
 
     if ctx.target_os == "android" {

--- a/tools/scripts/natives-pull.sh
+++ b/tools/scripts/natives-pull.sh
@@ -43,7 +43,9 @@ if [ ! -f "$SLICE/native.tar.gz" ]; then
   echo "natives-pull: pulled artifact missing native.tar.gz" >&2
   exit 1
 fi
-tar -C "$SLICE" -xzf "$SLICE/native.tar.gz" && rm -f "$SLICE/native.tar.gz" || exit 1
+# Relative -f from inside the dir: GNU tar parses a `D:` drive-letter prefix
+# in -f as a remote host on the windows runner (same fix as natives-push.sh).
+(cd "$SLICE" && tar -xzf native.tar.gz && rm -f native.tar.gz) || exit 1
 
 # build.rs re-validates completeness (required archives + include/) before
 # trusting the slice, so a partial unpack here just degrades to source.

--- a/tools/scripts/natives-push.sh
+++ b/tools/scripts/natives-push.sh
@@ -66,14 +66,16 @@ done
 
 slice_dirs=(lib include)
 [ -d "$SLICE/lib64" ] && slice_dirs+=(lib64)
-tar -C "$SLICE" -czf "$SLICE/native.tar.gz" "${slice_dirs[@]}"
 
-# Push from INSIDE the slice dir so the layer reference is a RELATIVE path:
-# oras rejects absolute file paths (path-validation), and a bare
-# `native.tar.gz` title is exactly what natives-pull.sh expects from
+# Everything below runs from INSIDE the slice dir so both tar and oras see
+# RELATIVE paths. tar: on the windows runner $SLICE starts with `D:`, which
+# GNU tar's -f parses as a remote host ("Cannot connect to D:") — a relative
+# archive name sidesteps it. oras: rejects absolute file paths outright, and
+# a bare `native.tar.gz` title is exactly what natives-pull.sh expects from
 # `oras pull -o <dir>` (it writes <dir>/native.tar.gz).
 (
   cd "$SLICE"
+  tar -czf native.tar.gz "${slice_dirs[@]}"
   oras push "$PKG:$FP" \
     --artifact-type application/vnd.xybrid.natives.layer.v1+gzip \
     --annotation "org.opencontainers.image.source=https://github.com/xybrid-ai/xybrid" \


### PR DESCRIPTION
Fixes the 3 failed rows of the first post-#526 \`build-natives\` run (32665978692); the other 17 rows published and the manifest PR (#531) carries their slices.

**Windows (both \`x86_64-pc-windows-msvc\` rows):** GNU tar on the windows runner parses the \`D:\` drive-letter prefix in \`-f\` as a remote host — \`tar (child): Cannot connect to D: resolve failed\` — after a successful build.

* \`tools/scripts/natives-push.sh\`: create \`native.tar.gz\` from inside the slice dir with a relative \`-f\` (the subsequent \`oras push\` already ran from there for the same relative-path reason).
* \`tools/scripts/natives-pull.sh\`: same fix for extraction.

**macOS (\`x86_64-apple-darwin\` vision row):** llama.cpp's vendored cpp-httplib defaults \`LLAMA_OPENSSL=ON\`; the arm64 runner cross-building x86_64 finds the arm64 homebrew libcrypto and every vision tool binary fails with \`symbol(s) not found for architecture x86_64\`.

* \`crates/llama-cpp-sys/build.rs\`: \`-DLLAMA_OPENSSL=OFF\` — the slices ship only static archives, so tool-binary TLS is dead weight.

Note: the build.rs edit re-keys every fingerprint's source hash, so merging re-triggers \`build-natives\`, republishes all slices against the new pins, and refreshes the manifest — the by-design staleness guard doing its job.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests pass (\`cargo test\`)
- [x] Code follows project style
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script and CI packaging only: tar path handling and a cmake flag. No runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes Windows native-slice packaging: GNU tar treated a `D:` drive prefix in `-f` as a remote host, so `x86_64-pc-windows-msvc` publish failed after a successful build.
> 
> `natives-push.sh` now creates `native.tar.gz` from inside the slice dir with a relative archive name (same relative-path pattern already used for `oras`). `natives-pull.sh` extracts the same way so a Windows pull job does not hit the same bug.
> 
> Also sets `LLAMA_OPENSSL=OFF` in the llama.cpp cmake build so vendored cpp-httplib does not pick up host OpenSSL—dead weight for static archives, and it broke arm64-macOS runners cross-building x86_64 vision tools against Homebrew libcrypto.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36f0322d03731ec9f73747766039f0a13f759d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->