### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.6.0] - 2026-08-25
+
+Tool calling reaches every binding, and an external `cargo build --features
+llm-llamacpp` stops compiling llama.cpp. FunctionGemma joins the local
+tool-calling backends, tool calls cross the FFI boundary into Swift, Kotlin,
+Python, Unity C# and Dart, and `supportsToolCalling` lets an app gate its tool
+UI on what a bundle actually declares. Separately, `xybrid-llama-sys` resolves a
+prebuilt, SHA-256-verified llama.cpp slice over plain HTTPS — no oras, no
+environment variable, no CMake — turning the dominant cold-build cost from
+roughly twenty minutes into a download.
+
 **Upgrade notes.** The HuggingFace cache moves to a repository-hash layout, so
 caches written by 0.5.0 and earlier are not reused: the next
 `from_huggingface(...)` load re-downloads the model, and the old copy stays on
@@ -19,6 +36,48 @@ the call site but needs a recompile against the new AAR.
 
 ### Added
 
+- **Prebuilt llama.cpp for a plain `cargo build`.** `xybrid-llama-sys` resolves
+  its native archives in three steps — an explicitly staged
+  `XYBRID_NATIVES_PREBUILT_DIR/<target>`, then a slice named in the generated
+  `natives-manifest.txt`, then the CMake source build. The middle step is new:
+  it fetches the layer over plain HTTPS from `ghcr.io/xybrid-ai/llama-natives`
+  and verifies its SHA-256, needing no oras, no environment variable and no
+  CMake, which takes the dominant cold-build cost for an external
+  `--features llm-llamacpp` consumer from roughly twenty minutes to a download.
+  Slices are cached by digest under `$CARGO_HOME/xybrid-natives/` and shared
+  across projects. Every miss falls through to the source build, so the fast
+  path can only fail to accelerate a build, never break one; the manifest pins
+  the sha256 of `build.rs`, `wrapper.cpp`, `wrapper.h` and the llama.cpp commit,
+  so a local edit to any of them disarms every row until CI republishes. Set
+  `XYBRID_NATIVES_FORCE_SOURCE=1` to opt out (#526).
+- **FunctionGemma tool calling.** The local llama.cpp backend recognizes
+  FunctionGemma's call protocol, including its space-separated form, alongside
+  the existing tool-calling models (#512).
+- **Tool calls cross the FFI boundary.** Tool definitions travel out on
+  `RunOptions` and parsed calls come back on the result, so Swift, Kotlin,
+  Python and Unity C# callers drive a tool loop turn by turn — the caller
+  executes the tool and issues another `run`, with no cross-boundary callback
+  (#513).
+- **`supportsToolCalling` on every binding.** `XybridModel` surfaces the
+  bundle's `tool_calling` metadata flag as an advisory tri-state — `null` means
+  the bundle says nothing — so an app can gate its tool UI on model capability.
+  Available on Swift, Kotlin, Python, Unity C# and Flutter. Enforcement stays at
+  run time: a tools-bearing request against a model whose chat template has no
+  tool support fails either way (#515).
+- **Grammar, `jsonSchemaToGbnf` and `reasoningContent` in Dart.** All three had
+  reached the generated layer and stopped at the hand-written Flutter wrapper.
+  `GenerationConfig.grammar` now passes through, the greedy and creative presets
+  take an optional grammar so the usual extraction shape is one call,
+  `jsonSchemaToGbnf` is re-exported, and `XybridResult.reasoningContent` is
+  readable. The Dart unit tests under `bindings/flutter/test` also run in CI for
+  the first time (#511).
+- **`TemperatureSample` postprocessing step.** Pipeline templates can sample a
+  token from logits with temperature, optional top-k and optional top-p, rather
+  than taking the argmax — sampling from the final sequence position, with
+  temperature zero preserved as exact argmax (#521).
+- **A runnable Flutter example app.** `xybrid_flutter` ships a real
+  single-screen app in `example/` instead of a snippet file, so a consumer of
+  the published package has something to run (#525, #152).
 - **Reasoning text as a typed field on the Bolt bindings.** `XybridResult`
   gains `reasoningContent`, carrying what a thinking model emits separately
   from its answer, on Swift, Kotlin, Python, and Unity C#. It is appended last
@@ -58,9 +117,52 @@ the call site but needs a recompile against the new AAR.
   iteration order, so two conversions of the same envelope produce identical
   wire bytes (#508).
 
-### Planned
+### Fixed
 
-- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+- **Streaming stop-boundary panics.** Three fixes in `StreamingTextFilter`'s
+  `last_emitted_len` invariant: a stop sequence completing across chunks could
+  land the emission boundary below already-emitted text, after which the
+  cumulative slice went out of bounds and panicked mid-stream. The boundary is
+  now clamped after a complete-stop truncation, and the potential-stop scan
+  holds the longest matching tail prefix per pattern and the earliest hold
+  across patterns, rather than the shortest prefix of the first pattern that
+  matched — the under-hold that let a later chunk complete a stop behind the
+  boundary (#518).
+- **A second ggml bundled into staticlib targets.** `flutter build macos` failed
+  on the example app with 1287 duplicate `ggml_*` symbols: one Rust staticlib
+  carried two copies, from `whisper-cpp-sys`'s deliberate ggml re-emission on
+  top of the one llama.cpp already links (#528).
+- **Published native slices are portable.** llama.cpp's `GGML_NATIVE` defaults
+  on for non-cross builds, so each published slice inherited the CPU of the
+  runner that built it — the x86_64 Linux slice carried AVX-512 and AMX, and the
+  aarch64 Linux slice carried SVE, either of which is an illegal-instruction
+  trap on a consumer without them, while the cross-built darwin x86_64 slices
+  had the inverse problem and shipped scalar ggml. Slices now pin an explicit
+  x86-64-v3 baseline (SSE4.2/AVX/AVX2/BMI2/FMA/F16C) on non-Android x86_64 and
+  plain armv8-a on aarch64, so no consumer traps and the cross-built slices
+  regain SIMD (#534).
+- **Windows slice publishing and darwin cross-arch linking.** GNU tar on the
+  Windows runner read the `D:` drive-letter prefix as a remote host, so neither
+  `x86_64-pc-windows-msvc` slice ever published; and llama.cpp's vendored
+  cpp-httplib defaults `LLAMA_OPENSSL` on, so the arm64 macOS runner
+  cross-building x86_64 picked up an arm64 libcrypto and failed to link. The
+  slices ship only static archives, so tool-binary TLS is now off (#529).
+- **`clippy::chunks_exact_to_as_chunks` under Rust 1.98.** Constant-size slice
+  chunking moves to `as_chunks`, restoring a green `-D warnings` build on the
+  stable toolchain (#522).
+- **crates.io publish ordering.** The whisper crates publish before
+  `xybrid-core`, which is what broke v0.5.0's publish run, and the generated
+  Python binding's `PACKAGE_VERSION` is synced by the version bump rather than
+  being left behind for `gen_python_bolt.py --check` to reject (#488, #490).
+
+### Performance
+
+- **Metal for whisper.cpp on Apple silicon.** Measured inference latency drops
+  2.7-7.8x on an M1 Pro with no word-level regressions. Other targets stay on
+  CPU until measured independently (#491).
+- **Cached stream language detection.** A streaming session detects its language
+  once and reuses the result across windows instead of re-detecting per chunk
+  (#493).
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel 2.5.0",
  "async-task",
@@ -741,7 +741,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -989,7 +989,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1341,7 +1341,7 @@ checksum = "a84c9a9c129b98e707ac9a31e204c10c064dd9f949b7da362310ff1a8b137d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1475,7 +1475,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1527,9 +1527,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "ena"
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -1797,7 +1797,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1890,7 +1890,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2384,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2549,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2576,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2590,16 +2590,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2610,15 +2611,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2752,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2976,9 +2977,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -2991,9 +2992,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -3012,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 dependencies = [
  "value-bag",
 ]
@@ -3172,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.23.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d74234349a775546a83af0f0c0c0e3a73227dee4950a542cda81a47240b3e6"
+checksum = "86886cf6dbf4e614b19c9a1eec9775f021869d7eadde0fc73921a81b90c9b4c9"
 dependencies = [
  "memo-map",
  "serde",
@@ -3182,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.23.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c96d8fae7fa4743bbcf06f486ff43f81837f5e8826f8bf525dbc4c0e03be5d"
+checksum = "bd3e5f077bc2379f0f7d911e7cfdd921114ed99fc884533dca502944cb355b11"
 dependencies = [
  "minijinja",
  "serde",
@@ -3416,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -3742,9 +3743,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3752,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3762,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3775,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -3832,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -3921,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4110,9 +4111,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -4374,22 +4375,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4554,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4616,7 +4617,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4658,7 +4659,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4669,7 +4670,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4931,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5083,7 +5084,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5170,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5261,7 +5262,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5682,9 +5683,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6208,9 +6209,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xattr"
@@ -6224,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6238,14 +6239,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6274,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6344,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -6354,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6363,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6376,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6385,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6411,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-whisper"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6420,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-whisper-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6429,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_bolt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "android_logger",
  "boltffi",
@@ -6441,7 +6442,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",
@@ -6567,9 +6568,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke 0.8.3",
@@ -6578,9 +6579,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke 0.8.3",
  "zerofrom",
@@ -6589,13 +6590,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.5.0"
+let sdkVersion = "0.6.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.6.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "86e7c6bbe26b3d3605e10cfa5733417bf5eb03ce5822cd649196be761ce01c72"
+let xybridFFIChecksum = "a8be42862da9ee13343a9e3502a03e9494a3d6e45786d70568f501d27a51f55f"
 
 let package = Package(
     name: "Xybrid",

--- a/bindings/apple/XybridFFI-Info.plist
+++ b/bindings/apple/XybridFFI-Info.plist
@@ -7,8 +7,8 @@
 	     CFBundlePackageType) on top of these; only the version keys must be
 	     supplied. This is the embedded static framework's Info.plist. -->
 	<key>CFBundleVersion</key>
-	<string>0.5.0</string>
+	<string>0.6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.6.0</string>
 </dict>
 </plist>

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.6.0
+
+Structured output, reasoning text, and tool-capability reporting reach the Dart
+surface, and the package finally ships a runnable example app.
+
+* Added: `GenerationConfig.grammar` and `jsonSchemaToGbnf` — constrain
+  generation to a JSON Schema, with the greedy and creative presets taking an
+  optional grammar so the usual extraction shape is a single call. Both had
+  reached the generated layer and stopped at the hand-written wrapper
+  (xybrid-ai/xybrid#511)
+* Added: `XybridResult.reasoningContent`, what a thinking model emits separately
+  from its answer (xybrid-ai/xybrid#511)
+* Added: `XybridModel.supportsToolCalling`, the bundle's tool-calling metadata
+  flag as an advisory tri-state — `null` means the bundle says nothing
+  (xybrid-ai/xybrid#515)
+* Added: a runnable single-screen example app in `example/`, replacing the
+  `example.md` snippet file. The snippets themselves remain in the package
+  README (xybrid-ai/xybrid#525, xybrid-ai/xybrid#152)
+* Fixed: `flutter build macos` failed with 1287 duplicate `ggml_*` symbols — one
+  Rust staticlib carried two copies of ggml (xybrid-ai/xybrid#528)
+* Changed: the Dart unit tests under `test/` run in CI for the first time, so
+  wrapper-level regressions are caught before release (xybrid-ai/xybrid#511)
+
 ## 0.5.0
 
 Live streaming speech recognition, now on the whisper.cpp backend, plus the

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.5.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.6.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.5.0"
+version = "0.6.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xybrid"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python SDK for local-first xybrid inference"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/xybrid/_bolt/__init__.py
+++ b/bindings/python/xybrid/_bolt/__init__.py
@@ -2145,7 +2145,7 @@ def telemetry_shutdown() -> None:
 
 MODULE_NAME = "xybrid_bolt"
 PACKAGE_NAME = "xybrid_bolt"
-PACKAGE_VERSION = "0.5.0"
+PACKAGE_VERSION = "0.6.0"
 
 __all__ = [
     "MODULE_NAME",

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.5.0"
+  implementation "ai.xybrid:xybrid-kotlin:0.6.0"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xybrid/web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "Preview browser tensor runtime for Xybrid metadata backed by LiteRT.",

--- a/crates/whisper-cpp-sys/Cargo.toml
+++ b/crates/whisper-cpp-sys/Cargo.toml
@@ -39,7 +39,7 @@ committed-bindings = ["bindings"]
 # "exactly one ggml" invariant enforceable: `links = "llama"` metadata tells
 # us where that ggml's headers and archives are, so whisper.cpp compiles and
 # links against them instead of configuring its own bundled copy.
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.5.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.6.0" }
 
 [build-dependencies]
 # whisper.cpp's library is ONE translation unit (`src/whisper.cpp`) whose only

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,11 +25,11 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.5.0", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.5.0", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.6.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.6.0", optional = true }
 # Safe whisper.cpp wrappers. Gated behind `asr-whispercpp`, which also pulls
 # `llm-llamacpp` — that is where the shared ggml comes from.
-xybrid-whisper = { path = "../xybrid-whisper", version = "0.5.0", optional = true }
+xybrid-whisper = { path = "../xybrid-whisper", version = "0.6.0", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.5.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.6.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.5.0", path = "../../macros" }
+xybrid-macros = { version = "0.6.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.5.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.6.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.5.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.6.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid-whisper/Cargo.toml
+++ b/crates/xybrid-whisper/Cargo.toml
@@ -20,6 +20,6 @@ default = []
 bindings = ["xybrid-whisper-sys/bindings"]
 
 [dependencies]
-xybrid-whisper-sys = { path = "../whisper-cpp-sys", version = "0.5.0" }
+xybrid-whisper-sys = { path = "../whisper-cpp-sys", version = "0.6.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.5.0", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.6.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Release **v0.6.0**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.6.0).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.6.0`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release PRs affect all distribution channels; an incorrect SPM checksum or version skew between bindings would break consumer installs until corrected.
> 
> **Overview**
> **Release cut for v0.6.0** — bumps the workspace and every shipping surface from `0.5.0` to `0.6.0` (Rust crates, Flutter/Kotlin/Python/React Native/Unity/web manifests, Apple `XybridFFI` plist, and generated Python `PACKAGE_VERSION`).
> 
> The root and Flutter **CHANGELOG** entries for **0.6.0** are added (prior feature work is documented there, not introduced in this diff). **SPM** consumers get an updated `sdkVersion` and **xcframework zip checksum** in `Package.swift`. **`Cargo.lock`** is refreshed with transitive dependency updates (e.g. `syn`, `blocking`, ICU crates).
> 
> Merging triggers the documented **Release Publish** flow (tag, draft release, crates.io / pub.dev / Maven, `swift` branch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f543e172bce8f2977f5af7cb0bbc409c3156d5df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->