### PR TITLE
feat(bindings): finish the tool-call surface parity

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -427,6 +427,10 @@ public typealias ToolCall = XybridToolCall
 /// The outcome of running one tool, fed back with `Envelope.toolResults`.
 public typealias ToolResult = XybridToolResult
 
+/// One token emitted by a streaming run. The terminal token carries the
+/// turn's `toolCalls` and `rawText`.
+public typealias StreamToken = XybridStreamToken
+
 // MARK: - GenerationConfig ergonomics
 //
 // The generated memberwise init takes every field positionally, so setting one
@@ -574,6 +578,20 @@ public extension XybridResult {
 
     /// The latency as a `TimeInterval` in seconds.
     var latency: TimeInterval { TimeInterval(latencyMs) / 1000.0 }
+
+    /// `true` if the model asked to call at least one tool this turn.
+    var hasToolCalls: Bool { !toolCalls.isEmpty }
+}
+
+// MARK: - XybridStreamToken ergonomics
+
+public extension XybridStreamToken {
+    /// `true` if this token carries tool calls to execute.
+    ///
+    /// Only ever true on the terminal token. Tool-call blocks are suppressed
+    /// from the streamed text, so this — not the token text — is what a
+    /// streaming loop branches on.
+    var hasToolCalls: Bool { !toolCalls.isEmpty }
 }
 
 // MARK: - XybridEnvelope compatibility factories

--- a/bindings/apple/Tests/XybridTests/ModelLoaderTests.swift
+++ b/bindings/apple/Tests/XybridTests/ModelLoaderTests.swift
@@ -57,4 +57,65 @@ final class ModelLoaderTests: XCTestCase {
         XCTAssertNil(sourceCompatible.reasoningContent)
         XCTAssertEqual(reader.position, writer.data.count)
     }
+
+    /// Guards the `hasToolCalls` conveniences. They exist so the branch a
+    /// tool loop actually writes reads the same in Swift as it does in Dart,
+    /// Kotlin and C#.
+    func testToolCallConveniencesOnResultAndStreamToken() {
+        let call = XybridToolCall(
+            id: "call_0",
+            name: "get_weather",
+            argumentsJson: #"{"city":"Paris"}"#
+        )
+        let metrics = XybridInferenceMetrics(
+            totalMs: 0,
+            ttftMs: nil,
+            tokensPerSecond: nil,
+            prefillTps: nil,
+            decodeTps: nil,
+            tokensOut: nil,
+            stageLatenciesMs: []
+        )
+        func result(_ toolCalls: [XybridToolCall]) -> XybridResult {
+            XybridResult(
+                envelope: XybridEnvelope(kind: .text(text: "answer"), metadata: []),
+                outputType: .text,
+                modelId: "model",
+                latencyMs: 0,
+                executionTarget: .local,
+                metrics: metrics,
+                toolCalls: toolCalls
+            )
+        }
+
+        XCTAssertFalse(result([]).hasToolCalls)
+        XCTAssertTrue(result([call]).hasToolCalls)
+
+        let midStream = XybridStreamToken(
+            token: "check",
+            tokenId: nil,
+            index: 0,
+            cumulativeText: "check",
+            finishReason: nil,
+            toolCalls: [],
+            rawText: nil
+        )
+        let terminal = XybridStreamToken(
+            token: "",
+            tokenId: nil,
+            index: 1,
+            cumulativeText: "checking",
+            finishReason: "tool_calls",
+            toolCalls: [call],
+            rawText: #"checking<|tool_call_start|>[get_weather(city="Paris")]<|tool_call_end|>"#
+        )
+
+        XCTAssertFalse(midStream.hasToolCalls)
+        XCTAssertTrue(terminal.hasToolCalls)
+
+        // rawText, not cumulativeText, is what the continuation replays: call
+        // blocks are suppressed from the emitted text.
+        XCTAssertTrue(terminal.rawText?.contains("tool_call_start") == true)
+        XCTAssertFalse(terminal.cumulativeText.contains("tool_call_start"))
+    }
 }

