### PR TITLE
docs: refresh for 0.6.0 and fix examples that do not compile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,6 @@ After editing `bindings/flutter/rust`, regenerate the Dart glue with
 `flutter_rust_bridge` in `bindings/flutter/rust/Cargo.toml`); `flutter run` then
 rebuilds the native lib via cargokit.
 
-Note: `tools/README.md` still documents the pre-Bazel xtask matrix and is stale.
 
 ### Prebuilt llama.cpp natives (the cargo fast path)
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 **モデルを実行:**
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.6.0")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.5.0"
+xybrid = "0.6.0"
 ```
 
 **モデルを実行:**

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) fo
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 **Run a model:**
@@ -159,7 +159,7 @@ final result = await model.run(XybridEnvelope.text('Hello world'));
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 
@@ -177,7 +177,7 @@ val result = model.runAsync(Envelope.text("Hello world"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.6.0")
 ]
 ```
 
@@ -216,7 +216,7 @@ var result = model.Run(Envelope.Text("Hello world"));
 
 ```toml
 [dependencies]
-xybrid = "0.5.0"
+xybrid = "0.6.0"
 ```
 
 **Run a model:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ xybrid run --model kokoro-82m --input-text "国破山河在，城春草木深" -
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 **运行模型：**
@@ -171,7 +171,7 @@ final result = await model.run(XybridEnvelope.text('国破山河在，城春草�
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 
@@ -189,7 +189,7 @@ val result = model.runAsync(Envelope.text("国破山河在，城春草木深"))
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid.git", from: "0.6.0")
 ]
 ```
 
@@ -223,7 +223,7 @@ var result = model.Run(Envelope.Text("国破山河在，城春草木深"));
 
 ```toml
 [dependencies]
-xybrid = "0.5.0"
+xybrid = "0.6.0"
 ```
 
 **运行模型：**

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -12,14 +12,14 @@ Add Xybrid to your Xcode project:
 
 1. In Xcode, select **File > Add Package Dependencies...**
 2. Enter: `https://github.com/xybrid-ai/xybrid`
-3. Set **Dependency Rule** to **Up to Next Major Version** → `0.5.0`
+3. Set **Dependency Rule** to **Up to Next Major Version** → `0.6.0`
 4. Select the **Xybrid** library product
 
 Or add it to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.6.0")
 ]
 ```
 

--- a/bindings/flutter/README.md
+++ b/bindings/flutter/README.md
@@ -15,7 +15,7 @@ Or add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 <details>
@@ -161,6 +161,78 @@ final result = await model.run(XybridEnvelope.text(
 if (result.text != null) print('Answer: ${result.text}');
 if (result.reasoningContent != null) print('Reasoning: ${result.reasoningContent}');
 ```
