### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+
+---
+
+## [0.7.0] - 2026-08-28
+
+Streaming tool loops now keep both live token delivery and conversation history.
+The terminal token carries parsed calls plus the raw assistant turn needed for
+the continuation, and every text execution path accepts that continuation.
+Separately, apps can opt into releasing idle models under memory pressure; an
+evicted model reloads itself transparently on its next use.
+
+**Upgrade notes.** `PartialToken`, the SDK `StreamToken`, and the FFI facade
+`StreamToken` gain `tool_calls` and `raw_text`. Code using their constructors is
+unchanged, but external Rust code that builds these public types with struct
+literals must populate the new fields. Image-bearing tool continuations remain
+unsupported because their embeddings cannot be reconstructed from replayed
+text.
+
 ### Added
 
 - **Tool calling works in a streaming chat.** A tools-bearing streaming run now
@@ -15,13 +36,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `raw_text` (the turn's output *with* its protocol block, which is what the
   continuation replays). Nothing needs parsing on the caller's side — call
   blocks were already suppressed from the token feed. Exposed on every stream
-  token: Rust, Swift, Kotlin, Python, Unity C#, and Dart.
+  token: Rust, Swift, Kotlin, Python, Unity C#, and Dart. Every foreign binding
+  also exposes the idiomatic `hasToolCalls` / `has_tool_calls` convenience on
+  results and stream tokens (#542, #546).
 - **`tool_results` continuations run on every text path.** `execute_with_context`,
   `execute_streaming`, and `execute_streaming_with_context` compose the
   continuation instead of rejecting it, so a chat screen keeps both its history
   and its token-by-token output across a tool turn. Backed by a new
   `LlmBackend::generate_raw_streaming`. Reference loop:
-  `crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs`.
+  `crates/xybrid-core/examples/functiongemma_tools_streaming_context.rs` (#542).
+- **Idle models can release their memory without invalidating their handles.**
+  `release_memory()` evicts least-recently-used idle models and skips busy runs;
+  the next use reloads an evicted model from disk transparently. Automatic
+  release is opt-in through `ModelLoader::with_auto_release` or the
+  process-global `set_auto_release`, and only runs before a load when the device
+  reports memory pressure. The explicit release call works regardless of that
+  setting. The Rust, BoltFFI, Python, and Dart surfaces expose the controls
+  (#539).
 
 ### Fixed
 
@@ -53,11 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **image-bearing conversation** — a continuation replays prior turns as a
   composed text prompt, and image embeddings cannot be re-evaluated from text.
   The error message and the tool-calling guide now say that it is a property of
-  the replay mechanism rather than an unfinished path.
-
-### Planned
-
-- **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.
+  the replay mechanism rather than an unfinished path (#542).
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,12 +897,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -2711,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2977,9 +2977,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -5683,9 +5683,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6239,14 +6239,14 @@ dependencies = [
 
 [[package]]
 name = "xybrid"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "xybrid-sdk",
 ]
 
 [[package]]
 name = "xybrid-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-ffi-facade"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde_json",
  "tokio",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6364,7 +6364,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-llama-sys"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-sdk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6412,7 +6412,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-whisper"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid-whisper-sys"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -6430,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_bolt"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "android_logger",
  "boltffi",
@@ -6442,7 +6442,7 @@ dependencies = [
 
 [[package]]
 name = "xybrid_flutter"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "android_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/xybrid-ai/xybrid"

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let useLocalNatives = false
 
 // Version for remote XybridFFI download (used when useLocalNatives = false).
 // Updated by the release workflow at tag time.
-let sdkVersion = "0.6.0"
+let sdkVersion = "0.7.0"
 
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let sdkVersion = "0.7.0"
 // SHA-256 of XybridFFI-v<sdkVersion>.xcframework.zip on the GitHub release.
 // Updated by `bindings/apple/scripts/sync-spm-checksum.sh` (or the release
 // workflow) so the manifest at the tagged commit matches the published asset.
-let xybridFFIChecksum = "a8be42862da9ee13343a9e3502a03e9494a3d6e45786d70568f501d27a51f55f"
+let xybridFFIChecksum = "61bb868f3904715d6779ce467d623396e014ad21e981d600d26f0e79fba82cd0"
 
 let package = Package(
     name: "Xybrid",

--- a/bindings/apple/XybridFFI-Info.plist
+++ b/bindings/apple/XybridFFI-Info.plist
@@ -7,8 +7,8 @@
 	     CFBundlePackageType) on top of these; only the version keys must be
 	     supplied. This is the embedded static framework's Info.plist. -->
 	<key>CFBundleVersion</key>
-	<string>0.6.0</string>
+	<string>0.7.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>0.7.0</string>
 </dict>
 </plist>

--- a/bindings/flutter/CHANGELOG.md
+++ b/bindings/flutter/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.7.0
+
+Streaming tool loops can now keep both live output and conversation history,
+and apps can release idle model memory without throwing away model handles.
+
+* Added: a terminal streaming token carries typed `toolCalls`,
+  `finishReason: "tool_calls"`, and `rawText`, so callers dispatch a tool without
+  parsing protocol text and retain the exact assistant turn needed for the
+  continuation (xybrid-ai/xybrid#542)
+* Added: `tool_results` continuations work through
+  `runStreamingWithContext`, preserving history and token-by-token output on the
+  second turn (xybrid-ai/xybrid#542)
+* Added: `Xybrid.releaseMemory`, `Xybrid.setAutoRelease`, and
+  `Xybrid.isAutoReleaseEnabled`. Explicit release skips busy models and an
+  evicted model reloads itself on its next use; automatic release is off by
+  default (xybrid-ai/xybrid#539)
+* Fixed: a terminal tool call is delivered exactly once. The native terminal
+  token and the completion event previously exposed the same call, which could
+  make a straightforward `hasToolCalls` loop dispatch every tool twice
+  (xybrid-ai/xybrid#542)
+* Fixed: cloud fallback preserves `maxTokens`, `temperature`, `topP`, and exact
+  `stopSequences` values instead of silently using gateway defaults or
+  corrupting whitespace- and comma-bearing stops (xybrid-ai/xybrid#545)
+* Changed: image-bearing tool continuations still fail closed, with an error
+  that explains image embeddings cannot be reconstructed from replayed text
+  (xybrid-ai/xybrid#542)
+
 ## 0.6.0
 
 Structured output, reasoning text, and tool-capability reporting reach the Dart

--- a/bindings/flutter/pubspec.yaml
+++ b/bindings/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xybrid_flutter
 description: "Xybrid Flutter SDK — run ML models on-device or in the cloud with intelligent hybrid routing and streaming inference."
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/xybrid-ai/xybrid
 repository: https://github.com/xybrid-ai/xybrid
 issue_tracker: https://github.com/xybrid-ai/xybrid/issues

--- a/bindings/flutter/rust/Cargo.toml
+++ b/bindings/flutter/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xybrid_flutter"
-version = "0.6.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
+version = "0.7.0"  # Hardcoded (not workspace) — cargokit hashes this file to detect changes
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.xybrid"
-version = "0.6.0"
+version = "0.7.0"
 
 android {
     namespace = "ai.xybrid"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xybrid"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SDK for local-first xybrid inference"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/xybrid/_bolt/__init__.py
+++ b/bindings/python/xybrid/_bolt/__init__.py
@@ -2157,7 +2157,7 @@ def telemetry_shutdown() -> None:
 
 MODULE_NAME = "xybrid_bolt"
 PACKAGE_NAME = "xybrid_bolt"
-PACKAGE_VERSION = "0.6.0"
+PACKAGE_VERSION = "0.7.0"
 
 __all__ = [
     "MODULE_NAME",

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -91,5 +91,5 @@ dependencies {
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).
-  implementation "ai.xybrid:xybrid-kotlin:0.6.0"
+  implementation "ai.xybrid:xybrid-kotlin:0.7.0"
 }

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-xybrid",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "On-device + cloud ML inference for React Native (iOS + Android), backed by the Xybrid Rust SDK",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/unity/package.json
+++ b/bindings/unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai.xybrid.sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "displayName": "Xybrid SDK",
   "description": "On-device AI SDK for Unity - LLMs, voice, npc dialogs and more",
   "unity": "2021.3",

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xybrid/web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "Preview browser tensor runtime for Xybrid metadata backed by LiteRT.",

--- a/crates/whisper-cpp-sys/Cargo.toml
+++ b/crates/whisper-cpp-sys/Cargo.toml
@@ -39,7 +39,7 @@ committed-bindings = ["bindings"]
 # "exactly one ggml" invariant enforceable: `links = "llama"` metadata tells
 # us where that ggml's headers and archives are, so whisper.cpp compiles and
 # links against them instead of configuring its own bundled copy.
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.6.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.7.0" }
 
 [build-dependencies]
 # whisper.cpp's library is ONE translation unit (`src/whisper.cpp`) whose only

--- a/crates/xybrid-core/Cargo.toml
+++ b/crates/xybrid-core/Cargo.toml
@@ -25,11 +25,11 @@ path = "src/lib.rs"
 #   `xybrid-llama-sys`  : raw FFI + cmake build (Phase 1)
 #   `xybrid-llama`   : safe RAII + typed errors + streaming trampoline (Phase 2)
 #   `xybrid-core`    : thin adapter glue (Phase 3 reduction)
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.6.0", optional = true }
-xybrid-llama = { path = "../xybrid-llama", version = "0.6.0", optional = true }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.7.0", optional = true }
+xybrid-llama = { path = "../xybrid-llama", version = "0.7.0", optional = true }
 # Safe whisper.cpp wrappers. Gated behind `asr-whispercpp`, which also pulls
 # `llm-llamacpp` — that is where the shared ggml comes from.
-xybrid-whisper = { path = "../xybrid-whisper", version = "0.6.0", optional = true }
+xybrid-whisper = { path = "../xybrid-whisper", version = "0.7.0", optional = true }
 # Real Jinja engine for the llama.cpp chat-template fallback: when llama.cpp's
 # hardcoded non-Jinja matcher rejects a GGUF's embedded template (returns -1),
 # we render that template here instead. Gated with the deps below into

--- a/crates/xybrid-llama/Cargo.toml
+++ b/crates/xybrid-llama/Cargo.toml
@@ -21,6 +21,6 @@ bindings = ["xybrid-llama-sys/bindings"]
 vision = ["bindings", "xybrid-llama-sys/vision"]
 
 [dependencies]
-xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.6.0" }
+xybrid-llama-sys = { path = "../llama-cpp-sys", version = "0.7.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid-sdk/Cargo.toml
+++ b/crates/xybrid-sdk/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-macros = { version = "0.6.0", path = "../../macros" }
+xybrid-macros = { version = "0.7.0", path = "../../macros" }
 anyhow = "1.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,12 +34,12 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["ndarray
 # Platform-specific dependencies (NOT features - those are in presets)
 # Android: rustls with ring backend (aws-lc-rs uses getentropy unavailable on API 24)
 [target.'cfg(target_os = "android")'.dependencies]
-xybrid-core = { version = "0.6.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
+xybrid-core = { version = "0.7.0", path = "../xybrid-core", default-features = false, features = ["ort-dynamic"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-xybrid-core = { version = "0.6.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
+xybrid-core = { version = "0.7.0", path = "../xybrid-core", default-features = false, features = ["ort-download"] }
 ureq = { version = "2.9", default-features = false, features = ["json", "tls"] }
 
 [features]

--- a/crates/xybrid-whisper/Cargo.toml
+++ b/crates/xybrid-whisper/Cargo.toml
@@ -20,6 +20,6 @@ default = []
 bindings = ["xybrid-whisper-sys/bindings"]
 
 [dependencies]
-xybrid-whisper-sys = { path = "../whisper-cpp-sys", version = "0.6.0" }
+xybrid-whisper-sys = { path = "../whisper-cpp-sys", version = "0.7.0" }
 thiserror = { workspace = true }
 tracing = "0.1"

--- a/crates/xybrid/Cargo.toml
+++ b/crates/xybrid/Cargo.toml
@@ -14,7 +14,7 @@ name = "xybrid"
 path = "src/lib.rs"
 
 [dependencies]
-xybrid-sdk = { version = "0.6.0", path = "../xybrid-sdk", default-features = false }
+xybrid-sdk = { version = "0.7.0", path = "../xybrid-sdk", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
Release **v0.7.0**.

Artifacts are staged in a [draft release](https://github.com/xybrid-ai/xybrid/releases/tag/v0.7.0).

When this PR merges, the **Release Publish** workflow will:
- Tag the merge commit `v0.7.0`
- Publish the draft release (asset URLs become public)
- Publish to crates.io, pub.dev, and Maven Central
- Update the `swift` branch

Close this PR (without merging) to abort. The draft release will
be cleaned up by the next `release-prep` run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/manifest sync only; behavior ships from already-merged feature work documented in the new 0.7.0 notes.
> 
> **Overview**
> **Release v0.7.0** — bumps the workspace and every published binding from `0.6.0` to `0.7.0` and freezes release notes; no runtime or API code changes appear in this diff.
> 
> The root `CHANGELOG.md` gains a dated **[0.7.0]** section (streaming tool-call termination with `tool_calls` / `raw_text`, `tool_results` on streaming paths, optional idle `release_memory` / auto-release, cloud-fallback `GenerationConfig` fixes) and moves **Multimodal KV-prefix reuse** back under **Unreleased → Planned**. Flutter’s `CHANGELOG.md` mirrors the same user-facing bullets.
> 
> Distribution metadata is aligned: `Cargo.toml` / `Cargo.lock` (all `xybrid-*` crates), Flutter `pubspec.yaml` and rust crate version, Kotlin Gradle, Python `pyproject.toml` and `PACKAGE_VERSION`, React Native and Unity `package.json`, RN’s `xybrid-kotlin` Maven pin, Apple `Package.swift` `sdkVersion` plus updated **XybridFFI** xcframework checksum, and `XybridFFI-Info.plist` bundle versions. `Cargo.lock` also picks up minor transitive bumps (`chacha20`, `cpufeatures`, `imgref`, `libredox`, `uuid`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7422c64d21e8f9db989d59b2b2987d6baf12844a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->