### PR TITLE
fix(cloud): carry GenerationConfig across the local to cloud fallback seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reach the cloud leg. Metadata already on the envelope still wins: it targets
   the cloud leg specifically, while `GenerationConfig` describes the run in
   general.
+- **Stop sequences survive the metadata bridge.** `stop_sequences` crosses the
+  envelope as a JSON array now, not a comma-delimited string. The old encoding
+  corrupted the most common values there are: `"\n\n"` trimmed away to empty
+  and was dropped, so a run that should have stopped at a blank line continued
+  to `max_tokens`; `"\nUser:"` arrived as `"User:"`; anything containing a
+  comma was split in two. The local leg kept the caller's exact values, so the
+  two legs stopped on different text. Local and cloud now share one encoder and
+  one parser; hand-written comma-separated metadata is still read.
 - **`top_p` and `stop_sequences` reach cloud at all.** `CloudRuntimeAdapter`
   never read either from metadata, so both were dropped on *every* cloud path
   — speculative serving included — even though the gateway request body has
-  always serialised them. `stop_sequences` uses the same comma-separated
-  encoding the local path already reads.
+  always serialised them.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LlmBackend::generate_raw_streaming`. Reference loop:
   `crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs`.
 
+### Fixed
+
+- **Cloud fallback no longer discards the caller's `GenerationConfig`.**
+  `run_streaming_with_fallback` handed the cloud adapter the untouched
+  envelope, and that adapter reads its request settings from envelope metadata
+  alone — so `max_tokens`, `temperature`, `top_p`, and `stop_sequences` were
+  dropped and the gateway answered with its own defaults. The run still
+  succeeded with plausible output, so nothing signalled the loss. All four now
+  reach the cloud leg. Metadata already on the envelope still wins: it targets
+  the cloud leg specifically, while `GenerationConfig` describes the run in
+  general.
+- **`top_p` and `stop_sequences` reach cloud at all.** `CloudRuntimeAdapter`
+  never read either from metadata, so both were dropped on *every* cloud path
+  — speculative serving included — even though the gateway request body has
+  always serialised them. `stop_sequences` uses the same comma-separated
+  encoding the local path already reads.
+
 ### Changed
 
 - The only tool-continuation shape that still fails closed is an

--- a/crates/xybrid-core/src/cloud/completion.rs
+++ b/crates/xybrid-core/src/cloud/completion.rs
@@ -181,6 +181,12 @@ impl CompletionRequest {
         self
     }
 
+    /// Set top-p (nucleus) sampling.
+    pub fn with_top_p(mut self, top_p: f32) -> Self {
+        self.top_p = Some(top_p);
+        self
+    }
+
     /// Set stop sequences.
     pub fn with_stop(mut self, stop: Vec<String>) -> Self {
         self.stop = Some(stop);

--- a/crates/xybrid-core/src/execution/strategies/llm.rs
+++ b/crates/xybrid-core/src/execution/strategies/llm.rs
@@ -15,6 +15,7 @@ use crate::execution::types::ExecutorResult;
 use crate::gateway::Tool;
 use crate::runtime_adapter::AdapterError;
 use crate::runtime_adapter::MultimodalChatMessage;
+use crate::runtime_adapter::{parse_stop_sequences, STOP_SEQUENCES_METADATA_KEY};
 
 // ============================================================================
 // LLM Inference Trait (for mockability)
@@ -183,7 +184,7 @@ impl LlmGenerationParams {
     /// - `top_p`: Nucleus sampling threshold
     /// - `top_k`: Top-k sampling
     /// - `system_prompt`: System prompt text
-    /// - `stop_sequences`: Comma-separated list of stop sequences
+    /// - `stop_sequences`: Stop sequences — see [`parse_stop_sequences`]
     /// - `model_id`: Used to auto-detect stop sequences if not explicitly provided
     pub fn from_envelope_metadata(metadata: &std::collections::HashMap<String, String>) -> Self {
         let mut params = Self::default();
@@ -204,13 +205,8 @@ impl LlmGenerationParams {
             params.system_prompt = Some(val.clone());
         }
 
-        // Parse stop sequences from comma-separated string
-        if let Some(val) = metadata.get("stop_sequences") {
-            params.stop_sequences = val
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
+        if let Some(val) = metadata.get(STOP_SEQUENCES_METADATA_KEY) {
+            params.stop_sequences = parse_stop_sequences(val);
         }
 
         params

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -32,6 +32,36 @@ use serde_json::json;
 use std::io::{BufRead, BufReader};
 use std::time::{Duration, Instant};
 
+/// Envelope-metadata key carrying stop sequences.
+///
+/// The metadata map is `String`-valued, so a list needs an encoding: this one
+/// is comma-separated, matching what
+/// `LlmGenerationParams::from_envelope_metadata` already reads on the local
+/// path. One envelope therefore yields the same stop list either side of the
+/// local/cloud seam.
+pub const STOP_SEQUENCES_METADATA_KEY: &str = "stop_sequences";
+
+/// Split a comma-separated `stop_sequences` metadata value, trimming each
+/// entry and dropping empties.
+///
+/// A stop sequence containing a comma cannot be expressed. That is a
+/// pre-existing limit of the `String`-valued metadata channel — the local path
+/// has it too — not something the cloud leg introduces.
+pub fn parse_stop_sequences(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Encode stop sequences for [`STOP_SEQUENCES_METADATA_KEY`]. Inverse of
+/// [`parse_stop_sequences`] for any sequence free of commas and edge
+/// whitespace.
+pub fn encode_stop_sequences(stop_sequences: &[String]) -> String {
+    stop_sequences.join(",")
+}
+
 /// Cloud runtime adapter for third-party LLM API integrations.
 ///
 /// This adapter handles cloud-based inference through providers like OpenAI,
@@ -188,6 +218,21 @@ impl CloudRuntimeAdapter {
         if let Some(max_str) = envelope.metadata.get("max_tokens") {
             if let Ok(max) = max_str.parse::<u32>() {
                 request = request.with_max_tokens(max);
+            }
+        }
+
+        // Top-p (nucleus) sampling
+        if let Some(top_p_str) = envelope.metadata.get("top_p") {
+            if let Ok(top_p) = top_p_str.parse::<f32>() {
+                request = request.with_top_p(top_p);
+            }
+        }
+
+        // Stop sequences
+        if let Some(stop_str) = envelope.metadata.get(STOP_SEQUENCES_METADATA_KEY) {
+            let stop = parse_stop_sequences(stop_str);
+            if !stop.is_empty() {
+                request = request.with_stop(stop);
             }
         }
 
@@ -676,6 +721,78 @@ mod tests {
 
         let result = adapter.execute(&input);
         assert!(matches!(result, Err(AdapterError::InvalidInput(_))));
+    }
+
+    /// The adapter reads every request setting off envelope metadata, so a key
+    /// it ignores is a caller value silently dropped. `top_p` and
+    /// `stop_sequences` were ignored even though `gateway_chat_body` already
+    /// serialises both.
+    #[test]
+    fn build_request_reads_top_p_and_stop_sequences_from_metadata() {
+        let adapter = CloudRuntimeAdapter::new();
+        let mut input = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+        input
+            .metadata
+            .insert("top_p".to_string(), "0.72".to_string());
+        input.metadata.insert(
+            STOP_SEQUENCES_METADATA_KEY.to_string(),
+            "STOP,END".to_string(),
+        );
+
+        let request = adapter.build_request("hello", &input);
+
+        assert!((request.top_p.unwrap() - 0.72).abs() < 1e-6);
+        assert_eq!(
+            request.stop.as_deref(),
+            Some(["STOP".to_string(), "END".to_string()].as_slice())
+        );
+    }
+
+    /// The cloud leg reads the same encoding the local path writes, so a
+    /// hand-written `" STOP , END "` behaves identically on both sides.
+    #[test]
+    fn stop_sequences_round_trip_through_the_metadata_encoding() {
+        let stop = vec!["STOP".to_string(), "END".to_string()];
+        assert_eq!(parse_stop_sequences(&encode_stop_sequences(&stop)), stop);
+        assert_eq!(parse_stop_sequences(" STOP , END "), stop);
+    }
+
+    /// An empty value must not become `"stop": []` on the wire.
+    #[test]
+    fn build_request_omits_an_empty_stop_list() {
+        let adapter = CloudRuntimeAdapter::new();
+        let mut input = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+        input
+            .metadata
+            .insert(STOP_SEQUENCES_METADATA_KEY.to_string(), String::new());
+
+        let request = adapter.build_request("hello", &input);
+
+        assert!(request.stop.is_none());
+    }
+
+    /// End to end through the body serialiser: metadata in, wire fields out.
+    #[test]
+    fn gateway_chat_body_carries_top_p_and_stop_from_metadata() {
+        let adapter = CloudRuntimeAdapter::new();
+        let config = CloudConfig::gateway();
+        let mut input = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+        input
+            .metadata
+            .insert("model".to_string(), "lfm2.5-350m".to_string());
+        input
+            .metadata
+            .insert("top_p".to_string(), "0.72".to_string());
+        input.metadata.insert(
+            STOP_SEQUENCES_METADATA_KEY.to_string(),
+            "STOP,END".to_string(),
+        );
+
+        let request = adapter.build_request("hello", &input);
+        let body = gateway_chat_body(&request, &config, false).expect("model is set");
+
+        assert!((body["top_p"].as_f64().unwrap() - 0.72).abs() < 1e-6);
+        assert_eq!(body["stop"], json!(["STOP", "END"]));
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -25,42 +25,14 @@ use crate::cloud::{
 use crate::gateway::ChatCompletionChunk;
 use crate::ir::{Envelope, EnvelopeKind};
 use crate::pipeline::IntegrationProvider;
-use crate::runtime_adapter::types::{PartialToken, StreamingCallback};
+use crate::runtime_adapter::types::{
+    parse_stop_sequences, PartialToken, StreamingCallback, STOP_SEQUENCES_METADATA_KEY,
+};
 use crate::runtime_adapter::{AdapterError, AdapterResult, RuntimeAdapter};
 use crate::tracing as trace;
 use serde_json::json;
 use std::io::{BufRead, BufReader};
 use std::time::{Duration, Instant};
-
-/// Envelope-metadata key carrying stop sequences.
-///
-/// The metadata map is `String`-valued, so a list needs an encoding: this one
-/// is comma-separated, matching what
-/// `LlmGenerationParams::from_envelope_metadata` already reads on the local
-/// path. One envelope therefore yields the same stop list either side of the
-/// local/cloud seam.
-pub const STOP_SEQUENCES_METADATA_KEY: &str = "stop_sequences";
-
-/// Split a comma-separated `stop_sequences` metadata value, trimming each
-/// entry and dropping empties.
-///
-/// A stop sequence containing a comma cannot be expressed. That is a
-/// pre-existing limit of the `String`-valued metadata channel — the local path
-/// has it too — not something the cloud leg introduces.
-pub fn parse_stop_sequences(value: &str) -> Vec<String> {
-    value
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
-}
-
-/// Encode stop sequences for [`STOP_SEQUENCES_METADATA_KEY`]. Inverse of
-/// [`parse_stop_sequences`] for any sequence free of commas and edge
-/// whitespace.
-pub fn encode_stop_sequences(stop_sequences: &[String]) -> String {
-    stop_sequences.join(",")
-}
 
 /// Cloud runtime adapter for third-party LLM API integrations.
 ///
@@ -736,7 +708,7 @@ mod tests {
             .insert("top_p".to_string(), "0.72".to_string());
         input.metadata.insert(
             STOP_SEQUENCES_METADATA_KEY.to_string(),
-            "STOP,END".to_string(),
+            r#"["STOP","END"]"#.to_string(),
         );
 
         let request = adapter.build_request("hello", &input);
@@ -746,15 +718,6 @@ mod tests {
             request.stop.as_deref(),
             Some(["STOP".to_string(), "END".to_string()].as_slice())
         );
-    }
-
-    /// The cloud leg reads the same encoding the local path writes, so a
-    /// hand-written `" STOP , END "` behaves identically on both sides.
-    #[test]
-    fn stop_sequences_round_trip_through_the_metadata_encoding() {
-        let stop = vec!["STOP".to_string(), "END".to_string()];
-        assert_eq!(parse_stop_sequences(&encode_stop_sequences(&stop)), stop);
-        assert_eq!(parse_stop_sequences(" STOP , END "), stop);
     }
 
     /// An empty value must not become `"stop": []` on the wire.
@@ -785,7 +748,7 @@ mod tests {
             .insert("top_p".to_string(), "0.72".to_string());
         input.metadata.insert(
             STOP_SEQUENCES_METADATA_KEY.to_string(),
-            "STOP,END".to_string(),
+            r#"["STOP","END"]"#.to_string(),
         );
 
         let request = adapter.build_request("hello", &input);

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -112,7 +112,10 @@ pub mod llama_cpp;
 pub mod whisper_cpp;
 
 // Re-exports from runtime backends
-pub use cloud::{CloudRuntimeAdapter, CloudStreaming};
+pub use cloud::{
+    encode_stop_sequences, parse_stop_sequences, CloudRuntimeAdapter, CloudStreaming,
+    STOP_SEQUENCES_METADATA_KEY,
+};
 pub use metadata_driven::MetadataDrivenAdapter;
 pub use onnx::OnnxBackend;
 pub use onnx::OnnxRuntimeAdapter;

--- a/crates/xybrid-core/src/runtime_adapter/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/mod.rs
@@ -112,10 +112,7 @@ pub mod llama_cpp;
 pub mod whisper_cpp;
 
 // Re-exports from runtime backends
-pub use cloud::{
-    encode_stop_sequences, parse_stop_sequences, CloudRuntimeAdapter, CloudStreaming,
-    STOP_SEQUENCES_METADATA_KEY,
-};
+pub use cloud::{CloudRuntimeAdapter, CloudStreaming};
 pub use metadata_driven::MetadataDrivenAdapter;
 pub use onnx::OnnxBackend;
 pub use onnx::OnnxRuntimeAdapter;
@@ -157,7 +154,8 @@ pub use traits::ModelRuntime;
 
 // Always-available streaming and chat types (NOT feature-gated)
 pub use types::{
-    ChatMessage, GenerationConfig, LlmConfig, PartialToken, StreamingCallback, StreamingError,
+    encode_stop_sequences, parse_stop_sequences, ChatMessage, GenerationConfig, LlmConfig,
+    PartialToken, StreamingCallback, StreamingError, STOP_SEQUENCES_METADATA_KEY,
 };
 pub use types::{MultimodalChatMessage, MultimodalImagePart, MultimodalMessagePart};
 pub use vision::{VisionEmbeddings, VisionEncoder, VisionTokenId};

--- a/crates/xybrid-core/src/runtime_adapter/types.rs
+++ b/crates/xybrid-core/src/runtime_adapter/types.rs
@@ -18,6 +18,45 @@ use crate::{
     ir::{Envelope, EnvelopeKind, ImageDimensions, ImageFormat, ImageSource},
     runtime_adapter::AdapterError,
 };
+
+/// Envelope-metadata key carrying stop sequences.
+///
+/// The metadata map is `String`-valued, so a list needs an encoding.
+/// [`encode_stop_sequences`] writes a JSON array and [`parse_stop_sequences`]
+/// reads one; both the cloud adapter and the local LLM strategy go through
+/// that pair, so one envelope yields the same stop list either side of the
+/// local/cloud seam.
+pub const STOP_SEQUENCES_METADATA_KEY: &str = "stop_sequences";
+
+/// Decode the [`STOP_SEQUENCES_METADATA_KEY`] metadata value.
+///
+/// A JSON array of strings is the canonical form and round-trips any sequence
+/// exactly — including the whitespace-only and comma-bearing values a
+/// delimiter-based encoding mangles (`"\n\n"` would trim away to nothing).
+///
+/// Anything else is read as the legacy comma-separated list, trimming each
+/// entry and dropping empties, so hand-written metadata like
+/// `stop_sequences = "<|im_end|>,<|im_start|>"` keeps working. That legacy form
+/// stays lossy by construction; write JSON for anything whitespace- or
+/// comma-bearing.
+pub fn parse_stop_sequences(value: &str) -> Vec<String> {
+    if let Ok(parsed) = serde_json::from_str::<Vec<String>>(value) {
+        return parsed;
+    }
+    value
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Encode stop sequences for [`STOP_SEQUENCES_METADATA_KEY`] as a JSON array.
+///
+/// Lossless: [`parse_stop_sequences`] returns exactly what went in.
+pub fn encode_stop_sequences(stop_sequences: &[String]) -> String {
+    serde_json::to_string(stop_sequences).expect("a Vec<String> always serialises to JSON")
+}
+
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -766,6 +805,49 @@ mod tests {
                 parameters: None,
             },
         }
+    }
+
+    /// Regression: the metadata bridge used a comma-delimited encoding, which
+    /// silently corrupted the most common stop sequences of all. `"\n\n"`
+    /// trimmed away to empty and was dropped entirely, so a cloud leg that
+    /// should have stopped at a blank line ran on to `max_tokens`; `"\nUser:"`
+    /// arrived as `"User:"`; and anything containing a comma was split in two.
+    /// The local leg kept the caller's exact values, so the two legs stopped
+    /// on different text.
+    #[test]
+    fn stop_sequences_round_trip_losslessly() {
+        let hostile = vec![
+            "\n\n".to_string(),
+            "\nUser:".to_string(),
+            "one, two".to_string(),
+            "  ".to_string(),
+            "<|im_end|>".to_string(),
+        ];
+
+        assert_eq!(
+            parse_stop_sequences(&encode_stop_sequences(&hostile)),
+            hostile
+        );
+    }
+
+    #[test]
+    fn stop_sequences_round_trip_an_empty_list() {
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(parse_stop_sequences(&encode_stop_sequences(&empty)), empty);
+    }
+
+    /// Hand-written metadata predates the JSON encoding and must keep working.
+    #[test]
+    fn stop_sequences_still_read_the_legacy_comma_form() {
+        assert_eq!(
+            parse_stop_sequences("<|im_end|>,<|im_start|>"),
+            vec!["<|im_end|>".to_string(), "<|im_start|>".to_string()]
+        );
+        assert_eq!(
+            parse_stop_sequences(" STOP , END "),
+            vec!["STOP".to_string(), "END".to_string()]
+        );
+        assert!(parse_stop_sequences("").is_empty());
     }
 
     #[test]

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -34,7 +34,10 @@ use xybrid_core::orchestrator::authority::{
 };
 use xybrid_core::orchestrator::routing_engine::LocalReliabilityHint;
 use xybrid_core::runtime_adapter::types::GenerationConfig;
-use xybrid_core::runtime_adapter::{CloudRuntimeAdapter, CloudStreaming, RuntimeAdapter};
+use xybrid_core::runtime_adapter::{
+    encode_stop_sequences, CloudRuntimeAdapter, CloudStreaming, RuntimeAdapter,
+    STOP_SEQUENCES_METADATA_KEY,
+};
 use xybrid_core::streaming::{StreamConfig as CoreStreamConfig, VadStreamConfig as CoreVadConfig};
 
 /// A token generated during streaming inference.
@@ -512,6 +515,12 @@ fn local_reliability_hint_after_abort(
 /// would silently drop `GenerationConfig::tools`. On any other shape the
 /// original result is returned unchanged.
 ///
+/// `generation_config` is the caller's [`RunOptions::generation_config`]. It
+/// serves two purposes on the cloud leg: its `tools` gate the tool refusal
+/// below, and [`apply_generation_config_metadata`] copies its sampling knobs
+/// onto the cloud envelope so the gateway honours them instead of falling back
+/// to its own defaults.
+///
 /// `cancellation_token`, when set, makes the cloud retry leg honour
 /// caller-driven cancellation. The cloud leg cannot meaningfully react to
 /// resource pressure on the device, so only `UserCancelled` is consulted —
@@ -533,7 +542,7 @@ fn dispatch_after_local<F, S>(
     policy_metrics: xybrid_core::context::DeviceMetrics,
     signal_context: Option<SignalContext>,
     cancellation_token: Option<CancellationToken>,
-    tools_requested: bool,
+    generation_config: Option<&GenerationConfig>,
     on_token: &mut F,
     on_seam: &mut S,
 ) -> SdkResult<InferenceResult>
@@ -544,6 +553,7 @@ where
         + Send,
     S: FnMut(SeamInfo) + Send,
 {
+    let tools_requested = generation_config.is_some_and(|config| !config.tools.is_empty());
     match local_result {
         Ok(result) => Ok(result),
         Err(SdkError::AbortedForCloudFallback { reason }) => {
@@ -578,6 +588,10 @@ where
 
             // FR-6: reuse the original prompt; no partial-token reuse.
             let mut cloud_envelope = envelope.clone();
+            // The cloud adapter reads its request settings off metadata alone,
+            // so the caller's sampling config has to be projected onto the
+            // envelope here or the gateway silently answers with its defaults.
+            apply_generation_config_metadata(&mut cloud_envelope, generation_config);
             // Default the cloud-leg routing to the registry model when the caller
             // didn't pick an explicit hosted override: the platform gateway routes
             // an id it doesn't recognise as a hosted provider's model through to
@@ -1163,12 +1177,54 @@ pub struct ModelLoader {
     auto_release: Option<AutoReleasePolicy>,
 }
 
+/// Copy a caller's [`GenerationConfig`] onto a cloud-bound envelope's metadata.
+///
+/// Envelope metadata is the *only* channel
+/// [`CloudRuntimeAdapter`](xybrid_core::runtime_adapter::CloudRuntimeAdapter)
+/// reads request settings from, so a config that never lands here is silently
+/// dropped and the gateway answers with its own defaults. Every sampling knob
+/// the cloud request shape can express is forwarded: `max_tokens`,
+/// `temperature`, `top_p`, and `stop_sequences`. The rest of
+/// [`GenerationConfig`] (`top_k`, `min_p`, `repetition_penalty`, `grammar`,
+/// `tools`) has no OpenAI-compatible wire field and stays local-only.
+///
+/// **Precedence: existing metadata wins.** A caller who wrote `temperature`
+/// straight onto the envelope is addressing the cloud leg specifically, while
+/// `GenerationConfig` describes the run in general — so the config only fills
+/// keys the envelope left empty.
+fn apply_generation_config_metadata(cloud: &mut Envelope, config: Option<&GenerationConfig>) {
+    let Some(cfg) = config else {
+        return;
+    };
+    cloud
+        .metadata
+        .entry("max_tokens".to_string())
+        .or_insert_with(|| cfg.max_tokens.to_string());
+    cloud
+        .metadata
+        .entry("temperature".to_string())
+        .or_insert_with(|| cfg.temperature.to_string());
+    cloud
+        .metadata
+        .entry("top_p".to_string())
+        .or_insert_with(|| cfg.top_p.to_string());
+    // An empty list is not an instruction — writing the key would only add
+    // noise the adapter then has to special-case.
+    if !cfg.stop_sequences.is_empty() {
+        cloud
+            .metadata
+            .entry(STOP_SEQUENCES_METADATA_KEY.to_string())
+            .or_insert_with(|| encode_stop_sequences(&cfg.stop_sequences));
+    }
+}
+
 /// Build the cloud-bound envelope for serving a not-yet-local model from the
 /// gateway. Sets `model` to the registry id so the gateway routes it to xycloud
 /// (the CPU cluster that runs the edge model) — an id it doesn't recognise as a
 /// hosted provider's model falls through there. `provider` is a benign
 /// validation/trace label, never sent on the wire (the gateway routes on
-/// `model` alone). `backend`/`max_tokens`/`temperature` defer to caller values.
+/// `model` alone). `backend` and every key
+/// [`apply_generation_config_metadata`] writes defer to caller values.
 fn build_speculative_cloud_envelope(
     model_id: &str,
     envelope: &Envelope,
@@ -1185,16 +1241,7 @@ fn build_speculative_cloud_envelope(
         .metadata
         .entry("backend".to_string())
         .or_insert_with(|| "gateway".to_string());
-    if let Some(cfg) = config {
-        cloud
-            .metadata
-            .entry("max_tokens".to_string())
-            .or_insert_with(|| cfg.max_tokens.to_string());
-        cloud
-            .metadata
-            .entry("temperature".to_string())
-            .or_insert_with(|| cfg.temperature.to_string());
-    }
+    apply_generation_config_metadata(&mut cloud, config);
     cloud
 }
 
@@ -4177,9 +4224,16 @@ impl XybridModel {
     /// - `correlation_id` is taken from `options.correlation_id` if set,
     ///   otherwise generated via `uuid::Uuid::new_v4()`.
     /// - The `envelope` must carry cloud-side routing metadata (`provider`,
-    ///   `model`, `system_prompt`, `temperature`, …) for the retry leg. See
+    ///   `model`, `system_prompt`, …) for the retry leg. See
     ///   [`CloudRuntimeAdapter`](xybrid_core::runtime_adapter::CloudRuntimeAdapter)
     ///   for supported keys.
+    /// - `options.generation_config` reaches the cloud leg: `max_tokens`,
+    ///   `temperature`, `top_p`, and `stop_sequences` are copied onto the
+    ///   cloud envelope's metadata. Metadata already present on the envelope
+    ///   wins — it targets the cloud leg specifically, so it overrides the
+    ///   generic config. The remaining knobs (`top_k`, `min_p`,
+    ///   `repetition_penalty`, `grammar`) have no OpenAI-compatible wire field
+    ///   and stay local-only.
     /// - Requests with `GenerationConfig::tools` do not enter the cloud leg yet:
     ///   the gateway adapter does not forward tools, so the wrapper emits the
     ///   local abort seam and then fails closed before policy or cloud dispatch.
@@ -4232,10 +4286,6 @@ impl XybridModel {
         let local_resource_summary = local_resource_guard.finish();
         let policy_metrics = fallback_policy_metrics(options);
         let signal_context = Some(SignalContext::from_metrics(&policy_metrics));
-        let tools_requested = options
-            .generation_config
-            .as_ref()
-            .is_some_and(|config| !config.tools.is_empty());
 
         dispatch_after_local(
             local_result,
@@ -4250,7 +4300,7 @@ impl XybridModel {
             policy_metrics,
             signal_context,
             options.cancellation_token.clone(),
-            tools_requested,
+            options.generation_config.as_ref(),
             on_token,
             on_seam,
         )
@@ -5472,6 +5522,67 @@ mod tests {
         );
     }
 
+    /// Every sampling knob the cloud request shape can express must land in
+    /// metadata — `top_p` and `stop_sequences` used to be dropped on *every*
+    /// cloud path, so a caller's nucleus threshold and stop words never
+    /// reached the gateway.
+    #[test]
+    fn build_envelope_forwards_top_p_and_stop_sequences() {
+        let input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
+        let config = GenerationConfig {
+            top_p: 0.72,
+            stop_sequences: vec!["STOP".to_string(), "END".to_string()],
+            ..Default::default()
+        };
+        let cloud = build_speculative_cloud_envelope("lfm2.5-350m", &input, Some(&config));
+        assert_eq!(
+            cloud.metadata.get("top_p").map(String::as_str),
+            Some("0.72")
+        );
+        assert_eq!(
+            cloud
+                .metadata
+                .get(STOP_SEQUENCES_METADATA_KEY)
+                .map(String::as_str),
+            Some("STOP,END")
+        );
+    }
+
+    /// An empty stop list is not an instruction — writing `[]` would be noise
+    /// the adapter then has to special-case.
+    #[test]
+    fn build_envelope_omits_empty_stop_sequences() {
+        let input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
+        let config = GenerationConfig::default();
+        assert!(config.stop_sequences.is_empty(), "guard the premise");
+        let cloud = build_speculative_cloud_envelope("lfm2.5-350m", &input, Some(&config));
+        assert!(!cloud.metadata.contains_key(STOP_SEQUENCES_METADATA_KEY));
+    }
+
+    /// Metadata written straight onto the envelope targets the cloud leg
+    /// specifically, so it outranks the generic `GenerationConfig`.
+    #[test]
+    fn build_envelope_lets_caller_metadata_outrank_generation_config() {
+        let mut input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
+        input
+            .metadata
+            .insert("max_tokens".to_string(), "7".to_string());
+        input
+            .metadata
+            .insert("top_p".to_string(), "0.1".to_string());
+        let config = GenerationConfig {
+            max_tokens: 999,
+            top_p: 0.95,
+            ..Default::default()
+        };
+        let cloud = build_speculative_cloud_envelope("lfm2.5-350m", &input, Some(&config));
+        assert_eq!(
+            cloud.metadata.get("max_tokens").map(String::as_str),
+            Some("7")
+        );
+        assert_eq!(cloud.metadata.get("top_p").map(String::as_str), Some("0.1"));
+    }
+
     #[test]
     fn build_envelope_does_not_clobber_caller_backend() {
         let mut input = Envelope::new(xybrid_core::ir::EnvelopeKind::Text("hi".to_string()));
@@ -6386,7 +6497,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         )
@@ -6403,6 +6514,161 @@ mod tests {
         let tokens = collected.lock().unwrap().clone();
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0], "hello from cloud");
+    }
+
+    /// Regression: the explicit-adapter fallback path used to hand
+    /// `dispatch_after_local` the untouched envelope, so a caller's
+    /// `GenerationConfig` never reached `CloudRuntimeAdapter` — which reads its
+    /// settings from metadata alone. The request still succeeded with
+    /// plausible-looking output generated under the gateway's defaults, so
+    /// nothing signalled that `max_tokens`/`temperature`/`top_p`/
+    /// `stop_sequences` had been dropped.
+    #[test]
+    fn dispatch_after_local_forwards_generation_config_to_the_cloud_envelope() {
+        let cloud = FakeCloudAdapter::new("hello from cloud");
+        let authority = FakeAuthority::allow();
+        let envelope = text_envelope("write me a haiku");
+        let mut on_token =
+            |_: xybrid_core::runtime_adapter::types::PartialToken| -> Result<(), Box<dyn std::error::Error + Send + Sync>> { Ok(()) };
+        let mut on_seam = |_s: SeamInfo| {};
+        let local_result: SdkResult<InferenceResult> = Err(SdkError::AbortedForCloudFallback {
+            reason: xybrid_core::abort::AbortReason::StressMemory,
+        });
+        let config = GenerationConfig {
+            max_tokens: 13,
+            temperature: 0.31,
+            top_p: 0.72,
+            stop_sequences: vec!["STOP".to_string(), "END".to_string()],
+            ..Default::default()
+        };
+
+        dispatch_after_local(
+            local_result,
+            &envelope,
+            &cloud,
+            "corr-genconfig".to_string(),
+            "test-model",
+            3,
+            100,
+            None,
+            &authority,
+            default_metrics(),
+            Some(default_signal()),
+            None,
+            Some(&config),
+            &mut on_token,
+            &mut on_seam,
+        )
+        .expect("retry should succeed");
+
+        let calls = cloud.calls();
+        assert_eq!(calls.len(), 1);
+        let sent = &calls[0].metadata;
+        assert_eq!(sent.get("max_tokens").map(String::as_str), Some("13"));
+        assert_eq!(sent.get("temperature").map(String::as_str), Some("0.31"));
+        assert_eq!(sent.get("top_p").map(String::as_str), Some("0.72"));
+        assert_eq!(
+            sent.get(STOP_SEQUENCES_METADATA_KEY).map(String::as_str),
+            Some("STOP,END")
+        );
+    }
+
+    /// No config means no invented settings: the fallback leg must not stamp
+    /// `GenerationConfig::default()` onto the envelope, which would pin
+    /// `temperature = 0.0` on callers who never asked for greedy decoding.
+    #[test]
+    fn dispatch_after_local_writes_no_sampling_metadata_without_a_config() {
+        let cloud = FakeCloudAdapter::new("hello from cloud");
+        let authority = FakeAuthority::allow();
+        let envelope = text_envelope("write me a haiku");
+        let mut on_token =
+            |_: xybrid_core::runtime_adapter::types::PartialToken| -> Result<(), Box<dyn std::error::Error + Send + Sync>> { Ok(()) };
+        let mut on_seam = |_s: SeamInfo| {};
+        let local_result: SdkResult<InferenceResult> = Err(SdkError::AbortedForCloudFallback {
+            reason: xybrid_core::abort::AbortReason::StressMemory,
+        });
+
+        dispatch_after_local(
+            local_result,
+            &envelope,
+            &cloud,
+            "corr-no-genconfig".to_string(),
+            "test-model",
+            3,
+            100,
+            None,
+            &authority,
+            default_metrics(),
+            Some(default_signal()),
+            None,
+            None,
+            &mut on_token,
+            &mut on_seam,
+        )
+        .expect("retry should succeed");
+
+        let calls = cloud.calls();
+        assert_eq!(calls.len(), 1);
+        let sent = &calls[0].metadata;
+        for key in [
+            "max_tokens",
+            "temperature",
+            "top_p",
+            STOP_SEQUENCES_METADATA_KEY,
+        ] {
+            assert!(
+                !sent.contains_key(key),
+                "unexpected `{key}` on the cloud envelope"
+            );
+        }
+    }
+
+    /// Cloud-targeted metadata already on the envelope outranks the generic
+    /// `GenerationConfig` on the fallback leg too, matching the speculative path.
+    #[test]
+    fn dispatch_after_local_lets_envelope_metadata_outrank_generation_config() {
+        let cloud = FakeCloudAdapter::new("hello from cloud");
+        let authority = FakeAuthority::allow();
+        let mut envelope = text_envelope("write me a haiku");
+        envelope
+            .metadata
+            .insert("max_tokens".to_string(), "7".to_string());
+        let mut on_token =
+            |_: xybrid_core::runtime_adapter::types::PartialToken| -> Result<(), Box<dyn std::error::Error + Send + Sync>> { Ok(()) };
+        let mut on_seam = |_s: SeamInfo| {};
+        let local_result: SdkResult<InferenceResult> = Err(SdkError::AbortedForCloudFallback {
+            reason: xybrid_core::abort::AbortReason::StressMemory,
+        });
+        let config = GenerationConfig {
+            max_tokens: 999,
+            ..Default::default()
+        };
+
+        dispatch_after_local(
+            local_result,
+            &envelope,
+            &cloud,
+            "corr-precedence".to_string(),
+            "test-model",
+            3,
+            100,
+            None,
+            &authority,
+            default_metrics(),
+            Some(default_signal()),
+            None,
+            Some(&config),
+            &mut on_token,
+            &mut on_seam,
+        )
+        .expect("retry should succeed");
+
+        let calls = cloud.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].metadata.get("max_tokens").map(String::as_str),
+            Some("7")
+        );
     }
 
     #[test]
@@ -6573,7 +6839,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         )
@@ -6625,6 +6891,14 @@ mod tests {
         let local_result: SdkResult<InferenceResult> = Err(SdkError::AbortedForCloudFallback {
             reason: xybrid_core::abort::AbortReason::StressMemory,
         });
+        let tool_config = GenerationConfig {
+            tools: vec![xybrid_core::gateway::Tool::function(
+                "get_weather",
+                "Current weather for a city.",
+                serde_json::json!({"type": "object", "properties": {}}),
+            )],
+            ..Default::default()
+        };
 
         let result = dispatch_after_local(
             local_result,
@@ -6639,7 +6913,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            true,
+            Some(&tool_config),
             &mut on_token,
             &mut on_seam,
         );
@@ -6704,7 +6978,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         );
@@ -6774,7 +7048,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         )
@@ -6823,7 +7097,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             Some(cancellation),
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         );
@@ -7493,7 +7767,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         );
@@ -7552,7 +7826,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         )
@@ -7590,7 +7864,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         )
@@ -7628,7 +7902,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         )
@@ -7668,7 +7942,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         );
@@ -7714,7 +7988,7 @@ mod tests {
             default_metrics(),
             Some(default_signal()),
             None,
-            false,
+            None,
             &mut on_token,
             &mut on_seam,
         );

--- a/crates/xybrid-sdk/src/model.rs
+++ b/crates/xybrid-sdk/src/model.rs
@@ -5544,7 +5544,7 @@ mod tests {
                 .metadata
                 .get(STOP_SEQUENCES_METADATA_KEY)
                 .map(String::as_str),
-            Some("STOP,END")
+            Some(r#"["STOP","END"]"#)
         );
     }
 
@@ -6569,7 +6569,7 @@ mod tests {
         assert_eq!(sent.get("top_p").map(String::as_str), Some("0.72"));
         assert_eq!(
             sent.get(STOP_SEQUENCES_METADATA_KEY).map(String::as_str),
-            Some("STOP,END")
+            Some(r#"["STOP","END"]"#)
         );
     }
 


### PR DESCRIPTION
## Summary

This pull request fixes a silent correctness bug in the SDK's local→cloud fallback path: a caller's `GenerationConfig` never reached the cloud leg, so `max_tokens`, `temperature`, `top_p`, and `stop_sequences` were dropped and the gateway answered with its own defaults. The request still succeeded with plausible-looking output, so nothing signalled the loss. While fixing it, two adjacent gaps surfaced — `top_p` and `stop_sequences` were unreadable by the cloud adapter on *every* path, and the `stop_sequences` metadata encoding was lossy enough to corrupt the most common values there are.

**The reported bug — config dropped on the explicit-adapter fallback path:**

* `run_streaming_with_fallback` handed `dispatch_after_local` the original envelope, which cloned it untouched. `CloudRuntimeAdapter` reads its request settings from envelope metadata *only*, so an empty metadata map meant gateway defaults.
* Added `apply_generation_config_metadata` in `crates/xybrid-sdk/src/model.rs` — the single place that projects a config onto a cloud-bound envelope — and called it from **both** `dispatch_after_local` (the broken path) and `build_speculative_cloud_envelope` (the working one), so the two cannot drift again.
* `dispatch_after_local` now takes `Option<&GenerationConfig>` instead of a `tools_requested: bool`, so one argument serves both the tool refusal and the metadata copy and a future caller cannot pass one without the other.
* Precedence is unchanged and now documented + tested: metadata already on the envelope wins, because it targets the cloud leg specifically while `GenerationConfig` describes the run in general.

**Adjacent gap — `top_p` and `stop_sequences` never reached cloud at all:**

* `CloudRuntimeAdapter::build_request` read neither from metadata, so both were dropped on every cloud path (speculative serving included) even though `gateway_chat_body` has always serialised them. Added `CompletionRequest::with_top_p` and the two metadata reads.

**Adjacent gap — the `stop_sequences` encoding was lossy:**

* The comma-delimited encoding trimmed `"\n\n"` away to empty and dropped it, so a run that should have stopped at a blank line continued to `max_tokens`; `"\nUser:"` arrived as `"User:"`; anything containing a comma was split in two. The local leg kept the caller's exact values, so the two legs stopped on different text.
* `encode_stop_sequences` / `parse_stop_sequences` moved next to `GenerationConfig` in `runtime_adapter::types`, encoding as a JSON array, with **both** readers routed through them — the cloud adapter and the local `LlmGenerationParams` parser that was the origin of the comma convention. Parsing tries JSON first and falls back to the comma split, so hand-written metadata keeps working.

**Test coverage:**

* The bug report's exact reproduction is now a test: `dispatch_after_local_forwards_generation_config_to_the_cloud_envelope` asserts `13` / `0.31` / `0.72` / `["STOP","END"]` land on the envelope the adapter receives.
* Plus: no config writes no metadata (so nobody is pinned to `temperature = 0.0`), empty stop lists are omitted, envelope metadata outranks the config on both paths, and `stop_sequences_round_trip_losslessly` covers `"\n\n"`, `"\nUser:"`, `"one, two"`, and `"  "`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (describe below)

## Checklist

- [x] Tests pass (`cargo test --workspace --features ort-download` — 78 suites, zero failures)
- [x] Code follows project style (`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean)
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