+
+### Structured Output (JSON Schema)
+
+Constrain a local llama model so its output is always schema-valid — no
+retry loop, no parse failures. `jsonSchemaToGbnf` turns a JSON Schema into the
+GBNF grammar `GenerationConfig.grammar` expects:
+
+```dart
+final grammar = jsonSchemaToGbnf(
+  schemaJson: '{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}',
+);
+
+final result = await model.run(
+  XybridEnvelope.text('Extract the city: "I flew into Paris last night."'),
+  config: GenerationConfig.greedy(grammar: grammar),
+);
+// result.text is guaranteed to parse against the schema
+```
+
+`GenerationConfig.greedy` is the usual pairing — deterministic decoding plus a
+grammar is the standard extraction shape. Raw GBNF works too: pass it to
+`grammar` directly.
+
+### Tool Calling
+
+One `run` is one model turn, so the loop lives in your code: run a request
+carrying tools, execute the calls the model asks for, then run a continuation
+envelope that feeds the outcomes back.
+
+```dart
+final tools = [
+  ToolDefinition(
+    name: 'get_weather',
+    description: 'Current weather for a city',
+    parametersJson: '{"type":"object","properties":{"city":{"type":"string"}}}',
+  ),
+];
+final config = GenerationConfig.greedy(tools: tools);
+
+const question = 'Weather in Paris?';
+final first = await model.run(XybridEnvelope.text(question), config: config);
+
+if (first.hasToolCalls) {
+  final results = [
+    for (final call in first.toolCalls)
+      ToolResult(callId: call.id, name: call.name, contentJson: runTool(call)),
+  ];
+
+  final answer = await model.run(
+    XybridEnvelope.toolResults(
+      userText: question,
+      priorAssistantText: first.text!,  // raw output, tool-call block included
+      results: results,
+    ),
+    config: config,  // same tools as the first turn
+  );
+}
+```
+
+Two rules the loop depends on: run the continuation with the **same tools** as
+the original turn so the executor rebuilds an identical chat prefix, and pass
+`priorAssistantText` **verbatim** — tool-call block included.
+
+Gate your tool UI on the bundle's advisory flag:
+
+```dart
+if (model.supportsToolCalling == true) showToolsToggle();
+```
+
+`null` means the bundle says nothing and never implies support. Tool calling is
+llama.cpp-only; unsupported paths reject tool-bearing requests rather than
+silently generating without them.
 
 ### LLM Streaming
 

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -12,7 +12,7 @@ Add to your `build.gradle.kts`:
 
 ```gradle
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 

--- a/bindings/unity/README.md
+++ b/bindings/unity/README.md
@@ -42,7 +42,7 @@ Or edit `Packages/manifest.json` directly:
     }
   ],
   "dependencies": {
-    "ai.xybrid.sdk": "0.5.0"
+    "ai.xybrid.sdk": "0.6.0"
   }
 }
 ```