--- a/bindings/flutter/example/pubspec.lock
+++ b/bindings/flutter/example/pubspec.lock
@@ -419,7 +419,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0"
 sdks:
   dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.35.6"

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/Xybrid.kt
@@ -432,6 +432,12 @@ typealias VoiceInfo = XybridVoiceInfo
 /** LLM generation parameters (temperature, top-p, max tokens, etc.). */
 typealias GenerationConfig = XybridGenerationConfig
 
+/**
+ * One token emitted by a streaming run. The terminal token carries the
+ * turn's [XybridStreamToken.toolCalls] and [XybridStreamToken.rawText].
+ */
+typealias StreamToken = XybridStreamToken
+
 // -- GenerationConfig Presets --
 
 /** Preset factory methods for [GenerationConfig]. */
@@ -494,6 +500,18 @@ val XybridResult.embedding: FloatArray?
 
 /** The latency in seconds as a Double. */
 val XybridResult.latencySeconds: Double get() = latencyMs.toDouble() / 1000.0
+
+/** `true` if the model asked to call at least one tool this turn. */
+val XybridResult.hasToolCalls: Boolean get() = toolCalls.isNotEmpty()
+
+/**
+ * `true` if this token carries tool calls to execute.
+ *
+ * Only ever true on the terminal token. Tool-call blocks are suppressed from
+ * the streamed text, so this — not the token text — is what a streaming loop
+ * branches on.
+ */
+val XybridStreamToken.hasToolCalls: Boolean get() = toolCalls.isNotEmpty()
 
 // -- XybridEnvelope Factory Methods --
 //

--- a/bindings/kotlin/src/test/kotlin/ai/xybrid/ToolCallConveniencesTest.kt
+++ b/bindings/kotlin/src/test/kotlin/ai/xybrid/ToolCallConveniencesTest.kt
@@ -1,0 +1,70 @@
+package ai.xybrid
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the `hasToolCalls` extensions. They exist so the branch a tool loop
+ * actually writes reads the same in Kotlin as it does in Dart, Swift and C#.
+ */
+class ToolCallConveniencesTest {
+    private val call = XybridToolCall("call_0", "get_weather", """{"city":"Paris"}""")
+
+    @Test
+    fun resultReportsWhetherTheTurnAskedForTools() {
+        assertFalse(result(emptyList()).hasToolCalls)
+        assertTrue(result(listOf(call)).hasToolCalls)
+    }
+
+    @Test
+    fun onlyTheTerminalStreamTokenCarriesCalls() {
+        val midStream = XybridStreamToken(
+            token = "check",
+            tokenId = null,
+            index = 0uL,
+            cumulativeText = "check",
+            finishReason = null,
+            toolCalls = emptyList(),
+            rawText = null,
+        )
+        val terminal = XybridStreamToken(
+            token = "",
+            tokenId = null,
+            index = 1uL,
+            cumulativeText = "checking",
+            finishReason = "tool_calls",
+            toolCalls = listOf(call),
+            rawText = "checking<|tool_call_start|>[get_weather(city=\"Paris\")]<|tool_call_end|>",
+        )
+
+        assertFalse(midStream.hasToolCalls)
+        assertTrue(terminal.hasToolCalls)
+        assertEquals("tool_calls", terminal.finishReason)
+
+        // rawText, not cumulativeText, is what the continuation replays: call
+        // blocks are suppressed from the emitted text.
+        assertTrue(terminal.rawText!!.contains("tool_call_start"))
+        assertFalse(terminal.cumulativeText.contains("tool_call_start"))
+    }
+
+    private fun result(toolCalls: List<XybridToolCall>) = XybridResult(
+        envelope = XybridEnvelope(XybridEnvelopeKind.Text("answer"), emptyList()),
+        outputType = XybridOutputType.TEXT,
+        modelId = "model",
+        latencyMs = 0u,
+        executionTarget = XybridExecutionTarget.LOCAL,
+        metrics = XybridInferenceMetrics(
+            totalMs = 0u,
+            ttftMs = null,
+            tokensPerSecond = null,
+            prefillTps = null,
+            decodeTps = null,
+            tokensOut = null,
+            stageLatenciesMs = emptyList(),
+        ),
+        toolCalls = toolCalls,
+        reasoningContent = null,
+    )
+}

