### PR TITLE
fix(natives): pin a portable ISA baseline for published slices

### DIFF
--- a/crates/llama-cpp-sys/build.rs
+++ b/crates/llama-cpp-sys/build.rs
@@ -665,7 +665,37 @@ fn build_from_source(
         // x86_64 it finds the arm64 homebrew libcrypto and the vision tools
         // fail to link ("symbol(s) not found for architecture x86_64").
         .define("LLAMA_OPENSSL", "OFF")
-        .define("GGML_OPENMP", "OFF");
+        .define("GGML_OPENMP", "OFF")
+        // Distribution baseline: never optimize for the build machine's CPU.
+        // GGML_NATIVE defaults ON for non-cross builds and bakes
+        // -march=native / -mcpu=native into the archives. The published
+        // 2026-08-24 x86_64-linux vision slice picked up AVX-512 + AMX from a
+        // Sapphire-Rapids runner and SIGILLed every consumer without them,
+        // and the aarch64-linux slice carried Graviton SVE. Slices must run
+        // on any reasonable consumer CPU; publishers and consumers do not
+        // share hardware.
+        .define("GGML_NATIVE", "OFF");
+
+    // GGML_NATIVE=OFF alone is not a baseline: llama.cpp then defaults every
+    // x86 SIMD family (SSE4.2/AVX/AVX2/FMA/F16C/BMI2) to OFF for cross builds
+    // and scalar ggml is 3-5x slower. Pin x86-64-v3 (Haswell 2013 / Zen1
+    // 2017) explicitly — every GitHub runner and effectively all consumer
+    // x86_64 hardware clears it. Android x86_64 is excluded: its ABI only
+    // guarantees SSE4.2, and configure_android keeps today's conservative
+    // flags. Pre-Haswell hosts can XYBRID_NATIVES_FORCE_SOURCE=1.
+    if ctx.target_arch == "x86_64" && ctx.target_os != "android" {
+        cmake_config
+            .define("GGML_SSE42", "ON")
+            .define("GGML_AVX", "ON")
+            .define("GGML_AVX2", "ON")
+            .define("GGML_BMI2", "ON")
+            .define("GGML_FMA", "ON")
+            .define("GGML_F16C", "ON");
+    }
+    // aarch64 stays on the compiler's plain armv8-a default: adding dotprod
+    // would break Cortex-A72 (Raspberry Pi 4) consumers with a runtime
+    // SIGILL, the one failure mode a prebuilt slice must never have. Apple
+    // arm64 is unaffected (the M1 baseline already includes dotprod).
 
     if ctx.target_os == "android" {
         ndk_path_used = configure_android(&mut cmake_config, ctx);


### PR DESCRIPTION
Root-causes the \`SIGILL: illegal instruction\` that kills \`Test (ubuntu-latest)\` on the manifest PRs (#532/#533): those branches arm the download fast path, so the workspace test job links the published \`x86_64-unknown-linux-gnu\` vision slice — and that slice is not portable.

**Why:** \`GGML_NATIVE\` defaults ON for non-cross builds, so every published slice was optimized for whatever CPU its matrix runner happened to have. Disassembly of the current slices:

* x86_64-linux vision: AVX-512 mask ops, AVX-512 FP16, and AMX tile instructions (Sapphire Rapids) — SIGILL on any consumer without them. The previous slice was AVX2-only by pure runner luck, which is why CI passed twice before.
* aarch64-linux: ~12,800 SVE instructions (Graviton) — would SIGILL Raspberry Pi 5 / Cortex-A76 class consumers.
* darwin x86_64 (cross-built): the inverse bug — cross builds default every SIMD family OFF, so those slices ship 3-5x slower scalar ggml.

**Fix** (\`crates/llama-cpp-sys/build.rs\`):

* \`GGML_NATIVE=OFF\` for all targets.
* Explicit x86-64-v3 baseline (SSE4.2/AVX/AVX2/BMI2/FMA/F16C) for non-android x86_64 — portable to Haswell 2013 / Zen1 2017 and every GitHub runner, and it fixes the scalar darwin-x86 slices too. Android x86_64 keeps its conservative ABI flags via \`configure_android\`.
* aarch64 stays plain armv8-a: adding dotprod would trade a 3-5x quantized-inference win for runtime SIGILL on Cortex-A72 (Raspberry Pi 4), and a prebuilt slice must never trap.

**Rollout:** merging re-keys every fingerprint (build.rs hash), \`build-natives\` republishes all slices portable, and a fresh manifest PR supersedes #532/#533 — close both, merge the new one. Pre-Haswell x86 hosts can still \`XYBRID_NATIVES_FORCE_SOURCE=1\`.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests pass (\`cargo test\`)
- [x] Code follows project style
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CPU ISA baked into all prebuilt llama.cpp archives. Wrong flags would SIGILL or regress inference speed across published slices until they are rebuilt.
> 
> **Overview**
> Stops published llama.cpp natives from being compiled for the **build machine’s CPU**, which caused `SIGILL` on consumers (AVX-512/AMX on x86_64-linux, SVE on aarch64-linux) and scalar ggml on cross-built darwin x86_64.
> 
> `GGML_NATIVE` is now always `OFF`. Non-Android `x86_64` explicitly enables the **x86-64-v3** SIMD set (SSE4.2/AVX/AVX2/BMI2/FMA/F16C). aarch64 stays on plain armv8-a so Raspberry Pi 4–class hosts do not trap. Android x86_64 keeps its existing conservative flags.
> 
> This re-keys slice fingerprints, so natives must be republished after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7b32327650b83f02d72c44f93b1fa2bf7beba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->