@@ -59,7 +59,7 @@ https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 Pin a version by appending a tag:
 
 ```
-https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.5.0
+https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity#v0.6.0
 ```
 
 (**Window → Package Manager → + → Add package from git URL**, or add it under

--- a/bindings/web/README.md
+++ b/bindings/web/README.md
@@ -1,6 +1,6 @@
 # @xybrid/web preview
 
-`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.5.0` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
+`@xybrid/web` is the future umbrella browser package for Xybrid. Version `0.6.0` is a private preview with two surfaces: a low-level LiteRT tensor surface backed by `@litertjs/core` `2.5.2`, and a text-generation surface backed by `@litert-lm/core` `0.14.0`.
 
 ## Supported now
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -145,21 +145,37 @@ warning: llama.cpp: downloading prebuilt natives for aarch64-apple-darwin (visio
 warning: llama.cpp: linked prebuilt natives for aarch64-apple-darwin (vision); skipped the cmake build
 ```
 
-Nothing to install and nothing to configure. Slices are cached under
-`$CARGO_HOME/xybrid-natives/` and shared across every project on the machine.
+Nothing to install and nothing to configure. Slices are cached by content
+digest under `$CARGO_HOME/xybrid-natives/` and shared across every project on
+the machine. If `CARGO_HOME` is not set in your environment the cache falls back
+to the build directory, which is per-project and does not survive `cargo clean`
+— rustup's `cargo` shim exports it for you, so this mostly affects a cargo
+installed from a distro package, Homebrew, or Nix.
 
 Every miss falls back to the source build, so this can only make a build
 faster, never break one. It is skipped when no slice is published for your
 target, when your local sources differ from what was published (an edited
-`wrapper.cpp` or a bumped llama.cpp pin), when the CRT or glibc would not
-match, and when you are offline.
+`wrapper.cpp` or a bumped llama.cpp pin), and when the CRT or glibc would not
+match.
+
+Two cases are worth knowing about because they look like the fast path is
+broken when it is working as designed:
+
+- **Linux glibc floor.** Published Linux slices record the glibc of the machine
+  that built them, and a host on anything older declines the slice rather than
+  hitting an unresolved-versioned-symbol link error. Distributions older than
+  the publisher's therefore build from source.
+- **Cross-compiling.** The glibc check reads the *build host*, so it cannot see
+  a foreign sysroot. If you cross-compile to `*-unknown-linux-gnu` (for example
+  with `cargo-zigbuild`) against an older glibc than the slice was built for,
+  set `XYBRID_NATIVES_FORCE_SOURCE=1`.
 
 Controls:
 
 | Variable | Effect |
 |---|---|
 | `XYBRID_NATIVES_FORCE_SOURCE=1` | Never download; always build with CMake |
-| `CARGO_NET_OFFLINE=true` | Same, via cargo's standard offline switch |
+| `CARGO_NET_OFFLINE=true` | Same. Must be exported as an environment variable — cargo does not pass `--offline` or `net.offline` through to build scripts |
 | `XYBRID_NATIVES_CACHE_DIR` | Where downloaded slices are unpacked |
 | `XYBRID_NATIVES_PREBUILT_DIR` | Link a slice you staged yourself, `<dir>/<target>/{lib,include}` |
 | `XYBRID_NATIVES_PKG` | Pull from a different OCI repository |

--- a/docs/INSTALLATION.zh.md
+++ b/docs/INSTALLATION.zh.md
@@ -80,6 +80,50 @@ cargo install --git https://github.com/xybrid-ai/xybrid xybrid-cli --features pl
 
 </details>
 
+### 预编译的 llama.cpp（无需 CMake，省去 20 分钟构建）
+
+启用 `llm-llamacpp` 通常意味着用 CMake 从源码编译 llama.cpp——这是冷构建中最
+昂贵的一步，大约需要二十分钟。
+
+其实不必如此。`xybrid-llama-sys` 的构建脚本会在 crate 内置的清单中查找你的目标
+三元组与 feature 组合，通过 HTTPS 下载对应的预编译静态库，校验其 SHA-256，然后
+直接链接：
+
+```
+$ cargo build --release -p xybrid-cli --features platform-desktop
+warning: llama.cpp: downloading prebuilt natives for aarch64-apple-darwin (vision) ...
+warning: llama.cpp: linked prebuilt natives for aarch64-apple-darwin (vision); skipped the cmake build
+```
+
+无需安装、无需配置。切片按内容摘要缓存在 `$CARGO_HOME/xybrid-natives/`，供本机
+所有项目共用。若环境中未设置 `CARGO_HOME`，缓存会退回到构建目录——那是按项目
+隔离的，且无法在 `cargo clean` 后保留。rustup 的 `cargo` 包装器会自动导出该变量，
+因此这一情况主要出现在通过发行版软件包、Homebrew 或 Nix 安装的 cargo 上。
+
+任何一步未命中都会退回源码构建，所以这条路径只会让构建更快，绝不会让构建失败。
+以下情况会跳过下载：你的目标平台没有已发布的切片；本地源码与发布时不一致（改动
+过 `wrapper.cpp` 或提升了 llama.cpp 的 pin）；以及 CRT 或 glibc 不匹配。
+
+有两种情况看起来像是快速路径失效，其实是设计使然：
+
+- **Linux 的 glibc 下限。** 已发布的 Linux 切片会记录构建机器的 glibc 版本；低于
+  该版本的主机会主动放弃该切片，而不是撞上无法解析的符号版本链接错误。因此比
+  发布方更旧的发行版会走源码构建。
+- **交叉编译。** glibc 检查读取的是*构建主机*，无法感知外部 sysroot。若你交叉
+  编译到 `*-unknown-linux-gnu`（例如使用 `cargo-zigbuild`）且目标 glibc 比切片
+  构建时更旧，请设置 `XYBRID_NATIVES_FORCE_SOURCE=1`。
+
+控制变量：
+
+| 变量 | 作用 |
+|---|---|
+| `XYBRID_NATIVES_FORCE_SOURCE=1` | 从不下载，始终用 CMake 构建 |
+| `CARGO_NET_OFFLINE=true` | 同上。必须作为环境变量导出——cargo 不会把 `--offline` 或 `net.offline` 传递给构建脚本 |
+| `XYBRID_NATIVES_CACHE_DIR` | 下载的切片解压到何处 |
+| `XYBRID_NATIVES_PREBUILT_DIR` | 链接你自行准备的切片，路径为 `<dir>/<target>/{lib,include}` |
+| `XYBRID_NATIVES_PKG` | 从其他 OCI 仓库拉取 |
+| `XYBRID_NATIVES_TOKEN` | Bearer token，用于私有镜像 |
+
 ### 从本地克隆构建
 
 ```bash

--- a/docs/content/docs/(integration)/sdks/android.mdx
+++ b/docs/content/docs/(integration)/sdks/android.mdx
@@ -11,7 +11,7 @@ Add the Xybrid SDK from Maven Central:
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/android.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/android.zh.mdx
@@ -11,7 +11,7 @@ Android SDK 通过 BoltFFI 为 Xybrid 运行时提供原生 Kotlin 绑定，支�
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 

--- a/docs/content/docs/(integration)/sdks/flutter.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.mdx
@@ -11,7 +11,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 ## Initialization

--- a/docs/content/docs/(integration)/sdks/flutter.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/flutter.zh.mdx
@@ -11,7 +11,7 @@ Flutter SDK（`xybrid_flutter`）通过 FFI 提供到 Xybrid Rust 核心的 Dart
 
 ```yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 ## 初始化

--- a/docs/content/docs/(integration)/sdks/ios.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.mdx
@@ -15,7 +15,7 @@ Add the Xybrid package via Swift Package Manager:
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.6.0")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/ios.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/ios.zh.mdx
@@ -15,7 +15,7 @@ Swift SDK 处于早期访问阶段。正式版本通过 Swift Package Manager �
 
 ```swift title="Package.swift"
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.6.0")
 ]
 ```
 

--- a/docs/content/docs/(integration)/sdks/web.mdx
+++ b/docs/content/docs/(integration)/sdks/web.mdx
@@ -6,7 +6,7 @@ description: Browser SDK preview for on-device ML inference with WebAssembly and
 The Web SDK (`@xybrid/web`) runs Xybrid models directly in the browser. It has two surfaces: a tensor surface (`XybridModel`) for TfLite models and a text-generation surface (`XybridLlm`) for `.litertlm` language models. Inference executes locally through WebAssembly, with WebGPU acceleration when available — no server round-trip.
 
 <Callout type="info">
-`@xybrid/web` `0.5.0` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
+`@xybrid/web` `0.6.0` is a **private preview** and is not yet published to npm. It lives in [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) in the Xybrid repository, ships as ESM only, and its API may change. The underlying engines are an implementation detail — application code should only speak in terms of `@xybrid/web`.
 </Callout>
 
 ## Try the Demo

--- a/docs/content/docs/(integration)/sdks/web.zh.mdx
+++ b/docs/content/docs/(integration)/sdks/web.zh.mdx
@@ -6,7 +6,7 @@ description: 基于 WebAssembly 与 WebGPU 的浏览器端设备内 ML 推理 SD
 Web SDK（`@xybrid/web`）让 Xybrid 模型直接在浏览器中运行。它包含两个界面：用于 TfLite 模型的张量界面（`XybridModel`），以及用于 `.litertlm` 语言模型的文本生成界面（`XybridLlm`）。推理通过 WebAssembly 在本地执行，在可用时使用 WebGPU 加速——无需服务器往返。
 
 <Callout type="info">
-`@xybrid/web` `0.5.0` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
+`@xybrid/web` `0.6.0` 为**私有预览版**，尚未发布到 npm。它位于 Xybrid 仓库的 [`bindings/web`](https://github.com/xybrid-ai/xybrid/tree/master/bindings/web) 目录中，仅提供 ESM 格式，API 可能发生变化。底层引擎属于实现细节——应用代码应只使用 `@xybrid/web` 的概念。
 </Callout>
 
 ## 体验示例

--- a/docs/content/docs/guides/tool-calling.mdx
+++ b/docs/content/docs/guides/tool-calling.mdx
@@ -202,6 +202,73 @@ Contract:
   template still fails loudly at run time). A bundle that declares
   `tool_calling: false` stays off.
 
+## From the Mobile and Desktop SDKs
+
+Tool calling crosses the FFI boundary as of 0.6.0, so Swift, Kotlin, Python,
+Unity C# and Dart drive the same loop. It stays **turn-based**: one `run` is one model
+turn, your code executes the tools, and a continuation envelope feeds the
+outcomes back. There is no cross-boundary callback.
+
+Three pieces make up the loop:
+
+1. Put your tool schemas on `GenerationConfig.tools`.
+2. Read `XybridResult.toolCalls` — each carries `id`, `name` and
+   `argumentsJson`.
+3. Build the continuation with `XybridEnvelope.toolResults(...)` and run it
+   **with the same tools as the original turn**, so the executor rebuilds an
+   identical chat prefix.
+
+```swift
+let tools = [XybridToolDefinition(
+    name: "get_weather",
+    description: "Current weather for a city",
+    parametersJson: #"{"type":"object","properties":{"city":{"type":"string"}}}"#
+)]
+let config = XybridGenerationConfig.greedy(tools: tools)
+
+let options = XybridRunOptions(
+    generationConfig: config,
+    abortOn: [],
+    fallbackToCloud: false,
+    maxGraceTokens: 0,
+    correlationId: nil
+)
+let first = try model.run(envelope: .text("Weather in Paris?"), options: options)
+
+if !first.toolCalls.isEmpty {
+    let results = first.toolCalls.map { call in
+        XybridToolResult(callId: call.id, name: call.name, contentJson: execute(call))
+    }
+    let continuation = try XybridEnvelope.toolResults(
+        "Weather in Paris?",
+        priorAssistantText: first.text ?? "",  // raw output, tool-call block included
+        results: results
+    )
+    // same options — the continuation must carry the same tools
+    let answer = try model.run(envelope: continuation, options: options)
+}
+```
+
+Kotlin mirrors it with `XybridEnvelope.toolResults(userText, priorAssistantText,
+results)`. Python uses `tool_results_envelope(...)` and snake_case fields. Dart
+uses the named-argument factory `XybridEnvelope.toolResults(userText:,
+priorAssistantText:, results:)` with `GenerationConfig.greedy(tools: ...)` and
+`result.hasToolCalls`.
+
+`priorAssistantText` must be the turn's raw `text` verbatim — tool-call block
+included. Stripping it breaks the prefix the model continues from.
+
+Gate your tool UI on the bundle's advisory flag rather than assuming:
+
+```swift
+if model.supportsToolCalling() == true { showToolsToggle() }
+```
+
+`nil` means the bundle says nothing and never implies support. Enforcement
+still happens at run time: tool calling is llama.cpp-only, and unsupported
+paths — no embedded chat template, the mistralrs backend, the cloud fallback
+leg — reject tool-bearing requests rather than quietly generating without them.
+
 ## Declaring Support in Your Own Bundles
 
 Add the flag to `model_metadata.json` for models whose chat template renders

--- a/docs/content/docs/guides/tool-calling.zh.mdx
+++ b/docs/content/docs/guides/tool-calling.zh.mdx
@@ -180,6 +180,68 @@ xybrid repl --model-file ./LFM2.5-350M-Q4_K_M.gguf --tools-file my-tools.json
   `tool_calling` 的模型启用工具（不受支持的模板在运行时仍会明确报错）。声明了
   `tool_calling: false` 的 Bundle 则保持关闭。
 
+## 在移动端与桌面端 SDK 中使用
+
+自 0.6.0 起，工具调用可以跨越 FFI 边界，因此 Swift、Kotlin、Python、Unity C#
+与 Dart 都能驱动同一套循环。它保持**按轮次进行**：一次 `run` 就是模型的一轮，
+由你的代码执行工具，再用一个续接 Envelope 把结果回传。不存在跨边界回调。
+
+整个循环由三部分组成：
+
+1. 把工具的 schema 放到 `GenerationConfig.tools`。
+2. 读取 `XybridResult.toolCalls`——每一项包含 `id`、`name` 和 `argumentsJson`。
+3. 用 `XybridEnvelope.toolResults(...)` 构造续接 Envelope，并**使用与原始轮次
+   相同的工具**来运行它，这样执行器才能重建出完全一致的对话前缀。
+
+```swift
+let tools = [XybridToolDefinition(
+    name: "get_weather",
+    description: "Current weather for a city",
+    parametersJson: #"{"type":"object","properties":{"city":{"type":"string"}}}"#
+)]
+let config = XybridGenerationConfig.greedy(tools: tools)
+
+let options = XybridRunOptions(
+    generationConfig: config,
+    abortOn: [],
+    fallbackToCloud: false,
+    maxGraceTokens: 0,
+    correlationId: nil
+)
+let first = try model.run(envelope: .text("Weather in Paris?"), options: options)
+
+if !first.toolCalls.isEmpty {
+    let results = first.toolCalls.map { call in
+        XybridToolResult(callId: call.id, name: call.name, contentJson: execute(call))
+    }
+    let continuation = try XybridEnvelope.toolResults(
+        "Weather in Paris?",
+        priorAssistantText: first.text ?? "",  // 原始输出，包含工具调用块
+        results: results
+    )
+    // same options — the continuation must carry the same tools
+    let answer = try model.run(envelope: continuation, options: options)
+}
+```
+
+Kotlin 的对应写法是 `XybridEnvelope.toolResults(userText, priorAssistantText,
+results)`；Python 使用 `tool_results_envelope(...)` 与 snake_case 字段；Dart 使用
+具名参数工厂 `XybridEnvelope.toolResults(userText:, priorAssistantText:,
+results:)`，搭配 `GenerationConfig.greedy(tools: ...)` 与 `result.hasToolCalls`。
+
+`priorAssistantText` 必须是该轮**原封不动**的 `text`——包含工具调用块在内。删掉
+它会破坏模型续写所依赖的前缀。
+
+请依据 Bundle 的建议性标志来控制工具相关的界面，而不要想当然：
+
+```swift
+if model.supportsToolCalling() == true { showToolsToggle() }
+```
+
+`nil` 表示该 Bundle 未作声明，绝不意味着支持。强制校验仍在运行时进行：工具调用
+目前仅支持 llama.cpp，不受支持的路径——没有内嵌对话模板、mistralrs 后端、云端
+回退分支——会直接拒绝带工具的请求，而不是悄悄地在没有工具的情况下生成。
+
 ## 在你自己的 Bundle 中声明支持
 
 为聊天模板能渲染工具的模型，在 `model_metadata.json` 中添加该标志

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Get Xybrid running in your app with a few lines of code. Choose your SDK below.
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 ```bash
@@ -54,7 +54,7 @@ Or add to `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.6.0")
 ]
 ```
 
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 
@@ -119,7 +119,7 @@ In Unity, go to **Window > Package Manager > + > Add package from git URL** and 
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.5.0` to the git URL.
+Or via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/): `openupm add ai.xybrid.sdk`. Native libraries download automatically on first import (SHA-256 verified); pin a version by appending `#v0.6.0` to the git URL.
 
 **Run inference**
 
@@ -191,7 +191,7 @@ See the [Web SDK guide](/docs/sdks/web) for the tensor surface, registry loading
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.5.0"
+xybrid = "0.6.0"
 ```
 
 **Run inference**

--- a/docs/content/docs/quickstart.zh.mdx
+++ b/docs/content/docs/quickstart.zh.mdx
@@ -12,7 +12,7 @@ description: 几分钟内开始使用 Xybrid
 ```yaml
 # pubspec.yaml
 dependencies:
-  xybrid_flutter: ^0.5.0
+  xybrid_flutter: ^0.6.0
 ```
 
 ```bash
@@ -54,7 +54,7 @@ https://github.com/xybrid-ai/xybrid
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.5.0")
+    .package(url: "https://github.com/xybrid-ai/xybrid", from: "0.6.0")
 ]
 ```
 
@@ -85,7 +85,7 @@ let result = try await model.runAsync(envelope: envelope)
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("ai.xybrid:xybrid-kotlin:0.5.0")
+    implementation("ai.xybrid:xybrid-kotlin:0.6.0")
 }
 ```
 