## Downstream note

xycloud has a contract test that deliberately pins the broken behaviour (asserting `max_tokens == Some(2048)`). It will go red with *"generation config now reaches cloud fallback — assert the requested 13 instead"*. That failure is expected and means the fix landed; it should be updated, not reverted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cloud sampling and stop behavior on every fallback and speculative cloud path; intentional fix but alters gateway requests and may require downstream contract test updates.
> 
> **Overview**
> Fixes a **silent correctness bug** on local→cloud streaming fallback: the cloud adapter only reads sampling settings from envelope metadata, but the fallback path used to clone the prompt envelope unchanged, so **`max_tokens`, `temperature`, `top_p`, and `stop_sequences` from `RunOptions::generation_config` never reached the gateway** and runs succeeded with gateway defaults.
> 
> The SDK now centralizes projection in **`apply_generation_config_metadata`**, invoked from **`dispatch_after_local`** (explicit-adapter fallback) and **`build_speculative_cloud_envelope`** (speculative cloud), with **envelope metadata winning** over the generic config when both are set. **`dispatch_after_local`** takes **`Option<&GenerationConfig>`** instead of a separate tools flag so tool refusal and metadata copy stay aligned.
> 
> **`CloudRuntimeAdapter::build_request`** now reads **`top_p`** and **`stop_sequences`** from metadata (plus **`CompletionRequest::with_top_p`**), closing a gap where the gateway body could serialize them but the adapter never populated the request.
> 
> **Stop sequences** cross the metadata bridge as a **JSON array** via shared **`encode_stop_sequences` / `parse_stop_sequences`** (local LLM params and cloud use the same parser); legacy comma-separated values still parse. This fixes lossy encoding that mangled values like **`"\n\n"`** and split comma-containing stops, which could make local and cloud legs stop on different text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391c63374c820427c4690dfe515a6b712254b3dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->