### PR TITLE
ci: gate docs-only changes + restructure the README

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -46,6 +46,8 @@ on:
       - "Cargo.lock"
       - "tools/unity-runtime-smoke/**"
       - ".github/workflows/bazel.yml"
+      # Markdown inside any path above cannot change a Bazel build.
+      - "!**.md"
   workflow_dispatch:
 
 permissions:
@@ -75,9 +77,12 @@ jobs:
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Drop docs before matching: the patterns below are directory
+          # prefixes (`crates/`, `bindings/kotlin/`, ...), so a README inside
+          # one of them would otherwise trigger the full RBE matrix.
           FILES=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename')
+            --jq '.[].filename' | grep -vE '\.mdx?$' || true)
           if printf '%s\n' "$FILES" | grep -qE '^(MODULE\.bazel|\.bazelrc|\.bazelversion|\.bazelignore|BUILD\.bazel|.*/BUILD\.bazel|.*\.bzl|bazel/|tools/scripts/|rules_android_ndk\.patch|rules_foreign_cc\.patch|rules_rs\.patch|rules_rust\.patch|hermetic_llvm\.patch|crates/|bindings/kotlin/|macros/|vendor/llama-cpp|vendor/ort-macos/|Cargo\.toml|Cargo\.lock|tools/unity-runtime-smoke/|\.github/workflows/bazel\.yml)'; then
             REL=true
           else

--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -30,6 +30,8 @@ on:
       - 'crates/llama-cpp-sys/**'
       - 'tools/scripts/natives-*.sh'
       - '.github/workflows/build-natives.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   # Weekly re-publish: GitHub rotates the macOS/Linux runner images, changing
   # the host toolchain (Xcode SDK, gcc) folded into apple/host fingerprints.
   # Re-running weekly re-warms those slices under the current image so the cache

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - '**.md'
       - 'docs/**'
+      - 'examples/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'LICENSE'
   pull_request:
@@ -23,6 +24,7 @@ on:
     paths:
       - '**.md'
       - 'docs/**'
+      - 'examples/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'LICENSE'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - 'examples/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'LICENSE'
   pull_request:
@@ -13,6 +14,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - 'examples/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'LICENSE'
 

--- a/.github/workflows/test-candle.yml
+++ b/.github/workflows/test-candle.yml
@@ -25,6 +25,8 @@ on:
       - 'integration-tests/**'
       - 'Cargo.lock'
       - '.github/workflows/test-candle.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   pull_request:
     branches: [master]
     paths:
@@ -44,6 +46,8 @@ on:
       - 'integration-tests/**'
       - 'Cargo.lock'
       - '.github/workflows/test-candle.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-whispercpp.yml
+++ b/.github/workflows/test-whispercpp.yml
@@ -20,6 +20,8 @@ on:
       - 'vendor/whisper-cpp'
       - 'Cargo.lock'
       - '.github/workflows/test-whispercpp.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   pull_request:
     branches: [master]
     paths:
@@ -36,6 +38,8 @@ on:
       - 'vendor/whisper-cpp'
       - 'Cargo.lock'
       - '.github/workflows/test-whispercpp.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/unity-editor.yml
+++ b/.github/workflows/unity-editor.yml
@@ -29,6 +29,8 @@ on:
       - "tools/scripts/bazel-output.sh"
       - "tools/scripts/write-buildbuddy-rc.sh"
       - ".github/workflows/unity-editor.yml"
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   push:
     branches: [master]
     paths:
@@ -41,6 +43,8 @@ on:
       - "tools/scripts/bazel-output.sh"
       - "tools/scripts/write-buildbuddy-rc.sh"
       - ".github/workflows/unity-editor.yml"
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
   workflow_dispatch:
 
 permissions:

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -28,11 +28,11 @@
 <p align="center">
 
 [![Build][build-shield]][build-url]