@@ -119,7 +119,7 @@ val result = model.runAsync(envelope)
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
-或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.5.0`。
+或通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) 安装：`openupm add ai.xybrid.sdk`。原生库在首次导入时自动下载（经 SHA-256 校验）；如需固定版本，在 git URL 后追加 `#v0.6.0`。
 
 **运行推理**
 
@@ -190,7 +190,7 @@ const llm = await XybridLlm.fromHuggingFace("litert-community/SmolLM2-135M-Instr
 ```toml
 # Cargo.toml
 [dependencies]
-xybrid = "0.5.0"
+xybrid = "0.6.0"
 ```
 
 **运行推理**

--- a/docs/telemetry/registry.md
+++ b/docs/telemetry/registry.md
@@ -37,7 +37,7 @@ The command exits 0 in both cases — it is a status report, not an error.
 The header is a single line, semicolon-separated:
 
 ```
-X-Xybrid-Client: binding=flutter; sdk_version=0.5.0; core_version=0.5.0; platform=ios-arm64; backends=asr-whispercpp,llm-llamacpp,llm-llamacpp-vision,ort-coreml,ort-download,vision
+X-Xybrid-Client: binding=flutter; sdk_version=0.6.0; core_version=0.6.0; platform=ios-arm64; backends=asr-whispercpp,llm-llamacpp,llm-llamacpp-vision,ort-coreml,ort-download,vision
 ```
 
 | Field | Type | Description |

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -183,7 +183,8 @@ let result = try model.run(
         generationConfig: config,
         abortOn: [],
         fallbackToCloud: false,
-        maxGraceTokens: 0
+        maxGraceTokens: 0,
+        correlationId: nil
     )
 )
 ```
@@ -201,7 +202,8 @@ let result = try model.run(
         generationConfig: config,
         abortOn: [],
         fallbackToCloud: false,
-        maxGraceTokens: 0
+        maxGraceTokens: 0,
+        correlationId: nil
     )
 )
 let caption = result.text

--- a/examples/ios/XybridExample/ExtractionView.swift
+++ b/examples/ios/XybridExample/ExtractionView.swift
@@ -291,7 +291,8 @@ struct ExtractionView: View {
                     generationConfig: config,
                     abortOn: [],
                     fallbackToCloud: false,
-                    maxGraceTokens: 0
+                    maxGraceTokens: 0,
+                    correlationId: nil
                 )
 
                 let envelope = XybridEnvelope(

--- a/examples/ios/XybridExample/LiveVision.swift
+++ b/examples/ios/XybridExample/LiveVision.swift
@@ -357,7 +357,8 @@ final class LiveVisionViewModel: ObservableObject {
                 ),
                 abortOn: [],
                 fallbackToCloud: false,
-                maxGraceTokens: 0
+                maxGraceTokens: 0,
+                correlationId: nil
             )
             // bolt's `run` is synchronous + blocking; execute it OFF the main
             // actor so the camera feed and UI stay responsive (the realtime gate

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,7 +6,13 @@ Build automation and scripts for the xybrid project.
 
 ```
 tools/
