### PR TITLE
ci: compile the llm-llamacpp examples in clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,8 +304,15 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ubuntu-clippy-llm
+      # `--all-targets` is what compiles the examples. Without it the
+      # llm-llamacpp examples (the tool-calling reference loops) are checked by
+      # nobody: the plain `clippy` job passes --all-targets but not the feature,
+      # so cargo skips them on `required-features`, and this job had the feature
+      # but not the flag. That gap is how examples rot into a "fix examples that
+      # do not compile" PR. Clippy stops at .rmeta, so there is no link step and
+      # none of the disk pressure that made the test job skip examples.
       - name: Clippy with llm-llamacpp
-        run: cargo clippy -p xybrid-core --features "ort-download,llm-llamacpp" -- -D warnings
+        run: cargo clippy -p xybrid-core --features "ort-download,llm-llamacpp" --all-targets -- -D warnings
 
   test-llm:
     name: test (llm-llamacpp, ubuntu-latest)


### PR DESCRIPTION
## Summary

The `llm-llamacpp` tool-calling examples were not compiled by CI. The plain `clippy` job runs `--all-targets` without the feature, so Cargo skips examples that declare `required-features`. `clippy-llm` enables the feature but previously linted only the library.

Add `--all-targets` to `clippy-llm`. It now type-checks the `functiongemma_tools`, `functiongemma_tools_streaming_context`, `lfm2_230m_tools`, and `gemma4_e2b_tools` reference loops on relevant PRs. The inline comment records why both the feature and `--all-targets` are required.

Clippy stops at `.rmeta`, so this adds no link step. The test job continues to exclude examples because linking them exhausts runner disk.

## Verification

`cargo clippy -p xybrid-core --features "ort-download,llm-llamacpp" --all-targets -- -D warnings`
