### PR TITLE
feat(llm): unlock tool calling on the streaming and context paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Tool calling works in a streaming chat.** A tools-bearing streaming run now
+  halts at the call boundary and hands back typed calls: the terminal stream
+  token carries `finish_reason: "tool_calls"`, the parsed `tool_calls`, and
+  `raw_text` (the turn's output *with* its protocol block, which is what the
+  continuation replays). Nothing needs parsing on the caller's side — call
+  blocks were already suppressed from the token feed. Exposed on every stream
+  token: Rust, Swift, Kotlin, Python, Unity C#, and Dart.
+- **`tool_results` continuations run on every text path.** `execute_with_context`,
+  `execute_streaming`, and `execute_streaming_with_context` compose the
+  continuation instead of rejecting it, so a chat screen keeps both its history
+  and its token-by-token output across a tool turn. Backed by a new
+  `LlmBackend::generate_raw_streaming`. Reference loop:
+  `crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs`.
+
+### Changed
+
+- The only tool-continuation shape that still fails closed is an
+  **image-bearing conversation** — a continuation replays prior turns as a
+  composed text prompt, and image embeddings cannot be re-evaluated from text.
+  The error message and the tool-calling guide now say that it is a property of
+  the replay mechanism rather than an unfinished path.
+
 ### Planned
 
 - **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.

--- a/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
+++ b/bindings/apple/Sources/Xybrid/xybrid_bolt.swift
@@ -410,20 +410,41 @@ public struct XybridStreamToken: Hashable, Equatable, Sendable {
     public var tokenId: Int64?
     public var index: UInt64
     public var cumulativeText: String
+    /// `"tool_calls"` when the turn ended on a parseable tool-call block.
     public var finishReason: String?
+    /// Tool calls parsed from the completed turn — populated on the
+    /// **terminal** token only (the one carrying `finish_reason`).
+    ///
+    /// Tool-call blocks are suppressed from the emitted stream, so there is
+    /// nothing in the token text to parse: a streaming caller halts here,
+    /// runs the tools, then continues the turn by streaming a
+    /// [`tool_results_envelope`] through the same call. Empty on every
+    /// mid-stream token and on turns that emitted no call.
+    public var toolCalls: [XybridToolCall]
+    /// The completed turn's raw output text, tool-call block included — pass
+    /// it to [`tool_results_envelope`] as `prior_assistant_text`.
+    ///
+    /// Present only alongside a non-empty [`Self::tool_calls`]. Not the same
+    /// as `cumulative_text`, which reports the *emitted* text with the
+    /// protocol blocks suppressed — which is why this field exists at all.
+    public var rawText: String?
 
     public init(
         token: String,
         tokenId: Int64?,
         index: UInt64,
         cumulativeText: String,
-        finishReason: String?
+        finishReason: String?,
+        toolCalls: [XybridToolCall],
+        rawText: String?
     ) {
         self.token = token
         self.tokenId = tokenId
         self.index = index
         self.cumulativeText = cumulativeText
         self.finishReason = finishReason
+        self.toolCalls = toolCalls
+        self.rawText = rawText
     }
 
     @inlinable static func decode(from reader: inout WireReader) -> XybridStreamToken {
@@ -432,7 +453,9 @@ public struct XybridStreamToken: Hashable, Equatable, Sendable {
             tokenId: reader.readOptional { reader in reader.readI64() },
             index: reader.readU64(),
             cumulativeText: reader.readString(),
-            finishReason: reader.readOptional { reader in reader.readString() }
+            finishReason: reader.readOptional { reader in reader.readString() },
+            toolCalls: reader.readArray { reader in XybridToolCall.decode(from: &reader) },
+            rawText: reader.readOptional { reader in reader.readString() }
         )
     }
 
@@ -442,6 +465,8 @@ public struct XybridStreamToken: Hashable, Equatable, Sendable {
         writer.writeU64(self.index)
         writer.writeString(self.cumulativeText)
         writer.writeOptional(self.finishReason) { writer, boltffiValue0 in writer.writeString(boltffiValue0) }
+        writer.writeArray(self.toolCalls) { writer, boltffiValue0 in boltffiValue0.encode(to: &writer) }
+        writer.writeOptional(self.rawText) { writer, boltffiValue0 in writer.writeString(boltffiValue0) }
     }
 }
 