-├── scripts/        # Shell scripts for platform builds
+├── scripts/        # Build, release, and codegen helpers (see below)
+│   ├── natives-*.sh          # Prebuilt llama.cpp slices: fingerprint, push,
+│   │                         #   pull, manifest, anonymous-pull verification
+│   ├── gen_*_bolt*.py        # Generate the Kotlin / Python / Unity C# bolt
+│   │                         #   bindings (CI byte-compares with --check)
+│   ├── version-sync.sh       # Read or set the version across every manifest
+│   ├── api-contract-check.sh # Soft-warning public SDK signature check
 │   ├── build-xcframework.sh  # Build XCFramework for Apple platforms
 │   └── build-android.sh      # Build AAR for Android
 └── README.md       # This file


### PR DESCRIPTION
Post-release docs sweep for 0.6.0. Three kinds of change: stale version pins, claims that are wrong, and 0.6.0 surfaces that were never documented.

**Version pins → 0.6.0**

* Every README (en/ja/zh), quickstart, SDK page, binding README, and the telemetry header example.
* Verified each registry actually serves 0.6.0 before bumping — crates.io, pub.dev and OpenUPM do.
* **Maven Central does not yet.** The Kotlin artifact uploaded fine but the config uses `publishToMavenCentral(CENTRAL_PORTAL)` without `automaticRelease`, so the deployment is sitting in the Central Portal awaiting a manual "Publish". The Android pin in these docs is correct only once that is clicked.