--- a/bindings/python/tests/test_sdk.py
+++ b/bindings/python/tests/test_sdk.py
@@ -128,6 +128,57 @@ def test_result_conveniences_on_synthetic_result() -> None:
     assert isinstance(xybrid.XybridVoiceInfo.is_female, property)
 
 
+def test_tool_call_conveniences_on_result_and_stream_token() -> None:
+    call = xybrid.XybridToolCall(id="call_0", name="get_weather", arguments_json='{"city":"Paris"}')
+
+    without = _result(xybrid.XybridEnvelope.text("plain answer"), xybrid.XybridOutputType.TEXT)
+    assert not without.has_tool_calls
+
+    with_calls = xybrid.XybridResult(
+        envelope=xybrid.XybridEnvelope.text("checking"),
+        output_type=xybrid.XybridOutputType.TEXT,
+        model_id="model",
+        latency_ms=0,
+        execution_target=xybrid.XybridExecutionTarget.LOCAL,
+        metrics=_metrics(0),
+        reasoning_content=None,
+        tool_calls=[call],
+    )
+    assert with_calls.has_tool_calls
+
+    # The terminal stream token is where a streaming loop branches: call
+    # blocks are suppressed from the emitted text, so the token text never
+    # carries them.
+    mid_stream = xybrid.XybridStreamToken(
+        token="check",
+        token_id=None,
+        index=0,
+        cumulative_text="check",
+        finish_reason=None,
+        tool_calls=[],
+        raw_text=None,
+    )
+    terminal = xybrid.XybridStreamToken(
+        token="",
+        token_id=None,
+        index=1,
+        cumulative_text="checking",
+        finish_reason="tool_calls",
+        tool_calls=[call],
+        raw_text="checking<|tool_call_start|>[get_weather(city=\"Paris\")]<|tool_call_end|>",
+    )
+
+    assert not mid_stream.has_tool_calls
+    assert terminal.has_tool_calls
+    # raw_text, not cumulative_text, is what the continuation replays.
+    assert terminal.raw_text is not None
+    assert "tool_call_start" in terminal.raw_text
+    assert "tool_call_start" not in terminal.cumulative_text
+
+    assert isinstance(xybrid.XybridResult.has_tool_calls, property)
+    assert isinstance(xybrid.XybridStreamToken.has_tool_calls, property)
+
+
 def test_result_reasoning_field_defaults_to_none() -> None:
     result = xybrid.XybridResult(
         envelope=xybrid.XybridEnvelope.text("answer"),

--- a/bindings/python/xybrid/_sugar.py
+++ b/bindings/python/xybrid/_sugar.py
@@ -197,8 +197,41 @@ def _install_result_accessors() -> None:
 
         return self.latency_ms / 1000.0
 
-    for accessor in (text, audio_bytes, embedding, success, is_failure, latency_seconds):
+    def has_tool_calls(self: Any) -> bool:
+        """``True`` when the model asked to call at least one tool this turn."""
+
+        return bool(self.tool_calls)
+
+    for accessor in (
+        text,
+        audio_bytes,
+        embedding,
+        success,
+        is_failure,
+        latency_seconds,
+        has_tool_calls,
+    ):
         setattr(result, accessor.__name__, property(accessor, doc=accessor.__doc__))
+
+
+def _install_stream_token_accessors() -> None:
+    stream_token = _bolt.XybridStreamToken
+
+    def has_tool_calls(self: Any) -> bool:
+        """``True`` when this token carries tool calls to execute.
+
+        Only ever true on the terminal token. Tool-call blocks are suppressed
+        from the streamed text, so this — not the token text — is what a
+        streaming loop branches on.
+        """
+
+        return bool(self.tool_calls)
+
+    setattr(
+        stream_token,
+        has_tool_calls.__name__,
+        property(has_tool_calls, doc=has_tool_calls.__doc__),
+    )
 
 
 def _install_voice_accessors() -> None:
@@ -299,6 +332,7 @@ def install() -> None:
     _install_envelope_kind_factories()
     _install_envelope_factories()
     _install_result_accessors()
+    _install_stream_token_accessors()
     _install_voice_accessors()
     _install_model_accessors()
     _bolt._xybrid_sugar_installed = True

--- a/docs/content/docs/guides/tool-calling.mdx
+++ b/docs/content/docs/guides/tool-calling.mdx
@@ -207,9 +207,10 @@ Three things make this work without any parsing on your side:
 - The `tool_results` envelope goes back through the **same** call, so the
   continuation keeps the conversation context and keeps streaming.
 
-Swift, Kotlin, Python, and Unity C# expose the same trio on their stream
-token — `toolCalls`, `rawText`, `finishReason` — and feed the continuation
-back through the same streaming call.
+Swift, Kotlin, Python, and Unity C# expose the same fields on their stream
+token — `toolCalls`, `rawText`, `finishReason`, plus a `hasToolCalls`
+convenience — and feed the continuation back through the same streaming call.
+Python spells it `has_tool_calls`; Unity C# spells it `HasToolCalls`.
 
 ## Tool Calling in the CLI (`xybrid repl`)
 

--- a/docs/content/docs/guides/tool-calling.zh.mdx
+++ b/docs/content/docs/guides/tool-calling.zh.mdx
@@ -183,8 +183,10 @@ Envelope 自身会回放 `userText`，因此循环中途的 push 会让问题在
 - `tool_results` Envelope 通过**同一个**方法送回，因此续接既保留对话上下文，
   也继续保持流式。
 
-Swift、Kotlin、Python 与 Unity C# 在各自的 stream token 上暴露同样的三件套
-——`toolCalls`、`rawText`、`finishReason`——并同样通过原来的流式方法送回续接。
+Swift、Kotlin、Python 与 Unity C# 在各自的 stream token 上暴露同样的字段
+——`toolCalls`、`rawText`、`finishReason`，外加一个 `hasToolCalls` 便捷属性
+——并同样通过原来的流式方法送回续接。Python 写作 `has_tool_calls`，
+Unity C# 写作 `HasToolCalls`。
 
 ## 在 CLI 中进行工具调用（`xybrid repl`）
 

--- a/docs/sdk/api-surface.yaml
+++ b/docs/sdk/api-surface.yaml
@@ -2,7 +2,8 @@
 # Machine-readable companion to API_REFERENCE.md
 #
 # This file is parsed by tools/scripts/api-contract-check.sh and the /sync-api command.
-# Status values: implemented, partial, stub, planned
+# Status values: implemented, partial, stub, planned, na (not applicable
+# to that language, as opposed to `planned` = intended but not built yet)
 #
 # IMPORTANT: When modifying SDK public APIs, update BOTH this file and API_REFERENCE.md.
 
@@ -484,6 +485,12 @@ classes:
         # tools. The raw tool-call block stays in `text`.
         status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
         since: "0.5.0"
+      hasToolCalls:
+        type: bool
+        # Convenience over `toolCalls.isEmpty`, so the branch a tool loop
+        # actually writes reads the same in every language.
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
+        since: "0.7.0"
       audioAsWav:
         type: "Uint8List?"
         status: { dart: implemented, kotlin: planned, swift: planned, csharp: planned }
@@ -684,7 +691,9 @@ classes:
   StreamToken:
     type: data
     section: "8. Supporting Types"
-    status: { dart: implemented, kotlin: planned, swift: planned, csharp: implemented }
+    # Kotlin and Swift reach this through a `StreamToken` typealias over the
+    # generated bolt type, the same way ToolCall/GenerationConfig work there.
+    status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
     properties:
       toolCalls:
         type: "List<ToolCall>"
@@ -699,6 +708,13 @@ classes:
         # what the tool-results envelope needs as priorAssistantText. Set only
         # alongside a non-empty toolCalls; NOT the same as cumulativeText,
         # which is the emitted (block-suppressed) text.
+        status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
+        since: "0.7.0"
+      hasToolCalls:
+        type: bool
+        # Only ever true on the terminal token. Call blocks are suppressed
+        # from the streamed text, so this is what a streaming loop branches
+        # on rather than the token text.
         status: { dart: implemented, kotlin: implemented, swift: implemented, csharp: implemented }
         since: "0.7.0"
 

--- a/tools/scripts/api-contract-check.sh
+++ b/tools/scripts/api-contract-check.sh
@@ -125,9 +125,12 @@ check_method_in_sdk() {
         kotlin)
             src_dir="$KOTLIN_SRC"
             [ ! -d "$src_dir" ] && return 2
-            # Match both plain (val foo) and backticked (var `foo`) — UniFFI
-            # generates the backticked form for record fields.
-            pattern="(fun ${method_name}|val ${method_name}|var ${method_name}|val \`${method_name}\`|var \`${method_name}\`|${method_name}\()"
+            # Match plain (val foo), backticked (var `foo`, the form UniFFI
+            # generated for record fields), and extension properties
+            # (val XybridResult.foo) — the Kotlin SDK layers most of its
+            # ergonomics on the generated bolt types as extensions, so without
+            # that last form every one of them reports a false "not found".
+            pattern="(fun ${method_name}|val ${method_name}|var ${method_name}|val [A-Za-z0-9_]+\.${method_name}|var [A-Za-z0-9_]+\.${method_name}|val \`${method_name}\`|var \`${method_name}\`|${method_name}\()"
             ;;
         swift)
             src_dir="$SWIFT_SRC"