--- a/bindings/flutter/lib/src/envelope.dart
+++ b/bindings/flutter/lib/src/envelope.dart
@@ -198,8 +198,11 @@ class XybridEnvelope {
   /// included, i.e. [XybridResult.text] verbatim
   /// [results] - Tool outcomes, in call order
   ///
-  /// Only the immediately prior assistant turn is replayed, and continuation
-  /// runs on the non-streaming text path only.
+  /// Only the immediately prior assistant turn is replayed. A continuation
+  /// runs on every text path — batch, streaming, and both conversation-context
+  /// variants, so a streaming chat screen keeps both history and streaming.
+  /// Image-bearing conversations are the one exception and are rejected:
+  /// image embeddings cannot be re-evaluated from the composed text prompt.
   ///
   /// Throws [XybridException] if a result's content is not valid JSON.
   factory XybridEnvelope.toolResults({

--- a/bindings/flutter/lib/src/llm.dart
+++ b/bindings/flutter/lib/src/llm.dart
@@ -4,6 +4,7 @@
 library;
 
 import 'result.dart';
+import 'tools.dart';
 
 /// A single token emitted during streaming generation.
 class StreamToken {
@@ -19,11 +20,32 @@ class StreamToken {
   /// Whether this is the final token.
   final bool isFinal;
 
-  /// Finish reason if this is the final token (e.g., "stop", "length", "error").
+  /// Finish reason if this is the final token (e.g., "stop", "length",
+  /// "tool_calls", "error").
   final String? finishReason;
 
   /// Final inference metrics. Present only on the completion token.
   final XybridInferenceMetrics? metrics;
+
+  /// Tool calls the model asked for this turn — final token only.
+  ///
+  /// Tool-call blocks are suppressed from the streamed text, so there is
+  /// nothing in [token] to parse: stop at this token, run the calls, then
+  /// continue the turn by streaming a [XybridEnvelope.toolResults] envelope
+  /// through the same method. Empty on every other token, and on turns that
+  /// asked for no tool.
+  final List<ToolCall> toolCalls;
+
+  /// Whether the model asked to call at least one tool.
+  bool get hasToolCalls => toolCalls.isNotEmpty;
+
+  /// The completed turn's raw output text, tool-call block included — pass it
+  /// as [XybridEnvelope.toolResults]'s `priorAssistantText` to continue the
+  /// turn. Null unless [hasToolCalls] is true.
+  ///
+  /// Deliberately not [cumulativeText]: that is the text your UI painted,
+  /// with the tool-call blocks suppressed.
+  final String? rawText;
 
   StreamToken({
     required this.token,
@@ -32,6 +54,8 @@ class StreamToken {
     required this.isFinal,
     this.finishReason,
     this.metrics,
+    this.toolCalls = const [],
+    this.rawText,
   });
 
   /// Check if this token represents an error.

--- a/bindings/flutter/lib/src/model_loader.dart
+++ b/bindings/flutter/lib/src/model_loader.dart
@@ -14,6 +14,7 @@ import 'llm.dart';
 import 'result.dart';
 import 'rust/api/model.dart';
 import 'run_options.dart';
+import 'tools.dart';
 
 /// Exception thrown when Xybrid operations fail.
 class XybridException implements Exception {
@@ -435,17 +436,26 @@ class XybridModel {
               cumulativeText: field0.cumulativeText,
               isFinal: isFinal,
               finishReason: field0.finishReason,
+              toolCalls: field0.toolCalls
+                  .map(ToolCall.fromFfi)
+                  .toList(growable: false),
+              rawText: field0.rawText,
             );
           case FfiStreamEvent_Complete(:final field0):
             // Only emit if we haven't already emitted a final token
             if (!emittedFinal) {
+              final calls = field0.toolCalls
+                  .map(ToolCall.fromFfi)
+                  .toList(growable: false);
               yield StreamToken(
                 token: '',
                 index: 0,
                 cumulativeText: field0.text ?? '',
                 isFinal: true,
-                finishReason: 'stop',
+                finishReason: calls.isEmpty ? 'stop' : 'tool_calls',
                 metrics: XybridInferenceMetrics.fromFfi(field0.metrics),
+                toolCalls: calls,
+                rawText: calls.isEmpty ? null : field0.text,
               );
             }
           case FfiStreamEvent_Error(:final field0):
@@ -532,16 +542,25 @@ class XybridModel {
               cumulativeText: field0.cumulativeText,
               isFinal: isFinal,
               finishReason: field0.finishReason,
+              toolCalls: field0.toolCalls
+                  .map(ToolCall.fromFfi)
+                  .toList(growable: false),
+              rawText: field0.rawText,
             );
           case FfiStreamEvent_Complete(:final field0):
             if (!emittedFinal) {
+              final calls = field0.toolCalls
+                  .map(ToolCall.fromFfi)
+                  .toList(growable: false);
               yield StreamToken(
                 token: '',
                 index: 0,
                 cumulativeText: field0.text ?? '',
                 isFinal: true,
-                finishReason: 'stop',
+                finishReason: calls.isEmpty ? 'stop' : 'tool_calls',
                 metrics: XybridInferenceMetrics.fromFfi(field0.metrics),
+                toolCalls: calls,
+                rawText: calls.isEmpty ? null : field0.text,
               );
             }
           case FfiStreamEvent_Error(:final field0):
@@ -624,24 +643,42 @@ class XybridModel {
         frameSessionId: frameSessionId,
       );
 
+      // This method emits the native terminal token AND a completion token
+      // (the latter is where metrics arrive). Tool calls must be delivered
+      // across that pair exactly once, or a caller looping on [hasToolCalls]
+      // would execute every tool twice.
+      var emittedToolCalls = false;
+
       await for (final event in stream) {
         switch (event) {
           case FfiStreamEvent_Token(:final field0):
+            final calls =
+                field0.toolCalls.map(ToolCall.fromFfi).toList(growable: false);
+            if (calls.isNotEmpty) emittedToolCalls = true;
             yield StreamToken(
               token: field0.token,
               index: field0.index,
               cumulativeText: field0.cumulativeText,
               isFinal: field0.finishReason != null,
               finishReason: field0.finishReason,
+              toolCalls: calls,
+              rawText: field0.rawText,
             );
           case FfiStreamEvent_Complete(:final field0):
+            final calls = emittedToolCalls
+                ? const <ToolCall>[]
+                : field0.toolCalls
+                    .map(ToolCall.fromFfi)
+                    .toList(growable: false);
             yield StreamToken(
               token: '',
               index: 0,
               cumulativeText: field0.text ?? '',
               isFinal: true,
-              finishReason: 'stop',
+              finishReason: calls.isEmpty ? 'stop' : 'tool_calls',
               metrics: XybridInferenceMetrics.fromFfi(field0.metrics),
+              toolCalls: calls,
+              rawText: calls.isEmpty ? null : field0.text,
             );
           case FfiStreamEvent_Error(:final field0):
             yield StreamToken(

--- a/bindings/flutter/lib/src/rust/api/envelope.dart
+++ b/bindings/flutter/lib/src/rust/api/envelope.dart
@@ -92,8 +92,11 @@ abstract class FfiEnvelope implements RustOpaqueInterface {
   /// `prior_assistant_text` is that turn's raw output text, tool-call block
   /// included. Pass `results` in call order.
   ///
-  /// Only the immediately prior assistant turn is replayed, and continuation
-  /// runs on the non-streaming text path only.
+  /// Only the immediately prior assistant turn is replayed. A continuation
+  /// runs on every text path — batch, streaming, and both conversation-context
+  /// variants. Image-bearing conversations are the one exception and are
+  /// rejected: image embeddings cannot be re-evaluated from the composed
+  /// text prompt.
   static FfiEnvelope toolResults(
           {required String userText,
           required String priorAssistantText,

--- a/bindings/flutter/lib/src/rust/api/model.dart
+++ b/bindings/flutter/lib/src/rust/api/model.dart
@@ -16,7 +16,7 @@ import 'result.dart';
 import 'streaming.dart';
 part 'model.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `apply_cloud_fallback_metadata`, `from_sdk`, `into_facade`, `into_facade`, `is_debug_gateway_host`, `is_ipv6_link_local`, `is_ipv6_unique_local`, `is_v1_gateway_base`, `is_xybrid_gateway_host`, `non_empty`, `normalize_gateway_url`, `should_cancel_on_sink_close`, `streaming_run_options`, `to_facade`, `to_facade`, `to_sdk_over`, `to_sdk_with_cancellation_over`, `validate_cloud_gateway_url`, `validated_cloud_gateway_url`
+// These functions are ignored because they are not marked as `pub`: `apply_cloud_fallback_metadata`, `from_sdk`, `from_sdk`, `into_facade`, `into_facade`, `is_debug_gateway_host`, `is_ipv6_link_local`, `is_ipv6_unique_local`, `is_v1_gateway_base`, `is_xybrid_gateway_host`, `non_empty`, `normalize_gateway_url`, `should_cancel_on_sink_close`, `streaming_run_options`, `to_facade`, `to_facade`, `to_sdk_over`, `to_sdk_with_cancellation_over`, `validate_cloud_gateway_url`, `validated_cloud_gateway_url`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `FlutterFallbackResourceProvider`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `current_snapshot`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
 
@@ -530,8 +530,25 @@ class FfiStreamToken {
   /// Cumulative text generated so far
   final String cumulativeText;
 
-  /// Reason for stopping (if this is the final token)
+  /// Reason for stopping (if this is the final token). `"tool_calls"` when
+  /// the turn ended on a parseable tool-call block.
   final String? finishReason;
+
+  /// Tool calls the model emitted this turn — final token only.
+  ///
+  /// Tool-call blocks are suppressed from the streamed text, so there is
+  /// nothing in `token` to parse: halt here, run the tools, then continue
+  /// the turn by streaming a `FfiEnvelope::tool_results` envelope through
+  /// the same call. Empty on every other token.
+  final List<FfiToolCall> toolCalls;
+
+  /// The completed turn's raw output text, tool-call block included — pass
+  /// it to `FfiEnvelope::tool_results` as `prior_assistant_text`.
+  ///
+  /// Set only alongside a non-empty `tool_calls`. Deliberately not the same
+  /// as `cumulative_text`, which reports the *emitted* text with the
+  /// protocol blocks suppressed.
+  final String? rawText;
 
   const FfiStreamToken({
     required this.token,
@@ -539,6 +556,8 @@ class FfiStreamToken {
     required this.index,
     required this.cumulativeText,
     this.finishReason,
+    required this.toolCalls,
+    this.rawText,
   });
 
   @override
@@ -547,7 +566,9 @@ class FfiStreamToken {
       tokenId.hashCode ^
       index.hashCode ^
       cumulativeText.hashCode ^
-      finishReason.hashCode;
+      finishReason.hashCode ^
+      toolCalls.hashCode ^
+      rawText.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -558,7 +579,9 @@ class FfiStreamToken {
           tokenId == other.tokenId &&
           index == other.index &&
           cumulativeText == other.cumulativeText &&
-          finishReason == other.finishReason;
+          finishReason == other.finishReason &&
+          toolCalls == other.toolCalls &&
+          rawText == other.rawText;
 }
 
 /// One tool call the model emitted, from `FfiResult.toolCalls`.

--- a/bindings/flutter/lib/src/rust/frb_generated.dart
+++ b/bindings/flutter/lib/src/rust/frb_generated.dart
@@ -3276,14 +3276,16 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
   FfiStreamToken dco_decode_ffi_stream_token(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return FfiStreamToken(
       token: dco_decode_String(arr[0]),
       tokenId: dco_decode_opt_box_autoadd_i_64(arr[1]),
       index: dco_decode_u_32(arr[2]),
       cumulativeText: dco_decode_String(arr[3]),
       finishReason: dco_decode_opt_String(arr[4]),
+      toolCalls: dco_decode_list_ffi_tool_call(arr[5]),
+      rawText: dco_decode_opt_String(arr[6]),
     );
   }
 
@@ -4248,12 +4250,16 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     var var_index = sse_decode_u_32(deserializer);
     var var_cumulativeText = sse_decode_String(deserializer);
     var var_finishReason = sse_decode_opt_String(deserializer);
+    var var_toolCalls = sse_decode_list_ffi_tool_call(deserializer);
+    var var_rawText = sse_decode_opt_String(deserializer);
     return FfiStreamToken(
         token: var_token,
         tokenId: var_tokenId,
         index: var_index,
         cumulativeText: var_cumulativeText,
-        finishReason: var_finishReason);
+        finishReason: var_finishReason,
+        toolCalls: var_toolCalls,
+        rawText: var_rawText);
   }
 
   @protected
@@ -5316,6 +5322,8 @@ class XybridRustLibApiImpl extends XybridRustLibApiImplPlatform
     sse_encode_u_32(self.index, serializer);
     sse_encode_String(self.cumulativeText, serializer);
     sse_encode_opt_String(self.finishReason, serializer);
+    sse_encode_list_ffi_tool_call(self.toolCalls, serializer);
+    sse_encode_opt_String(self.rawText, serializer);
   }
 
   @protected

--- a/bindings/flutter/lib/src/tools.dart
+++ b/bindings/flutter/lib/src/tools.dart
@@ -38,7 +38,18 @@
 /// Tool calling is llama.cpp-only today. Unsupported paths — a model with no
 /// embedded chat template, the mistralrs backend, the cloud fallback leg —
 /// reject a tool-bearing request rather than quietly generating without the
-/// tools. Continuation runs on the non-streaming text path only.
+/// tools.
+///
+/// A streaming chat screen keeps both history and streaming: run
+/// `runStreamingWithContext` with tools, halt on the token whose
+/// `hasToolCalls` is true, then feed the outcomes back through the same call
+/// with a [XybridEnvelope.toolResults] envelope. Tool-call blocks are
+/// suppressed from the streamed text, so nothing needs parsing — that token's
+/// `rawText` is the turn text to pass as `priorAssistantText`.
+///
+/// The one shape that stays closed is an image-bearing conversation: a
+/// continuation replays prior turns as a composed text prompt, and image
+/// embeddings cannot be re-evaluated from text.
 library;
 
 import 'rust/api/model.dart';

--- a/bindings/flutter/rust/src/api/envelope.rs
+++ b/bindings/flutter/rust/src/api/envelope.rs
@@ -222,8 +222,11 @@ impl FfiEnvelope {
     /// `prior_assistant_text` is that turn's raw output text, tool-call block
     /// included. Pass `results` in call order.
     ///
-    /// Only the immediately prior assistant turn is replayed, and continuation
-    /// runs on the non-streaming text path only.
+    /// Only the immediately prior assistant turn is replayed. A continuation
+    /// runs on every text path — batch, streaming, and both conversation-context
+    /// variants. Image-bearing conversations are the one exception and are
+    /// rejected: image embeddings cannot be re-evaluated from the composed
+    /// text prompt.
     #[frb(sync)]
     pub fn tool_results(
         user_text: String,

--- a/bindings/flutter/rust/src/api/model.rs
+++ b/bindings/flutter/rust/src/api/model.rs
@@ -556,8 +556,47 @@ pub struct FfiStreamToken {
     pub index: u32,
     /// Cumulative text generated so far
     pub cumulative_text: String,
-    /// Reason for stopping (if this is the final token)
+    /// Reason for stopping (if this is the final token). `"tool_calls"` when
+    /// the turn ended on a parseable tool-call block.
     pub finish_reason: Option<String>,
+    /// Tool calls the model emitted this turn — final token only.
+    ///
+    /// Tool-call blocks are suppressed from the streamed text, so there is
+    /// nothing in `token` to parse: halt here, run the tools, then continue
+    /// the turn by streaming a `FfiEnvelope::tool_results` envelope through
+    /// the same call. Empty on every other token.
+    pub tool_calls: Vec<FfiToolCall>,
+    /// The completed turn's raw output text, tool-call block included — pass
+    /// it to `FfiEnvelope::tool_results` as `prior_assistant_text`.
+    ///
+    /// Set only alongside a non-empty `tool_calls`. Deliberately not the same
+    /// as `cumulative_text`, which reports the *emitted* text with the
+    /// protocol blocks suppressed.
+    pub raw_text: Option<String>,
+}
+
+impl FfiStreamToken {
+    /// Translate one SDK stream token, index rebased onto the FFI stream's
+    /// own counter (the callers own that numbering).
+    fn from_sdk(token: &xybrid_core::runtime_adapter::types::PartialToken, index: u32) -> Self {
+        Self {
+            token: token.token.clone(),
+            token_id: token.token_id,
+            index,
+            cumulative_text: token.cumulative_text.clone(),
+            finish_reason: token.finish_reason.clone(),
+            tool_calls: token
+                .tool_calls
+                .iter()
+                .map(|call| FfiToolCall {
+                    id: call.id.clone(),
+                    name: call.function.name.clone(),
+                    arguments_json: call.function.arguments.clone(),
+                })
+                .collect(),
+            raw_text: token.raw_text.clone(),
+        }
+    }
 }
 
 /// Lifecycle of the background download behind a speculative load.
@@ -612,6 +651,16 @@ impl From<xybrid_sdk::StreamEvent> for FfiStreamEvent {
                 index: token.index as u32,
                 cumulative_text: token.cumulative_text,
                 finish_reason: token.finish_reason,
+                tool_calls: token
+                    .tool_calls
+                    .into_iter()
+                    .map(|call| FfiToolCall {
+                        id: call.id,
+                        name: call.function.name,
+                        arguments_json: call.function.arguments,
+                    })
+                    .collect(),
+                raw_text: token.raw_text,
             }),
             xybrid_sdk::StreamEvent::Complete(result) => {
                 FfiStreamEvent::Complete(FfiResult::from_inference_result(&result))
@@ -889,13 +938,7 @@ impl FfiModel {
                 let token_sink = sink.clone();
                 let on_token = move |token: xybrid_core::runtime_adapter::types::PartialToken| {
                     let is_final = token.finish_reason.is_some();
-                    let ffi_token = FfiStreamToken {
-                        token: token.token.clone(),
-                        token_id: token.token_id,
-                        index: token_index,
-                        cumulative_text: token.cumulative_text.clone(),
-                        finish_reason: token.finish_reason.clone(),
-                    };
+                    let ffi_token = FfiStreamToken::from_sdk(&token, token_index);
                     token_index = token_index.saturating_add(1);
                     // Mark terminal *before* the final emit so a sink-close that
                     // races the last token does not look like a mid-stream cancel.
@@ -1152,13 +1195,7 @@ impl FfiModel {
                     preempt,
                     move |token| {
                         let is_final = token.finish_reason.is_some();
-                        let ffi_token = FfiStreamToken {
-                            token: token.token.clone(),
-                            token_id: token.token_id,
-                            index: token_index,
-                            cumulative_text: token.cumulative_text.clone(),
-                            finish_reason: token.finish_reason.clone(),
-                        };
+                        let ffi_token = FfiStreamToken::from_sdk(&token, token_index);
                         token_index = token_index.saturating_add(1);
                         if is_final {
                             reached_terminal.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -1243,13 +1280,7 @@ impl FfiModel {
                 let token_sink = sink.clone();
                 let mut on_token = |token: xybrid_core::runtime_adapter::types::PartialToken| {
                     let is_final = token.finish_reason.is_some();
-                    let ffi_token = FfiStreamToken {
-                        token: token.token.clone(),
-                        token_id: token.token_id,
-                        index: token_index,
-                        cumulative_text: token.cumulative_text.clone(),
-                        finish_reason: token.finish_reason.clone(),
-                    };
+                    let ffi_token = FfiStreamToken::from_sdk(&token, token_index);
                     token_index = token_index.saturating_add(1);
                     if is_final {
                         reached_terminal.store(true, std::sync::atomic::Ordering::SeqCst);

--- a/bindings/flutter/rust/src/frb_generated.rs
+++ b/bindings/flutter/rust/src/frb_generated.rs
@@ -4037,12 +4037,16 @@ impl SseDecode for crate::api::model::FfiStreamToken {
         let mut var_index = <u32>::sse_decode(deserializer);
         let mut var_cumulativeText = <String>::sse_decode(deserializer);
         let mut var_finishReason = <Option<String>>::sse_decode(deserializer);
+        let mut var_toolCalls = <Vec<crate::api::model::FfiToolCall>>::sse_decode(deserializer);
+        let mut var_rawText = <Option<String>>::sse_decode(deserializer);
         return crate::api::model::FfiStreamToken {
             token: var_token,
             token_id: var_tokenId,
             index: var_index,
             cumulative_text: var_cumulativeText,
             finish_reason: var_finishReason,
+            tool_calls: var_toolCalls,
+            raw_text: var_rawText,
         };
     }
 }
@@ -5392,6 +5396,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::model::FfiStreamToken {
             self.index.into_into_dart().into_dart(),
             self.cumulative_text.into_into_dart().into_dart(),
             self.finish_reason.into_into_dart().into_dart(),
+            self.tool_calls.into_into_dart().into_dart(),
+            self.raw_text.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -6143,6 +6149,8 @@ impl SseEncode for crate::api::model::FfiStreamToken {
         <u32>::sse_encode(self.index, serializer);
         <String>::sse_encode(self.cumulative_text, serializer);
         <Option<String>>::sse_encode(self.finish_reason, serializer);
+        <Vec<crate::api::model::FfiToolCall>>::sse_encode(self.tool_calls, serializer);
+        <Option<String>>::sse_encode(self.raw_text, serializer);
     }
 }
 

--- a/bindings/flutter/test/stream_token_test.dart
+++ b/bindings/flutter/test/stream_token_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xybrid_flutter/xybrid_flutter.dart';
+
+/// The raw output of a tools-bearing turn: display text plus the protocol
+/// block. Only `rawText` carries it — `cumulativeText` is what the UI painted,
+/// with the block suppressed.
+const _rawTurn =
+    'checking<|tool_call_start|>[get_weather(city="Paris")]<|tool_call_end|>';
+
+void main() {
+  test('a mid-stream token carries no tool calls', () {
+    final token = StreamToken(
+      token: 'chec',
+      index: 0,
+      cumulativeText: 'chec',
+      isFinal: false,
+    );
+
+    expect(token.hasToolCalls, isFalse);
+    expect(token.toolCalls, isEmpty);
+    expect(token.rawText, isNull);
+  });
+
+  test('the terminal token hands back typed calls without parsing text', () {
+    final token = StreamToken(
+      token: '',
+      index: 4,
+      cumulativeText: 'checking',
+      isFinal: true,
+      finishReason: 'tool_calls',
+      toolCalls: const [
+        ToolCall(
+          id: 'call_0',
+          name: 'get_weather',
+          argumentsJson: '{"city":"Paris"}',
+        ),
+      ],
+      rawText: _rawTurn,
+    );
+
+    expect(token.hasToolCalls, isTrue);
+    expect(token.finishReason, 'tool_calls');
+    expect(token.toolCalls.single.name, 'get_weather');
+    expect(token.toolCalls.single.argumentsJson, '{"city":"Paris"}');
+
+    // The streamed text never contained the protocol block...
+    expect(token.cumulativeText, isNot(contains('<|tool_call_start|>')));
+    // ...but the continuation needs it verbatim, which is what rawText is for.
+    expect(token.rawText, _rawTurn);
+  });
+
+  test('rawText is what the continuation envelope replays', () {
+    final token = StreamToken(
+      token: '',
+      index: 4,
+      cumulativeText: 'checking',
+      isFinal: true,
+      finishReason: 'tool_calls',
+      toolCalls: const [
+        ToolCall(
+          id: 'call_0',
+          name: 'get_weather',
+          argumentsJson: '{"city":"Paris"}',
+        ),
+      ],
+      rawText: _rawTurn,
+    );
+
+    // Building the turn-2 envelope is a straight read off the terminal token:
+    // no text parsing, no second source of truth.
+    final results = [
+      for (final call in token.toolCalls)
+        ToolResult(
+          callId: call.id,
+          name: call.name,
+          contentJson: '{"tempC":21}',
+        ),
+    ];
+
+    expect(results.single.callId, 'call_0');
+    expect(token.rawText, contains('<|tool_call_start|>'));
+  });
+}

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
@@ -1380,10 +1380,12 @@ data class XybridStreamToken(
     val tokenId: Long?,
     val index: ULong,
     val cumulativeText: String,
-    val finishReason: String?
+    val finishReason: String?,
+    val toolCalls: List<XybridToolCall>,
+    val rawText: String?
 ) {
     internal fun wireSize(): Int {
-        return 4 + Utf8Codec.maxBytes(this.token) + 1 + (this.tokenId?.let { __boltffi_value_0 -> 8 } ?: 0) + 8 + 4 + Utf8Codec.maxBytes(this.cumulativeText) + 1 + (this.finishReason?.let { __boltffi_value_0 -> 4 + Utf8Codec.maxBytes(__boltffi_value_0) } ?: 0)
+        return 4 + Utf8Codec.maxBytes(this.token) + 1 + (this.tokenId?.let { __boltffi_value_0 -> 8 } ?: 0) + 8 + 4 + Utf8Codec.maxBytes(this.cumulativeText) + 1 + (this.finishReason?.let { __boltffi_value_0 -> 4 + Utf8Codec.maxBytes(__boltffi_value_0) } ?: 0) + 4 + this.toolCalls.sumOf { __boltffi_value_0 -> (__boltffi_value_0.wireSize()).toInt() } + 1 + (this.rawText?.let { __boltffi_value_0 -> 4 + Utf8Codec.maxBytes(__boltffi_value_0) } ?: 0)
     }
 
     internal fun writeTo(writer: WireWriter) {
@@ -1392,6 +1394,8 @@ data class XybridStreamToken(
         writer.writeU64(this.index)
         writer.writeString(this.cumulativeText)
         writer.writeOptionalValue(this.finishReason, { writer, __boltffi_value_0 -> writer.writeString(__boltffi_value_0) })
+        writer.writeSequence(this.toolCalls, this.toolCalls.size, { writer, __boltffi_value_0 -> __boltffi_value_0.writeTo(writer) })
+        writer.writeOptionalValue(this.rawText, { writer, __boltffi_value_0 -> writer.writeString(__boltffi_value_0) })
     }
 
     internal fun toByteArray(): ByteArray {
@@ -1412,6 +1416,8 @@ data class XybridStreamToken(
                 reader.readOptionalValue({ reader -> reader.readI64() }),
                 reader.readU64(),
                 reader.readString(),
+                reader.readOptionalValue({ reader -> reader.readString() }),
+                reader.readSequence({ reader -> XybridToolCall.fromReader(reader) }),
                 reader.readOptionalValue({ reader -> reader.readString() })
             )
         }

--- a/bindings/python/xybrid/_bolt/__init__.py
+++ b/bindings/python/xybrid/_bolt/__init__.py
@@ -1108,6 +1108,8 @@ class XybridStreamToken:
     index: int
     cumulative_text: str
     finish_reason: str | None
+    tool_calls: list[XybridToolCall]
+    raw_text: str | None
 
     def _boltffi_wire(self) -> bytes:
         return b"".join((
@@ -1116,6 +1118,8 @@ class XybridStreamToken:
             _boltffi_wire_u64(self.index),
             _boltffi_wire_string(self.cumulative_text),
             _boltffi_wire_optional(self.finish_reason, lambda __boltffi_value_0: _boltffi_wire_string(__boltffi_value_0)),
+            _boltffi_wire_sequence(self.tool_calls, len(self.tool_calls), lambda __boltffi_value_0: __boltffi_value_0._boltffi_wire()),
+            _boltffi_wire_optional(self.raw_text, lambda __boltffi_value_0: _boltffi_wire_string(__boltffi_value_0)),
         ))
 
     @classmethod
@@ -1136,6 +1140,8 @@ class XybridStreamToken:
             index=reader.u64(),
             cumulative_text=reader.string(),
             finish_reason=reader.optional(lambda: reader.string()),
+            tool_calls=reader.sequence(lambda: XybridToolCall._boltffi_from_reader(reader)),
+            raw_text=reader.optional(lambda: reader.string()),
         )
 
 

--- a/bindings/python/xybrid/_bolt/__init__.pyi
+++ b/bindings/python/xybrid/_bolt/__init__.pyi
@@ -127,6 +127,8 @@ class XybridStreamToken:
     index: int
     cumulative_text: str
     finish_reason: str | None
+    tool_calls: list[XybridToolCall]
+    raw_text: str | None
 
 
 

--- a/bindings/unity/Runtime/Api/Envelope.cs
+++ b/bindings/unity/Runtime/Api/Envelope.cs
@@ -196,8 +196,11 @@ namespace Xybrid
         /// the same tools as the original turn so the executor rebuilds an
         /// identical chat prefix.
         ///
-        /// Only the immediately prior assistant turn is replayed, and
-        /// continuation runs on the non-streaming text path only.
+        /// Only the immediately prior assistant turn is replayed. A
+        /// continuation runs on every text path — batch, streaming, and both
+        /// conversation-context variants. Image-bearing conversations are the
+        /// one exception and are rejected: image embeddings cannot be
+        /// re-evaluated from the composed text prompt.
         /// </remarks>
         /// <param name="userText">The original user message of the turn being continued.</param>
         /// <param name="priorAssistantText">

--- a/bindings/unity/Runtime/Api/Model.cs
+++ b/bindings/unity/Runtime/Api/Model.cs
@@ -387,7 +387,9 @@ namespace Xybrid
                 token.TokenId,
                 (uint)token.Index,
                 token.CumulativeText,
-                token.FinishReason);
+                token.FinishReason,
+                token.ToolCalls ?? System.Array.Empty<XybridBolt.XybridToolCall>(),
+                token.RawText);
 
         private static VoiceInfo MapVoice(XybridBolt.XybridVoiceInfo voice) =>
             new VoiceInfo(voice.Id, voice.Name, voice.Gender, voice.Language, voice.Style);

--- a/bindings/unity/Runtime/Api/StreamToken.cs
+++ b/bindings/unity/Runtime/Api/StreamToken.cs
@@ -1,6 +1,8 @@
 // Xybrid SDK - StreamToken
 // Data class for tokens received during streaming inference.
 
+using System.Collections.Generic;
+
 namespace Xybrid
 {
     /// <summary>
@@ -34,7 +36,8 @@ namespace Xybrid
 
         /// <summary>
         /// Reason for stopping, or null if generation is still in progress.
-        /// Values: "stop" (hit stop sequence/EOS), "length" (hit max_tokens).
+        /// Values: "stop" (hit stop sequence/EOS), "length" (hit max_tokens),
+        /// "tool_calls" (the turn ended on a parseable tool-call block).
         /// </summary>
         public string FinishReason { get; }
 
@@ -43,14 +46,45 @@ namespace Xybrid
         /// </summary>
         public bool IsFinal => FinishReason != null;
 
+        /// <summary>
+        /// Tool calls the model emitted this turn, on the final token only.
+        /// </summary>
+        /// <remarks>
+        /// Tool-call blocks are suppressed from the streamed text, so there is
+        /// nothing in <see cref="Token"/> to parse: halt here, run the tools,
+        /// then continue the turn by streaming a tool-results envelope through
+        /// the same call. Empty on every other token.
+        /// </remarks>
+        public IReadOnlyList<XybridBolt.XybridToolCall> ToolCalls { get; }
+
+        /// <summary>
+        /// Whether this token carries tool calls to execute.
+        /// </summary>
+        public bool HasToolCalls => ToolCalls != null && ToolCalls.Count > 0;
+
+        /// <summary>
+        /// The completed turn's raw output text, tool-call block included.
+        /// Pass it as the prior assistant text when building the tool-results
+        /// envelope. Null unless <see cref="HasToolCalls"/> is true.
+        /// </summary>
+        /// <remarks>
+        /// Not the same as <see cref="CumulativeText"/>, which reports the
+        /// streamed text with the protocol blocks suppressed.
+        /// </remarks>
+        public string RawText { get; }
+
         internal StreamToken(string token, long? tokenId, uint index,
-                           string cumulativeText, string finishReason)
+                           string cumulativeText, string finishReason,
+                           IReadOnlyList<XybridBolt.XybridToolCall> toolCalls = null,
+                           string rawText = null)
         {
             Token = token;
             TokenId = tokenId;
             Index = index;
             CumulativeText = cumulativeText;
             FinishReason = finishReason;
+            ToolCalls = toolCalls ?? System.Array.Empty<XybridBolt.XybridToolCall>();
+            RawText = rawText;
         }
 
         /// <summary>

--- a/bindings/unity/Runtime/Bolt/XybridStreamToken.cs
+++ b/bindings/unity/Runtime/Bolt/XybridStreamToken.cs
@@ -7,14 +7,35 @@ using System.Runtime.InteropServices;
 
 namespace XybridBolt
 {
+    /// <param name="FinishReason">`"tool_calls"` when the turn ended on a parseable tool-call block.</param>
+    /// <param name="ToolCalls">
+    /// Tool calls parsed from the completed turn — populated on the
+    /// **terminal** token only (the one carrying `finish_reason`).
+    ///
+    /// Tool-call blocks are suppressed from the emitted stream, so there is
+    /// nothing in the token text to parse: a streaming caller halts here,
+    /// runs the tools, then continues the turn by streaming a
+    /// [`tool_results_envelope`] through the same call. Empty on every
+    /// mid-stream token and on turns that emitted no call.
+    /// </param>
+    /// <param name="RawText">
+    /// The completed turn's raw output text, tool-call block included — pass
+    /// it to [`tool_results_envelope`] as `prior_assistant_text`.
+    ///
+    /// Present only alongside a non-empty [`Self::tool_calls`]. Not the same
+    /// as `cumulative_text`, which reports the *emitted* text with the
+    /// protocol blocks suppressed — which is why this field exists at all.
+    /// </param>
     public readonly struct XybridStreamToken
     {
-        public XybridStreamToken(string Token, long? TokenId, ulong Index, string CumulativeText, string? FinishReason) { this.Token = Token; this.TokenId = TokenId; this.Index = Index; this.CumulativeText = CumulativeText; this.FinishReason = FinishReason; }
+        public XybridStreamToken(string Token, long? TokenId, ulong Index, string CumulativeText, string? FinishReason, XybridToolCall[] ToolCalls, string? RawText) { this.Token = Token; this.TokenId = TokenId; this.Index = Index; this.CumulativeText = CumulativeText; this.FinishReason = FinishReason; this.ToolCalls = ToolCalls; this.RawText = RawText; }
         public string Token { get; }
         public long? TokenId { get; }
         public ulong Index { get; }
         public string CumulativeText { get; }
         public string? FinishReason { get; }
+        public XybridToolCall[] ToolCalls { get; }
+        public string? RawText { get; }
 
         internal static XybridStreamToken Decode(WireReader reader) =>
             new XybridStreamToken(
@@ -22,6 +43,8 @@ namespace XybridBolt
                 reader.ReadU8() == 0 ? default(long?) : reader.ReadI64(),
                 reader.ReadU64(),
                 reader.ReadString(),
+                reader.ReadU8() == 0 ? default(string?) : reader.ReadString(),
+                reader.ReadArray(reader => XybridToolCall.Decode(reader)),
                 reader.ReadU8() == 0 ? default(string?) : reader.ReadString()
             );
 
@@ -49,6 +72,24 @@ namespace XybridBolt
             }
             {
                 if (this.FinishReason is { } boltffiValue0)
+                {
+                    writer.WriteU8(1);
+                    writer.WriteString(boltffiValue0);
+                }
+                else
+                {
+                    writer.WriteU8(0);
+                }
+            }
+            {
+                writer.WriteU32(checked((uint)this.ToolCalls.Length));
+                foreach (var boltffiValue0 in this.ToolCalls)
+                {
+                    boltffiValue0.Encode(writer);
+                }
+            }
+            {
+                if (this.RawText is { } boltffiValue0)
                 {
                     writer.WriteU8(1);
                     writer.WriteString(boltffiValue0);

--- a/crates/xybrid-bolt/src/lib.rs
+++ b/crates/xybrid-bolt/src/lib.rs
@@ -693,7 +693,24 @@ pub struct XybridStreamToken {
     pub token_id: Option<i64>,
     pub index: u64,
     pub cumulative_text: String,
+    /// `"tool_calls"` when the turn ended on a parseable tool-call block.
     pub finish_reason: Option<String>,
+    /// Tool calls parsed from the completed turn — populated on the
+    /// **terminal** token only (the one carrying `finish_reason`).
+    ///
+    /// Tool-call blocks are suppressed from the emitted stream, so there is
+    /// nothing in the token text to parse: a streaming caller halts here,
+    /// runs the tools, then continues the turn by streaming a
+    /// [`tool_results_envelope`] through the same call. Empty on every
+    /// mid-stream token and on turns that emitted no call.
+    pub tool_calls: Vec<XybridToolCall>,
+    /// The completed turn's raw output text, tool-call block included — pass
+    /// it to [`tool_results_envelope`] as `prior_assistant_text`.
+    ///
+    /// Present only alongside a non-empty [`Self::tool_calls`]. Not the same
+    /// as `cumulative_text`, which reports the *emitted* text with the
+    /// protocol blocks suppressed — which is why this field exists at all.
+    pub raw_text: Option<String>,
 }
 
 impl From<facade::StreamToken> for XybridStreamToken {
@@ -704,6 +721,8 @@ impl From<facade::StreamToken> for XybridStreamToken {
             index: token.index,
             cumulative_text: token.cumulative_text,
             finish_reason: token.finish_reason,
+            tool_calls: token.tool_calls.into_iter().map(Into::into).collect(),
+            raw_text: token.raw_text,
         }
     }
 }
@@ -1615,12 +1634,43 @@ mod tests {
             index: 3,
             cumulative_text: "say hi".into(),
             finish_reason: None,
+            tool_calls: Vec::new(),
+            raw_text: None,
         }));
 
         assert_eq!(event.kind, XybridStreamEventKind::Token);
         let token = event.token.expect("token event should carry a token");
         assert_eq!(token.token, "hi");
         assert_eq!(token.index, 3);
+        assert!(token.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn terminal_stream_token_carries_tool_calls_across_the_boundary() {
+        // Foreign callers dispatch on this instead of parsing token text —
+        // the call blocks never reach the stream.
+        let event = XybridStreamEvent::from(facade::StreamEvent::Token(facade::StreamToken {
+            token: String::new(),
+            token_id: None,
+            index: 9,
+            cumulative_text: "checking".into(),
+            finish_reason: Some("tool_calls".into()),
+            raw_text: Some("checking<|tool_call_start|>[x()]<|tool_call_end|>".into()),
+            tool_calls: vec![facade::ToolCall {
+                id: "call_0".into(),
+                name: "get_temperature".into(),
+                arguments_json: r#"{"room":"kitchen"}"#.into(),
+            }],
+        }));
+
+        let token = event.token.expect("token event should carry a token");
+        assert_eq!(token.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(token.tool_calls.len(), 1);
+        assert_eq!(token.tool_calls[0].name, "get_temperature");
+        assert!(
+            token.raw_text.is_some(),
+            "the replayable raw text must cross too"
+        );
     }
 
     #[test]

--- a/crates/xybrid-cli/src/commands/repl/agent_loop.rs
+++ b/crates/xybrid-cli/src/commands/repl/agent_loop.rs
@@ -177,10 +177,13 @@ pub(crate) fn run_query(
     }
 
     if stream {
-        // Cue the stream→batch transition: continuation answers arrive
-        // whole (streaming rejects them), and a well-behaved model calls
-        // its tool almost immediately, so often nothing streamed at all —
-        // without a cue the drop to silence reads as a hang.
+        // Cue the stream→batch transition. Continuations can stream, but the
+        // REPL runs them batched on purpose: the agent loop interleaves tool
+        // output, duplicate-call detection, and a forced synthesis turn, and
+        // partial text between those would read as interleaved noise. A
+        // well-behaved model also calls its tool almost immediately, so often
+        // nothing streamed at all — without a cue the drop to silence reads
+        // as a hang.
         if first_turn.already_printed {
             println!();
         }
@@ -208,7 +211,7 @@ pub(crate) fn run_query(
     // thinking model's tool turn — show it next to the calls it produced.
     print_turn_reasoning(show_reasoning, first_turn.reasoning_content.as_deref());
 
-    // ── Tool continuation turns (non-context, non-streaming) ────────────────
+    // ── Tool continuation turns (batched by choice — see the cue above) ────
     let mut findings: Vec<String> = Vec::new();
     let mut seen_calls: HashSet<String> = HashSet::new();
     let mut prior_text = first_turn.text;

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -243,6 +243,11 @@ required-features = ["llm-llamacpp"]
 name = "functiongemma_tools"
 required-features = ["llm-llamacpp"]
 
+[[example]]
+name = "functiongemma_tools_streaming_context"
+# Real inference — needs llama.cpp linked.
+required-features = ["llm-llamacpp"]
+
 [[bench]]
 name = "inference_backends"
 harness = false

--- a/crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs
+++ b/crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs
@@ -1,0 +1,214 @@
+//! Tool calling in a streaming chat: tokens, history, and a continuation.
+//!
+//! This is the shape a chat UI actually needs, and the one that used to fail
+//! closed. It runs the whole loop through `execute_streaming_with_context`:
+//!
+//! 1. Turn 1 streams. Tool-call blocks never reach the token feed — they are
+//!    protocol traffic, not answer text — and the terminal `PartialToken`
+//!    carries `finish_reason: "tool_calls"`, the parsed `tool_calls`, and
+//!    `raw_text` (the turn's output *with* the block, which is what the
+//!    continuation replays).
+//! 2. The tool runs in ordinary application code.
+//! 3. Turn 2 feeds an `Envelope::tool_results` envelope back through the same
+//!    streaming-with-context call. It streams too, and it still sees history.
+//!
+//! Fetch the fixture first:
+//!   ./integration-tests/download.sh functiongemma-270m-it
+//!
+//! Run with:
+//!   cargo run --example functiongemma_tools_streaming_context \
+//!       -p xybrid-core --features llm-llamacpp
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use xybrid_core::conversation::ConversationContext;
+use xybrid_core::execution::{ExecutionTemplate, ModelMetadata, TemplateExecutor};
+use xybrid_core::gateway::Tool;
+use xybrid_core::ir::{Envelope, EnvelopeKind, MessageRole, ToolCallResult};
+use xybrid_core::runtime_adapter::types::{GenerationConfig, PartialToken};
+use xybrid_core::testing::model_fixtures;
+
+const MODEL_ID: &str = "functiongemma-270m-it";
+const SYSTEM_PROMPT: &str = "Use the available function and report its result clearly.";
+const USER_PROMPT: &str = "What's the current temperature in London?";
+
+fn weather_tool() -> Tool {
+    Tool::function(
+        "get_current_temperature",
+        "Gets the current temperature for a given location.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city name, e.g. San Francisco"
+                }
+            },
+            "required": ["location"]
+        }),
+    )
+}
+
+fn model_dir() -> PathBuf {
+    model_fixtures::model_path(MODEL_ID)
+        .unwrap_or_else(|| PathBuf::from("integration-tests/fixtures/models").join(MODEL_ID))
+}
+
+/// What a streaming turn hands back: the text the UI painted, plus the typed
+/// handoff on the terminal token.
+#[derive(Default)]
+struct StreamedTurn {
+    emitted: String,
+    terminal: Option<PartialToken>,
+}
+
+/// Run one turn through the streaming-with-context path, collecting the token
+/// feed and the terminal token. The `Arc<Mutex<..>>` is only because the
+/// callback is `Send`; a real UI would push straight into its own state.
+fn stream_turn(
+    executor: &mut TemplateExecutor,
+    metadata: &ModelMetadata,
+    input: &Envelope,
+    context: &ConversationContext,
+    config: &GenerationConfig,
+) -> Result<(StreamedTurn, Envelope), Box<dyn std::error::Error>> {
+    let turn = Arc::new(Mutex::new(StreamedTurn::default()));
+    let sink = turn.clone();
+
+    let response = executor.execute_streaming_with_context(
+        metadata,
+        input,
+        context,
+        Box::new(move |token: PartialToken| {
+            let mut turn = sink.lock().unwrap_or_else(|e| e.into_inner());
+            print!("{}", token.token);
+            use std::io::Write;
+            std::io::stdout().flush().ok();
+            turn.emitted.push_str(&token.token);
+            if token.finish_reason.is_some() {
+                turn.terminal = Some(token);
+            }
+            Ok(())
+        }),
+        Some(config),
+    )?;
+    println!();
+
+    let turn = Arc::try_unwrap(turn)
+        .map_err(|_| "streaming callback outlived the run")?
+        .into_inner()
+        .unwrap_or_else(|e| e.into_inner());
+    Ok((turn, response))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("═══════════════════════════════════════════════════════");
+    println!("  FunctionGemma — streaming tool calling, with context");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    let dir = model_dir();
+    let metadata_path = dir.join("model_metadata.json");
+    if !metadata_path.exists() {
+        return Err(format!(
+            "metadata not found at {}; run ./integration-tests/download.sh {MODEL_ID}",
+            metadata_path.display()
+        )
+        .into());
+    }
+    let metadata: ModelMetadata = serde_json::from_str(&std::fs::read_to_string(&metadata_path)?)?;
+    let model_file = match &metadata.execution_template {
+        ExecutionTemplate::Gguf { model_file, .. } => model_file,
+        other => return Err(format!("expected Gguf metadata, got {other:?}").into()),
+    };
+    if !dir.join(model_file).exists() {
+        return Err(format!(
+            "model not found at {}; run ./integration-tests/download.sh {MODEL_ID}",
+            dir.join(model_file).display()
+        )
+        .into());
+    }
+
+    let mut executor =
+        TemplateExecutor::with_base_path(dir.to_str().ok_or("model dir is not valid UTF-8")?);
+    let config = GenerationConfig::greedy()
+        .with_max_tokens(128)
+        .with_tools(vec![weather_tool()]);
+
+    // A chat screen's state: system turn plus whatever has been said so far.
+    let mut context = ConversationContext::new().with_system(
+        Envelope::new(EnvelopeKind::Text(SYSTEM_PROMPT.to_string())).with_role(MessageRole::System),
+    );
+
+    // ── Turn 1: stream, and halt at the tool-call boundary ─────────────────
+    println!("── turn 1 (streaming) ──");
+    let request = Envelope::new(EnvelopeKind::Text(USER_PROMPT.to_string()));
+    let (turn, _response) = stream_turn(&mut executor, &metadata, &request, &context, &config)?;
+
+    let terminal = turn
+        .terminal
+        .ok_or("streaming turn emitted no terminal token")?;
+    if terminal.tool_calls.is_empty() {
+        return Err("model emitted no parseable tool call".into());
+    }
+    if turn.emitted.contains("<start_function_call>") {
+        return Err("tool-call protocol text leaked into the token feed".into());
+    }
+    let raw_text = terminal
+        .raw_text
+        .as_deref()
+        .ok_or("terminal token carried calls but no raw text to replay")?;
+
+    println!("finish_reason: {:?}", terminal.finish_reason);
+    println!("parsed tool calls: {:#?}", terminal.tool_calls);
+    println!("raw turn text (replayed next): {raw_text}");
+
+    // ── Execute the tools: ordinary application code ───────────────────────
+    let results: Vec<ToolCallResult> = terminal
+        .tool_calls
+        .iter()
+        .map(|call| ToolCallResult {
+            call_id: call.id.clone(),
+            name: call.function.name.clone(),
+            content: serde_json::json!({"location": "London", "temperature_c": 21}),
+        })
+        .collect();
+
+    // NOTE: the user turn is deliberately NOT pushed to history yet. The
+    // continuation envelope replays `USER_PROMPT` itself, so pushing it here
+    // would put the question in the prompt twice. History gets the completed
+    // exchange once the loop settles, below.
+
+    // ── Turn 2: the continuation, streamed, still context-aware ────────────
+    println!("\n── turn 2 (continuation, streaming, same context) ──");
+    let continuation = Envelope::tool_results(USER_PROMPT, raw_text, &results);
+    let (final_turn, final_response) =
+        stream_turn(&mut executor, &metadata, &continuation, &context, &config)?;
+
+    let final_text = match &final_response.kind {
+        EnvelopeKind::Text(text) => text.trim().to_string(),
+        other => return Err(format!("expected Text output, got {other:?}").into()),
+    };
+    if final_text.is_empty() {
+        return Err("continuation produced no final answer".into());
+    }
+    if final_turn.emitted.trim().is_empty() {
+        return Err("continuation returned text but streamed nothing".into());
+    }
+
+    // The exchange is settled: commit it to history as one user turn plus one
+    // assistant turn. The next question then sees this turn as context.
+    context.push(
+        Envelope::new(EnvelopeKind::Text(USER_PROMPT.to_string())).with_role(MessageRole::User),
+    );
+    context.push(
+        Envelope::new(EnvelopeKind::Text(final_text.clone())).with_role(MessageRole::Assistant),
+    );
+
+    println!("\nfinal answer: {final_text}");
+    println!(
+        "\nStatus: PASS - {} call(s) streamed and answered without leaving the streaming path",
+        results.len()
+    );
+    Ok(())
+}

--- a/crates/xybrid-core/src/execution/executor.rs
+++ b/crates/xybrid-core/src/execution/executor.rs
@@ -51,8 +51,8 @@ use super::llm_telemetry::{
 };
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 use super::tool_continuation::{
-    reject_nested_tool_continuation_parts, reject_tool_continuation_input, run_tool_continuation,
-    text_messages_from_multimodal,
+    reject_nested_tool_continuation_parts, run_tool_continuation, run_tool_continuation_streaming,
+    text_messages_from_multimodal, ToolContinuation,
 };
 
 fn mark_execution_terminal(guard: &ExecutionGuard, error: &AdapterError) {
@@ -666,7 +666,7 @@ impl TemplateExecutor {
                 // and run the non-vision LLM path. Audio/Embedding parts (and
                 // any other non-text/image kind) still fail here, inside
                 // `MultimodalChatMessage::from_envelope`.
-                reject_tool_continuation_input(input, "text-only vision-language")?;
+                reject_nested_tool_continuation_parts(input, "text-only vision-language")?;
                 let messages = vec![MultimodalChatMessage::from_envelope(input)?];
                 let mut chat_messages = text_messages_from_multimodal(&messages)?;
                 // Mirror the flat-Text path's envelope handling: the
@@ -686,6 +686,7 @@ impl TemplateExecutor {
                     &chat_messages,
                     backend_hint,
                     Some(&gen_config),
+                    ToolContinuation::from_input(input),
                 )
             };
         }
@@ -1078,12 +1079,16 @@ impl TemplateExecutor {
             }
         }
 
-        // Fail closed: tool-result continuations do not compose with
-        // conversation context (v1). Without this guard the continuation
-        // metadata would be silently dropped and the turn would run as a
-        // fresh question, producing a plausible but ungrounded answer.
+        // A tool-result continuation composes fine with conversation
+        // context: the rendered chat prefix is history + this turn's user
+        // text, and the replayed assistant turn plus the tool responses are
+        // appended after it. Resolve the payload here — the messages-based
+        // functions below never see the envelope, so it has to be threaded
+        // explicitly or it would be silently dropped.
         #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-        reject_tool_continuation_input(input, "context")?;
+        let continuation = ToolContinuation::from_input(input);
+        #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+        reject_nested_tool_continuation_parts(input, "context")?;
 
         #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
         if let ExecutionTemplate::VisionLanguage {
@@ -1121,6 +1126,7 @@ impl TemplateExecutor {
                     &chat_messages,
                     backend_hint,
                     config,
+                    continuation,
                 )?
             };
 
@@ -1186,6 +1192,7 @@ impl TemplateExecutor {
                 &chat_messages,
                 backend_hint,
                 config,
+                continuation,
             )?;
 
             // Tag the result as an assistant message
@@ -1307,7 +1314,10 @@ impl TemplateExecutor {
                     // Text-only MultiPart: same conversion as the
                     // non-streaming path (see `execute_impl`), routed through
                     // the streaming ChatMessages entry point.
-                    reject_tool_continuation_input(input, "text-only vision-language streaming")?;
+                    reject_nested_tool_continuation_parts(
+                        input,
+                        "text-only vision-language streaming",
+                    )?;
                     let messages = vec![MultimodalChatMessage::from_envelope(input)?];
                     let mut chat_messages = text_messages_from_multimodal(&messages)?;
                     // Same envelope lift as the non-streaming branch above.
@@ -1324,6 +1334,7 @@ impl TemplateExecutor {
                         backend_hint,
                         on_token,
                         Some(&gen_config),
+                        ToolContinuation::from_input(input),
                     )
                 };
             }
@@ -1463,9 +1474,13 @@ impl TemplateExecutor {
             }
         }
 
-        // Fail closed: continuations are non-streaming and context-free (v1).
+        // Continuations stream, and they compose with conversation context —
+        // see `execute_with_context_impl` for why the payload is resolved
+        // here and threaded down rather than re-read further in.
         #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-        reject_tool_continuation_input(input, "streaming context")?;
+        let continuation = ToolContinuation::from_input(input);
+        #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+        reject_nested_tool_continuation_parts(input, "streaming context")?;
 
         #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
         {
@@ -1506,6 +1521,7 @@ impl TemplateExecutor {
                         backend_hint,
                         on_token,
                         config,
+                        continuation,
                     )?
                 };
 
@@ -1569,6 +1585,7 @@ impl TemplateExecutor {
                     backend_hint,
                     on_token,
                     config,
+                    continuation,
                 )?;
 
                 // Tag the result as an assistant message
@@ -1627,7 +1644,7 @@ impl TemplateExecutor {
         stamp_llm_span_cost_attribution(metadata);
 
         reject_text_only_model_image_input(metadata, input)?;
-        reject_tool_continuation_input(input, "streaming")?;
+        let continuation = ToolContinuation::from_input(input);
 
         // Build full model path
         let model_path = Path::new(&self.base_path).join(model_file);
@@ -1694,7 +1711,20 @@ impl TemplateExecutor {
                 // bundle metadata).
                 stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
-                let out = backend.generate_streaming(&messages, &gen_config, on_token)?;
+                // A continuation replays the prior assistant turn plus the
+                // tool responses through the raw streaming path; a first turn
+                // goes through the chat path. Both stream token-by-token.
+                let out = match continuation {
+                    Some(continuation) => run_tool_continuation_streaming(
+                        backend,
+                        &messages,
+                        &gen_config,
+                        continuation.input,
+                        continuation.responses_json,
+                        on_token,
+                    )?,
+                    None => backend.generate_streaming(&messages, &gen_config, on_token)?,
+                };
                 let name = backend.name().to_string();
                 let cached = backend.last_cached_prefix_len();
                 (out, name, cached)
@@ -1721,7 +1751,12 @@ impl TemplateExecutor {
     ///
     /// Used by `execute_with_context` to pass conversation history
     /// to the LLM without our custom template formatting.
+    ///
+    /// `continuation` carries the tool-result payload when this turn is a
+    /// continuation (see `tool_continuation::ToolContinuation`); `messages`
+    /// is then the chat prefix the continuation prompt is composed on top of.
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[allow(clippy::too_many_arguments)]
     fn execute_llm_with_messages(
         &mut self,
         metadata: &ModelMetadata,
@@ -1731,6 +1766,7 @@ impl TemplateExecutor {
         messages: &[ChatMessage],
         backend_hint: Option<&str>,
         config: Option<&GenerationConfig>,
+        continuation: Option<ToolContinuation<'_>>,
     ) -> ExecutorResult<Envelope> {
         info!(
             target: "xybrid_core",
@@ -1792,7 +1828,16 @@ impl TemplateExecutor {
                 // bundle metadata).
                 stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
-                let out = backend.generate(messages, &gen_config)?;
+                let out = match continuation {
+                    Some(continuation) => run_tool_continuation(
+                        backend,
+                        messages,
+                        &gen_config,
+                        continuation.input,
+                        continuation.responses_json,
+                    )?,
+                    None => backend.generate(messages, &gen_config)?,
+                };
                 let name = backend.name().to_string();
                 let cached = backend.last_cached_prefix_len();
                 (out, name, cached)
@@ -1912,6 +1957,75 @@ impl TemplateExecutor {
                 "LLM adapter cache unexpectedly empty".to_string(),
             ));
         };
+
+        Ok(build_llm_response_envelope(
+            output,
+            &backend_name,
+            cached_prefix,
+            None,
+            !gen_config.tools.is_empty(),
+        ))
+    }
+
+    /// Streaming sibling of `execute_vlm_tool_continuation`.
+    ///
+    /// Same replay, same text-only constraint — an image-bearing
+    /// conversation is refused by `text_messages_from_multimodal` here just
+    /// as it is on the batch path, because image embeddings cannot be
+    /// re-evaluated from a composed text prompt.
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[allow(clippy::too_many_arguments)]
+    fn execute_vlm_tool_continuation_streaming(
+        &mut self,
+        metadata: &ModelMetadata,
+        model_file: &str,
+        chat_template: Option<&str>,
+        context_length: usize,
+        input: &Envelope,
+        responses_json: &str,
+        backend_hint: Option<&str>,
+        on_token: StreamingCallback<'_>,
+        config: Option<&GenerationConfig>,
+    ) -> ExecutorResult<Envelope> {
+        let _llm_span = xybrid_trace::SpanGuard::new("vlm_inference_streaming_with_messages");
+        xybrid_trace::add_metadata("model", model_file);
+        xybrid_trace::add_metadata("streaming", "true");
+        stamp_llm_span_cost_attribution(metadata);
+
+        self.ensure_vlm_adapter(
+            metadata,
+            model_file,
+            chat_template,
+            context_length,
+            backend_hint,
+        )?;
+
+        let gen_config = config
+            .cloned()
+            .unwrap_or_else(|| model_default_gen_config(metadata));
+        let messages = vec![MultimodalChatMessage::from_envelope(input)?];
+        let chat_messages = text_messages_from_multimodal(&messages)?;
+
+        let (output, backend_name, cached_prefix) =
+            if let Some((_, adapter)) = &self.llm_adapter_cache {
+                stamp_llm_runtime_backend(adapter);
+                let backend = adapter.backend();
+                let out = run_tool_continuation_streaming(
+                    backend,
+                    &chat_messages,
+                    &gen_config,
+                    input,
+                    responses_json,
+                    on_token,
+                )?;
+                let name = backend.name().to_string();
+                let cached = backend.last_cached_prefix_len();
+                (out, name, cached)
+            } else {
+                return Err(AdapterError::RuntimeError(
+                    "LLM adapter cache unexpectedly empty".to_string(),
+                ));
+            };
 
         Ok(build_llm_response_envelope(
             output,
@@ -2085,7 +2199,25 @@ impl TemplateExecutor {
     ) -> ExecutorResult<Envelope> {
         let gen_config = build_gen_config_from_input(metadata, input, config);
 
-        reject_tool_continuation_input(input, "vision-language streaming")?;
+        // Mirror of the batch path: continuations replay through the raw
+        // text path and must be intercepted before envelope → message
+        // conversion, since the messages-based functions never see
+        // continuation metadata.
+        if let Some(responses_json) = input.metadata.get(Envelope::TOOL_RESPONSES_METADATA_KEY) {
+            return self.execute_vlm_tool_continuation_streaming(
+                metadata,
+                model_file,
+                chat_template,
+                context_length,
+                input,
+                responses_json,
+                backend_hint,
+                on_token,
+                Some(&gen_config),
+            );
+        }
+
+        reject_nested_tool_continuation_parts(input, "vision-language streaming")?;
         let messages = vec![MultimodalChatMessage::from_envelope(input)?];
         self.execute_llm_multimodal_streaming_messages(
             metadata,
@@ -2209,7 +2341,11 @@ impl TemplateExecutor {
     ///
     /// Used by `execute_streaming_with_context` to pass conversation history
     /// to the LLM without our custom template formatting.
+    ///
+    /// `continuation` carries the tool-result payload when this turn is a
+    /// continuation — see `execute_llm_with_messages`.
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[allow(clippy::too_many_arguments)]
     fn execute_llm_streaming_with_messages(
         &mut self,
         metadata: &ModelMetadata,
@@ -2220,6 +2356,7 @@ impl TemplateExecutor {
         backend_hint: Option<&str>,
         on_token: StreamingCallback<'_>,
         config: Option<&GenerationConfig>,
+        continuation: Option<ToolContinuation<'_>>,
     ) -> ExecutorResult<Envelope> {
         // GenerationConfig, LlmConfig are imported at module level from types
 
@@ -2283,7 +2420,17 @@ impl TemplateExecutor {
                 // bundle metadata).
                 stamp_llm_runtime_backend(adapter);
                 let backend = adapter.backend();
-                let out = backend.generate_streaming(messages, &gen_config, on_token)?;
+                let out = match continuation {
+                    Some(continuation) => run_tool_continuation_streaming(
+                        backend,
+                        messages,
+                        &gen_config,
+                        continuation.input,
+                        continuation.responses_json,
+                        on_token,
+                    )?,
+                    None => backend.generate_streaming(messages, &gen_config, on_token)?,
+                };
                 let name = backend.name().to_string();
                 let cached = backend.last_cached_prefix_len();
                 (out, name, cached)
@@ -3619,35 +3766,21 @@ mod tests {
     }
 
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-    #[test]
-    fn tool_continuation_envelopes_are_rejected_on_unsupported_paths() {
-        let envelope = crate::ir::Envelope::tool_results(
-            "user text",
-            "prior assistant text",
+    fn sample_tool_continuation_envelope() -> crate::ir::Envelope {
+        crate::ir::Envelope::tool_results(
+            "what is the weather?",
+            "<|tool_call_start|>[weather(city=\"Paris\")]<|tool_call_end|>",
             &[crate::ir::ToolCallResult {
                 call_id: "call_0".to_string(),
-                name: "f".to_string(),
-                content: serde_json::json!({"ok": true}),
+                name: "weather".to_string(),
+                content: serde_json::json!({"temperature_c": 21}),
             }],
-        );
-        let err = reject_tool_continuation_input(&envelope, "streaming").unwrap_err();
-        assert!(
-            matches!(err, AdapterError::InvalidInput(ref msg) if msg.contains("streaming")),
-            "continuation envelopes must be rejected loudly, got: {err:?}"
-        );
-
-        // A plain envelope passes through untouched.
-        let plain = crate::ir::Envelope::new(EnvelopeKind::Text("hi".to_string()));
-        assert!(reject_tool_continuation_input(&plain, "streaming").is_ok());
+        )
     }
 
     #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
-    #[test]
-    fn execute_with_context_rejects_tool_continuation_envelopes() {
-        // The context path does not compose continuations (v1) — it must
-        // fail closed rather than silently drop the tool results and answer
-        // the replayed user text as a fresh question.
-        let metadata = ModelMetadata {
+    fn llm_metadata_for_continuation_tests() -> ModelMetadata {
+        ModelMetadata {
             model_id: "test-llm".into(),
             version: "1".into(),
             execution_template: ExecutionTemplate::Gguf {
@@ -3665,39 +3798,302 @@ mod tests {
             voices: None,
             max_chunk_chars: None,
             trim_trailing_samples: None,
-        };
-        let envelope = crate::ir::Envelope::tool_results(
-            "user text",
-            "prior assistant text",
-            &[crate::ir::ToolCallResult {
-                call_id: "call_0".to_string(),
-                name: "f".to_string(),
-                content: serde_json::json!({"ok": true}),
-            }],
+        }
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn tool_continuation_payload_is_resolved_off_the_envelope() {
+        let envelope = sample_tool_continuation_envelope();
+        let continuation = ToolContinuation::from_input(&envelope).expect(
+            "a tool_results envelope is a
+ continuation",
         );
-        let context = crate::conversation::ConversationContext::new();
+        assert!(
+            continuation.responses_json.contains("call_0"),
+            "the resolved payload must carry the serialized tool responses"
+        );
+
+        let plain = crate::ir::Envelope::new(EnvelopeKind::Text("hi".to_string()));
+        assert!(
+            ToolContinuation::from_input(&plain).is_none(),
+            "a first-turn envelope is not a continuation"
+        );
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn nested_multipart_tool_continuation_is_rejected() {
+        // Continuation metadata inside a MultiPart part would be discarded by
+        // the multimodal conversion, so it must fail loudly rather than run
+        // as an ungrounded fresh turn.
+        let nested = crate::ir::Envelope::new(EnvelopeKind::MultiPart(vec![
+            sample_tool_continuation_envelope(),
+        ]));
+        let err = reject_nested_tool_continuation_parts(&nested, "context").unwrap_err();
+        assert!(
+            matches!(err, AdapterError::InvalidInput(ref msg) if msg.contains("MultiPart")),
+            "nested continuations must be rejected loudly, got: {err:?}"
+        );
+
+        let plain = crate::ir::Envelope::new(EnvelopeKind::Text("hi".to_string()));
+        assert!(reject_nested_tool_continuation_parts(&plain, "context").is_ok());
+    }
+
+    /// Backend that records the prompts it is handed and refuses the chat
+    /// path, so a test can prove a continuation composed a raw prompt rather
+    /// than silently replaying the user text as a fresh question.
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[derive(Default)]
+    struct ContinuationProbeBackend {
+        raw_prompts: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    impl ContinuationProbeBackend {
+        const ANSWER: &'static str = "It is 21C in Paris.";
+
+        fn output(&self) -> crate::runtime_adapter::GenerationOutput {
+            let mut out = sample_generation_output(4);
+            out.text = Self::ANSWER.to_string();
+            out
+        }
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    impl crate::runtime_adapter::LlmBackend for ContinuationProbeBackend {
+        fn name(&self) -> &str {
+            "continuation-probe"
+        }
+
+        fn supported_formats(&self) -> Vec<&'static str> {
+            vec!["gguf"]
+        }
+
+        fn load(&mut self, _config: &crate::runtime_adapter::LlmConfig) -> ExecutorResult<()> {
+            Ok(())
+        }
+
+        fn is_loaded(&self) -> bool {
+            true
+        }
+
+        fn unload(&mut self) -> ExecutorResult<()> {
+            Ok(())
+        }
+
+        fn generate(
+            &self,
+            _messages: &[ChatMessage],
+            _config: &GenerationConfig,
+        ) -> ExecutorResult<crate::runtime_adapter::GenerationOutput> {
+            panic!("a continuation must not run through the chat path")
+        }
+
+        fn generate_streaming(
+            &self,
+            _messages: &[ChatMessage],
+            _config: &GenerationConfig,
+            _on_token: StreamingCallback<'_>,
+        ) -> ExecutorResult<crate::runtime_adapter::GenerationOutput> {
+            panic!("a continuation must not run through the streaming chat path")
+        }
+
+        fn render_chat_prompt(
+            &self,
+            messages: &[ChatMessage],
+            _config: &GenerationConfig,
+        ) -> ExecutorResult<String> {
+            // Minimal ChatML so `compose_tool_continuation` detects the LFM2
+            // protocol the way a real template would.
+            let mut prompt = String::new();
+            for message in messages {
+                prompt.push_str(&format!(
+                    "<|im_start|>{}\n{}<|im_end|>\n",
+                    message.role.as_str(),
+                    message.content
+                ));
+            }
+            prompt.push_str("<|im_start|>assistant\n");
+            Ok(prompt)
+        }
+
+        fn generate_raw(
+            &self,
+            prompt: &str,
+            _config: &GenerationConfig,
+        ) -> ExecutorResult<crate::runtime_adapter::GenerationOutput> {
+            self.raw_prompts
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(prompt.to_string());
+            Ok(self.output())
+        }
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    fn cache_continuation_probe_backend(
+        executor: &mut TemplateExecutor,
+    ) -> std::sync::Arc<ContinuationProbeBackend> {
+        let backend = std::sync::Arc::new(ContinuationProbeBackend::default());
+        executor.llm_adapter_cache = Some((
+            LlmAdapterCacheKey::new("model.gguf".to_string(), None, 2048, None, None),
+            crate::runtime_adapter::LlmRuntimeAdapter::with_backend(Box::new(ProbeHandle(
+                backend.clone(),
+            ))),
+        ));
+        backend
+    }
+
+    /// Shared-ownership shim so a test can keep reading the probe's recorded
+    /// prompts after the adapter takes the boxed backend.
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    struct ProbeHandle(std::sync::Arc<ContinuationProbeBackend>);
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    impl crate::runtime_adapter::LlmBackend for ProbeHandle {
+        fn name(&self) -> &str {
+            self.0.name()
+        }
+
+        fn supported_formats(&self) -> Vec<&'static str> {
+            self.0.supported_formats()
+        }
+
+        fn load(&mut self, _config: &crate::runtime_adapter::LlmConfig) -> ExecutorResult<()> {
+            Ok(())
+        }
+
+        fn is_loaded(&self) -> bool {
+            self.0.is_loaded()
+        }
+
+        fn unload(&mut self) -> ExecutorResult<()> {
+            Ok(())
+        }
+
+        fn generate(
+            &self,
+            messages: &[ChatMessage],
+            config: &GenerationConfig,
+        ) -> ExecutorResult<crate::runtime_adapter::GenerationOutput> {
+            self.0.generate(messages, config)
+        }
+
+        fn generate_streaming(
+            &self,
+            messages: &[ChatMessage],
+            config: &GenerationConfig,
+            on_token: StreamingCallback<'_>,
+        ) -> ExecutorResult<crate::runtime_adapter::GenerationOutput> {
+            self.0.generate_streaming(messages, config, on_token)
+        }
+
+        fn render_chat_prompt(
+            &self,
+            messages: &[ChatMessage],
+            config: &GenerationConfig,
+        ) -> ExecutorResult<String> {
+            self.0.render_chat_prompt(messages, config)
+        }
+
+        fn generate_raw(
+            &self,
+            prompt: &str,
+            config: &GenerationConfig,
+        ) -> ExecutorResult<crate::runtime_adapter::GenerationOutput> {
+            self.0.generate_raw(prompt, config)
+        }
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn execute_with_context_composes_a_tool_continuation() {
+        let metadata = llm_metadata_for_continuation_tests();
+        let envelope = sample_tool_continuation_envelope();
+        let mut context = crate::conversation::ConversationContext::new();
+        context.push(
+            crate::ir::Envelope::new(EnvelopeKind::Text("earlier question".to_string()))
+                .with_role(MessageRole::User),
+        );
 
         let mut executor = TemplateExecutor::default();
-        let err = executor
+        let probe = cache_continuation_probe_backend(&mut executor);
+
+        let result = executor
             .execute_with_context(&metadata, &envelope, &context, None)
-            .unwrap_err();
+            .expect("the context path must compose the continuation, not reject it");
+
+        match &result.kind {
+            EnvelopeKind::Text(text) => assert_eq!(text, ContinuationProbeBackend::ANSWER),
+            other => panic!("expected a text envelope, got {other:?}"),
+        }
+
+        let prompts = probe
+            .raw_prompts
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let prompt = prompts.first().expect("the raw path must have run once");
         assert!(
-            matches!(err, AdapterError::InvalidInput(ref msg) if msg.contains("context")),
-            "context path must reject continuation envelopes, got: {err:?}"
+            prompt.contains("earlier question"),
+            "the continuation prompt must keep conversation history: {prompt}"
+        );
+        assert!(
+            prompt.contains("<|tool_response_start|>"),
+            "the continuation prompt must replay the tool responses: {prompt}"
+        );
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn execute_streaming_with_context_streams_a_tool_continuation() {
+        let metadata = llm_metadata_for_continuation_tests();
+        let envelope = sample_tool_continuation_envelope();
+        let mut context = crate::conversation::ConversationContext::new();
+        context.push(
+            crate::ir::Envelope::new(EnvelopeKind::Text("earlier question".to_string()))
+                .with_role(MessageRole::User),
         );
 
-        let streaming_err = executor
+        let mut executor = TemplateExecutor::default();
+        let probe = cache_continuation_probe_backend(&mut executor);
+
+        let streamed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = streamed.clone();
+        let result = executor
             .execute_streaming_with_context(
                 &metadata,
                 &envelope,
                 &context,
-                Box::new(|_| Ok(())),
+                Box::new(move |token| {
+                    sink.lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .push(token.token);
+                    Ok(())
+                }),
                 None,
             )
-            .unwrap_err();
+            .expect("the streaming context path must compose the continuation, not reject it");
+
+        match &result.kind {
+            EnvelopeKind::Text(text) => assert_eq!(text, ContinuationProbeBackend::ANSWER),
+            other => panic!("expected a text envelope, got {other:?}"),
+        }
+        assert_eq!(
+            streamed
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .concat(),
+            ContinuationProbeBackend::ANSWER,
+            "the continuation turn must reach the token callback"
+        );
         assert!(
-            matches!(streaming_err, AdapterError::InvalidInput(ref msg) if msg.contains("streaming context")),
-            "streaming context path must reject continuation envelopes, got: {streaming_err:?}"
+            !probe
+                .raw_prompts
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty(),
+            "the streaming continuation must go through the raw path"
         );
     }
 

--- a/crates/xybrid-core/src/execution/tool_continuation.rs
+++ b/crates/xybrid-core/src/execution/tool_continuation.rs
@@ -3,10 +3,18 @@
 //! One `run` is always one model turn. When an input envelope carries tool
 //! results (see [`Envelope::tool_results`]), the executor replays the prior
 //! assistant turn plus the results as a raw, protocol-faithful continuation
-//! prompt through the backend's `generate_raw` path. The helpers here are
-//! pure orchestration glue shared by the text path (`execute_llm`) and the
-//! text-only vision-language path; the protocol text itself (composition,
-//! parsing, turn markers) is owned by `runtime_adapter::tool_call`.
+//! prompt through the backend's `generate_raw` / `generate_raw_streaming`
+//! path. The helpers here are pure orchestration glue shared by every LLM
+//! path that can compose one — plain text, conversation context, streaming,
+//! streaming-with-context, and the text-only vision-language variants; the
+//! protocol text itself (composition, parsing, turn markers) is owned by
+//! `runtime_adapter::tool_call`.
+//!
+//! The one shape that stays closed is a conversation whose replayed turns
+//! contain images: `generate_raw` is a text-only surface, so those image
+//! embeddings cannot be re-evaluated from the composed prompt. That is a
+//! property of the replay mechanism, not an unfinished path — see
+//! [`text_messages_from_multimodal`].
 
 use crate::ir::Envelope;
 use crate::runtime_adapter::llm::GenerationOutput;
@@ -20,6 +28,7 @@ use crate::runtime_adapter::tool_call::{
 };
 use crate::runtime_adapter::{
     AdapterError, ChatMessage, GenerationConfig, LlmBackend, MultimodalChatMessage,
+    StreamingCallback,
 };
 
 use super::types::ExecutorResult;
@@ -47,6 +56,44 @@ pub(crate) fn run_tool_continuation(
     input: &Envelope,
     responses_json: &str,
 ) -> ExecutorResult<GenerationOutput> {
+    let (prompt, raw_config) =
+        compose_continuation_prompt(backend, messages, gen_config, input, responses_json)?;
+    let out = backend.generate_raw(&prompt, &raw_config)?;
+    Ok(finish_continuation_output(out))
+}
+
+/// Streaming sibling of [`run_tool_continuation`].
+///
+/// Composes the identical prompt and runs it through the backend's
+/// `generate_raw_streaming`, so a continuation turn emits tokens as it
+/// generates instead of arriving as one block. The emitted stream is already
+/// filtered (reasoning and tool-protocol blocks suppressed) by the backend's
+/// streaming filter; the returned output gets the same final cleanup as the
+/// batch path so envelope and stream agree.
+pub(crate) fn run_tool_continuation_streaming(
+    backend: &dyn LlmBackend,
+    messages: &[ChatMessage],
+    gen_config: &GenerationConfig,
+    input: &Envelope,
+    responses_json: &str,
+    on_token: StreamingCallback<'_>,
+) -> ExecutorResult<GenerationOutput> {
+    let (prompt, raw_config) =
+        compose_continuation_prompt(backend, messages, gen_config, input, responses_json)?;
+    let out = backend.generate_raw_streaming(&prompt, &raw_config, on_token)?;
+    Ok(finish_continuation_output(out))
+}
+
+/// Render the chat prefix, append the replayed assistant turn plus the tool
+/// responses in the model's own protocol, and return the composed raw prompt
+/// alongside the generation config to run it with.
+fn compose_continuation_prompt(
+    backend: &dyn LlmBackend,
+    messages: &[ChatMessage],
+    gen_config: &GenerationConfig,
+    input: &Envelope,
+    responses_json: &str,
+) -> ExecutorResult<(String, GenerationConfig)> {
     let prior_text = input
         .metadata
         .get(Envelope::TOOL_PRIOR_TEXT_METADATA_KEY)
@@ -71,7 +118,11 @@ pub(crate) fn run_tool_continuation(
             raw_config.stop_sequences.push((*stop).to_string());
         }
     }
-    let mut out = backend.generate_raw(&prompt, &raw_config)?;
+    Ok((prompt, raw_config))
+}
+
+/// Final cleanup shared by the batch and streaming continuation paths.
+fn finish_continuation_output(mut out: GenerationOutput) -> GenerationOutput {
     // The raw path keeps stop-marker text in the output (the chat path
     // truncates it). Cut it so the answer is clean and a further
     // continuation doesn't double the turn marker.
@@ -84,7 +135,7 @@ pub(crate) fn run_tool_continuation(
         out.text = clean;
         out.reasoning_content = reasoning.or(out.reasoning_content);
     }
-    Ok(out)
+    out
 }
 
 /// Flatten backend-neutral multimodal messages to plain text chat messages
@@ -104,8 +155,12 @@ pub(crate) fn text_messages_from_multimodal(
                     Some(text) => content.push_str(text),
                     None => {
                         return Err(AdapterError::InvalidInput(
-                            "tool-result continuation requires a text-only conversation; \
-                             image inputs cannot replay through the raw continuation path"
+                            "tool-result continuation requires a text-only conversation. \
+                             A continuation replays the prior turns as a composed text \
+                             prompt, and image embeddings cannot be re-evaluated from \
+                             text — so an image-bearing conversation cannot continue on \
+                             any path, streaming or not. Run the tool loop on a text-only \
+                             conversation, or describe the image in text first."
                                 .to_string(),
                         ))
                     }
@@ -119,33 +174,46 @@ pub(crate) fn text_messages_from_multimodal(
         .collect()
 }
 
-/// Reject tool-result continuation envelopes on paths that do not compose
-/// the raw continuation prompt. Without this guard those paths would treat
-/// the envelope as a fresh first turn — silently dropping the prior
-/// assistant turn and the tool results — and produce a plausible but wrong
-/// answer. v1 supports continuation on the non-streaming, **non-context**
-/// paths only (plain text, and text-only vision-language turns); streaming
-/// and conversation-context paths all reject.
-pub(crate) fn reject_tool_continuation_input(
-    input: &Envelope,
-    path: &str,
-) -> Result<(), AdapterError> {
-    if carries_tool_continuation(input) {
-        return Err(AdapterError::InvalidInput(format!(
-            "tool-result continuation envelopes are not supported on the {path} path; \
-             run the continuation turn through the non-streaming text path"
-        )));
-    }
-    Ok(())
+/// The tool-result payload carried by a continuation envelope, resolved once
+/// at the executor's entry point and threaded down to whichever
+/// message-based execution function ends up running the turn.
+///
+/// Those functions never see the envelope itself, so without this the
+/// continuation metadata would be silently dropped and the turn would run as
+/// a fresh question — a plausible but ungrounded answer.
+#[derive(Clone, Copy)]
+pub(crate) struct ToolContinuation<'a> {
+    /// The continuation envelope, for `tool_prior_text` and turn replay.
+    pub input: &'a Envelope,
+    /// Serialized tool responses (`Envelope::TOOL_RESPONSES_METADATA_KEY`).
+    pub responses_json: &'a str,
 }
 
-/// Like [`reject_tool_continuation_input`], but ignores the outer envelope's
-/// own metadata. For paths that intercept outer continuations themselves
-/// (the batch vision-language path routes them to
-/// `execute_vlm_tool_continuation`) yet must still refuse continuation
-/// metadata buried inside `MultiPart` parts — the multimodal conversion
-/// discards part metadata, so a nested continuation would silently lose its
-/// tool results.
+impl<'a> ToolContinuation<'a> {
+    /// Resolve the continuation payload from `input`, or `None` when the
+    /// envelope is an ordinary first-turn request.
+    ///
+    /// Only the envelope's own metadata is inspected. Continuation metadata
+    /// buried inside a `MultiPart` part is a different shape and is refused
+    /// by [`reject_nested_tool_continuation_parts`], because the multimodal
+    /// conversion discards part metadata.
+    pub fn from_input(input: &'a Envelope) -> Option<Self> {
+        input
+            .metadata
+            .get(Envelope::TOOL_RESPONSES_METADATA_KEY)
+            .map(|responses_json| Self {
+                input,
+                responses_json,
+            })
+    }
+}
+
+/// Refuse continuation metadata buried inside `MultiPart` parts.
+///
+/// Outer continuations are composed by every LLM path now; a *nested* one is
+/// not a supported envelope shape, and the multimodal conversion discards
+/// part metadata, so a nested continuation would silently lose its tool
+/// results. Fail loudly instead.
 pub(crate) fn reject_nested_tool_continuation_parts(
     input: &Envelope,
     path: &str,
@@ -153,17 +221,17 @@ pub(crate) fn reject_nested_tool_continuation_parts(
     if let crate::ir::EnvelopeKind::MultiPart(parts) = &input.kind {
         if parts.iter().any(carries_tool_continuation) {
             return Err(AdapterError::InvalidInput(format!(
-                "tool-result continuation envelopes are not supported on the {path} path; \
-                 run the continuation turn through the non-streaming text path"
+                "tool-result continuation metadata inside a MultiPart part is not a supported \
+                 envelope shape on the {path} path; build the turn with Envelope::tool_results \
+                 so the continuation rides the envelope itself"
             )));
         }
     }
     Ok(())
 }
 
-/// Continuation metadata can ride the envelope itself or any nested
-/// `MultiPart` part; flattening a nested part would silently drop its
-/// tool results, so the guard must see through the whole tree.
+/// Whether `input` (or any nested `MultiPart` part) carries continuation
+/// metadata.
 fn carries_tool_continuation(input: &Envelope) -> bool {
     if input
         .metadata

--- a/crates/xybrid-core/src/ir/envelope.rs
+++ b/crates/xybrid-core/src/ir/envelope.rs
@@ -1313,9 +1313,10 @@ impl Envelope {
     ///
     /// Only the immediately prior assistant turn is replayed: multi-hop
     /// chains work turn by turn, but earlier tool exchanges are not re-sent.
-    /// Continuation runs on the non-streaming text paths; streaming paths
-    /// and image-bearing conversations reject these envelopes as invalid
-    /// input (image embeddings cannot replay through the raw text path).
+    /// A continuation runs on every text path — batch, streaming, and both
+    /// conversation-context variants. Image-bearing conversations are the one
+    /// exception and are rejected as invalid input: image embeddings cannot
+    /// replay through the raw text path a continuation is composed on.
     ///
     /// # Examples
     ///

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -486,6 +486,10 @@ fn stream_with_gateway_sse(
                 index: token_index,
                 cumulative_text: cumulative.clone(),
                 finish_reason: choice_finish.clone(),
+                // The cloud gateway rejects tool-bearing requests today, so a
+                // cloud stream never carries parsed calls.
+                tool_calls: Vec::new(),
+                raw_text: None,
             };
             terminal_emitted = choice_finish.is_some();
             token_index += 1;
@@ -503,6 +507,8 @@ fn stream_with_gateway_sse(
             index: token_index,
             cumulative_text: cumulative.clone(),
             finish_reason: Some(reason.clone()),
+            tool_calls: Vec::new(),
+            raw_text: None,
         };
         finish_reason = Some(reason);
         on_token(token).map_err(|e| {

--- a/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llama_cpp/mod.rs
@@ -1053,6 +1053,145 @@ impl LlmBackend for LlamaCppBackend {
         })
     }
 
+    /// Streaming sibling of [`Self::generate_raw`] — the seam tool-result
+    /// continuations use.
+    ///
+    /// Stop handling stays raw (only `config.stop_sequences`, no chat-marker
+    /// merge) exactly like `generate_raw`; the continuation composer pushes
+    /// the turn markers it needs onto the config before calling. The emitted
+    /// stream still runs through `StreamingTextFilter`, because a
+    /// continuation IS a chat turn: it can deliberate in a reasoning block
+    /// and it can call another tool, and neither belongs in the caller's
+    /// visible text.
+    fn generate_raw_streaming(
+        &self,
+        prompt: &str,
+        config: &GenerationConfig,
+        on_token: crate::runtime_adapter::llm::StreamingCallback<'_>,
+    ) -> LlmResult<GenerationOutput> {
+        let mut on_token = on_token;
+
+        self.with_model_and_context(|model, context| {
+            let tokens = Self::tokenize_raw_prompt(model, prompt)?;
+            let prepared =
+                self.prepare_generation(model, context, tokens, config, PromptKind::Raw)?;
+
+            let stop_patterns = config.stop_sequences.clone();
+            let suppress_tools = !config.tools.is_empty();
+            // Deliberately NOT `new_reasoning_primed`. A continuation prompt
+            // appends a fresh, *unprimed* assistant turn after the replayed
+            // one (see `tool_call::compose_tool_continuation`), so the model
+            // self-opens `<think>` if it reasons — which this filter catches.
+            // Starting primed would instead swallow a plain answer whole.
+            //
+            // Residual, shared with the batch path: a model that saw `<think>`
+            // primed on the *prior* turn may open its reasoning markerless. The
+            // batch path's dangling-close handling recovers the final text, and
+            // so does `finish_continuation_output` here — but the streaming
+            // filter has no dangling-close rule, so that reasoning would flash
+            // in the token feed before the clean text lands. Same known v1
+            // limitation `run_tool_continuation` documents; the models tested
+            // self-open the tag.
+            let mut filter = StreamingTextFilter::new(stop_patterns.clone());
+            if suppress_tools {
+                filter = filter.with_tool_call_suppression();
+            }
+            let mut token_index = 0usize;
+
+            let stream_result = Self::run_streaming_generation(
+                context,
+                model,
+                &prepared,
+                config,
+                &stop_patterns,
+                |token_id, token_text, tel| {
+                    tel.record_chunk();
+                    emit_filtered_partial_token(
+                        &mut filter,
+                        token_id,
+                        token_text,
+                        &mut token_index,
+                        &mut on_token,
+                    )
+                },
+            );
+            let (output_tokens, stopped_by_callback, fields) = match stream_result {
+                Ok(result) => result,
+                Err(err) => {
+                    self.reset_kv_cache_after_failed_stream(context);
+                    return Err(err);
+                }
+            };
+
+            let ended_on_eog = output_tokens
+                .last()
+                .is_some_and(|&token| model.vocab_is_eog(token));
+            let mut text = model.detokenize(text_tokens_without_terminal_eog(
+                &output_tokens,
+                ended_on_eog,
+            ))?;
+            let stopped_in_text = truncate_at_first_stop(&mut text, &stop_patterns);
+            let trimmed_partial = trim_partial_stop_suffix(&mut text, &stop_patterns);
+            let truncated_by_budget = generation_truncated_by_budget(
+                filter.is_stopped() || stopped_in_text || trimmed_partial || stopped_by_callback,
+                ended_on_eog,
+                output_tokens.len(),
+                prepared.max_tokens,
+            );
+            // `primed = false` for the same reason the filter is unprimed.
+            let (clean, reasoning_content) =
+                strip_and_capture_thinking_tags_primed(&text, false, truncated_by_budget);
+            let text = clean.trim().to_string();
+
+            let parsed_tool_calls = if suppress_tools {
+                crate::runtime_adapter::tool_call::parse_tool_calls(&text)
+            } else {
+                Vec::new()
+            };
+            let emitted_tool_calls = !parsed_tool_calls.is_empty();
+            let finish_reason = if emitted_tool_calls {
+                "tool_calls".to_string()
+            } else if filter.is_stopped()
+                || stopped_in_text
+                || trimmed_partial
+                || stopped_by_callback
+                || ended_on_eog
+            {
+                "stop".to_string()
+            } else {
+                "length".to_string()
+            };
+
+            let tool_block_suppressed = suppress_tools && filter.saw_tool_call_block();
+            // No `should_emit_recovered_answer` here, unlike the chat paths:
+            // that recovery only fires for a *primed* stream that suppressed
+            // its whole output, and this path is never primed (see the filter
+            // construction above). An unprimed stream that emitted nothing has
+            // nothing to recover — the text was either a suppressed tool block
+            // (signalled by the terminal token) or empty after cleanup.
+
+            if token_index > 0 || tool_block_suppressed {
+                let final_cumulative = if tool_block_suppressed {
+                    filter.cumulative_emitted().to_string()
+                } else {
+                    text.clone()
+                };
+                let final_partial = PartialToken::new(String::new(), token_index, final_cumulative)
+                    .with_finish_reason(&finish_reason)
+                    .with_tool_calls(parsed_tool_calls, &text);
+                on_token(final_partial).map_err(AdapterError::from_streaming_callback_error)?;
+            }
+
+            Ok(output_from_fields(
+                text,
+                output_tokens.len(),
+                finish_reason,
+                reasoning_content,
+                fields,
+            ))
+        })
+    }
+
     fn render_chat_prompt(
         &self,
         messages: &[ChatMessage],
@@ -1185,8 +1324,12 @@ impl LlmBackend for LlamaCppBackend {
             // NOT used here: a complete-but-unparseable block suppresses
             // fine but is not a tool call.
             let saw_tool_call_block = filter.saw_tool_call_block();
-            let emitted_tool_calls = suppress_tools
-                && !crate::runtime_adapter::tool_call::parse_tool_calls(&text).is_empty();
+            let parsed_tool_calls = if suppress_tools {
+                crate::runtime_adapter::tool_call::parse_tool_calls(&text)
+            } else {
+                Vec::new()
+            };
+            let emitted_tool_calls = !parsed_tool_calls.is_empty();
             let finish_reason = if emitted_tool_calls {
                 "tool_calls".to_string()
             } else if filter.is_stopped()
@@ -1230,8 +1373,13 @@ impl LlmBackend for LlamaCppBackend {
                 } else {
                     text.clone()
                 };
+                // The terminal token is the streaming caller's typed
+                // handoff: the call blocks were suppressed from the emitted
+                // text on purpose, so parsed calls ride here rather than
+                // forcing the caller to re-parse what it never received.
                 let final_partial = PartialToken::new(String::new(), token_index, final_cumulative)
-                    .with_finish_reason(&finish_reason);
+                    .with_finish_reason(&finish_reason)
+                    .with_tool_calls(parsed_tool_calls, &text);
                 // Terminal errors propagate like every other callback error
                 // (the trait contract, and what mistral already does) — the
                 // typed conversion keeps a CloudFallbackAbort returned here
@@ -1634,8 +1782,12 @@ impl LlmBackend for LlamaCppBackend {
             // token's finish_reason must match what the executor's envelope
             // will report, and a complete-but-unparseable block is not a
             // tool call.
-            let emitted_tool_calls = suppress_tools
-                && !crate::runtime_adapter::tool_call::parse_tool_calls(&text).is_empty();
+            let parsed_tool_calls = if suppress_tools {
+                crate::runtime_adapter::tool_call::parse_tool_calls(&text)
+            } else {
+                Vec::new()
+            };
+            let emitted_tool_calls = !parsed_tool_calls.is_empty();
             let finish_reason = if emitted_tool_calls {
                 "tool_calls".to_string()
             } else if filter_stopped
@@ -1672,8 +1824,13 @@ impl LlmBackend for LlamaCppBackend {
                 } else {
                     text.clone()
                 };
+                // The terminal token is the streaming caller's typed
+                // handoff: the call blocks were suppressed from the emitted
+                // text on purpose, so parsed calls ride here rather than
+                // forcing the caller to re-parse what it never received.
                 let final_partial = PartialToken::new(String::new(), token_index, final_cumulative)
-                    .with_finish_reason(&finish_reason);
+                    .with_finish_reason(&finish_reason)
+                    .with_tool_calls(parsed_tool_calls, &text);
                 // Terminal errors propagate like every other callback error
                 // (the trait contract, and what mistral already does) — the
                 // typed conversion keeps a CloudFallbackAbort returned here

--- a/crates/xybrid-core/src/runtime_adapter/llm.rs
+++ b/crates/xybrid-core/src/runtime_adapter/llm.rs
@@ -104,6 +104,18 @@ fn unsupported_vision_input_error(backend_name: &str) -> AdapterError {
     ))
 }
 
+/// Tool calls to stamp on a terminal streaming token.
+///
+/// Parsing runs only for requests that actually offered tools, mirroring
+/// `build_llm_response_envelope`'s gate — so the terminal token and the
+/// response envelope can never disagree about whether a turn called a tool.
+fn parsed_tool_calls(text: &str, config: &GenerationConfig) -> Vec<crate::gateway::ToolCall> {
+    if config.tools.is_empty() {
+        return Vec::new();
+    }
+    crate::runtime_adapter::tool_call::parse_tool_calls(text)
+}
+
 // =============================================================================
 // Generation Output
 // =============================================================================
@@ -239,14 +251,56 @@ pub trait LlmBackend: Send + Sync {
         // Default implementation: fall back to non-streaming and emit all at once
         let output = self.generate(messages, config)?;
 
-        // Emit the entire output as a single "token"
+        // Emit the entire output as a single "token". This lone token is
+        // also the terminal one, so it carries the turn's parsed tool calls
+        // — the streaming contract is identical whether a backend streams
+        // natively or falls back to here.
         let partial = PartialToken {
             token: output.text.clone(),
             token_id: None,
             index: 0,
             cumulative_text: output.text.clone(),
             finish_reason: Some(output.finish_reason.clone()),
-        };
+            tool_calls: Vec::new(),
+            raw_text: None,
+        }
+        .with_tool_calls(parsed_tool_calls(&output.text, config), &output.text);
+
+        let mut callback = on_token;
+        callback(partial).map_err(AdapterError::from_streaming_callback_error)?;
+
+        Ok(output)
+    }
+
+    /// Generate text from a raw prompt (no chat template) with streaming.
+    ///
+    /// The raw-prompt sibling of [`Self::generate_streaming`], and the seam
+    /// tool-result continuations stream through: a continuation is a
+    /// protocol-faithful raw prompt (see the executor's `tool_continuation`
+    /// module), so it cannot ride the chat path.
+    ///
+    /// # Default Implementation
+    ///
+    /// Falls back to non-streaming [`Self::generate_raw`] and emits the whole
+    /// output as one terminal token. Override for true streaming.
+    fn generate_raw_streaming(
+        &self,
+        prompt: &str,
+        config: &GenerationConfig,
+        on_token: StreamingCallback<'_>,
+    ) -> LlmResult<GenerationOutput> {
+        let output = self.generate_raw(prompt, config)?;
+
+        let partial = PartialToken {
+            token: output.text.clone(),
+            token_id: None,
+            index: 0,
+            cumulative_text: output.text.clone(),
+            finish_reason: Some(output.finish_reason.clone()),
+            tool_calls: Vec::new(),
+            raw_text: None,
+        }
+        .with_tool_calls(parsed_tool_calls(&output.text, config), &output.text);
 
         let mut callback = on_token;
         callback(partial).map_err(AdapterError::from_streaming_callback_error)?;
@@ -915,6 +969,110 @@ mod tests {
         assert_eq!(received_tokens[0].cumulative_text, "Test response");
         assert_eq!(received_tokens[0].finish_reason, Some("stop".to_string()));
         assert!(received_tokens[0].is_final());
+    }
+
+    /// A tools-bearing streaming turn must hand the caller typed calls plus
+    /// the raw turn text on the terminal token — otherwise the loop cannot
+    /// close without re-parsing text the caller never received.
+    #[test]
+    fn default_streaming_stamps_tool_calls_and_raw_text_on_the_terminal_token() {
+        struct ToolEmittingBackend;
+
+        const TURN: &str =
+            "checking<|tool_call_start|>[get_temperature(room=\"kitchen\")]<|tool_call_end|>";
+
+        impl LlmBackend for ToolEmittingBackend {
+            fn name(&self) -> &str {
+                "mock"
+            }
+            fn supported_formats(&self) -> Vec<&'static str> {
+                vec!["test"]
+            }
+            fn load(&mut self, _config: &LlmConfig) -> LlmResult<()> {
+                Ok(())
+            }
+            fn is_loaded(&self) -> bool {
+                true
+            }
+            fn unload(&mut self) -> LlmResult<()> {
+                Ok(())
+            }
+            fn generate(
+                &self,
+                _messages: &[ChatMessage],
+                _config: &GenerationConfig,
+            ) -> LlmResult<GenerationOutput> {
+                Ok(GenerationOutput {
+                    text: TURN.to_string(),
+                    tokens_generated: 8,
+                    generation_time_ms: 50,
+                    tokens_per_second: 40.0,
+                    finish_reason: "stop".to_string(),
+                    ttft_ms: None,
+                    mean_itl_ms: None,
+                    p95_itl_ms: None,
+                    emitted_chunks: None,
+                    inter_chunk_ms: Vec::new(),
+                    decode_tps: None,
+                    prefill_tps: None,
+                    image_preprocess_ms: None,
+                    reasoning_content: None,
+                })
+            }
+            fn generate_raw(
+                &self,
+                prompt: &str,
+                config: &GenerationConfig,
+            ) -> LlmResult<GenerationOutput> {
+                self.generate(&[ChatMessage::user(prompt)], config)
+            }
+        }
+
+        let tools_config = GenerationConfig {
+            tools: vec![crate::gateway::Tool::function(
+                "get_temperature",
+                "Room temperature.",
+                serde_json::json!({"type": "object", "properties": {}}),
+            )],
+            ..Default::default()
+        };
+
+        let mut tokens: Vec<PartialToken> = Vec::new();
+        ToolEmittingBackend
+            .generate_streaming(
+                &[ChatMessage::user("how warm is the kitchen?")],
+                &tools_config,
+                Box::new(|token| {
+                    tokens.push(token);
+                    Ok(())
+                }),
+            )
+            .expect("streaming should succeed");
+
+        let terminal = tokens.last().expect("a terminal token must be emitted");
+        assert_eq!(terminal.tool_calls.len(), 1);
+        assert_eq!(terminal.tool_calls[0].function.name, "get_temperature");
+        assert_eq!(
+            terminal.raw_text.as_deref(),
+            Some(TURN),
+            "the raw turn text is what `Envelope::tool_results` replays"
+        );
+
+        // A tools-off request parses nothing, even when the text happens to
+        // contain markers — same gate as `build_llm_response_envelope`.
+        let mut plain: Vec<PartialToken> = Vec::new();
+        ToolEmittingBackend
+            .generate_streaming(
+                &[ChatMessage::user("hi")],
+                &GenerationConfig::default(),
+                Box::new(|token| {
+                    plain.push(token);
+                    Ok(())
+                }),
+            )
+            .expect("streaming should succeed");
+        assert!(plain.last().unwrap().tool_calls.is_empty());
+        assert!(plain.last().unwrap().raw_text.is_none());
     }
 
     /// Test that callback errors propagate correctly in default streaming

--- a/crates/xybrid-core/src/runtime_adapter/types.rs
+++ b/crates/xybrid-core/src/runtime_adapter/types.rs
@@ -11,7 +11,7 @@
 //! - `GenerationConfig` - Generation parameters for LLM inference
 //! - `LlmConfig` - Configuration for loading a local LLM
 
-use crate::gateway::Tool;
+use crate::gateway::{Tool, ToolCall};
 use crate::ir::MessageRole;
 use crate::{
     conversation::ConversationContext,
@@ -38,8 +38,27 @@ pub struct PartialToken {
     /// Cumulative text generated so far (all tokens concatenated)
     pub cumulative_text: String,
     /// Finish reason if this is the final token, None otherwise.
-    /// Values: "stop" (hit stop sequence/EOS), "length" (hit max_tokens)
+    /// Values: "stop" (hit stop sequence/EOS), "length" (hit max_tokens),
+    /// "tool_calls" (the turn ended on a parseable tool-call block).
     pub finish_reason: Option<String>,
+    /// Tool calls parsed from the completed turn. Only ever populated on the
+    /// **terminal** token (the one carrying `finish_reason`), and only for a
+    /// request that offered tools.
+    ///
+    /// A streaming caller dispatches on this instead of re-parsing the token
+    /// text: the protocol blocks are suppressed from the emitted stream, so
+    /// the raw call text never reaches the callback in the first place.
+    /// Empty on every mid-stream token and on turns that emitted no call.
+    pub tool_calls: Vec<ToolCall>,
+    /// The completed turn's raw output text, tool-call block included —
+    /// exactly what `Envelope::tool_results` wants as `prior_assistant_text`.
+    ///
+    /// `Some` only alongside a non-empty [`Self::tool_calls`], which is the
+    /// only situation it is useful in. It exists because `cumulative_text`
+    /// deliberately reports the *emitted* text (protocol blocks suppressed),
+    /// so without this a streaming caller would have no way to compose the
+    /// continuation turn.
+    pub raw_text: Option<String>,
 }
 
 impl PartialToken {
@@ -51,6 +70,8 @@ impl PartialToken {
             index,
             cumulative_text,
             finish_reason: None,
+            tool_calls: Vec::new(),
+            raw_text: None,
         }
     }
 
@@ -63,6 +84,22 @@ impl PartialToken {
     /// Mark this as the final token with the given finish reason.
     pub fn with_finish_reason(mut self, reason: impl Into<String>) -> Self {
         self.finish_reason = Some(reason.into());
+        self
+    }
+
+    /// Attach the tool calls parsed from the completed turn, plus the raw
+    /// turn text needed to compose the continuation. Terminal tokens only —
+    /// see [`PartialToken::tool_calls`] and [`PartialToken::raw_text`].
+    ///
+    /// A call-free turn is left untouched: `raw_text` is only meaningful next
+    /// to calls, and stamping it unconditionally would put the unsuppressed
+    /// protocol text on every terminal token for no consumer.
+    pub fn with_tool_calls(mut self, calls: Vec<ToolCall>, raw_text: &str) -> Self {
+        if calls.is_empty() {
+            return self;
+        }
+        self.tool_calls = calls;
+        self.raw_text = Some(raw_text.to_string());
         self
     }
 

--- a/crates/xybrid-ffi-facade/src/lib.rs
+++ b/crates/xybrid-ffi-facade/src/lib.rs
@@ -406,8 +406,11 @@ impl Envelope {
     ///
     /// Only the immediately prior assistant turn is replayed: multi-hop
     /// chains work turn by turn, but earlier tool exchanges are not re-sent.
-    /// Continuation runs on the non-streaming text paths only — the
-    /// streaming and image-bearing paths reject these envelopes.
+    /// A continuation runs on every text path — batch, streaming, and both
+    /// conversation-context variants. Image-bearing conversations are the one
+    /// exception and are rejected: a continuation replays prior turns as a
+    /// composed text prompt, and image embeddings cannot be re-evaluated from
+    /// text.
     ///
     /// # Errors
     ///
@@ -1207,7 +1210,25 @@ pub struct StreamToken {
     pub token_id: Option<i64>,
     pub index: u64,
     pub cumulative_text: String,
+    /// `"tool_calls"` when the turn ended on a parseable tool-call block.
     pub finish_reason: Option<String>,
+    /// Tool calls parsed from the completed turn — populated on the
+    /// **terminal** token only (the one carrying `finish_reason`).
+    ///
+    /// A streaming caller halts here and dispatches these instead of parsing
+    /// raw text: the protocol blocks are suppressed from the emitted stream,
+    /// so the call text never reaches the token callback. Empty on every
+    /// mid-stream token and on turns that emitted no call. Feed the outcomes
+    /// back with [`Envelope::tool_results`] and stream the continuation
+    /// through the same call.
+    pub tool_calls: Vec<ToolCall>,
+    /// The completed turn's raw output text, tool-call block included — pass
+    /// it to [`Envelope::tool_results`] as `prior_assistant_text`.
+    ///
+    /// `Some` only alongside a non-empty [`Self::tool_calls`]. It is not the
+    /// same as `cumulative_text`, which reports the *emitted* text with the
+    /// protocol blocks suppressed.
+    pub raw_text: Option<String>,
 }
 
 impl StreamToken {
@@ -1218,6 +1239,12 @@ impl StreamToken {
             index: token.index as u64,
             cumulative_text: token.cumulative_text,
             finish_reason: token.finish_reason,
+            tool_calls: token
+                .tool_calls
+                .into_iter()
+                .map(ToolCall::from_sdk)
+                .collect(),
+            raw_text: token.raw_text,
         }
     }
 }
@@ -2676,6 +2703,63 @@ mod tests {
     }
 
     #[test]
+    fn stream_token_carries_the_terminal_turns_tool_calls() {
+        // The core suppresses tool-call blocks from the emitted stream, so a
+        // streaming caller has nothing to re-parse — the typed calls have to
+        // survive the SDK → facade translation on the terminal token.
+        let token = StreamToken::from_sdk(xybrid_core::runtime_adapter::types::PartialToken {
+            token: String::new(),
+            token_id: None,
+            index: 7,
+            cumulative_text: "checking".into(),
+            finish_reason: Some("tool_calls".into()),
+            raw_text: Some(
+                "checking<|tool_call_start|>[get_temperature(room=\"kitchen\")]<|tool_call_end|>"
+                    .into(),
+            ),
+            tool_calls: vec![xybrid_core::gateway::ToolCall {
+                id: "call_0".into(),
+                tool_type: "function".into(),
+                function: xybrid_core::gateway::FunctionCall {
+                    name: "get_temperature".into(),
+                    arguments: r#"{"room":"kitchen"}"#.into(),
+                },
+            }],
+        });
+
+        assert_eq!(token.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(
+            token.tool_calls,
+            vec![ToolCall {
+                id: "call_0".into(),
+                name: "get_temperature".into(),
+                arguments_json: r#"{"room":"kitchen"}"#.into(),
+            }]
+        );
+        // The raw turn text is what closes the loop: `cumulative_text` has the
+        // protocol block suppressed, so only this can be replayed as
+        // `prior_assistant_text`.
+        assert!(
+            token
+                .raw_text
+                .as_deref()
+                .is_some_and(|raw| raw.contains("<|tool_call_start|>")),
+            "a terminal token with calls must carry the replayable raw text"
+        );
+    }
+
+    #[test]
+    fn a_mid_stream_token_carries_no_tool_calls() {
+        let token = StreamToken::from_sdk(xybrid_core::runtime_adapter::types::PartialToken::new(
+            "hel".into(),
+            0,
+            "hel".into(),
+        ));
+        assert!(token.tool_calls.is_empty());
+        assert!(token.raw_text.is_none());
+    }
+
+    #[test]
     fn tool_calls_are_parsed_off_the_response_envelope() {
         let mut metadata = HashMap::new();
         metadata.insert(
@@ -2779,6 +2863,8 @@ mod tests {
                     index: 0,
                     cumulative_text: "hel".into(),
                     finish_reason: None,
+                    tool_calls: Vec::new(),
+                    raw_text: None,
                 }))
                 .expect("test stream receiver should remain connected");
             sender
@@ -2788,6 +2874,8 @@ mod tests {
                     index: 1,
                     cumulative_text: "hello".into(),
                     finish_reason: Some("stop".into()),
+                    tool_calls: Vec::new(),
+                    raw_text: None,
                 }))
                 .expect("test stream receiver should remain connected");
             sender

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -49,8 +49,23 @@ pub struct StreamToken {
     pub index: usize,
     /// All text generated so far (cumulative)
     pub cumulative_text: String,
-    /// Reason for stopping (only set on the final token)
+    /// Reason for stopping (only set on the final token). `"tool_calls"` when
+    /// the turn ended on a parseable tool-call block.
     pub finish_reason: Option<String>,
+    /// Tool calls parsed from the completed turn, on the **terminal** token
+    /// only (see [`xybrid_core::runtime_adapter::types::PartialToken::tool_calls`]).
+    ///
+    /// A streaming caller dispatches on this instead of parsing raw text:
+    /// tool-call blocks are suppressed from the emitted stream, so they never
+    /// reach the callback. Empty on mid-stream tokens and on turns that
+    /// emitted no call.
+    pub tool_calls: Vec<xybrid_core::gateway::ToolCall>,
+    /// The completed turn's raw output text, tool-call block included —
+    /// exactly what `Envelope::tool_results` wants as `prior_assistant_text`.
+    /// `Some` only alongside a non-empty [`Self::tool_calls`], because
+    /// `cumulative_text` reports the *emitted* text with protocol blocks
+    /// suppressed. This is what makes the streaming tool loop closable.
+    pub raw_text: Option<String>,
 }
 
 /// Events emitted during streaming inference.
@@ -3497,6 +3512,9 @@ impl XybridModel {
                     index: 0,
                     cumulative_text: text.clone(),
                     finish_reason: Some("stop".to_string()),
+                    // Non-LLM template: tool calling is an LLM feature.
+                    tool_calls: Vec::new(),
+                    raw_text: None,
                 };
                 on_token(token).map_err(streaming_callback_error)?;
             }
@@ -3705,6 +3723,9 @@ impl XybridModel {
                     index: 0,
                     cumulative_text: text.clone(),
                     finish_reason: Some("stop".to_string()),
+                    // Non-LLM template: tool calling is an LLM feature.
+                    tool_calls: Vec::new(),
+                    raw_text: None,
                 };
                 on_token(token).map_err(streaming_callback_error)?;
             }
@@ -4096,6 +4117,8 @@ impl XybridModel {
                                 index: token.index,
                                 cumulative_text: token.cumulative_text.clone(),
                                 finish_reason: token.finish_reason.clone(),
+                                tool_calls: token.tool_calls.clone(),
+                                raw_text: token.raw_text.clone(),
                             }));
                             Ok(())
                         },
@@ -4136,6 +4159,8 @@ impl XybridModel {
                                     index: token.index,
                                     cumulative_text: token.cumulative_text.clone(),
                                     finish_reason: token.finish_reason.clone(),
+                                    tool_calls: token.tool_calls.clone(),
+                                    raw_text: token.raw_text.clone(),
                                 };
                                 // Ignore send errors (receiver dropped)
                                 let _ =
@@ -4162,6 +4187,9 @@ impl XybridModel {
                             index: 0,
                             cumulative_text: text.clone(),
                             finish_reason: Some("stop".to_string()),
+                            // Non-LLM template: tool calling is an LLM feature.
+                            tool_calls: Vec::new(),
+                            raw_text: None,
                         };
                         let _ = tx.blocking_send(StreamEvent::Token(stream_token));
                     }
@@ -5391,6 +5419,8 @@ mod tests {
                 index: 0,
                 cumulative_text: self.response_text.clone(),
                 finish_reason: Some("stop".to_string()),
+                tool_calls: Vec::new(),
+                raw_text: None,
             };
             on_token(token).map_err(|e| {
                 xybrid_core::runtime_adapter::AdapterError::InferenceFailed(format!("{}", e))

--- a/crates/xybrid-sdk/tests/cloud_fallback_e2e.rs
+++ b/crates/xybrid-sdk/tests/cloud_fallback_e2e.rs
@@ -95,6 +95,8 @@ impl CloudStreaming for RecordingCloud {
             index: 0,
             cumulative_text: self.response.clone(),
             finish_reason: Some("stop".to_string()),
+            tool_calls: Vec::new(),
+            raw_text: None,
         };
         on_token(token).map_err(|e| AdapterError::InferenceFailed(format!("{}", e)))?;
         self.tokens_emitted.fetch_add(1, Ordering::SeqCst);

--- a/docs/content/docs/guides/tool-calling.mdx
+++ b/docs/content/docs/guides/tool-calling.mdx
@@ -24,8 +24,16 @@ what a tool does, only its declaration and its JSON result.
 Tool calling runs on the local llama.cpp backend. Paths that cannot honor a
 tool-bearing request fail closed with an invalid-input error instead of
 silently generating without the tools: models without an embedded chat
-template, the mistralrs backend, streaming continuations,
-conversation-context continuations, and the SDK's cloud-fallback leg.
+template, the mistralrs backend, and the SDK's cloud-fallback leg.
+
+Streaming and conversation context are **not** in that list. A tools-bearing
+run streams, and a `tool_results` continuation runs on every text path —
+batch, streaming, and both conversation-context variants — so a streaming chat
+screen keeps its history and its token-by-token output. The one shape that
+stays closed is an **image-bearing conversation**: a continuation replays the
+prior turns as a composed text prompt, and image embeddings cannot be
+re-evaluated from text. That is a property of the replay mechanism, not an
+unfinished path.
 </Callout>
 
 ## Supported Models
@@ -121,14 +129,87 @@ cargo run -p xybrid-core --example functiongemma_tools --features llm-llamacpp
   immediately prior assistant turn — for multi-hop chains, fold earlier
   results into the user text you pass to `tool_results` (the examples show
   the pattern).
-- **Continuations are non-streaming and context-free.** A `tool_results`
-  envelope on a streaming or conversation-context path is rejected as
-  invalid input. The tools-*offering* turn may stream — tool-call blocks are
-  suppressed from the token stream and the terminal token carries
-  `finish_reason: "tool_calls"`.
+- **Streaming halts at the call boundary.** A tools-bearing streaming run
+  suppresses tool-call blocks from the token stream, and the terminal token
+  carries `finish_reason: "tool_calls"`, the parsed calls
+  (`PartialToken::tool_calls`), and the raw turn text to replay
+  (`PartialToken::raw_text`) — all surfaced on every binding's stream token,
+  so a streaming caller never parses raw text.
+- **Continuations stream, and they keep context.** Feed the `tool_results`
+  envelope back through the same call you started with, streaming or not,
+  with or without a `ConversationContext`. Only image-bearing conversations
+  are refused (see the callout above).
+- **Push to history after the loop, not between turns.** A continuation
+  envelope replays the user turn itself, so pushing it to the context first
+  duplicates it in the prompt. Commit the user message and the final answer
+  once the loop settles. Reference loop:
+  [`crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs`](https://github.com/xybrid-ai/xybrid/blob/master/crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs).
 - **Budget your turns.** Small models can search forever without settling;
   cap the loop and force a tools-off synthesis turn from your accumulated
   notes when the budget runs out.
+
+## Streaming Chat With Tools
+
+A chat UI wants both: tokens as they arrive, and history across turns. The
+loop is the same three steps as above, run through
+`runStreamingWithContext` — the model streams its answer, halts at the call
+boundary, and the continuation streams too:
+
+```dart
+Stream<StreamToken> turn(XybridEnvelope input) =>
+    model.runStreamingWithContext(input, context,
+        config: GenerationConfig.greedy(tools: tools));
+
+var input = XybridEnvelope.text(userText);
+var prior = '';
+
+for (var step = 0; step < maxSteps; step++) {
+  List<ToolCall> calls = const [];
+
+  await for (final token in turn(input)) {
+    buffer.write(token.token);          // paint tokens as they arrive
+    if (token.hasToolCalls) {
+      calls = token.toolCalls;          // typed, already parsed
+      prior = token.rawText!;           // the turn text to replay
+    }
+  }
+
+  if (calls.isEmpty) break;             // the model answered; done
+
+  input = XybridEnvelope.toolResults(
+    userText: userText,
+    priorAssistantText: prior,
+    results: [
+      for (final call in calls)
+        ToolResult(
+          callId: call.id,
+          name: call.name,
+          contentJson: await runMyTool(call.name, call.argumentsJson),
+        ),
+    ],
+  );
+}
+```
+
+Push to the context **once the exchange settles**, not between turns: the
+`tool_results` envelope replays `userText` itself, so a mid-loop push puts the
+question in the prompt twice.
+
+Three things make this work without any parsing on your side:
+
+- Tool-call blocks are **suppressed from the token stream**, so `token.token`
+  is always display text. The calls arrive typed on the terminal token
+  instead.
+- `rawText` on that same token is the turn's raw output *including* the
+  tool-call block — the streaming equivalent of `XybridResult.text`, and what
+  `priorAssistantText` needs. Don't use `cumulativeText`: that is what your UI
+  painted, with the blocks suppressed.
+- The `tool_results` envelope goes back through the **same** call, so the
+  continuation keeps the conversation context and keeps streaming.
+
+Swift, Kotlin, Python, and Unity C# expose the same trio on their stream
+token — `toolCalls`, `rawText`, `finishReason` — and feed the continuation
+back through the same streaming call.
 
 ## Tool Calling in the CLI (`xybrid repl`)
 

--- a/docs/content/docs/guides/tool-calling.zh.mdx
+++ b/docs/content/docs/guides/tool-calling.zh.mdx
@@ -21,7 +21,13 @@ Xybrid 的设计准则是**能力是数据，而非入口点**。工具端到端
 <Callout type="info">
 工具调用运行在本地 llama.cpp 后端上。无法处理带工具请求的路径会以“无效输入”
 错误保守失败（fail closed），而不是在没有工具的情况下静默生成：没有内嵌聊天
-模板的模型、`mistralrs` 后端、流式续接、对话上下文续接，以及 SDK 的云端回退分支。
+模板的模型、`mistralrs` 后端，以及 SDK 的云端回退分支。
+
+流式与对话上下文**不在**该列表中。带工具的运行可以流式输出，`tool_results`
+续接可在任意文本路径上运行——批量、流式，以及两种对话上下文变体——因此流式
+聊天界面既能保留历史，也能保留逐 token 输出。唯一仍然关闭的形态是**包含图像
+的对话**：续接会将先前轮次回放为一段组合出的文本提示，而图像 embedding 无法
+从文本重新计算。这是回放机制本身的性质，而不是尚未完成的路径。
 </Callout>
 
 ## 支持的模型
@@ -107,9 +113,18 @@ println!("{}", final_turn.text().unwrap_or_default());
 - **一次 `run` 就是一个模型轮次。** 续接只回放紧邻的上一个助手轮次——对于
   多跳链，请将更早的结果折叠进你传给 `tool_results` 的用户文本中（示例展示了
   这一模式）。
-- **续接为非流式且无上下文。** 在流式或对话上下文路径上使用 `tool_results`
-  Envelope 会被作为无效输入拒绝。*提供*工具的那一轮次可以流式——工具调用块会
-  从 token 流中被抑制，且终止 token 携带 `finish_reason: "tool_calls"`。
+- **流式会在工具调用边界处停下。** 带工具的流式运行会从 token 流中抑制工具
+  调用块，终止 token 同时携带 `finish_reason: "tool_calls"`、已解析出的调用
+  （`PartialToken::tool_calls`），以及用于回放的原始轮次文本
+  （`PartialToken::raw_text`）——三者在各语言绑定的 stream token 上均有暴露，
+  因此流式调用方完全无需解析原始文本。
+- **续接可以流式，也能保留上下文。** 把 `tool_results` Envelope 通过你最初
+  使用的同一个方法送回去即可，无论是否流式、是否带 `ConversationContext`。
+  仅包含图像的对话会被拒绝（见上方提示框）。
+- **在循环结束后再写入历史，而不是在轮次之间。** 续接 Envelope 自身会回放
+  该用户轮次，因此提前把它 push 进上下文会让问题在提示中出现两次。等循环
+  收敛后，再一次性提交用户消息与最终答案。参考循环见
+  [`crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs`](https://github.com/xybrid-ai/xybrid/blob/master/crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs)。
 - **为你的轮次设定预算。** 小模型可能会无休止地搜索而始终无法收敛；请限制
   循环次数，并在预算耗尽时，强制基于你已累积的笔记进行一次关闭工具的总结轮次。
 

--- a/docs/content/docs/guides/tool-calling.zh.mdx
+++ b/docs/content/docs/guides/tool-calling.zh.mdx
@@ -128,6 +128,64 @@ println!("{}", final_turn.text().unwrap_or_default());
 - **为你的轮次设定预算。** 小模型可能会无休止地搜索而始终无法收敛；请限制
   循环次数，并在预算耗尽时，强制基于你已累积的笔记进行一次关闭工具的总结轮次。
 
+## 带工具的流式聊天
+
+聊天界面同时需要两件事：token 逐个到达，以及跨轮次的历史。循环仍是上面那
+三步，只是走 `runStreamingWithContext`——模型流式输出回答，在工具调用边界
+处停下，续接同样是流式的：
+
+```dart
+Stream<StreamToken> turn(XybridEnvelope input) =>
+    model.runStreamingWithContext(input, context,
+        config: GenerationConfig.greedy(tools: tools));
+
+var input = XybridEnvelope.text(userText);
+var prior = '';
+
+for (var step = 0; step < maxSteps; step++) {
+  List<ToolCall> calls = const [];
+
+  await for (final token in turn(input)) {
+    buffer.write(token.token);          // token 到达即渲染
+    if (token.hasToolCalls) {
+      calls = token.toolCalls;          // 带类型，已解析
+      prior = token.rawText!;           // 待回放的轮次文本
+    }
+  }
+
+  if (calls.isEmpty) break;             // 模型已作答，结束
+
+  input = XybridEnvelope.toolResults(
+    userText: userText,
+    priorAssistantText: prior,
+    results: [
+      for (final call in calls)
+        ToolResult(
+          callId: call.id,
+          name: call.name,
+          contentJson: await runMyTool(call.name, call.argumentsJson),
+        ),
+    ],
+  );
+}
+```
+
+请在**这一轮交流收敛之后**再写入上下文，而不是在轮次之间：`tool_results`
+Envelope 自身会回放 `userText`，因此循环中途的 push 会让问题在提示中出现两次。
+
+有三点让这套流程无需你解析任何文本：
+
+- 工具调用块会**从 token 流中被抑制**，所以 `token.token` 始终是可展示的
+  文本；调用则以带类型的形式出现在终止 token 上。
+- 同一个 token 上的 `rawText` 是该轮次**包含**工具调用块的原始输出——相当于
+  流式版的 `XybridResult.text`，也正是 `priorAssistantText` 所需要的。不要用
+  `cumulativeText`：那是你的界面已经渲染出来的内容，其中的块已被抑制。
+- `tool_results` Envelope 通过**同一个**方法送回，因此续接既保留对话上下文，
+  也继续保持流式。
+
+Swift、Kotlin、Python 与 Unity C# 在各自的 stream token 上暴露同样的三件套
+——`toolCalls`、`rawText`、`finishReason`——并同样通过原来的流式方法送回续接。
+
 ## 在 CLI 中进行工具调用（`xybrid repl`）
 
 REPL 提供了参考体验。对于元数据声明了 `tool_calling: true` 的模型，有三个内置

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -348,8 +348,9 @@ classes:
         status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
       toolResults:
         # The continuation turn after the model asked for tools. Only the
-        # immediately prior assistant turn is replayed, and continuation runs
-        # on the non-streaming text path only.
+        # immediately prior assistant turn is replayed. A continuation runs on
+        # every text path — batch, streaming, and both conversation-context
+        # variants; image-bearing conversations are rejected.
         params:
           - { name: userText, type: String }
           - { name: priorAssistantText, type: String }
@@ -668,6 +669,22 @@ classes:
     type: data
     section: "8. Supporting Types"
     status: { dart: implemented, kotlin: planned, swift: planned, csharp: implemented }
+    properties:
+      toolCalls:
+        type: "List<ToolCall>"
+        # Tool calls the model emitted, on the terminal token only. Tool-call
+        # blocks are suppressed from the streamed text, so a streaming caller
+        # dispatches these rather than parsing token text.
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
+        since: "0.7.0"
+      rawText:
+        type: "String?"
+        # The completed turn's raw output text, tool-call block included —
+        # what the tool-results envelope needs as priorAssistantText. Set only
+        # alongside a non-empty toolCalls; NOT the same as cumulativeText,
+        # which is the emitted (block-suppressed) text.
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
+        since: "0.7.0"
 
   # -------------------------------------------------------------------
   # 9. Configuration Types


### PR DESCRIPTION
## Summary

This pull request makes tool calling usable from a real chat UI. Until now the only supported shape was `run()` → execute → `run()` with a `tool_results` envelope, so adopting tool calling meant giving up streaming, conversation history, or both — in a Flutter chat screen built on `runStreamingWithContext` there was no way to add tools without rewriting the screen around a non-streaming, self-managed-history path. Streaming runs now halt at the tool-call boundary and hand back typed calls, and `tool_results` continuations compose on every text path instead of being rejected. Verified end-to-end against real models on both protocol families (FunctionGemma-270M and LFM2.5-230M).

**Streaming reports tool calls:**

* The terminal stream token now carries `finish_reason: "tool_calls"`, the parsed `tool_calls`, and `raw_text` — no text parsing on the caller's side, since call blocks were already suppressed from the token feed.
* `raw_text` is what closes the loop. `cumulative_text` is deliberately the *emitted* text with protocol blocks suppressed, so replaying it as `prior_assistant_text` fails ("prior assistant text must contain tool calls"). It is set only alongside a non-empty `tool_calls`.
* Crosses SDK → facade → BoltFFI (Swift, Kotlin, Python, Unity C#) and FRB → Dart. All generated bindings regenerated with the pinned generators (boltffi 0.29.3, flutter_rust_bridge 2.11.1).

**Continuations run on every text path:**

* `execute_with_context`, `execute_streaming`, `execute_streaming_with_context` and the text-only vision-language variants compose the continuation rather than returning `InvalidInput`.
* Backed by a new `LlmBackend::generate_raw_streaming` (llama.cpp implementation plus a trait default), since a continuation is a raw prompt and cannot ride the chat path.
* `reject_tool_continuation_input` is removed. Nested `MultiPart` continuations still fail loudly — the multimodal conversion drops part metadata, so they would silently lose their tool results.

**Fail-closed behaviour restated as a decision:**

* The one remaining closed shape is an image-bearing conversation: a continuation replays prior turns as a composed *text* prompt, and image embeddings cannot be re-evaluated from text. The error message, both language guides and every binding doc now say that instead of reading like an oversight.

**Bug fix found while wiring Dart:**

* `runStreamingWithContext` yields both the native terminal token and the `Complete` event. With tool calls riding both, a `hasToolCalls` loop would have executed every tool twice. Calls are now delivered exactly once across that pair; metrics still arrive on the completion token.

**Tests and docs:**

* New reference loop `crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs`, core unit tests for the continuation and terminal-token contracts, facade/bolt translation tests, and Dart `StreamToken` tests.
* Tool-calling guide gains a "Streaming Chat With Tools" walkthrough in both English and Chinese; `StreamToken.toolCalls` / `rawText` registered in `docs/sdk/api-surface.yaml`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [ ] No breaking changes (or breaking changes documented)

**Breaking change, documented:** `PartialToken` (core) and `StreamToken` (SDK, facade, bolt, FRB) each gain two public fields, so external code constructing them with a struct literal must add `tool_calls` and `raw_text`. Everything built through `PartialToken::new()` and the binding constructors is unaffected, and Dart's `StreamToken` gained optional named parameters with defaults. `LlmBackend::generate_raw_streaming` has a default implementation, so existing backends compile unchanged.

## Verification

`cargo fmt --check`, workspace tests, the `test-llm` job (1184 pass), all three feature-matrix checks, Unity netstandard2.1 compile, `dart analyze`, `flutter test` (30 pass), `gen_python_bolt.py --check`, and the API contract check (unchanged from baseline).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM streaming and continuation routing across the executor and all bindings; regressions could mis-handle tool turns or break stream consumers, though image continuations still fail closed and coverage was expanded.
> 
> **Overview**
> **Streaming chat can complete a tool loop without parsing protocol text.** When a tools-bearing stream ends on a tool-call block, the **terminal** token now exposes `finish_reason: "tool_calls"`, typed `tool_calls`, and `raw_text` (full assistant output *with* the protocol block for `priorAssistantText`). Mid-stream tokens stay empty; call blocks remain suppressed from the visible token feed. The same fields are wired through Rust/SDK, BoltFFI (Swift, Kotlin, Python, Unity), and Flutter/Dart.
> 
> **`tool_results` continuations are no longer limited to batch, non-context runs.** `execute_with_context`, `execute_streaming`, and `execute_streaming_with_context` (plus text-only vision-language variants) compose continuations via shared `ToolContinuation` plumbing and **`LlmBackend::generate_raw_streaming`** (implemented in llama.cpp with a trait default). The old blanket rejection (`reject_tool_continuation_input`) is removed; nested continuation metadata inside `MultiPart` parts still fails loudly.
> 
> **Image-bearing conversations remain the only closed continuation shape** — replay is text-composed, so embeddings cannot be re-evaluated. Docs, guides, and binding comments now describe that as intentional.
> 
> **Dart `runStreamingWithContext`** delivers tool calls **once** across the native terminal token and the completion token so `hasToolCalls` loops do not double-execute tools.
> 
> **Breaking:** `PartialToken` / `StreamToken` (and generated bindings) add required `tool_calls` and `raw_text` where struct literals are used; constructors and defaults cover typical callers. Changelog, `functiongemma_tools_streaming_context` example, and tests document the streaming+context reference loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd910d845c9b9c80a5e7864ae973ea3cd1322ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->