**Wrong claims, corrected**

* `docs/INSTALLATION.md` said `CARGO_NET_OFFLINE=true` works "via cargo's standard offline switch". It does not — `cargo build --offline` and `net.offline` are not passed through to build scripts (verified on cargo 1.87 / 1.95 / 1.98). Only an exported environment variable suppresses the download.
* It also promised slices are "shared across every project on the machine". `CARGO_HOME` reaches a build script via rustup's shim, not cargo itself, so a distro / Homebrew / Nix cargo silently caches per-project instead.
* Documents the two cases that look like the fast path is broken but are working as designed: the Linux glibc floor, and cross-compiles where the host-side glibc check cannot see a foreign sysroot.

**Examples that do not compile**

* Four `XybridRunOptions(...)` call sites omit the required `correlationId` argument — two in `examples/ios/README.md`, two in the iOS example app itself. Confirmed with `swiftc` that the 4-argument form fails. No CI job builds the iOS example, which is how it drifted.

**Undocumented 0.6.0 surfaces**

* Tool calling from Swift / Kotlin / Python / Unity C# / Dart — added to both the English and Chinese guides. Covers the turn-based loop and the two rules it depends on: run the continuation with the same tools, and pass `priorAssistantText` verbatim.
* Structured output (`jsonSchemaToGbnf` + `GenerationConfig.grammar`) and tool calling in the Flutter README.
* The prebuilt-natives section, which `INSTALLATION.zh.md` never received.