-[![Release][release-shield]][release-url]
 [![License][license-shield]][license-url]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
 [![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
 <br>
+[![Release][release-shield]][release-url]
 [![crates.io][crates-shield]][crates-url]
 [![pub.dev][pubdev-shield]][pubdev-url]
 [![Maven Central][maven-shield]][maven-url]
@@ -92,41 +92,24 @@
 
 
 
-## はじめに
-
-| 目的 | パス |
-|------|------|
-| 最速デモ（2分） | [CLIをインストール →](#クイックスタート) |
-| モバイルまたはデスクトップアプリを構築 | [Flutter SDK →](bindings/flutter/) |
-| ゲームにAI NPCを追加 | [Unity SDK →](bindings/unity/) および [3D酒場デモ](https://github.com/xybrid-ai/xybrid-unity-tavern) を試す |
-| Androidネイティブ | [Kotlin SDK →](bindings/kotlin/) |
-| Rust / 組み込み | [Coreクレート →](crates/) |
----
-
-<p align="center">
-  <img src="docs/game-demo.gif" alt="ゲームデモ" width="540">
-</p>
-
-## SDK
-
-Xybridは**Rustベースのランタイム**であり、すべての主要プラットフォーム向けのネイティブバインディングを提供します。
-
-| SDK | プラットフォーム | インストール | ステータス | サンプル |
-|-----|-----------|---------|--------|--------|
-| **[Flutter](bindings/flutter/)** | iOS, Android, macOS, Linux, Windows | [pub.dev](https://pub.dev/packages/xybrid_flutter) | 利用可能 | [README](examples/flutter/README.md) |
-| **[Unity](bindings/unity/)** | macOS, Windows, Linux, iOS, Android | [下記参照](#クイックスタート) | 利用可能 | [Unity 3D AI酒場](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | 利用可能 | [README](examples/ios/README.md) |
-| **[Kotlin](bindings/kotlin/)** | Android | Maven Central | 利用可能 | [README](examples/android/README.md) |
-| **[CLI](https://github.com/xybrid-ai/xybrid/releases)** | macOS, Linux, Windows | `curl -sSL .../install.sh \| sh` | 利用可能 | — |
-| **[Rust](crates/)** | すべて | [crates.io](https://crates.io/crates/xybrid) | 利用可能 | — |
-
-すべてのSDKは同じRustコアをラップしており、すべてのプラットフォームで同一のモデルサポートと動作を提供します。
-
----
-
 ## クイックスタート
 
-お好みの言語でインストールしてモデルを実行できます。各セクションにはインストール手順と最小限のサンプルが含まれています。
+お好みの言語でインストールしてモデルを実行できます。
+
+<p align="center">
+  <a href="https://docs.xybrid.dev/en/docs/sdks/flutter"><img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/ios"><img src="https://img.shields.io/badge/Swift-F05138?style=for-the-badge&logo=swift&logoColor=white" alt="Swift SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/kotlin"><img src="https://img.shields.io/badge/Kotlin-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white" alt="Kotlin SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/unity"><img src="https://img.shields.io/badge/Unity-000000?style=for-the-badge&logo=unity&logoColor=white" alt="Unity SDK"></a>
+  <br>
+  <a href="https://crates.io/crates/xybrid"><img src="https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white" alt="Rust crate"></a>
+  <a href="bindings/python/"><img src="https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white" alt="Python SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/web"><img src="https://img.shields.io/badge/Web_preview-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black" alt="Web SDK preview"></a>
+  <a href="https://github.com/xybrid-ai/xybrid/releases"><img src="https://img.shields.io/badge/CLI-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="CLI"></a>
+</p>
+
+各バッジからプラットフォームごとのセットアップ手順を参照できます。すべての
+オプションは[インストールガイド](https://docs.xybrid.dev/en/docs/quickstart)をご覧ください。
 
 ### CLI
 
@@ -203,11 +186,26 @@ let result = try await model.runAsync(envelope: Envelope.text("Hello world"))
 
 ### Unity
 
-**インストール** [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/)（`openupm add ai.xybrid.sdk`）、または git サブフォルダから:
+<p align="center">
+  <img src="docs/game-demo.gif" alt="ゲームデモ" width="480">
+</p>
+
+**OpenUPM でインストール**（推奨）:
+
+```sh
+openupm add ai.xybrid.sdk
+```
+
+または `https://package.openupm.com` をスコープ `ai.xybrid` の scoped registry として追加します。
+
+**手動インストール** — git サブフォルダを UPM パッケージとして追加:
 
 ```sh
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
+
+ネイティブライブラリは初回インポート時に自動でダウンロードされます。詳細は
+[Unity SDK ガイド](https://docs.xybrid.dev/en/docs/sdks/unity)を参照してください。
 
 **モデルを実行:**
 
@@ -289,61 +287,52 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 
 ## 対応モデル
 
-すべてのモデルは完全にオンデバイスで実行されます。クラウド不要、APIキー不要です。完全なレジストリは `xybrid models list` で閲覧できます。
-
-### まずはこれから
-
-| モデル | タイプ | パラメータ数 | おすすめの理由 |
-|-------|------|--------|----------------|
-| **SmolLM2 360M** | LLM | 360M | あらゆるデバイスで最高の品質対サイズ比 |
-| **Kokoro 82M** | TTS | 82M | 高品質な音声、24種類の声、高速 |
-| **Whisper Tiny** | ASR | 39M | 正確な多言語文字起こし |
+すべてのモデルは完全にオンデバイスで実行されます。クラウド不要、APIキー不要です。
+全カタログは **[xybrid.ai/models](https://www.xybrid.ai/models)** で閲覧できます
+（`xybrid models list` でも一覧できます）。
 
 ### 音声認識（Speech-to-Text）
 
-| モデル | パラメータ数 | フォーマット | 説明 |
-|-------|--------|--------|-------------|
-| Whisper Tiny（`whisper-tiny-ggml`） | 39M | GGML Q5_1 | whisper.cpp による多言語文字起こし — すべてのプラットフォームプリセットに同梱 |
-| Whisper Tiny（`whisper-tiny`） | 39M | SafeTensors | 同じ重みを Candle ランタイムで実行 — `candle` フィーチャを有効にしたビルドが必要 |
-| Wav2Vec2 Base | 95M | ONNX | CTC復号による英語ASR |
+| モデル | パラメータ | 説明 |
+|--------|-----------|------|
+| [Whisper Tiny](https://www.xybrid.ai/models/whisper-tiny-ggml) | 39M | whisper.cpp による多言語文字起こし——すべてのプラットフォームプリセットに同梱 |
+| [Wav2Vec2 Base](https://www.xybrid.ai/models/wav2vec2-base-960h) | 95M | CTC デコードによる英語 ASR |
 
 ### テキスト読み上げ（Text-to-Speech）
 
-| モデル | パラメータ数 | フォーマット | 説明 |
-|-------|--------|--------|-------------|
-| Kokoro 82M | 82M | ONNX | 高品質、24種類の自然な声 |
-| KittenTTS Nano | 15M | ONNX | 超軽量、8種類の声 |
+| モデル | パラメータ | 説明 |
+|--------|-----------|------|
+| [Kokoro 82M](https://www.xybrid.ai/models/kokoro-82m) | 82M | 高品質、24種類の自然な音声 |
+| [KittenTTS Nano](https://www.xybrid.ai/models/kitten-tts-nano-0.8) | 15M | 超軽量、8種類の音声 |
+| [NeuTTS Nano](https://www.xybrid.ai/models/neutts-nano-q4) | 120M | コーデック TTS、音声クローン対応 |
 
-### 言語モデル
+### LLM
 
-| モデル | パラメータ数 | フォーマット | 説明 |
-|-------|--------|--------|-------------|
-| Gemma 3 1B | 1B | GGUF Q4_K_M | Googleのモバイル最適化LLM |
-| LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AIのハイブリッドconv+attention、9言語、ツール呼び出し対応 |
-| Llama 3.2 1B | 1B | GGUF Q4_K_M | Metaの汎用LLM、128Kコンテキスト |
-| Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | コンパクトなオンデバイスチャット |
-| Qwen 3.5 0.8B | 800M | GGUF Q4_K_M | 推論機能付き最新Qwen（思考モード） |
-| Qwen 3.5 2B | 2B | GGUF Q4_K_M | 拡張推論機能付き大型Qwen 3.5 |
-| SmolLM2 360M | 360M | GGUF Q4_K_M | 最高の小型LLM、優れた品質/サイズ比 |
+| モデル | パラメータ | 説明 |
+|--------|-----------|------|
+| [LFM2.5 230M](https://www.xybrid.ai/models/lfm2.5-230m) | 230M | Liquid AI 最小のハイブリッド conv+attention LLM——9言語、ツール呼び出し対応 |
+| [LFM2.5 350M](https://www.xybrid.ai/models/lfm2.5-350m) | 354M | 同じアーキテクチャでより余裕のある構成——9言語、ツール呼び出し対応 |
+| [LFM2.5 1.2B Instruct](https://www.xybrid.ai/models/lfm2.5-1.2b-instruct) | 1.2B | エージェント的タスクとデータ抽出向け |
+| [LFM2.5 1.2B Thinking](https://www.xybrid.ai/models/lfm2.5-1.2b-thinking) | 1.2B | 推論モデル——`reasoningContent` で思考過程を出力（[ガイド](https://docs.xybrid.dev/en/docs/guides/reasoning)） |
+| [SmolLM2 360M](https://www.xybrid.ai/models/smollm2-360m) | 360M | 最良の小型 LLM、品質とサイズのバランスに優れる |
+| [FunctionGemma 270M](https://www.xybrid.ai/models/functiongemma-270m-it) | 270M | 関数呼び出しに特化 |
+| [Gemma 3 1B](https://www.xybrid.ai/models/gemma-3-1b) | 1B | Google のモバイル最適化 LLM、32K コンテキスト |
+| [Gemma 4 E2B](https://www.xybrid.ai/models/gemma-4-e2b) | 5.1B | Google のコンパクトなマルチモーダル LLM、実効パラメータ 2.3B |
+| [Gemma 4 E4B](https://www.xybrid.ai/models/gemma-4-e4b) | 8B | Google のミドルレンジ マルチモーダル LLM、実効パラメータ 4.5B |
+| [Llama 3.2 1B](https://www.xybrid.ai/models/llama-3.2-1b) | 1B | Meta の汎用モデル、128K コンテキスト |
+| [Qwen 3.5 0.8B](https://www.xybrid.ai/models/qwen3.5-0.8b) | 800M | 推論（thinking モード）対応、201言語 |
+| [Qwen 3.5 2B](https://www.xybrid.ai/models/qwen3.5-2b) | 2B | より大きな Qwen 3.5、推論能力を強化 |
+| [Bonsai 27B](https://www.xybrid.ai/models/bonsai-27b) | 27B | PrismML の 1-bit マルチモーダル LLM（テキスト + 画像）、ハイブリッドアテンション |
 
 ### 視覚言語モデル（VLM）
 
-| モデル | パラメータ数 | フォーマット | 説明 |
-|-------|--------|--------|-------------|
-| LFM2-VL 450M | 450M | GGUF Q4_0 + mmproj | Liquid AIのコンパクトVLM（SigLIP2ビジョン）— 画像＋テキスト入力、llama.cpp mtmdで動作 |
+| モデル | パラメータ | 説明 |
+|--------|-----------|------|
+| [LFM2-VL 450M](https://www.xybrid.ai/models/lfm2-vl-450m) | 450M | Liquid AI のコンパクトな VLM（SigLIP2 ビジョンエンコーダ） |
+| [LFM2.5-VL 3B](https://www.xybrid.ai/models/lfm2.5-vl-3b) | 3B | より大きな Liquid VLM、ローカル推論向け |
 
-### 近日公開
-
-| モデル | タイプ | パラメータ数 | 優先度 | ステータス |
-|-------|------|--------|----------|--------|
-| Phi-4 Mini | LLM | 3.8B | P2 | 仕様準備完了（初のマルチ量子化: Q4, Q8, FP16） |
-| Qwen3 0.6B | LLM | 600M | P2 | 計画中 |
-| Trinity Nano | LLM (MoE) | 6B (1Bアクティブ) | P2 | 計画中 |
-| LFM2-VL 700M | Vision+LLM | 700M | P2 | 計画中 |
-| Nomic Embed Text v1.5 | Embeddings | 137M | P1 | ブロック中（Tokenize/MeanPoolステップが必要） |
-| Whisper Tiny CoreML | ASR | 39M | P2 | 計画中 |
-| Qwen3-TTS 0.6B | TTS | 600M | P2 | ブロック中（カスタムSafeTensorsランタイムが必要） |
-| Chatterbox Turbo | TTS | 350M | P3 | ブロック中（ModelGraphテンプレートが必要） |
+**ツール呼び出し:**
+[ツール呼び出しガイド](https://docs.xybrid.dev/en/docs/guides/tool-calling)を参照してください。
 
 <details>
 <summary><h3>独自モデルの使用（実験的機能）</h3></summary>
@@ -390,7 +379,7 @@ claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
 |------------|-----|---------|-------|-------|---------|
 | 音声認識 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | テキスト読み上げ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 言語モデル | ✅ | ✅ | ✅ | ✅ | ✅ |
+| LLM | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 画像認識モデル | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ツール呼び出し | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 埋め込み | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
@@ -400,23 +389,23 @@ claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
 
 **SDK MMP サポート:** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
-**ツール呼び出し:** ローカルモデルが自分で定義した関数を呼び出せます。ツールは
-単なるデータで、ループを回すのは自分のコードなので、どんなツールでも組み込めます。
-llama.cpp によりオンデバイスで動作（LFM2、gemma-4、FunctionGemma の各プロトコルに
-対応）。Rust SDK と CLI（`xybrid repl` には `web_search` が組み込み済みで、
-`--tools-file` で独自のツールも使えます）に加え、0.6.0 以降は Swift、Kotlin、
-Flutter、Python、Unity C# でも利用できます。詳しくは
+**ツール呼び出し:** ローカルモデルが自分で定義した関数を呼び出せます。ツールは単なる
+データで、ループを回すのは自分のコードです。詳しくは
 [ツール呼び出しガイド](https://docs.xybrid.dev/en/docs/guides/tool-calling)を参照してください。
 
 ---
 
 ## なぜXybridなのか？
 
-- **プライバシー最優先** — すべての推論はオンデバイスで実行。データがデバイスから出ることはありません。
-- **オフライン対応** — 初回のモデルダウンロード後はインターネット不要。
-- **クロスプラットフォーム** — iOS、Android、macOS、Linux、Windowsで統一されたAPI。
-- **マルチモデルパイプライン（MMP）** — モデルを連鎖（ASR → LLM → TTS）して1回の呼び出しで実行。
-- **ハードウェアアクセラレーション** — Appleプラットフォームでは Apple Neural Engine と Metal、Linux向けllama.cppビルドでは Vulkan をオプトイン可能。Android と Windows は現時点ではCPU実行で、配布済みのLinuxバイナリもCPUのみ（Vulkanはビルド時のオプトイン — [インストール](docs/INSTALLATION.md#platform-features) を参照）。
+- **プライベート / オフライン** — 推論はオンデバイスで実行され、初回のモデルダウンロード後はネットワークなしでも動作します。
+- **1つのAPIで5プラットフォーム** — iOS、Android、macOS、Linux、Windows。
+- **複数バックエンドを1つのAPIで** — ONNX Runtime、llama.cpp（GGUF）、whisper.cpp、Candle、CoreML。
+- **マルチモデルパイプライン** — ASR → LLM → TTS を1回の呼び出しで連鎖。
+- **ツール呼び出し** — ローカルモデルが自分で定義した関数を呼び出せます。すべてのSDKで利用可能。
+- **アプリを再リリースせずにモデルを差し替え** — モデルは実行時にレジストリから解決され、デバイス上にキャッシュされます。
+- **クラウドフォールバック** — 実行ごとにオプトイン（[ドキュメント](https://docs.xybrid.dev/en/docs/concepts/hybrid-execution)）。
+- **制御できるテレメトリ** — APIキーによるオプトイン（[ドキュメント](docs/telemetry/registry.md)）。
+- **ハードウェアアクセラレーション** — Apple では Metal と Apple Neural Engine、Linux ではオプトインの Vulkan。Android と Windows は現時点では CPU（[ドキュメント](docs/INSTALLATION.md#platform-features)）。
 
 ### 比較
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -115,7 +115,7 @@ Xybridは**Rustベースのランタイム**であり、すべての主要プラ
 |-----|-----------|---------|--------|--------|
 | **[Flutter](bindings/flutter/)** | iOS, Android, macOS, Linux, Windows | [pub.dev](https://pub.dev/packages/xybrid_flutter) | 利用可能 | [README](examples/flutter/README.md) |
 | **[Unity](bindings/unity/)** | macOS, Windows, Linux, iOS, Android | [下記参照](#クイックスタート) | 利用可能 | [Unity 3D AI酒場](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | 近日公開 | [README](examples/ios/README.md) |
+| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | 利用可能 | [README](examples/ios/README.md) |
 | **[Kotlin](bindings/kotlin/)** | Android | Maven Central | 利用可能 | [README](examples/android/README.md) |
 | **[CLI](https://github.com/xybrid-ai/xybrid/releases)** | macOS, Linux, Windows | `curl -sSL .../install.sh \| sh` | 利用可能 | — |
 | **[Rust](crates/)** | すべて | [crates.io](https://crates.io/crates/xybrid) | 利用可能 | — |
@@ -392,12 +392,21 @@ claude /xybrid-init hexgrad/Kokoro-82M-v1.0-ONNX
 | テキスト読み上げ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 言語モデル | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 画像認識モデル | ✅ | ✅ | ✅ | ✅ | ✅ |
+| ツール呼び出し | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 埋め込み | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | マルチモデルパイプライン（MMP） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | モデルのダウンロードとキャッシュ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ハードウェアアクセラレーション | Metal, ANE | CPU | Metal, ANE | CPU、オプトインのVulkan | CPU |
 
 **SDK MMP サポート:** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
+
+**ツール呼び出し:** ローカルモデルが自分で定義した関数を呼び出せます。ツールは
+単なるデータで、ループを回すのは自分のコードなので、どんなツールでも組み込めます。
+llama.cpp によりオンデバイスで動作（LFM2、gemma-4、FunctionGemma の各プロトコルに
+対応）。Rust SDK と CLI（`xybrid repl` には `web_search` が組み込み済みで、
+`--tools-file` で独自のツールも使えます）に加え、0.6.0 以降は Swift、Kotlin、
+Flutter、Python、Unity C# でも利用できます。詳しくは
+[ツール呼び出しガイド](https://docs.xybrid.dev/en/docs/guides/tool-calling)を参照してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@
   <img src="docs/demo-android.gif" alt="Android demo" width="150">
 </p>
 
-## SDKs
+## Quick Start
+
+Install and run a model in your language of choice.
 
 <p align="center">
   <a href="https://docs.xybrid.dev/en/docs/sdks/flutter"><img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter SDK"></a>
@@ -104,16 +106,7 @@
   <a href="https://github.com/xybrid-ai/xybrid/releases"><img src="https://img.shields.io/badge/CLI-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="CLI"></a>
 </p>
 
-Every SDK above shares the same Rust core. The Browser/Web preview is the one
-exception — a separate LiteRT.js adapter limited to raw typed-tensor I/O.
-
----
-
-## Quick Start
-
-Install and run a model in your language of choice.
-
-Platform-specific setup lives behind each badge above. See the full
+Each badge links to its platform setup. See the full
 [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) for all options.
 
 ### Flutter
@@ -298,39 +291,41 @@ full catalogue at **[xybrid.ai/models](https://www.xybrid.ai/models)**, or run
 
 | Model | Params | Description |
 |-------|--------|-------------|
-| Whisper Tiny (`whisper-tiny-ggml`) | 39M | Multilingual transcription on whisper.cpp — in every platform preset |
-| Wav2Vec2 Base | 95M | English ASR with CTC decoding |
+| [Whisper Tiny](https://www.xybrid.ai/models/whisper-tiny-ggml) | 39M | Multilingual transcription on whisper.cpp — in every platform preset |
+| [Wav2Vec2 Base](https://www.xybrid.ai/models/wav2vec2-base-960h) | 95M | English ASR with CTC decoding |
 
 ### Text-to-Speech
 
 | Model | Params | Description |
 |-------|--------|-------------|
-| Kokoro 82M | 82M | High-quality, 24 natural voices |
-| KittenTTS Nano | 15M | Ultra-lightweight, 8 voices |
-| NeuTTS Nano | 120M | Codec TTS with voice cloning |
+| [Kokoro 82M](https://www.xybrid.ai/models/kokoro-82m) | 82M | High-quality, 24 natural voices |
+| [KittenTTS Nano](https://www.xybrid.ai/models/kitten-tts-nano-0.8) | 15M | Ultra-lightweight, 8 voices |
+| [NeuTTS Nano](https://www.xybrid.ai/models/neutts-nano-q4) | 120M | Codec TTS with voice cloning |
 
 ### LLM
 
 | Model | Params | Description |
 |-------|--------|-------------|
-| LFM2.5 230M | 230M | Liquid AI's smallest hybrid conv+attention LLM — 9 languages, tool calling |
-| LFM2.5 350M | 354M | Same architecture, more headroom — 9 languages, tool calling |
-| LFM2.5 1.2B Instruct | 1.2B | Agentic tasks and data extraction |
-| LFM2.5 1.2B Thinking | 1.2B | Reasoning model — chain-of-thought via `reasoningContent` ([guide](https://docs.xybrid.dev/en/docs/guides/reasoning)) |
-| SmolLM2 360M | 360M | Best tiny LLM, excellent quality/size ratio |
-| FunctionGemma 270M | 270M | Purpose-built for function calling |
-| Gemma 3 1B | 1B | Google's mobile-optimized LLM, 32K context |
-| Llama 3.2 1B | 1B | Meta's general purpose, 128K context |
-| Qwen 3.5 0.8B | 800M | Reasoning (thinking mode), 201 languages |
-| Qwen 3.5 2B | 2B | Larger Qwen 3.5 with extended reasoning |
+| [LFM2.5 230M](https://www.xybrid.ai/models/lfm2.5-230m) | 230M | Liquid AI's smallest hybrid conv+attention LLM — 9 languages, tool calling |
+| [LFM2.5 350M](https://www.xybrid.ai/models/lfm2.5-350m) | 354M | Same architecture, more headroom — 9 languages, tool calling |
+| [LFM2.5 1.2B Instruct](https://www.xybrid.ai/models/lfm2.5-1.2b-instruct) | 1.2B | Agentic tasks and data extraction |
+| [LFM2.5 1.2B Thinking](https://www.xybrid.ai/models/lfm2.5-1.2b-thinking) | 1.2B | Reasoning model — chain-of-thought via `reasoningContent` ([guide](https://docs.xybrid.dev/en/docs/guides/reasoning)) |
+| [SmolLM2 360M](https://www.xybrid.ai/models/smollm2-360m) | 360M | Best tiny LLM, excellent quality/size ratio |
+| [FunctionGemma 270M](https://www.xybrid.ai/models/functiongemma-270m-it) | 270M | Purpose-built for function calling |
+| [Gemma 3 1B](https://www.xybrid.ai/models/gemma-3-1b) | 1B | Google's mobile-optimized LLM, 32K context |
+| [Gemma 4 E2B](https://www.xybrid.ai/models/gemma-4-e2b) | 5.1B | Google's compact multimodal LLM, 2.3B effective params |
+| [Gemma 4 E4B](https://www.xybrid.ai/models/gemma-4-e4b) | 8B | Google's mid-range multimodal LLM, 4.5B effective params |
+| [Llama 3.2 1B](https://www.xybrid.ai/models/llama-3.2-1b) | 1B | Meta's general purpose, 128K context |
+| [Qwen 3.5 0.8B](https://www.xybrid.ai/models/qwen3.5-0.8b) | 800M | Reasoning (thinking mode), 201 languages |
+| [Qwen 3.5 2B](https://www.xybrid.ai/models/qwen3.5-2b) | 2B | Larger Qwen 3.5 with extended reasoning |
 
 ### Vision-Language
 
 | Model | Params | Description |
 |-------|--------|-------------|
-| LFM2-VL 450M | 450M | Liquid AI's compact VLM (SigLIP2 vision) |
-| LFM2.5-VL 3B | 3B | Larger Liquid VLM for local inference |
-| Bonsai 27B | 27B | PrismML's 1-bit VLM for local reasoning |
+| [LFM2-VL 450M](https://www.xybrid.ai/models/lfm2-vl-450m) | 450M | Liquid AI's compact VLM (SigLIP2 vision) |
+| [LFM2.5-VL 3B](https://www.xybrid.ai/models/lfm2.5-vl-3b) | 3B | Larger Liquid VLM for local inference |
+| [Bonsai 27B](https://www.xybrid.ai/models/bonsai-27b) | 27B | PrismML's 1-bit VLM for local reasoning |
 
 **Tool calling:** see the
 [Tool Calling guide](https://docs.xybrid.dev/en/docs/guides/tool-calling).
@@ -398,23 +393,22 @@ data and the loop is your code. See the
 
 ## Why Xybrid?
 
-- **Private by default** — inference runs on-device; your data stays there.
-- **Offline capable** — no internet needed after the first model download.
+- **Private / offline** — inference runs on-device and keeps working with no
+  network after the first model download.
 - **One API, five platforms** — iOS, Android, macOS, Linux, Windows.
 - **Many backends, one API** — ONNX Runtime, llama.cpp (GGUF), whisper.cpp,
-  Candle and CoreML under a single call.
+  Candle and CoreML.
 - **Multi-model pipelines** — chain ASR → LLM → TTS in one call.
 - **Tool calling** — local models call functions you define, on every SDK.
 - **Swap models without shipping an app** — models resolve from the registry at
-  runtime and cache on device, so changing one is a config change.
-- **Cloud fallback** — opt in per run (`fallbackToCloud`) and a request routes
-  out only when the device cannot serve it.
-- **Telemetry you control** — inference traces are opt-in behind an API key.
-  Registry metadata calls carry one attribution header; opt out with
-  `XYBRID_TELEMETRY_OPTOUT=1` ([details](docs/telemetry/registry.md)).
-- **Hardware acceleration** — Metal and the Apple Neural Engine on Apple
-  platforms, opt-in Vulkan on Linux; Android and Windows are CPU today
-  ([details](docs/INSTALLATION.md#platform-features)).
+  runtime and cache on device.
+- **Cloud fallback** — opt in per run
+  ([docs](https://docs.xybrid.dev/en/docs/concepts/hybrid-execution)).
+- **Telemetry you control** — opt-in behind an API key
+  ([docs](docs/telemetry/registry.md)).
+- **Hardware acceleration** — Metal and the Apple Neural Engine on Apple, opt-in
+  Vulkan on Linux; Android and Windows are CPU today
+  ([docs](docs/INSTALLATION.md#platform-features)).
 
 ### How it compares
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@
 <p align="center">
 
 [![Build][build-shield]][build-url]
-[![Release][release-shield]][release-url]
 [![License][license-shield]][license-url]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
 [![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
 <br>
+[![Release][release-shield]][release-url]
 [![crates.io][crates-shield]][crates-url]
 [![pub.dev][pubdev-shield]][pubdev-url]
 [![Maven Central][maven-shield]][maven-url]
@@ -90,51 +90,31 @@
   <img src="docs/demo-android.gif" alt="Android demo" width="150">
 </p>
 
-
-
-## Start Here
-
-| Goal | Path |
-|------|------|
-| Fastest demo (2 min) | [Install CLI →](#quick-start) |
-| Build a mobile or desktop app | [Flutter SDK →](bindings/flutter/) |
-| Try the browser preview | [Web SDK →](bindings/web/) |
-| Add AI NPCs to your game | [Unity SDK →](bindings/unity/) and try the [3D tavern demo](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| Android native | [Kotlin SDK →](bindings/kotlin/) |
-| Rust / embedded | [Core crate →](crates/) |
----
-
-<p align="center">
-  <img src="docs/game-demo.gif" alt="Game demo" width="540">
-</p>
-
 ## SDKs
 
-Native SDKs are powered by the Rust runtime and expose its native model
-capabilities. The Browser/Web preview is a separate browser-native LiteRT.js
-adapter that consumes `model_metadata.json` and currently supports only LiteRT
-raw typed-tensor I/O.
+<p align="center">
+  <a href="https://docs.xybrid.dev/en/docs/sdks/flutter"><img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/ios"><img src="https://img.shields.io/badge/Swift-F05138?style=for-the-badge&logo=swift&logoColor=white" alt="Swift SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/kotlin"><img src="https://img.shields.io/badge/Kotlin-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white" alt="Kotlin SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/unity"><img src="https://img.shields.io/badge/Unity-000000?style=for-the-badge&logo=unity&logoColor=white" alt="Unity SDK"></a>
+  <br>
+  <a href="https://crates.io/crates/xybrid"><img src="https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white" alt="Rust crate"></a>
+  <a href="bindings/python/"><img src="https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white" alt="Python SDK"></a>
+  <a href="https://docs.xybrid.dev/en/docs/sdks/web"><img src="https://img.shields.io/badge/Web_preview-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black" alt="Web SDK preview"></a>
+  <a href="https://github.com/xybrid-ai/xybrid/releases"><img src="https://img.shields.io/badge/CLI-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="CLI"></a>
+</p>
 
-| SDK | Platforms | Install | Status | Sample |
-|-----|-----------|---------|--------|--------|
-| **[Flutter](bindings/flutter/)** | iOS, Android, macOS, Linux, Windows | [pub.dev](https://pub.dev/packages/xybrid_flutter) | Available | [README](examples/flutter/README.md) |
-| **[Unity](bindings/unity/)** | macOS, Windows, Linux, iOS, Android | [See below](#quick-start) | Available | [Unity 3D AI tavern](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | Available | [README](examples/ios/README.md) |
-| **[Kotlin](bindings/kotlin/)** | Android | Maven Central | Available | [README](examples/android/README.md) |
-| **[Browser/Web preview](bindings/web/)** | Modern browsers | `@xybrid/web` | Preview | [In-browser a+b demo](bindings/web/example/) |
-| **[CLI](https://github.com/xybrid-ai/xybrid/releases)** | macOS, Linux, Windows | `curl -sSL .../install.sh \| sh` | Available | — |
-| **[Rust](crates/)** | All | [crates.io](https://crates.io/crates/xybrid) | Available | — |
-
-The native SDKs share the Rust core; the Browser/Web preview does not and has the
-limited LiteRT tensor surface described above.
+Every SDK above shares the same Rust core. The Browser/Web preview is the one
+exception — a separate LiteRT.js adapter limited to raw typed-tensor I/O.
 
 ---
 
 ## Quick Start
 
-Install and run a model in your language of choice. Each section includes the install snippet and a minimal example.
+Install and run a model in your language of choice.
 
-See the full [Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) for all options.
+Platform-specific setup lives behind each badge above. See the full
+[Installation Guide](https://docs.xybrid.dev/en/docs/quickstart) for all options.
 
 ### Flutter
 
@@ -191,16 +171,26 @@ let result = try await model.runAsync(envelope: Envelope.text("Hello world"))
 
 ### Unity
 
-**Install** via [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/) —
-`openupm add ai.xybrid.sdk`, or add the `https://package.openupm.com` scoped
-registry for scope `ai.xybrid` — or straight from the git subfolder:
+<p align="center">
+  <img src="docs/game-demo.gif" alt="Game demo" width="480">
+</p>
+
+**Install via OpenUPM** (recommended):
+
+```sh
+openupm add ai.xybrid.sdk
+```
+
+Or add `https://package.openupm.com` as a scoped registry for scope `ai.xybrid`.
+
+**Install manually** — add the git subfolder as a UPM package:
 
 ```sh
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
 
 Native libraries download automatically on import. See the
-[Unity SDK README](bindings/unity/README.md) for details.
+[Unity SDK guide](https://docs.xybrid.dev/en/docs/sdks/unity) for details.
 
 **Run a model:**
 
@@ -246,8 +236,6 @@ irm https://raw.githubusercontent.com/xybrid-ai/xybrid/master/install.ps1 | iex
 ```sh
 xybrid run --model kokoro-82m --input-text "Hello world" -o output.wav
 ```
-
-For platform-specific setup, see each SDK's README: [Flutter](bindings/flutter/) · [Unity](bindings/unity/) · [Swift](bindings/apple/) · [Kotlin](bindings/kotlin/) · [Rust](crates/).
 
 <details>
 <summary><h3>Multi-Model Inference Pipelines — MMP (Experimental)</h3></summary>
@@ -302,63 +290,50 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 
 ## Supported Models
 
-All models run entirely on-device. No cloud, no API keys required. Browse the full registry with `xybrid models list`.
-
-### Start with these
-
-| Model | Type | Params | Why start here |
-|-------|------|--------|----------------|
-| **SmolLM2 360M** | LLM | 360M | Best quality-to-size ratio for any device |
-| **Kokoro 82M** | TTS | 82M | High-quality speech, 24 voices, fast |
-| **Whisper Tiny** | ASR | 39M | Accurate multilingual transcription |
+All models run entirely on-device. No cloud, no API keys required. Browse the
+full catalogue at **[xybrid.ai/models](https://www.xybrid.ai/models)**, or run
+`xybrid models list`.
 
 ### Speech-to-Text
 
-| Model | Params | Format | Description |
-|-------|--------|--------|-------------|
-| Whisper Tiny (`whisper-tiny-ggml`) | 39M | GGML Q5_1 | Multilingual transcription on whisper.cpp — in every platform preset |
-| Whisper Tiny (`whisper-tiny`) | 39M | SafeTensors | Same weights on the Candle runtime — needs a build with the `candle` feature |
-| Wav2Vec2 Base | 95M | ONNX | English ASR with CTC decoding |
+| Model | Params | Description |
+|-------|--------|-------------|
+| Whisper Tiny (`whisper-tiny-ggml`) | 39M | Multilingual transcription on whisper.cpp — in every platform preset |
+| Wav2Vec2 Base | 95M | English ASR with CTC decoding |
 
 ### Text-to-Speech
 
-| Model | Params | Format | Description |
-|-------|--------|--------|-------------|
-| Kokoro 82M | 82M | ONNX | High-quality, 24 natural voices |
-| KittenTTS Nano | 15M | ONNX | Ultra-lightweight, 8 voices |
+| Model | Params | Description |
+|-------|--------|-------------|
+| Kokoro 82M | 82M | High-quality, 24 natural voices |
+| KittenTTS Nano | 15M | Ultra-lightweight, 8 voices |
+| NeuTTS Nano | 120M | Codec TTS with voice cloning |
 
-### Language Models
+### LLM
 
-| Model | Params | Format | Description |
-|-------|--------|--------|-------------|
-| Gemma 3 1B | 1B | GGUF Q4_K_M | Google's mobile-optimized LLM |
-| LFM2.5 230M | 230M | GGUF Q4_K_M | Liquid AI's smallest hybrid conv+attention LLM for edge devices |
-| LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AI's hybrid conv+attention, 9 languages, tool calling |
-| LFM2.5 1.2B Thinking | 1.2B | GGUF Q4_K_M | Liquid AI reasoning model — chain-of-thought via `reasoningContent` ([guide](https://docs.xybrid.dev/en/docs/guides/reasoning)) |
-| Llama 3.2 1B | 1B | GGUF Q4_K_M | Meta's general purpose, 128K context |
-| Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | Compact on-device chat |
-| Qwen 3.5 0.8B | 800M | GGUF Q4_K_M | Latest Qwen with reasoning (thinking mode) |
-| Qwen 3.5 2B | 2B | GGUF Q4_K_M | Larger Qwen 3.5 with extended reasoning |
-| SmolLM2 360M | 360M | GGUF Q4_K_M | Best tiny LLM, excellent quality/size ratio |
+| Model | Params | Description |
+|-------|--------|-------------|
+| LFM2.5 230M | 230M | Liquid AI's smallest hybrid conv+attention LLM — 9 languages, tool calling |
+| LFM2.5 350M | 354M | Same architecture, more headroom — 9 languages, tool calling |
+| LFM2.5 1.2B Instruct | 1.2B | Agentic tasks and data extraction |
+| LFM2.5 1.2B Thinking | 1.2B | Reasoning model — chain-of-thought via `reasoningContent` ([guide](https://docs.xybrid.dev/en/docs/guides/reasoning)) |
+| SmolLM2 360M | 360M | Best tiny LLM, excellent quality/size ratio |
+| FunctionGemma 270M | 270M | Purpose-built for function calling |
+| Gemma 3 1B | 1B | Google's mobile-optimized LLM, 32K context |
+| Llama 3.2 1B | 1B | Meta's general purpose, 128K context |
+| Qwen 3.5 0.8B | 800M | Reasoning (thinking mode), 201 languages |
+| Qwen 3.5 2B | 2B | Larger Qwen 3.5 with extended reasoning |
 
 ### Vision-Language
 
-| Model | Params | Format | Description |
-|-------|--------|--------|-------------|
-| LFM2-VL 450M | 450M | GGUF Q4_0 + mmproj | Liquid AI's compact VLM (SigLIP2 vision) — image + text in, runs via llama.cpp mtmd |
+| Model | Params | Description |
+|-------|--------|-------------|
+| LFM2-VL 450M | 450M | Liquid AI's compact VLM (SigLIP2 vision) |
+| LFM2.5-VL 3B | 3B | Larger Liquid VLM for local inference |
+| Bonsai 27B | 27B | PrismML's 1-bit VLM for local reasoning |
 
-### Coming Soon
-
-| Model | Type | Params | Priority | Status |
-|-------|------|--------|----------|--------|
-| Phi-4 Mini | LLM | 3.8B | P2 | Spec Ready (first multi-quant: Q4, Q8, FP16) |
-| Qwen3 0.6B | LLM | 600M | P2 | Planned |
-| Trinity Nano | LLM (MoE) | 6B (1B active) | P2 | Planned |
-| LFM2-VL 700M | Vision+LLM | 700M | P2 | Planned |
-| Nomic Embed Text v1.5 | Embeddings | 137M | P1 | Blocked (needs Tokenize/MeanPool steps) |
-| Whisper Tiny CoreML | ASR | 39M | P2 | Planned |
-| Qwen3-TTS 0.6B | TTS | 600M | P2 | Blocked (needs custom SafeTensors runtime) |
-| Chatterbox Turbo | TTS | 350M | P3 | Blocked (needs ModelGraph template) |
+**Tool calling:** see the
+[Tool Calling guide](https://docs.xybrid.dev/en/docs/guides/tool-calling).
 
 <details>
 <summary><h3>Bring Your Own Model (Experimental)</h3></summary>
@@ -405,7 +380,7 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 |------------|-----|---------|-------|-------|---------|
 | Speech-to-Text | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Text-to-Speech | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Language Models | ✅ | ✅ | ✅ | ✅ | ✅ |
+| LLM | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Vision Models | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Tool Calling | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Embeddings | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
@@ -415,23 +390,31 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 
 **SDK MMP support:** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
-**Tool calling:** local models call functions you define — your tools are
-plain data and the loop is your code, so any tooling plugs in. On-device via
-llama.cpp (LFM2, gemma-4, and FunctionGemma protocols). Available from the Rust
-SDK, the CLI (`xybrid repl` ships built-in `web_search` plus your own via
-`--tools-file`), and — since 0.6.0 — Swift, Kotlin, Flutter, Python and Unity
-C#. See the
+**Tool calling:** local models call functions you define — your tools are plain
+data and the loop is your code. See the
 [Tool Calling guide](https://docs.xybrid.dev/en/docs/guides/tool-calling).
 
 ---
 
 ## Why Xybrid?
 
-- **Privacy first** — All inference runs on-device. Your data never leaves the device. The SDK attaches a small fleet-attribution header on registry metadata calls — see [registry telemetry](docs/telemetry/registry.md).
-- **Offline capable** — No internet required after initial model download.
-- **Cross-platform** — One API across iOS, Android, macOS, Linux, and Windows.
-- **Multi-model pipelines (MMP)** — Chain models together (ASR → LLM → TTS) in a single call.
-- **Hardware acceleration** — Apple Neural Engine and Metal on Apple platforms; opt-in Vulkan for Linux llama.cpp builds. Android and Windows run on CPU today, and prebuilt Linux binaries are CPU-only (Vulkan is a build-time opt-in — see [installation](docs/INSTALLATION.md#platform-features)).
+- **Private by default** — inference runs on-device; your data stays there.
+- **Offline capable** — no internet needed after the first model download.
+- **One API, five platforms** — iOS, Android, macOS, Linux, Windows.
+- **Many backends, one API** — ONNX Runtime, llama.cpp (GGUF), whisper.cpp,
+  Candle and CoreML under a single call.
+- **Multi-model pipelines** — chain ASR → LLM → TTS in one call.
+- **Tool calling** — local models call functions you define, on every SDK.
+- **Swap models without shipping an app** — models resolve from the registry at
+  runtime and cache on device, so changing one is a config change.
+- **Cloud fallback** — opt in per run (`fallbackToCloud`) and a request routes
+  out only when the device cannot serve it.
+- **Telemetry you control** — inference traces are opt-in behind an API key.
+  Registry metadata calls carry one attribution header; opt out with
+  `XYBRID_TELEMETRY_OPTOUT=1` ([details](docs/telemetry/registry.md)).
+- **Hardware acceleration** — Metal and the Apple Neural Engine on Apple
+  platforms, opt-in Vulkan on Linux; Android and Windows are CPU today
+  ([details](docs/INSTALLATION.md#platform-features)).
 
 ### How it compares
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ full catalogue at **[xybrid.ai/models](https://www.xybrid.ai/models)**, or run
 | [Llama 3.2 1B](https://www.xybrid.ai/models/llama-3.2-1b) | 1B | Meta's general purpose, 128K context |
 | [Qwen 3.5 0.8B](https://www.xybrid.ai/models/qwen3.5-0.8b) | 800M | Reasoning (thinking mode), 201 languages |
 | [Qwen 3.5 2B](https://www.xybrid.ai/models/qwen3.5-2b) | 2B | Larger Qwen 3.5 with extended reasoning |
+| [Bonsai 27B](https://www.xybrid.ai/models/bonsai-27b) | 27B | PrismML's 1-bit multimodal LLM (text + vision), hybrid attention |
 
 ### Vision-Language
 
@@ -325,7 +326,6 @@ full catalogue at **[xybrid.ai/models](https://www.xybrid.ai/models)**, or run
 |-------|--------|-------------|
 | [LFM2-VL 450M](https://www.xybrid.ai/models/lfm2-vl-450m) | 450M | Liquid AI's compact VLM (SigLIP2 vision) |
 | [LFM2.5-VL 3B](https://www.xybrid.ai/models/lfm2.5-vl-3b) | 3B | Larger Liquid VLM for local inference |
-| [Bonsai 27B](https://www.xybrid.ai/models/bonsai-27b) | 27B | PrismML's 1-bit VLM for local reasoning |
 
 **Tool calling:** see the
 [Tool Calling guide](https://docs.xybrid.dev/en/docs/guides/tool-calling).

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ raw typed-tensor I/O.
 |-----|-----------|---------|--------|--------|
 | **[Flutter](bindings/flutter/)** | iOS, Android, macOS, Linux, Windows | [pub.dev](https://pub.dev/packages/xybrid_flutter) | Available | [README](examples/flutter/README.md) |
 | **[Unity](bindings/unity/)** | macOS, Windows, Linux, iOS, Android | [See below](#quick-start) | Available | [Unity 3D AI tavern](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | Coming Soon | [README](examples/ios/README.md) |
+| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | Available | [README](examples/ios/README.md) |
 | **[Kotlin](bindings/kotlin/)** | Android | Maven Central | Available | [README](examples/android/README.md) |
 | **[Browser/Web preview](bindings/web/)** | Modern browsers | `@xybrid/web` | Preview | [In-browser a+b demo](bindings/web/example/) |
 | **[CLI](https://github.com/xybrid-ai/xybrid/releases)** | macOS, Linux, Windows | `curl -sSL .../install.sh \| sh` | Available | — |
@@ -407,7 +407,7 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 | Text-to-Speech | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Language Models | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Vision Models | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Tool Calling | 🔜 | 🔜 | ✅ | ✅ | ✅ |
+| Tool Calling | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Embeddings | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | Multi-Model Pipelines (MMP) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Model Download & Caching | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -416,10 +416,11 @@ See the [model metadata docs](docs/sdk/API_REFERENCE.md) for the full schema, or
 **SDK MMP support:** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
 **Tool calling:** local models call functions you define — your tools are
-plain data (`Tool::function(...)`) and the loop is your code, so any tooling
-plugs in. On-device via llama.cpp (LFM2, gemma-4, and FunctionGemma protocols);
-Rust SDK and CLI today (`xybrid repl` ships built-in `web_search` + your own via
-`--tools-file`), Swift/Kotlin/Flutter bindings next. See the
+plain data and the loop is your code, so any tooling plugs in. On-device via
+llama.cpp (LFM2, gemma-4, and FunctionGemma protocols). Available from the Rust
+SDK, the CLI (`xybrid repl` ships built-in `web_search` plus your own via
+`--tools-file`), and — since 0.6.0 — Swift, Kotlin, Flutter, Python and Unity
+C#. See the
 [Tool Calling guide](https://docs.xybrid.dev/en/docs/guides/tool-calling).
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,11 +28,11 @@
 <p align="center">
 
 [![Build][build-shield]][build-url]
-[![Release][release-shield]][release-url]
 [![License][license-shield]][license-url]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard-url]
 [![OpenSSF Best Practices][bestpractices-shield]][bestpractices-url]
 <br>
+[![Release][release-shield]][release-url]
 [![crates.io][crates-shield]][crates-url]
 [![pub.dev][pubdev-shield]][pubdev-url]
 [![Maven Central][maven-shield]][maven-url]
@@ -92,41 +92,24 @@
 
 
 
-## 从这里开始
-
-| 目标 | 路径 |
-|------|------|
-| 最快上手（2 分钟） | [安装 CLI →](#快速开始) |
-| 开发移动端或桌面应用 | [Flutter SDK →](bindings/flutter/) |
-| 为游戏添加 AI NPC | [Unity SDK →](bindings/unity/)，体验 [3D 酒馆示例](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| Android 原生开发 | [Kotlin SDK →](bindings/kotlin/) |
-| Rust / 嵌入式 | [核心 crate →](crates/) |
----
-
-<p align="center">
-  <img src="docs/game-demo.gif" alt="游戏演示" width="540">
-</p>
-
-## SDK
-
-Xybrid 是一个 **Rust 驱动的运行时**，为所有主流平台提供原生绑定：
-
-| SDK | 平台 | 安装 | 状态 | 示例 |
-|-----|------|------|------|------|
-| **[Flutter](bindings/flutter/)** | iOS, Android, macOS, Linux, Windows | [pub.dev](https://pub.dev/packages/xybrid_flutter) | 可用 | [README](examples/flutter/README.md) |
-| **[Unity](bindings/unity/)** | macOS, Windows, Linux, iOS, Android | [见下方](#快速开始) | 可用 | [Unity 3D AI 酒馆](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | 可用 | [README](examples/ios/README.md) |
-| **[Kotlin](bindings/kotlin/)** | Android | Maven Central | 可用 | [README](examples/android/README.md) |
-| **[CLI](https://github.com/xybrid-ai/xybrid/releases)** | macOS, Linux, Windows | `curl -sSL .../install.sh \| sh` | 可用 | — |
-| **[Rust](crates/)** | 全平台 | [crates.io](https://crates.io/crates/xybrid) | 可用 | — |
-
-所有 SDK 封装同一个 Rust 核心——跨平台行为和模型支持完全一致。
-
----
-
 ## 快速开始
 
-选择你喜欢的语言，安装并运行模型。每个语言下都包含安装片段和最小示例。
+选择你喜欢的语言，安装并运行模型。
+
+<p align="center">
+  <a href="https://docs.xybrid.dev/zh/docs/sdks/flutter"><img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter SDK"></a>
+  <a href="https://docs.xybrid.dev/zh/docs/sdks/ios"><img src="https://img.shields.io/badge/Swift-F05138?style=for-the-badge&logo=swift&logoColor=white" alt="Swift SDK"></a>
+  <a href="https://docs.xybrid.dev/zh/docs/sdks/kotlin"><img src="https://img.shields.io/badge/Kotlin-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white" alt="Kotlin SDK"></a>
+  <a href="https://docs.xybrid.dev/zh/docs/sdks/unity"><img src="https://img.shields.io/badge/Unity-000000?style=for-the-badge&logo=unity&logoColor=white" alt="Unity SDK"></a>
+  <br>
+  <a href="https://crates.io/crates/xybrid"><img src="https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white" alt="Rust crate"></a>
+  <a href="bindings/python/"><img src="https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white" alt="Python SDK"></a>
+  <a href="https://docs.xybrid.dev/zh/docs/sdks/web"><img src="https://img.shields.io/badge/Web_preview-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black" alt="Web SDK preview"></a>
+  <a href="https://github.com/xybrid-ai/xybrid/releases"><img src="https://img.shields.io/badge/CLI-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white" alt="CLI"></a>
+</p>
+
+每个徽章都链接到对应平台的配置说明。完整选项请参阅
+[安装指南](https://docs.xybrid.dev/zh/docs/quickstart)。
 
 ### CLI
 
@@ -203,11 +186,26 @@ let result = try await model.runAsync(envelope: Envelope.text("国破山河在�
 
 ### Unity
 
-**安装** 通过 [OpenUPM](https://openupm.com/packages/ai.xybrid.sdk/)（`openupm add ai.xybrid.sdk`），或直接从 git 子目录安装：
+<p align="center">
+  <img src="docs/game-demo.gif" alt="游戏演示" width="480">
+</p>
+
+**通过 OpenUPM 安装**（推荐）：
+
+```sh
+openupm add ai.xybrid.sdk
+```
+
+或将 `https://package.openupm.com` 添加为作用域 `ai.xybrid` 的 scoped registry。
+
+**手动安装** —— 将 git 子目录作为 UPM 包添加：
 
 ```sh
 https://github.com/xybrid-ai/xybrid.git?path=/bindings/unity
 ```
+
+原生库会在首次导入时自动下载。详情参见
+[Unity SDK 指南](https://docs.xybrid.dev/zh/docs/sdks/unity)。
 
 **运行模型：**
 
@@ -289,62 +287,51 @@ let result = pipeline.run(&Envelope::audio(audio_bytes))?;
 
 ## 支持的模型
 
-所有模型完全在设备端运行。无需云端，无需 API 密钥。使用 `xybrid models list` 查看完整的模型注册表。
-
-### 从这些模型开始
-
-| 模型 | 类型 | 参数量 | 推荐理由 |
-|------|------|--------|----------|
-| **SmolLM2 360M** | LLM | 360M | 最佳质量/体积比，适合任何设备 |
-| **Kokoro 82M** | TTS | 82M | 高质量语音合成，24 种声音，速度快 |
-| **Whisper Tiny** | ASR | 39M | 多语言转录，准确率高 |
+所有模型完全在设备端运行。无需云端，无需 API 密钥。完整目录请浏览
+**[xybrid.ai/models](https://www.xybrid.ai/models)**，或运行 `xybrid models list`。
 
 ### 语音转文本
 
-| 模型 | 参数量 | 格式 | 简介 |
-|------|--------|------|------|
-| Whisper Tiny（`whisper-tiny-ggml`） | 39M | GGML Q5_1 | 多语言转录，基于 whisper.cpp — 所有平台预设均已内置 |
-| Whisper Tiny（`whisper-tiny`） | 39M | SafeTensors | 相同权重，运行于 Candle — 需要启用 `candle` 特性重新构建 |
-| Wav2Vec2 Base | 95M | ONNX | 英语 ASR，CTC 解码 |
+| 模型 | 参数量 | 说明 |
+|------|--------|------|
+| [Whisper Tiny](https://www.xybrid.ai/models/whisper-tiny-ggml) | 39M | 基于 whisper.cpp 的多语言转写——已包含在所有平台预设中 |
+| [Wav2Vec2 Base](https://www.xybrid.ai/models/wav2vec2-base-960h) | 95M | 英语 ASR，使用 CTC 解码 |
 
 ### 文本转语音
 
-| 模型 | 参数量 | 格式 | 简介 |
-|------|--------|------|------|
-| Kokoro 82M | 82M | ONNX | 高质量，24 种自然声音 |
-| KittenTTS Nano | 15M | ONNX | 超轻量级，8 种声音 |
+| 模型 | 参数量 | 说明 |
+|------|--------|------|
+| [Kokoro 82M](https://www.xybrid.ai/models/kokoro-82m) | 82M | 高质量，24 种自然音色 |
+| [KittenTTS Nano](https://www.xybrid.ai/models/kitten-tts-nano-0.8) | 15M | 超轻量，8 种音色 |
+| [NeuTTS Nano](https://www.xybrid.ai/models/neutts-nano-q4) | 120M | 编解码器 TTS，支持声音克隆 |
 
-### 语言模型
+### LLM
 
-| 模型 | 参数量 | 格式 | 简介 |
-|------|--------|------|------|
-| Gemma 3 1B | 1B | GGUF Q4_K_M | Google 为移动端优化的模型 |
-| LFM2.5 230M | 230M | GGUF Q4_K_M | 最小的采用 Liquid AI 混合卷积+注意力架构的 LLM，适合边缘设备 |
-| LFM2.5 350M | 354M | GGUF Q4_K_M | Liquid AI 混合卷积+注意力架构，9 种语言，工具调用 |
-| Llama 3.2 1B | 1B | GGUF Q4_K_M | Meta 的通用模型，128K 上下文 |
-| Qwen 2.5 0.5B | 500M | GGUF Q4_K_M | 紧凑的本地聊天模型 |
-| Qwen 3.5 0.8B | 800M | GGUF Q4_K_M | 最新 Qwen，支持推理（思考模式） |
-| Qwen 3.5 2B | 2B | GGUF Q4_K_M | 更大的 Qwen 3.5，扩展推理能力 |
-| SmolLM2 360M | 360M | GGUF Q4_K_M | 最佳的微型模型，优秀的质量/体积比 |
+| 模型 | 参数量 | 说明 |
+|------|--------|------|
+| [LFM2.5 230M](https://www.xybrid.ai/models/lfm2.5-230m) | 230M | Liquid AI 最小的混合 conv+attention 模型——9 种语言，支持工具调用 |
+| [LFM2.5 350M](https://www.xybrid.ai/models/lfm2.5-350m) | 354M | 同架构，容量更大——9 种语言，支持工具调用 |
+| [LFM2.5 1.2B Instruct](https://www.xybrid.ai/models/lfm2.5-1.2b-instruct) | 1.2B | 面向 Agent 任务与数据抽取 |
+| [LFM2.5 1.2B Thinking](https://www.xybrid.ai/models/lfm2.5-1.2b-thinking) | 1.2B | 推理模型——通过 `reasoningContent` 输出思维链（[指南](https://docs.xybrid.dev/zh/docs/guides/reasoning)） |
+| [SmolLM2 360M](https://www.xybrid.ai/models/smollm2-360m) | 360M | 最佳超小型 LLM，质量与体积比出色 |
+| [FunctionGemma 270M](https://www.xybrid.ai/models/functiongemma-270m-it) | 270M | 专为函数调用打造 |
+| [Gemma 3 1B](https://www.xybrid.ai/models/gemma-3-1b) | 1B | Google 面向移动端优化的 LLM，32K 上下文 |
+| [Gemma 4 E2B](https://www.xybrid.ai/models/gemma-4-e2b) | 5.1B | Google 紧凑型多模态 LLM，有效参数 2.3B |
+| [Gemma 4 E4B](https://www.xybrid.ai/models/gemma-4-e4b) | 8B | Google 中端多模态 LLM，有效参数 4.5B |
+| [Llama 3.2 1B](https://www.xybrid.ai/models/llama-3.2-1b) | 1B | Meta 通用模型，128K 上下文 |
+| [Qwen 3.5 0.8B](https://www.xybrid.ai/models/qwen3.5-0.8b) | 800M | 支持推理（thinking 模式），201 种语言 |
+| [Qwen 3.5 2B](https://www.xybrid.ai/models/qwen3.5-2b) | 2B | 更大的 Qwen 3.5，推理能力更强 |
+| [Bonsai 27B](https://www.xybrid.ai/models/bonsai-27b) | 27B | PrismML 的 1-bit 多模态 LLM（文本 + 视觉），混合注意力 |
 
 ### 视觉语言模型（VLM）
 
-| 模型 | 参数量 | 格式 | 简介 |
-|------|--------|------|------|
-| LFM2-VL 450M | 450M | GGUF Q4_0 + mmproj | Liquid AI 的紧凑型 VLM（SigLIP2 视觉）— 图像+文本输入，通过 llama.cpp mtmd 运行 |
+| 模型 | 参数量 | 说明 |
+|------|--------|------|
+| [LFM2-VL 450M](https://www.xybrid.ai/models/lfm2-vl-450m) | 450M | Liquid AI 紧凑型 VLM（SigLIP2 视觉编码器） |
+| [LFM2.5-VL 3B](https://www.xybrid.ai/models/lfm2.5-vl-3b) | 3B | 更大的 Liquid VLM，用于本地推理 |
 
-### 即将推出
-
-| 模型 | 类型 | 参数量 | 优先级 | 状态 |
-|------|------|--------|--------|------|
-| Phi-4 Mini | LLM | 3.8B | P2 | 规格就绪（首个多量化：Q4, Q8, FP16） |
-| Qwen3 0.6B | LLM | 600M | P2 | 计划中 |
-| Trinity Nano | LLM (MoE) | 6B（1B 活跃） | P2 | 计划中 |
-| LFM2-VL 700M | Vision+LLM | 700M | P2 | 计划中 |
-| Nomic Embed Text v1.5 | 嵌入 | 137M | P1 | 受阻（需要 Tokenize/MeanPool 步骤） |
-| Whisper Tiny CoreML | ASR | 39M | P2 | 计划中 |
-| Qwen3-TTS 0.6B | TTS | 600M | P2 | 受阻（需要自定义 SafeTensors 运行时） |
-| Chatterbox Turbo | TTS | 350M | P3 | 受阻（需要 ModelGraph 模板） |
+**工具调用：** 参见
+[工具调用指南](https://docs.xybrid.dev/zh/docs/guides/tool-calling)。
 
 <details>
 <summary><h3>自定义模型（实验性）</h3></summary>
@@ -391,7 +378,7 @@ Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚�
 |------|-----|---------|-------|-------|---------|
 | 语音转文本 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 文本转语音 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 语言模型 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| LLM | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 视觉模型 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 工具调用 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 嵌入模型 | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
@@ -401,22 +388,22 @@ Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚�
 
 **SDK MMP 支持：** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
 
-**工具调用：** 本地模型可以调用你自己定义的函数——工具就是普通数据，循环由你的
-代码掌控，因此任何工具链都能接入。通过 llama.cpp 在设备端运行（支持 LFM2、
-gemma-4 与 FunctionGemma 协议）。Rust SDK、CLI（`xybrid repl` 内置 `web_search`，
-也可通过 `--tools-file` 使用你自己的工具）均已支持；自 0.6.0 起，Swift、Kotlin、
-Flutter、Python 与 Unity C# 也全部支持。参见
-[工具调用指南](https://docs.xybrid.dev/zh/docs/guides/tool-calling)。
+**工具调用：** 本地模型调用你定义的函数——工具就是普通数据，循环由你的代码掌控。
+参见[工具调用指南](https://docs.xybrid.dev/zh/docs/guides/tool-calling)。
 
 ---
 
 ## 为什么选择 Xybrid？
 
-- **隐私优先** — 所有推理在设备端运行。你的数据永远不会离开你的设备。
-- **离线可用** — 初次模型下载后无需互联网。
-- **跨平台** — iOS、Android、macOS、Linux 和 Windows 使用统一的 API。
-- **多模型流水线（MMP）** — 在单次调用中链接多个模型（ASR → LLM → TTS）。
-- **硬件加速** — Apple 平台支持 Apple Neural Engine 与 Metal；Linux 的 llama.cpp 构建可选启用 Vulkan。Android 与 Windows 目前使用 CPU，预编译的 Linux 二进制也仅为 CPU（Vulkan 需在构建时启用 — 参见[安装说明](docs/INSTALLATION.md#platform-features)）。
+- **私密 / 离线** — 推理在设备端运行，首次下载模型后即使无网络也能继续使用。
+- **一套 API，五个平台** — iOS、Android、macOS、Linux、Windows。
+- **多后端，统一 API** — ONNX Runtime、llama.cpp（GGUF）、whisper.cpp、Candle 与 CoreML。
+- **多模型流水线** — 在单次调用中串联 ASR → LLM → TTS。
+- **工具调用** — 本地模型调用你定义的函数，所有 SDK 均支持。
+- **无需发版即可更换模型** — 模型在运行时从注册表解析并缓存在设备上。
+- **云端回退** — 按次调用选择启用（[文档](https://docs.xybrid.dev/zh/docs/concepts/hybrid-execution)）。
+- **可控的遥测** — 需通过 API 密钥主动启用（[文档](docs/telemetry/registry.md)）。
+- **硬件加速** — Apple 平台支持 Metal 与 Apple Neural Engine，Linux 可选启用 Vulkan；Android 与 Windows 目前为 CPU（[文档](docs/INSTALLATION.md#platform-features)）。
 
 ### 与其他方案对比
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,7 +115,7 @@ Xybrid 是一个 **Rust 驱动的运行时**，为所有主流平台提供原生
 |-----|------|------|------|------|
 | **[Flutter](bindings/flutter/)** | iOS, Android, macOS, Linux, Windows | [pub.dev](https://pub.dev/packages/xybrid_flutter) | 可用 | [README](examples/flutter/README.md) |
 | **[Unity](bindings/unity/)** | macOS, Windows, Linux, iOS, Android | [见下方](#快速开始) | 可用 | [Unity 3D AI 酒馆](https://github.com/xybrid-ai/xybrid-unity-tavern) |
-| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | 即将推出 | [README](examples/ios/README.md) |
+| **[Swift](bindings/apple/)** | iOS, macOS | Swift Package Manager | 可用 | [README](examples/ios/README.md) |
 | **[Kotlin](bindings/kotlin/)** | Android | Maven Central | 可用 | [README](examples/android/README.md) |
 | **[CLI](https://github.com/xybrid-ai/xybrid/releases)** | macOS, Linux, Windows | `curl -sSL .../install.sh \| sh` | 可用 | — |
 | **[Rust](crates/)** | 全平台 | [crates.io](https://crates.io/crates/xybrid) | 可用 | — |
@@ -393,12 +393,20 @@ Skills 与 agent 无关，位于 [`agents/skills/`](agents/skills/)。安装脚�
 | 文本转语音 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 语言模型 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 视觉模型 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 工具调用 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 嵌入模型 | 🔜 | 🔜 | 🔜 | 🔜 | 🔜 |
 | 多模型流水线（MMP） | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 模型下载与缓存 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 硬件加速 | Metal, ANE | CPU | Metal, ANE | CPU，可选 Vulkan | CPU |
 
 **SDK MMP 支持：** Flutter ✅ · Rust ✅ · Kotlin 🔜 · Swift 🔜 · Unity 🔜
+
+**工具调用：** 本地模型可以调用你自己定义的函数——工具就是普通数据，循环由你的
+代码掌控，因此任何工具链都能接入。通过 llama.cpp 在设备端运行（支持 LFM2、
+gemma-4 与 FunctionGemma 协议）。Rust SDK、CLI（`xybrid repl` 内置 `web_search`，
+也可通过 `--tools-file` 使用你自己的工具）均已支持；自 0.6.0 起，Swift、Kotlin、
+Flutter、Python 与 Unity C# 也全部支持。参见
+[工具调用指南](https://docs.xybrid.dev/zh/docs/guides/tool-calling)。
 
 ---
 


### PR DESCRIPTION
Two things: the CI path gates that let a docs-only PR run native build matrices, and the README restructure.

## 1. CI path gates

#540 changed 28 files, 26 of them markdown, and still ran the full CI matrix — including `check vision (windows)` — plus four heavy Bazel lanes. Two separate gaps caused it.

* **`ci.yml` ignores markdown and `docs/**`, but not `examples/**`.** #540 touched two `.swift` files in the iOS example app, which is enough to defeat `paths-ignore` entirely. Nothing in CI builds `examples/`, so it is now ignored, with the same entry in `ci-docs.yml` so the required `CI Success` gate still reports.
* **`bazel.yml` matches directory prefixes** (`crates/`, `bindings/kotlin/`, …) against the PR file list, so `bindings/kotlin/README.md` made every RBE lane "relevant". Markdown is stripped before the match now.
* **The same flaw was latent in four more workflows** — `unity-editor.yml`, `test-candle.yml`, `test-whispercpp.yml`, `build-natives.yml`. A README under `crates/llama-cpp-sys/` would have triggered a ~30-minute native republish. All four get the `!**.md` exclusion `build-apple.yml` already used.

`gradle-wrapper-validation.yml` is unaffected — it has its own `**/gradle/wrapper/*` trigger, so `examples/android`'s wrapper jar is still validated. Verified the filter both ways: a #540-shaped file list yields `relevant=false`, one containing `crates/xybrid-bolt/src/lib.rs` still yields `true`.

## 2. README restructure

Goal was reaching Quick Start without scrolling. Rendered content above it drops 70 → 55 lines, and two tall tables plus a full-width gif leave the fold.

* Badges regroup into three lines: health · packages · community.
* **"Start Here" removed** — it answered the same question as the SDK table right below it.
* **SDK table → a lane of linked logo badges** pointing at the docs instead of in-repo READMEs. The one fact the table carried that the lane can't is kept as a caption: the Browser/Web preview doesn't share the Rust core.
* Game gif moves into the Unity quick-start, where it has context.
* Unity install splits into **OpenUPM** and **manual**.

**Supported Models** rebuilt against the live registry: links to [xybrid.ai/models](https://www.xybrid.ai/models) up front, Format column dropped (the runtime is format-agnostic), `whisper-tiny` (Candle) dropped in favour of the canonical `whisper-tiny-ggml`, "Language Models" → "LLM", Qwen 2.5 out, the full Liquid line + FunctionGemma + Bonsai 27B in, "Coming Soon" gone, tool-calling paragraph reduced to the guide link.

**"Why Xybrid?"** rewritten short, and gains multi-backend, tool calling, registry-resolved model swap, opt-in cloud fallback, and telemetry.

### Two claims I checked rather than copied

* **MLX is not listed as a backend.** It was on the requested list, but no MLX crate exists in this workspace — only doc-comments in `xybrid-llama` referencing one. The real set is ONNX Runtime, llama.cpp, whisper.cpp, Candle and CoreML.
* **Telemetry is described per surface.** "Off by default" would have been wrong: inference traces are opt-in behind an API key, but registry metadata calls carry an attribution header that ships by default and is disabled with `XYBRID_TELEMETRY_OPTOUT`.

Also fixed three claims 0.6.0 made false, in all three languages: tool calling was `🔜` for iOS/Android, and Swift said **Coming Soon** while the same file gives a working SPM snippet.

> **Note:** the zh and ja READMEs got the factual fixes but **not** this structural rewrite, so they now differ in shape from the English one. Happy to port it in a follow-up.

## Type of Change

- [x] Bug fix
- [x] Documentation

## Checklist

- [x] Code follows project style
- [x] Documentation updated
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI workflow path filters and documentation only; no runtime or build logic in application code.
> 
> **Overview**
> **CI path filtering** stops markdown and example-only PRs from firing heavy native/Bazel matrices. `ci.yml` now ignores `examples/**` (paired with `ci-docs.yml` so the required **CI Success** gate still reports). `bazel.yml` excludes `!**.md` on push and strips `.md`/`.mdx` from PR file lists before prefix matching so READMEs under `crates/` etc. do not mark Bazel as relevant. The same `!**.md` exclusion is added to `build-natives.yml`, `test-candle.yml`, `test-whispercpp.yml`, and `unity-editor.yml`.
> 
> **README updates** (English plus ja/zh factual sync): fold is shortened by removing the “Start Here” and SDK tables and leading with **Quick Start** SDK badge links to docs; Unity install is split into OpenUPM vs manual and the game demo gif moves into the Unity section. **Supported Models** points at [xybrid.ai/models](https://www.xybrid.ai/models), drops format/Candle-whisper rows and “Coming Soon”, and expands the live LLM/VLM catalog. **Features** and **Why Xybrid?** reflect tool calling on all platforms, multi-backend support, registry-resolved models, cloud fallback, and telemetry wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad4a0ec3e6e9c2b02549a764d707a8ee73d1703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->