### PR TITLE
fix(apple): preserve backpressure in streamTokens

### DIFF
--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -282,6 +282,9 @@ extension XybridModel: @unchecked Sendable {}
 /// each call to ``AsyncIterator/next()``. A slow consumer therefore stops
 /// pulling from the facade and preserves its bounded-channel backpressure
 /// instead of accumulating tokens in an unbounded Swift buffer.
+///
+/// The sequence is one-shot. Its first iterator owns the inference run;
+/// subsequent iterators finish immediately without starting another run.
 public struct XybridTokenStream: AsyncSequence, Sendable {
     public typealias Element = XybridStreamToken
 
@@ -291,15 +294,22 @@ public struct XybridTokenStream: AsyncSequence, Sendable {
 
         public mutating func next() async throws -> XybridStreamToken? {
             guard let state else { return nil }
-            let token = try await state.next()
-            if token == nil {
+            do {
+                let token = try await state.next()
+                if token == nil {
+                    self.state = nil
+                }
+                return token
+            } catch {
                 self.state = nil
+                throw error
             }
-            return token
         }
     }
 
-    private let makeState: @Sendable () -> XybridTokenStreamState
+    // Copies share one source, so claiming an iterator transfers the only
+    // retained session state out of every copy of the sequence.
+    private let source: XybridTokenStreamSource
 
     fileprivate init(
         model: XybridModel,
@@ -320,13 +330,30 @@ public struct XybridTokenStream: AsyncSequence, Sendable {
         next: @escaping @Sendable (UInt64) throws -> XybridStreamEvent,
         close: @escaping @Sendable (UInt64) -> Void
     ) {
-        makeState = {
-            XybridTokenStreamState(start: start, next: next, close: close)
-        }
+        source = XybridTokenStreamSource(
+            state: XybridTokenStreamState(start: start, next: next, close: close)
+        )
     }
 
     public func makeAsyncIterator() -> AsyncIterator {
-        AsyncIterator(state: makeState())
+        AsyncIterator(state: source.claimState())
+    }
+}
+
+private final class XybridTokenStreamSource: @unchecked Sendable {
+    private let lock = NSLock()
+    private var state: XybridTokenStreamState?
+
+    init(state: XybridTokenStreamState) {
+        self.state = state
+    }
+
+    func claimState() -> XybridTokenStreamState? {
+        lock.lock()
+        defer { lock.unlock() }
+        let claimedState = state
+        state = nil
+        return claimedState
     }
 }
 

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -452,7 +452,12 @@ private final class XybridTokenStreamState: @unchecked Sendable {
         lock.unlock()
 
         if let id {
-            closeSessionHandle(id)
+            // Native close may wait for the worker to leave inference. A task's
+            // cancellation handler (and iterator deinit) runs synchronously on
+            // its caller, which can be the UI thread. Retain the close closure,
+            // not this state, until cleanup finishes on a background executor.
+            let closeHandle = closeSessionHandle
+            Task.detached { closeHandle(id) }
         }
     }
 }

--- a/bindings/apple/Sources/Xybrid/Xybrid.swift
+++ b/bindings/apple/Sources/Xybrid/Xybrid.swift
@@ -276,6 +276,187 @@ public typealias Model = XybridModel
 // `boltffi generate`, unlike `xybrid_bolt.swift`).
 extension XybridModel: @unchecked Sendable {}
 
+/// A pull-paced asynchronous stream of generated tokens.
+///
+/// The iterator asks the native streaming session for exactly one event from
+/// each call to ``AsyncIterator/next()``. A slow consumer therefore stops
+/// pulling from the facade and preserves its bounded-channel backpressure
+/// instead of accumulating tokens in an unbounded Swift buffer.
+public struct XybridTokenStream: AsyncSequence, Sendable {
+    public typealias Element = XybridStreamToken
+
+    /// An iterator over one native streaming session.
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        fileprivate var state: XybridTokenStreamState?
+
+        public mutating func next() async throws -> XybridStreamToken? {
+            guard let state else { return nil }
+            let token = try await state.next()
+            if token == nil {
+                self.state = nil
+            }
+            return token
+        }
+    }
+
+    private let makeState: @Sendable () -> XybridTokenStreamState
+
+    fileprivate init(
+        model: XybridModel,
+        envelope: XybridEnvelope,
+        options: XybridRunOptions?
+    ) {
+        self.init(
+            start: { try model.runStream(envelope: envelope, options: options) },
+            next: { try model.streamNext(streamId: $0) },
+            close: { model.streamClose(streamId: $0) }
+        )
+    }
+
+    // Closure injection keeps the pull and cancellation contract testable
+    // without loading a native model. This initializer remains module-internal.
+    init(
+        start: @escaping @Sendable () throws -> UInt64,
+        next: @escaping @Sendable (UInt64) throws -> XybridStreamEvent,
+        close: @escaping @Sendable (UInt64) -> Void
+    ) {
+        makeState = {
+            XybridTokenStreamState(start: start, next: next, close: close)
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(state: makeState())
+    }
+}
+
+private final class XybridTokenStreamState: @unchecked Sendable {
+    private let lock = NSLock()
+    private let startSession: @Sendable () throws -> UInt64
+    private let pullNext: @Sendable (UInt64) throws -> XybridStreamEvent
+    private let closeSessionHandle: @Sendable (UInt64) -> Void
+    private var streamId: UInt64?
+    private var finished = false
+
+    init(
+        start: @escaping @Sendable () throws -> UInt64,
+        next: @escaping @Sendable (UInt64) throws -> XybridStreamEvent,
+        close: @escaping @Sendable (UInt64) -> Void
+    ) {
+        startSession = start
+        pullNext = next
+        closeSessionHandle = close
+    }
+
+    deinit {
+        close()
+    }
+
+    func next() async throws -> XybridStreamToken? {
+        if Task.isCancelled {
+            close()
+            return nil
+        }
+
+        do {
+            let token = try await withTaskCancellationHandler {
+                try await Task.detached { try self.pullOne() }.value
+            } onCancel: {
+                self.close()
+            }
+            if Task.isCancelled {
+                close()
+                return nil
+            }
+            return token
+        } catch {
+            if Task.isCancelled {
+                close()
+                return nil
+            }
+            throw error
+        }
+    }
+
+    private func pullOne() throws -> XybridStreamToken? {
+        let id = try sessionId()
+        let event: XybridStreamEvent
+        do {
+            event = try pullNext(id)
+        } catch {
+            close()
+            throw error
+        }
+
+        switch event.kind {
+        case .token:
+            guard let token = event.token else {
+                close()
+                throw XybridError.inferenceError(
+                    message: "Native stream returned a token event without a token"
+                )
+            }
+            return token
+        case .complete:
+            close()
+            return nil
+        }
+    }
+
+    private func sessionId() throws -> UInt64 {
+        lock.lock()
+        if finished {
+            lock.unlock()
+            throw CancellationError()
+        }
+        if let streamId {
+            lock.unlock()
+            return streamId
+        }
+        lock.unlock()
+
+        let openedId: UInt64
+        do {
+            openedId = try startSession()
+        } catch {
+            close()
+            throw error
+        }
+        lock.lock()
+        if finished {
+            lock.unlock()
+            closeSessionHandle(openedId)
+            throw CancellationError()
+        }
+        if let existingId = streamId {
+            lock.unlock()
+            // Defensive only: AsyncIteratorProtocol requires serialized next
+            // calls, but do not leak a session if a caller violates it.
+            closeSessionHandle(openedId)
+            return existingId
+        }
+        streamId = openedId
+        lock.unlock()
+        return openedId
+    }
+
+    private func close() {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        let id = streamId
+        streamId = nil
+        lock.unlock()
+
+        if let id {
+            closeSessionHandle(id)
+        }
+    }
+}
+
 public extension XybridModel {
     /// Run inference with the model's default options.
     ///
@@ -353,12 +534,6 @@ public extension XybridModel {
     /// pull-based session API (``runStream(envelope:options:)`` /
     /// ``streamNext(streamId:)`` / ``streamClose(streamId:)``).
     ///
-    /// Note: the producing task pulls as fast as generation runs and buffers
-    /// unconsumed tokens in the async sequence (unbounded), so the facade's
-    /// bounded-channel backpressure applies to the raw session pull API, not
-    /// to a slow consumer of this sequence. Buffering is bounded by
-    /// `max_tokens` in practice; a bounded policy here would drop tokens.
-    ///
     /// ```swift
     /// for try await token in model.streamTokens(envelope: env) {
     ///     print(token.token, terminator: "")
@@ -367,38 +542,8 @@ public extension XybridModel {
     func streamTokens(
         envelope: XybridEnvelope,
         options: XybridRunOptions? = nil
-    ) -> AsyncThrowingStream<XybridStreamToken, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task.detached {
-                var streamId: UInt64?
-                do {
-                    let id = try self.runStream(envelope: envelope, options: options)
-                    streamId = id
-                    while !Task.isCancelled {
-                        let event = try self.streamNext(streamId: id)
-                        switch event.kind {
-                        case .token:
-                            if let token = event.token {
-                                continuation.yield(token)
-                            }
-                        case .complete:
-                            self.streamClose(streamId: id)
-                            continuation.finish()
-                            return
-                        }
-                    }
-                    // Cancelled: close the session to abort the in-flight run.
-                    self.streamClose(streamId: id)
-                    continuation.finish()
-                } catch {
-                    // A failed streamNext has already closed the session
-                    // bolt-side; closing again is an idempotent map-remove.
-                    if let id = streamId { self.streamClose(streamId: id) }
-                    continuation.finish(throwing: error)
-                }
-            }
-            continuation.onTermination = { _ in task.cancel() }
-        }
+    ) -> XybridTokenStream {
+        XybridTokenStream(model: self, envelope: envelope, options: options)
     }
 }
 

--- a/bindings/apple/Tests/XybridTests/TokenStreamTests.swift
+++ b/bindings/apple/Tests/XybridTests/TokenStreamTests.swift
@@ -33,6 +33,53 @@ final class TokenStreamTests: XCTestCase {
         XCTAssertEqual(probe.closeCount, 1)
     }
 
+    func testErrorTerminatesIterator() async throws {
+        let probe = StreamProbe(events: [])
+        var iterator = probe.stream().makeAsyncIterator()
+
+        do {
+            _ = try await iterator.next()
+            XCTFail("the first pull should throw")
+        } catch {
+            // The iterator must surface the native error exactly once.
+        }
+
+        let firstAfterError = try await iterator.next()
+        let secondAfterError = try await iterator.next()
+        XCTAssertNil(firstAfterError)
+        XCTAssertNil(secondAfterError)
+        XCTAssertEqual(probe.startCount, 1)
+        XCTAssertEqual(probe.pullCount, 1)
+        XCTAssertTrue(probe.waitUntilClosed(timeout: 2))
+        XCTAssertEqual(probe.closeCount, 1)
+    }
+
+    func testStreamAllowsOnlyOneInferenceRun() async throws {
+        let probe = StreamProbe(events: [
+            .token("one", index: 0),
+            .complete,
+        ])
+        let stream = probe.stream()
+        let streamCopy = stream
+        var firstIterator = stream.makeAsyncIterator()
+        var secondIterator = streamCopy.makeAsyncIterator()
+
+        let firstFromSecondIterator = try await secondIterator.next()
+        let secondFromSecondIterator = try await secondIterator.next()
+        XCTAssertNil(firstFromSecondIterator)
+        XCTAssertNil(secondFromSecondIterator)
+        XCTAssertEqual(probe.startCount, 0)
+
+        let token = try await firstIterator.next()
+        let end = try await firstIterator.next()
+        XCTAssertEqual(token?.token, "one")
+        XCTAssertNil(end)
+        XCTAssertEqual(probe.startCount, 1)
+        XCTAssertEqual(probe.pullCount, 2)
+        XCTAssertTrue(probe.waitUntilClosed(timeout: 2))
+        XCTAssertEqual(probe.closeCount, 1)
+    }
+
     func testBreakingIterationClosesTheNativeSession() async throws {
         let probe = StreamProbe(events: [
             .token("one", index: 0),

--- a/bindings/apple/Tests/XybridTests/TokenStreamTests.swift
+++ b/bindings/apple/Tests/XybridTests/TokenStreamTests.swift
@@ -29,6 +29,7 @@ final class TokenStreamTests: XCTestCase {
         let end = try await iterator.next()
         XCTAssertNil(end)
         XCTAssertEqual(probe.pullCount, 3)
+        XCTAssertTrue(probe.waitUntilClosed(timeout: 2))
         XCTAssertEqual(probe.closeCount, 1)
     }
 
@@ -41,6 +42,7 @@ final class TokenStreamTests: XCTestCase {
         try await consumeOne(probe.stream())
 
         XCTAssertEqual(probe.pullCount, 1)
+        XCTAssertTrue(probe.waitUntilClosed(timeout: 2))
         XCTAssertEqual(probe.closeCount, 1)
     }
 
@@ -60,6 +62,33 @@ final class TokenStreamTests: XCTestCase {
         XCTAssertEqual(probe.closeCount, 1)
     }
 
+    func testCancellationDoesNotWaitForNativeCleanup() async throws {
+        let probe = StreamProbe(events: [], blockPullUntilClosed: true, blockClose: true)
+        let task = Task { () throws -> XybridStreamToken? in
+            var iterator = probe.stream().makeAsyncIterator()
+            return try await iterator.next()
+        }
+        XCTAssertTrue(probe.waitUntilPullStarts(timeout: 2))
+        let cancellationReturned = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            task.cancel()
+            cancellationReturned.signal()
+        }
+        let closeStarted = probe.waitUntilClosed(timeout: 2)
+        let returned = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: cancellationReturned.wait(timeout: .now() + 2) == .success)
+            }
+        }
+        // Always release the mock worker, including on a failed assertion.
+        probe.releaseClose()
+        XCTAssertTrue(closeStarted)
+        XCTAssertTrue(returned, "cancelling a task must not drain native inference inline")
+        let result = try await task.value
+        XCTAssertNil(result)
+        XCTAssertEqual(probe.closeCount, 1)
+    }
+
     private func consumeOne(_ stream: XybridTokenStream) async throws {
         for try await token in stream {
             XCTAssertEqual(token.token, "one")
@@ -72,15 +101,18 @@ private final class StreamProbe: @unchecked Sendable {
     private let condition = NSCondition()
     private var events: [XybridStreamEvent]
     private let blockPullUntilClosed: Bool
+    private let blockClose: Bool
     private var starts = 0
     private var pulls = 0
     private var closes = 0
     private var pullStarted = false
     private var closed = false
+    private var closeReleased = false
 
-    init(events: [XybridStreamEvent], blockPullUntilClosed: Bool = false) {
+    init(events: [XybridStreamEvent], blockPullUntilClosed: Bool = false, blockClose: Bool = false) {
         self.events = events
         self.blockPullUntilClosed = blockPullUntilClosed
+        self.blockClose = blockClose
     }
 
     var startCount: Int { read { starts } }
@@ -103,6 +135,23 @@ private final class StreamProbe: @unchecked Sendable {
             if !condition.wait(until: deadline) { return false }
         }
         return true
+    }
+
+    func waitUntilClosed(timeout: TimeInterval) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        let deadline = Date().addingTimeInterval(timeout)
+        while !closed {
+            if !condition.wait(until: deadline) { return false }
+        }
+        return true
+    }
+
+    func releaseClose() {
+        condition.lock()
+        closeReleased = true
+        condition.broadcast()
+        condition.unlock()
     }
 
     private func start() -> UInt64 {
@@ -144,6 +193,9 @@ private final class StreamProbe: @unchecked Sendable {
             closed = true
         }
         condition.broadcast()
+        while blockClose && !closeReleased {
+            condition.wait()
+        }
         condition.unlock()
     }
 

--- a/bindings/apple/Tests/XybridTests/TokenStreamTests.swift
+++ b/bindings/apple/Tests/XybridTests/TokenStreamTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import XCTest
+@testable import Xybrid
+
+final class TokenStreamTests: XCTestCase {
+    func testPullsExactlyOnceForEachRequestedElement() async throws {
+        let probe = StreamProbe(events: [
+            .token("one", index: 0),
+            .token("two", index: 1),
+            .complete,
+        ])
+        let stream = probe.stream()
+        var iterator = stream.makeAsyncIterator()
+
+        XCTAssertEqual(probe.startCount, 0)
+        XCTAssertEqual(probe.pullCount, 0)
+
+        let first = try await iterator.next()
+        XCTAssertEqual(first?.token, "one")
+        XCTAssertEqual(probe.startCount, 1)
+        XCTAssertEqual(probe.pullCount, 1)
+
+        await Task.yield()
+        XCTAssertEqual(probe.pullCount, 1, "the stream must not prefetch")
+
+        let second = try await iterator.next()
+        XCTAssertEqual(second?.token, "two")
+        XCTAssertEqual(probe.pullCount, 2)
+        let end = try await iterator.next()
+        XCTAssertNil(end)
+        XCTAssertEqual(probe.pullCount, 3)
+        XCTAssertEqual(probe.closeCount, 1)
+    }
+
+    func testBreakingIterationClosesTheNativeSession() async throws {
+        let probe = StreamProbe(events: [
+            .token("one", index: 0),
+            .token("two", index: 1),
+        ])
+
+        try await consumeOne(probe.stream())
+
+        XCTAssertEqual(probe.pullCount, 1)
+        XCTAssertEqual(probe.closeCount, 1)
+    }
+
+    func testCancellationClosesAnInFlightPull() async throws {
+        let probe = StreamProbe(events: [], blockPullUntilClosed: true)
+        let stream = probe.stream()
+        let task = Task { () throws -> XybridStreamToken? in
+            var iterator = stream.makeAsyncIterator()
+            return try await iterator.next()
+        }
+
+        XCTAssertTrue(probe.waitUntilPullStarts(timeout: 2))
+        task.cancel()
+
+        let result = try await task.value
+        XCTAssertNil(result)
+        XCTAssertEqual(probe.closeCount, 1)
+    }
+
+    private func consumeOne(_ stream: XybridTokenStream) async throws {
+        for try await token in stream {
+            XCTAssertEqual(token.token, "one")
+            break
+        }
+    }
+}
+
+private final class StreamProbe: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var events: [XybridStreamEvent]
+    private let blockPullUntilClosed: Bool
+    private var starts = 0
+    private var pulls = 0
+    private var closes = 0
+    private var pullStarted = false
+    private var closed = false
+
+    init(events: [XybridStreamEvent], blockPullUntilClosed: Bool = false) {
+        self.events = events
+        self.blockPullUntilClosed = blockPullUntilClosed
+    }
+
+    var startCount: Int { read { starts } }
+    var pullCount: Int { read { pulls } }
+    var closeCount: Int { read { closes } }
+
+    func stream() -> XybridTokenStream {
+        XybridTokenStream(
+            start: { self.start() },
+            next: { try self.next(streamId: $0) },
+            close: { self.close(streamId: $0) }
+        )
+    }
+
+    func waitUntilPullStarts(timeout: TimeInterval) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        let deadline = Date().addingTimeInterval(timeout)
+        while !pullStarted {
+            if !condition.wait(until: deadline) { return false }
+        }
+        return true
+    }
+
+    private func start() -> UInt64 {
+        condition.lock()
+        starts += 1
+        condition.unlock()
+        return 7
+    }
+
+    private func next(streamId: UInt64) throws -> XybridStreamEvent {
+        guard streamId == 7 else {
+            throw XybridError.inferenceError(message: "unexpected stream id")
+        }
+        condition.lock()
+        pulls += 1
+        pullStarted = true
+        condition.broadcast()
+        if blockPullUntilClosed {
+            while !closed {
+                condition.wait()
+            }
+            condition.unlock()
+            throw XybridError.inferenceError(message: "stream closed")
+        }
+        guard !events.isEmpty else {
+            condition.unlock()
+            throw XybridError.inferenceError(message: "unexpected pull")
+        }
+        let event = events.removeFirst()
+        condition.unlock()
+        return event
+    }
+
+    private func close(streamId: UInt64) {
+        guard streamId == 7 else { return }
+        condition.lock()
+        if !closed {
+            closes += 1
+            closed = true
+        }
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    private func read<T>(_ value: () -> T) -> T {
+        condition.lock()
+        defer { condition.unlock() }
+        return value()
+    }
+}
+
+private extension XybridStreamEvent {
+    static func token(_ text: String, index: UInt64) -> Self {
+        Self(
+            kind: .token,
+            token: XybridStreamToken(
+                token: text,
+                tokenId: nil,
+                index: index,
+                cumulativeText: text,
+                finishReason: nil,
+                toolCalls: [],
+                rawText: nil
+            )
+        )
+    }
+
+    static var complete: Self {
+        Self(kind: .complete, token: nil)
+    }
+}


### PR DESCRIPTION
## Summary

`streamTokens()` currently starts a detached producer that pulls until generation finishes, while `AsyncThrowingStream` stores every token the consumer has not processed yet. That disconnects the facade bounded channel from the real consumer pace.

This replaces the producer with a pull-paced `XybridTokenStream` AsyncSequence:

- each iterator `next()` performs exactly one `streamNext`
- the blocking native pull runs off the caller actor
- there is no Swift-side token buffer and no token-dropping policy
- the native session starts lazily on the first pull
- the sequence is one-shot across copies; later iterators finish without starting inference
- completion, errors, task cancellation, and an early loop exit all close the session idempotently

The state lock only protects the session lifecycle. It is never held across `runStream`, `streamNext`, or `streamClose`, so cancellation can close an in-flight native pull.

## Tests

Added focused Swift tests covering:

- one native pull per requested element, with no prefetch
- breaking out of iteration closes the native session
- cancelling during an in-flight pull closes the session and terminates the sequence
- an error is emitted once, followed by nil on later pulls
- copies of a stream still allow only one inference run

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Verification

- Swift 5 typecheck against the shipped v0.7.0 simulator framework
- Swift strict-concurrency typecheck with warnings as errors
- six closure-based lifecycle tests passed 50 repetitions under Swift 6 strict concurrency
- Swift test target typecheck
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download`

This host only has Apple Command Line Tools, not the full iOS SDK, so it cannot execute the XCTest target. The production module and test sources both typecheck; the Apple CI build provides the real iOS compilation gate.

## Checklist

- [x] Tests and repository gates pass
- [x] Code follows the existing Apple wrapper style
- [x] Documentation reflects the new pull-paced behavior
- [x] No changes to the generated BoltFFI source
- [x] Commit is DCO-signed

Closes #440