**Housekeeping**

* `AGENTS.md` claimed `tools/README.md` is stale; it documents the post-Bazel layout now, so the note is gone. `tools/README.md`'s directory tree listed 2 of 26 scripts — the natives and codegen ones are now in it.

Every code example was checked against the real generated bindings, which is how the `XybridToolResult(callId:)` label, the Dart `run(envelope, config:)` signature, and `XybridResult.text` being optional got caught.

## Type of Change

- [x] Documentation
- [x] Bug fix (non-compiling example code)

## Checklist

- [x] Code follows project style
- [x] Documentation updated
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no runtime or API behavior modifications in shipped libraries.
> 
> **Overview**
> Post-release documentation sweep for **0.6.0**: version pins, corrected install claims, new SDK surfaces, and iOS example fixes.
> 
> **Version pins** are bumped from `0.5.0` to `0.6.0` across English/Japanese/Chinese READMEs, quickstart tabs, SDK docs, binding READMEs, and the telemetry header example.
> 
> **Install / prebuilt natives docs** now state that `CARGO_NET_OFFLINE=true` must be an exported env var (cargo does not pass `--offline` to build scripts), explain content-digest caching under `$CARGO_HOME/xybrid-natives/` and the per-project fallback when `CARGO_HOME` is unset, and document the Linux glibc floor and cross-compile `XYBRID_NATIVES_FORCE_SOURCE=1` cases. The Chinese install guide gains the prebuilt llama.cpp section that English already had.
> 
> **0.6.0 SDK documentation** adds turn-based tool calling for Swift/Kotlin/Python/Unity/Dart in the tool-calling guides (same tools on continuation, verbatim `priorAssistantText`), plus Flutter README sections for **structured output** (`jsonSchemaToGbnf` + `GenerationConfig.grammar`) and **tool calling**.
> 
> **Examples** fix four `XybridRunOptions` call sites missing required `correlationId: nil` in the iOS example app and README.
> 
> **Housekeeping:** removes the stale `tools/README.md` note from `AGENTS.md` and expands `tools/README.md`’s script inventory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8fb5c7e9f10d5852b52dac4a7746c6a3e008b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->