@@ -232,7 +235,11 @@ validate_implementations() {
 # ─── Check for valid status values ────────────────────────────────────────
 check_status_values() {
     info "Checking status values are valid..."
-    local valid_statuses="implemented partial stub planned"
+    # `na` = deliberately not applicable to that language, as opposed to
+    # `planned` (intended, not built yet). runTtsStreaming has used it since
+    # the vision PR; without it here the whole check exits non-zero forever,
+    # which buries the warnings it exists to surface.
+    local valid_statuses="implemented partial stub planned na"
 
     # Extract all status values
     local statuses


### PR DESCRIPTION
## Summary

This pull request finishes the tool-calling surface that #542 started. That PR put `toolCalls` and `rawText` on every binding's stream token, but left the ergonomics uneven: Dart and Unity C# shipped a `hasToolCalls` convenience while Swift, Kotlin and Python made you write the emptiness check by hand. The branch a tool loop actually writes should read the same in every language, so this adds it to the three that were missing it. It also repairs `api-contract-check.sh`, which is the tool that should have caught this drift and instead was failing on every run for an unrelated reason.

**Binding Ergonomics:**

* Added `hasToolCalls` to `XybridResult` and `XybridStreamToken` in Swift (extension), Kotlin (extension properties) and Python (`has_tool_calls`, installed from `_sugar.py` — the generated `_bolt` package is byte-compared in CI, so ergonomics must not live there).
* Added the missing `StreamToken` typealias in Swift and Kotlin. Those SDKs only exposed the generated `XybridStreamToken`, so the friendly name the contract file documented did not actually exist; it now works the way `ToolCall` and `GenerationConfig` already do there.

**Contract Checker Repair:**

* Taught the checker to recognise Kotlin extension properties (`val XybridResult.foo`). The Kotlin SDK layers nearly all its ergonomics onto the generated bolt types that way, so every one of them reported a false "not found" — two of those stale warnings predate this branch.
* Accepted `na` as a status value. `runTtsStreaming` has used it since the vision PR, so the script exited non-zero on *every* run, burying the six real warnings it exists to surface. It now reports 0 errors and 6 pre-existing warnings, which makes future drift visible again.

**Tests and Docs:**

* New `ToolCallConveniencesTest` (Kotlin), a case in `ModelLoaderTests` (Swift) and one in `test_sdk.py` (Python). Each asserts that only the terminal token carries calls, and that `rawText` — not `cumulativeText` — is what the continuation replays, since call blocks are suppressed from the emitted text.
* Tool-calling guide updated in both English and Chinese; `hasToolCalls` registered on both types in `docs/sdk/api-surface.yaml`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor
- [x] Other — tooling repair (`api-contract-check.sh`)

## Checklist

- [ ] Tests pass (`cargo test`)
- [x] Code follows project style (see [RUST_GUIDE.md](../../RUST_GUIDE.md))
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes documented)

No Rust changes in this PR, so `cargo test` is not the relevant gate. Purely additive otherwise — new convenience properties and typealiases, nothing renamed or removed.

## Verification

Dart 30/30 pass, Unity netstandard2.1 compiles, `gen_python_bolt.py --check` clean (the generated package is untouched), Swift parses, and `api-contract-check.sh` reports 0 errors. `cargo check -p xybrid-sdk --features llm-llamacpp` is green after merging #545, which touched three of the same files that #542 did.

**One gap worth a reviewer's attention:** I could not compile the Kotlin locally — AGP 8.2.2 needs JDK 17 and this machine only has 11. The new test and the two extension properties were written against the generated signatures field by field (`index: ULong`, `latencyMs: UInt`, `XybridExecutionTarget.LOCAL`), but CI's `testDebugUnitTest` is the first real proof. Please don't merge on a red Android job.

## Not in this PR

React Native and Web still have no tool-calling surface at all. That is pre-existing — neither shipped it in 0.6.0 — and RN is deliberately waiting to be generated rather than hand-translated, so it is out of scope here.

One unrelated line rides along: the Flutter example's `pubspec.lock` still pinned the path dep at `0.5.0` after the 0.6.0 release, and `flutter test` refreshed it to `0.6.0`. Happy to drop it if you would rather keep the diff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK conveniences, tests, docs, and contract-checker fixes only; no runtime or FFI behavior changes.
> 
> **Overview**
> Brings **tool-loop ergonomics** in line with Dart and Unity C# by adding **`hasToolCalls`** on **`XybridResult`** and stream tokens in **Swift**, **Kotlin**, and **Python** (`has_tool_calls`), so streaming and batch callers can branch without hand-rolled emptiness checks.
> 
> Swift and Kotlin also gain a public **`StreamToken`** typealias over the generated bolt type, matching how **`ToolCall`** is exposed. Python wires stream-token accessors through **`_sugar.py`** (not the generated `_bolt` package). **Tests** in all three bindings lock in that only the **terminal** token carries calls and that **`rawText`** (not **`cumulativeText`**) is what continuations replay.
> 
> **Docs** and **`api-surface.yaml`** register **`hasToolCalls`** and mark **`StreamToken`** implemented for Kotlin/Swift. **`api-contract-check.sh`** now recognizes Kotlin **extension properties** and treats **`na`** as a valid contract status so the checker stops failing on unrelated entries. The Flutter example **`pubspec.lock`** bumps the path dependency to **0.6.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6462bf64fb0a78d1051807b4f331028aca63d2c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->