### PR TITLE
fix(kotlin): ship callable JNI AAR

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -382,9 +382,9 @@ jobs:
           APK=bindings/kotlin/consumer-smoke/app/build/outputs/apk/debug/app-debug.apk
           unzip -l "$APK"
           for f in \
-            lib/arm64-v8a/libxybrid-bolt.so lib/arm64-v8a/libc++_shared.so lib/arm64-v8a/libonnxruntime.so \
-            lib/armeabi-v7a/libxybrid-bolt.so lib/armeabi-v7a/libc++_shared.so \
-            lib/x86_64/libxybrid-bolt.so lib/x86_64/libc++_shared.so lib/x86_64/libonnxruntime.so \
+            lib/arm64-v8a/libxybrid_bolt.so lib/arm64-v8a/libc++_shared.so lib/arm64-v8a/libonnxruntime.so \
+            lib/armeabi-v7a/libxybrid_bolt.so lib/armeabi-v7a/libc++_shared.so \
+            lib/x86_64/libxybrid_bolt.so lib/x86_64/libc++_shared.so lib/x86_64/libonnxruntime.so \
             classes.dex; do
             unzip -l "$APK" | grep -q " $f\$" || { echo "MISSING: $f"; exit 1; }
           done

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -11,6 +11,7 @@ on:
       - 'crates/xybrid-sdk/**'
       - 'tools/scripts/android-dlopen-gate.sh'
       - 'tools/scripts/android-dlopen-probe.c'
+      - 'tools/scripts/verify_android_jni.py'
       - 'xtask/**'
       - 'Cargo.lock'
       - 'Cargo.toml'
@@ -35,6 +36,7 @@ on:
       - 'crates/xybrid-sdk/**'
       - 'tools/scripts/android-dlopen-gate.sh'
       - 'tools/scripts/android-dlopen-probe.c'
+      - 'tools/scripts/verify_android_jni.py'
       - 'xtask/**'
       - 'Cargo.lock'
       - 'Cargo.toml'
@@ -151,18 +153,8 @@ jobs:
             # The Kotlin surface is made of JVM `external fun`s, so a plain
             # Bolt C ABI is insufficient. Require every generated Java_* JNI
             # trampoline to survive the final link and symbol stripping.
-            expected_jni="$(grep -c 'JNICALL Java_ai_xybrid_Native_' bindings/kotlin/bazel/jni/jni_glue.c)"
-            dynamic_symbols="$("$READELF" --dyn-syms --wide "$SO")"
-            actual_jni="$(grep -c 'Java_ai_xybrid_Native_' <<< "$dynamic_symbols" || true)"
-            if [ "$actual_jni" -ne "$expected_jni" ]; then
-              echo "Error: $SO exports $actual_jni/$expected_jni generated JNI entry points"
-              exit 1
-            fi
-            if ! grep -F 'boltffi_function_xybrid_bolt_set_binding' <<< "$dynamic_symbols" > /dev/null; then
-              echo "Error: $SO is missing the underlying Bolt C ABI"
-              exit 1
-            fi
-            echo "  JNI exports: $actual_jni/$expected_jni present"
+            python3 tools/scripts/verify_android_jni.py --readelf "$READELF" \
+              --glue bindings/kotlin/bazel/jni/jni_glue.c "$SO"
             # libc++_shared must be a declared dependency. It's added at link
             # time by the Bazel JNI link (no patchelf), so the .so is a clean
             # linker output that survives a consumer's strip. Guard against a
@@ -220,11 +212,14 @@ jobs:
           NDKBIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
           SRC="bindings/kotlin/libs/x86_64"
           mkdir -p dlopen-gate
+          cp bazel-bin/bindings/kotlin/xybrid-kotlin.aar dlopen-gate/
           cp "$SRC/libxybrid_bolt.so" "$SRC/libc++_shared.so" "$SRC/libonnxruntime.so" dlopen-gate/
           # AGP-style strip — the exact step that corrupted the old patchelf'd
           # .so. The fixed clean .so must still dlopen after it.
           cp "$SRC/libxybrid_bolt.so" dlopen-gate/libxybrid_bolt.stripped.so
           "$NDKBIN/llvm-strip" --strip-all dlopen-gate/libxybrid_bolt.stripped.so
+          python3 tools/scripts/verify_android_jni.py --readelf "$NDKBIN/llvm-readelf" \
+            --glue bindings/kotlin/bazel/jni/jni_glue.c dlopen-gate/libxybrid_bolt.stripped.so
           # Probe executable for the emulator's x86_64 ABI.
           "$NDKBIN/x86_64-linux-android24-clang" \
             tools/scripts/android-dlopen-probe.c -o dlopen-gate/android-dlopen-probe
@@ -308,6 +303,15 @@ jobs:
           name: android-dlopen-gate
           path: dlopen-gate
 
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Stage the shipped AAR for the instrumented consumer
+        run: |
+          mkdir -p bindings/kotlin/consumer-smoke/app/libs
+          cp dlopen-gate/xybrid-kotlin.aar bindings/kotlin/consumer-smoke/app/libs/
+
       # `android-emulator-runner` installs the "latest emulator" with a single,
       # un-retried `sdkmanager --install emulator` call. That download
       # intermittently lands corrupt on the runner and fails the whole job with
@@ -345,7 +349,7 @@ jobs:
 
       # api-level 35 = Android 15 bionic, which is strict enough to reject the
       # DT_GNU_HASH corruption this gate guards against.
-      - name: dlopen libxybrid_bolt.so (as built + after AGP strip)
+      - name: Load native libraries and invoke JNI from the consumer APK
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: 35
@@ -354,4 +358,6 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           disable-animations: true
-          script: bash tools/scripts/android-dlopen-gate.sh dlopen-gate
+          script: |
+            bash tools/scripts/android-dlopen-gate.sh dlopen-gate
+            bindings/kotlin/gradlew -p bindings/kotlin/consumer-smoke :app:connectedDebugAndroidTest --no-daemon --console=plain

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -57,11 +57,9 @@ env:
   NDK_VERSION: "27.0.12077973"
 
 jobs:
-  # Single job (no per-ABI matrix): the bolt build
-  # (tools/scripts/build-android-bolt.sh, invoked by `cargo xtask
-  # build-android`) always builds every ABI in one `boltffi pack android`
-  # invocation, so a matrix would just re-run the full ~all-ABI build N
-  # times. Build once, verify the ABIs the Kotlin AAR ships.
+  # Single job (no per-ABI matrix): the Bazel AAR target fans out to every
+  # shipped ABI inside one graph. Build once, then audit the exact artifact a
+  # Maven consumer receives.
   build-android:
     name: Build Android .so (all ABIs)
     runs-on: ubuntu-latest
@@ -123,8 +121,8 @@ jobs:
 
       # Build the feature-complete 3-ABI AAR with Bazel and stage its jniLibs
       # into bindings/kotlin/libs/ (the layout the verify + gate steps and the
-      # Kotlin AAR expect). Replaces build-android-bolt.sh (boltffi pack +
-      # clang-shim relink + patchelf); the .so is a clean one-link output.
+      # Kotlin AAR expect). The target mirrors boltffi's JNI relink inside the
+      # Bazel graph; the .so is a clean one-link output.
       - name: Build Android jniLibs (Bazel AAR)
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -144,16 +142,31 @@ jobs:
           # bindings/kotlin/build.gradle.kts). i686/x86 is built but not
           # packaged, so it's not verified here.
           for abi in armeabi-v7a arm64-v8a x86_64; do
-            SO="$SO_BASE/$abi/libxybrid-bolt.so"
+            SO="$SO_BASE/$abi/libxybrid_bolt.so"
             if [ ! -f "$SO" ]; then
               echo "Error: $SO not found"
               exit 1
             fi
             echo "OK: $SO ($(du -h "$SO" | cut -f1))"
+            # The Kotlin surface is made of JVM `external fun`s, so a plain
+            # Bolt C ABI is insufficient. Require every generated Java_* JNI
+            # trampoline to survive the final link and symbol stripping.
+            expected_jni="$(grep -c 'JNICALL Java_ai_xybrid_Native_' bindings/kotlin/bazel/jni/jni_glue.c)"
+            dynamic_symbols="$("$READELF" --dyn-syms --wide "$SO")"
+            actual_jni="$(grep -c 'Java_ai_xybrid_Native_' <<< "$dynamic_symbols" || true)"
+            if [ "$actual_jni" -ne "$expected_jni" ]; then
+              echo "Error: $SO exports $actual_jni/$expected_jni generated JNI entry points"
+              exit 1
+            fi
+            if ! grep -F 'boltffi_function_xybrid_bolt_set_binding' <<< "$dynamic_symbols" > /dev/null; then
+              echo "Error: $SO is missing the underlying Bolt C ABI"
+              exit 1
+            fi
+            echo "  JNI exports: $actual_jni/$expected_jni present"
             # libc++_shared must be a declared dependency. It's added at link
-            # time by the clang shim in build-android-bolt.sh (no patchelf), so
-            # the .so is a clean linker output that survives a consumer's strip.
-            # Guard against a shim regression that would dlopen-fail on device.
+            # time by the Bazel JNI link (no patchelf), so the .so is a clean
+            # linker output that survives a consumer's strip. Guard against a
+            # link regression that would dlopen-fail on device.
             if ! "$READELF" -d "$SO" | grep -q 'libc++_shared.so'; then
               echo "Error: $SO is missing libc++_shared.so in DT_NEEDED"
               exit 1
@@ -207,11 +220,11 @@ jobs:
           NDKBIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
           SRC="bindings/kotlin/libs/x86_64"
           mkdir -p dlopen-gate
-          cp "$SRC/libxybrid-bolt.so" "$SRC/libc++_shared.so" "$SRC/libonnxruntime.so" dlopen-gate/
+          cp "$SRC/libxybrid_bolt.so" "$SRC/libc++_shared.so" "$SRC/libonnxruntime.so" dlopen-gate/
           # AGP-style strip — the exact step that corrupted the old patchelf'd
           # .so. The fixed clean .so must still dlopen after it.
-          cp "$SRC/libxybrid-bolt.so" dlopen-gate/libxybrid-bolt.stripped.so
-          "$NDKBIN/llvm-strip" --strip-all dlopen-gate/libxybrid-bolt.stripped.so
+          cp "$SRC/libxybrid_bolt.so" dlopen-gate/libxybrid_bolt.stripped.so
+          "$NDKBIN/llvm-strip" --strip-all dlopen-gate/libxybrid_bolt.stripped.so
           # Probe executable for the emulator's x86_64 ABI.
           "$NDKBIN/x86_64-linux-android24-clang" \
             tools/scripts/android-dlopen-probe.c -o dlopen-gate/android-dlopen-probe
@@ -264,7 +277,7 @@ jobs:
         working-directory: bindings/kotlin
         run: ./gradlew compileReleaseKotlin compileDebugKotlin testDebugUnitTest --console=plain --stacktrace
 
-  # The authoritative gate: actually dlopen the shipped libxybrid-bolt.so on an
+  # The authoritative gate: actually dlopen the shipped libxybrid_bolt.so on an
   # emulator — as built AND after an AGP-style strip. This is the regression
   # guard the strip-fragility bug needed and never had: nothing in CI ever
   # loaded the bolt .so in a process, so a .so that passed `readelf` but failed
@@ -332,7 +345,7 @@ jobs:
 
       # api-level 35 = Android 15 bionic, which is strict enough to reject the
       # DT_GNU_HASH corruption this gate guards against.
-      - name: dlopen libxybrid-bolt.so (as built + after AGP strip)
+      - name: dlopen libxybrid_bolt.so (as built + after AGP strip)
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: 35

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
       unity_bolt: ${{ steps.filter.outputs.unity_bolt }}
       python_sdk: ${{ steps.filter.outputs.python_sdk }}
+      kotlin_jni: ${{ steps.filter.outputs.kotlin_jni }}
     steps:
       - name: Check changed paths
         id: filter
@@ -77,6 +78,28 @@ jobs:
           fi
           echo "python_sdk=$PYTHON_SDK" >> "$GITHUB_OUTPUT"
           echo "Python SDK changes: $PYTHON_SDK"
+          if printf '%s\n' "$FILES" | grep -qE '^(bindings/kotlin/|tools/scripts/gen_kotlin_bolt\.py$|crates/xybrid-bolt/|crates/xybrid-ffi-facade/|\.github/workflows/ci\.yml$)'; then
+            KOTLIN_JNI=true
+          else
+            KOTLIN_JNI=false
+          fi
+          echo "kotlin_jni=$KOTLIN_JNI" >> "$GITHUB_OUTPUT"
+
+  kotlin-jni-drift:
+    name: Kotlin and JNI generation drift
+    needs: tooling-changes
+    if: needs.tooling-changes.outputs.kotlin_jni == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install the pinned boltffi CLI
+        run: cargo install boltffi_cli --version 0.29.3 --locked
+      - name: Compare committed Kotlin and JNI with fresh generation
+        run: python3 tools/scripts/gen_kotlin_bolt.py --check
 
   tooling-tests:
     name: Tooling tests (${{ matrix.platform }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
     runs-on: ubuntu-latest
     # Inspect dependency results even when the tooling path gate skips its matrix.
     if: ${{ !cancelled() }}
-    needs: [tooling-changes, tooling-tests, unity-bolt-compile, python-sdk, fmt, clippy, check-no-default-features, check-platform-macos, check-platform-desktop, check-vision-platforms, check-llamacpp-vulkan, clippy-llm, test-llm, test, api-contract, web]
+    needs: [tooling-changes, tooling-tests, unity-bolt-compile, python-sdk, kotlin-jni-drift, fmt, clippy, check-no-default-features, check-platform-macos, check-platform-desktop, check-vision-platforms, check-llamacpp-vulkan, clippy-llm, test-llm, test, api-contract, web]
     steps:
       - name: Verify required job results
         env:
@@ -528,6 +528,11 @@ jobs:
                   .key == "python-sdk"
                   and .value.result == "skipped"
                   and $needs["tooling-changes"].outputs.python_sdk == "false"
+                )
+                or (
+                  .key == "kotlin-jni-drift"
+                  and .value.result == "skipped"
+                  and $needs["tooling-changes"].outputs.kotlin_jni == "false"
                 )
               )
           ' <<<"$NEEDS_JSON"

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -313,7 +313,7 @@ jobs:
         run: |
           SO_BASE_PATH="bindings/kotlin/libs"
           for abi in armeabi-v7a arm64-v8a x86_64; do
-            SO_PATH="$SO_BASE_PATH/$abi/libxybrid-bolt.so"
+            SO_PATH="$SO_BASE_PATH/$abi/libxybrid_bolt.so"
             if [ ! -f "$SO_PATH" ]; then
               echo "Error: .so file not found at $SO_PATH"
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The published Kotlin AAR now contains a callable JNI library.** Its native
+  filename matches `System.loadLibrary("xybrid_bolt")`, and the Bazel link
+  includes every generated `Java_ai_xybrid_Native_*` trampoline over the Bolt
+  C ABI. Android CI compares the final ELF exports with the generated JNI
+  source so a filename-only or C-ABI-only artifact cannot ship again (#530).
+
 ### Planned
 
 - **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.

--- a/bindings/kotlin/.gitignore
+++ b/bindings/kotlin/.gitignore
@@ -1,6 +1,6 @@
 # Native libraries under libs/ are build outputs, not source. They are
 # staged from the Bazel AAR (`bazel build -c opt //bindings/kotlin:xybrid_kotlin_aar`):
-#   - libxybrid-bolt.so  — Bazel build of crates/xybrid-bolt
+#   - libxybrid_bolt.so  — Bazel build of crates/xybrid-bolt
 #   - libonnxruntime.so  — copied from vendor/ort-android/ (the tracked source)
 #   - libc++_shared.so   — copied from the NDK sysroot
 # Releases ship them via the GitHub Release asset → Maven Central, not from

--- a/bindings/kotlin/BUILD.bazel
+++ b/bindings/kotlin/BUILD.bazel
@@ -9,13 +9,14 @@
 # transitions too.
 #
 # jni payload per ABI:
-#   libxybrid-bolt.so   — the one-link cdylib (renamed: rustc emits underscore,
-#                         Kotlin's System.loadLibrary("xybrid-bolt") wants hyphen)
+#   libxybrid_bolt.so   — the BoltFFI JNI glue linked with the Rust staticlib;
+#                         matches System.loadLibrary("xybrid_bolt") exactly
 #   libc++_shared.so    — from @androidndk's sysroot (version-matched to the
 #                         NDK that linked the .so; no vendored drift)
 #   libonnxruntime.so   — vendored, arm64-v8a + x86_64 only (armv7 ships no ORT,
 #                         matching today's AAR)
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import")
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
@@ -40,14 +41,51 @@ ANDROID_ABIS = [
     ("x86_64", "@rules_rs//rs/platforms:x86_64-linux-android", "x86_64-linux-android", "//:ort_android_x86_64"),
 ]
 
-# The NDK repo's clang dir is pinned to linux-x86_64 binaries by
-# XYBRID_NDK_HOST_TAG in the committed .bazelrc (RBE workers run them).
-NDK_SYSROOT = "@androidndk//toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+cc_import(
+    name = "android_cxx_shared",
+    shared_library = select({
+        "@rules_rs//rs/platforms/config:aarch64-linux-android": "@androidndk//:libcxx_shared_aarch64-linux-android",
+        "@rules_rs//rs/platforms/config:armv7-linux-androideabi": "@androidndk//:libcxx_shared_arm-linux-androideabi",
+        "@rules_rs//rs/platforms/config:x86_64-linux-android": "@androidndk//:libcxx_shared_x86_64-linux-android",
+    }),
+)
+
+# BoltFFI's generated Kotlin declares JVM `external fun`s. The Rust staticlib
+# exports the underlying C ABI, while this generated C layer exports the
+# matching Java_* JNI entry points and translates JVM values to that ABI. This
+# mirrors `boltffi pack android`; packaging the Rust cdylib alone is not enough
+# for a JVM consumer.
+cc_binary(
+    name = "libxybrid_bolt.so",
+    srcs = [
+        "bazel/jni/jni_glue.c",
+        "bazel/jni/xybrid_bolt.h",
+    ],
+    additional_linker_inputs = ["bazel/jni/exports.map"],
+    deps = [
+        ":android_cxx_shared",
+        "//crates/xybrid-bolt:xybrid_bolt_staticlib",
+    ],
+    linkopts = [
+        "-Wl,--version-script,$(location bazel/jni/exports.map)",
+        "-Wl,--gc-sections",
+        "-Wl,-z,nodelete",
+        "-Wl,-z,max-page-size=16384",
+        "-Wl,-soname,libxybrid_bolt.so",
+        "-Wl,-s",
+        "-llog",
+        "-ldl",
+        "-lm",
+    ],
+    linkshared = True,
+    linkstatic = True,
+    target_compatible_with = ["@platforms//os:android"],
+)
 
 [
     platform_transition_filegroup(
         name = "bolt_so_" + abi,
-        srcs = ["//crates/xybrid-bolt:xybrid_bolt_cdylib"],
+        srcs = [":libxybrid_bolt.so"],
         target_platform = platform,
     )
     for abi, platform, _, _ in ANDROID_ABIS
@@ -58,7 +96,7 @@ NDK_SYSROOT = "@androidndk//toolchains/llvm/prebuilt/linux-x86_64/sysroot"
         name = "jni_bolt_" + abi,
         srcs = [":bolt_so_" + abi],
         prefix = "jni/" + abi,
-        renames = {":bolt_so_" + abi: "libxybrid-bolt.so"},
+        renames = {":bolt_so_" + abi: "libxybrid_bolt.so"},
     )
     for abi, _, _, _ in ANDROID_ABIS
 ]
@@ -66,7 +104,7 @@ NDK_SYSROOT = "@androidndk//toolchains/llvm/prebuilt/linux-x86_64/sysroot"
 [
     pkg_files(
         name = "jni_cxx_" + abi,
-        srcs = ["%s:libcxx_shared_%s" % (NDK_SYSROOT, tsn)],
+        srcs = ["@androidndk//:libcxx_shared_" + tsn],
         prefix = "jni/" + abi,
     )
     for abi, _, tsn, _ in ANDROID_ABIS

--- a/bindings/kotlin/BUILD.bazel
+++ b/bindings/kotlin/BUILD.bazel
@@ -43,11 +43,15 @@ ANDROID_ABIS = [
 
 cc_import(
     name = "android_cxx_shared",
+    # Resolve the select on host platforms so wildcard analysis can skip this
+    # Android-only target. Each shipped Android ABI still requires its NDK lib.
     shared_library = select({
         "@rules_rs//rs/platforms/config:aarch64-linux-android": "@androidndk//:libcxx_shared_aarch64-linux-android",
         "@rules_rs//rs/platforms/config:armv7-linux-androideabi": "@androidndk//:libcxx_shared_arm-linux-androideabi",
         "@rules_rs//rs/platforms/config:x86_64-linux-android": "@androidndk//:libcxx_shared_x86_64-linux-android",
+        "//conditions:default": None,
     }),
+    target_compatible_with = ["@platforms//os:android"],
 )
 
 # BoltFFI's generated Kotlin declares JVM `external fun`s. The Rust staticlib

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -206,15 +206,15 @@ Creating a source or loader is always cheap. Only `load()` and
 kotlin/
 ├── build.gradle.kts                     # Gradle build configuration
 ├── README.md                            # This file
-├── libs/                                # Native libraries (libxybrid-bolt.so built locally/CI, not committed)
+├── libs/                                # Native libraries (libxybrid_bolt.so built locally/CI, not committed)
 │   ├── armeabi-v7a/
-│   │   └── libxybrid-bolt.so
+│   │   └── libxybrid_bolt.so
 │   ├── arm64-v8a/
-│   │   ├── libxybrid-bolt.so
+│   │   ├── libxybrid_bolt.so
 │   │   ├── libonnxruntime.so            # ORT shared library (symlink → vendor/)
 │   │   └── libc++_shared.so             # C++ runtime (symlink → vendor/)
 │   └── x86_64/
-│       ├── libxybrid-bolt.so
+│       ├── libxybrid_bolt.so
 │       ├── libonnxruntime.so            # ORT shared library (symlink → vendor/)
 │       └── libc++_shared.so             # C++ runtime (symlink → vendor/)
 └── src/main/kotlin/ai/xybrid/
@@ -224,13 +224,13 @@ kotlin/
 
 ## Native Dependencies
 
-The SDK bundles ONNX Runtime (`libonnxruntime.so`) and the C++ shared library (`libc++_shared.so`) alongside `libxybrid-bolt.so`. These are included automatically in the AAR — no manual setup required.
+The SDK bundles ONNX Runtime (`libonnxruntime.so`) and the C++ shared library (`libc++_shared.so`) alongside `libxybrid_bolt.so`. These are included automatically in the AAR — no manual setup required.
 
-> **Note:** `libxybrid-bolt.so` is a build output and is **not** committed to the repository. The AAR published to Maven Central includes it (built in CI). For a **local** build, build the Bazel AAR and stage its jniLibs (see [Building Native Libraries](#building-native-libraries) below) so `libs/<abi>/` is populated before running `./gradlew`.
+> **Note:** `libxybrid_bolt.so` is a build output and is **not** committed to the repository. The AAR published to Maven Central includes it (built in CI). For a **local** build, build the Bazel AAR and stage its jniLibs (see [Building Native Libraries](#building-native-libraries) below) so `libs/<abi>/` is populated before running `./gradlew`.
 
 | Library | Purpose | Source |
 |---------|---------|--------|
-| `libxybrid-bolt.so` | Xybrid Rust SDK via BoltFFI | Built from `crates/xybrid-bolt/` |
+| `libxybrid_bolt.so` | Xybrid Rust SDK via BoltFFI | Built from `crates/xybrid-bolt/` |
 | `libonnxruntime.so` | ONNX Runtime inference engine | Vendored at `vendor/ort-android/` |
 | `libc++_shared.so` | C++ standard library runtime | Vendored at `vendor/ort-android/` |
 
@@ -242,18 +242,18 @@ The Kotlin bindings are generated from `crates/xybrid-bolt/` using [BoltFFI](htt
 - Single Rust source generates Swift, Kotlin, Java, C#, WASM, and a C header
 - Memory-safe wrappers with proper resource cleanup
 
-Regenerate `XybridBolt.kt` with the script, never by hand:
+Regenerate the Kotlin wrapper and its Bazel JNI inputs with the script, never
+by hand:
 
 ```bash
 python3 tools/scripts/gen_kotlin_bolt.py            # regenerate + write
 python3 tools/scripts/gen_kotlin_bolt.py --check    # fail on drift
 ```
 
-It runs `boltffi generate kotlin` and applies the one post-process the output
-needs: boltffi 0.29 emits each `XybridError` payload field verbatim, so the
-fourteen variants carrying a `message` collide with `Throwable.message` and the
-binding does not compile without an `override` modifier. A plain copy of the
-generator output silently reintroduces that break.
+It runs `boltffi generate kotlin`, commits the generated `jni_glue.c` and C
+header used by the AAR's Bazel link, and applies the Kotlin post-processes the
+output needs. The `--check` form compares all three outputs so JVM declarations
+cannot drift away from their native implementations.
 
 ## Building Native Libraries
 
@@ -309,24 +309,24 @@ After a successful build:
 ```
 bindings/kotlin/libs/
 ├── arm64-v8a/
-│   ├── libxybrid-bolt.so
+│   ├── libxybrid_bolt.so
 │   ├── libonnxruntime.so         # Bundled from vendor/ort-android/
 │   └── libc++_shared.so          # Bundled from vendor/ort-android/
 ├── armeabi-v7a/
-│   └── libxybrid-bolt.so
+│   └── libxybrid_bolt.so
 ├── x86_64/
-│   ├── libxybrid-bolt.so
+│   ├── libxybrid_bolt.so
 │   ├── libonnxruntime.so         # Bundled from vendor/ort-android/
 │   └── libc++_shared.so          # Bundled from vendor/ort-android/
 └── {version}/                    # Versioned copy
     ├── arm64-v8a/
-    │   ├── libxybrid-bolt.so
+    │   ├── libxybrid_bolt.so
     │   ├── libonnxruntime.so
     │   └── libc++_shared.so
     ├── armeabi-v7a/
-    │   └── libxybrid-bolt.so
+    │   └── libxybrid_bolt.so
     └── x86_64/
-        ├── libxybrid-bolt.so
+        ├── libxybrid_bolt.so
         ├── libonnxruntime.so
         └── libc++_shared.so
 ```
@@ -377,7 +377,7 @@ export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/26.1.10909125"
 **Cause**: Missing native library or corrupted .so file.
 
 **Fix**:
-1. Verify the .so file is valid: `file libs/arm64-v8a/libxybrid-bolt.so`
+1. Verify the .so file is valid: `file libs/arm64-v8a/libxybrid_bolt.so`
 2. Should show: `ELF 64-bit LSB shared object, ARM aarch64`
 3. Rebuild the Bazel AAR and restage its jniLibs (see Building Native Libraries above)
 

--- a/bindings/kotlin/bazel/jni/exports.map
+++ b/bindings/kotlin/bazel/jni/exports.map
@@ -1,0 +1,9 @@
+{
+    global:
+        Java_*;
+        JNI_OnLoad*;
+        JNI_OnUnload*;
+        boltffi_*;
+    local:
+        *;
+};

--- a/bindings/kotlin/bazel/jni/jni_glue.c
+++ b/bindings/kotlin/bazel/jni/jni_glue.c
@@ -1,0 +1,1437 @@
+#include <jni.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <string.h>
+#include <stdlib.h>
+#if defined(__ANDROID__)
+#include <pthread.h>
+#endif
+
+#include "xybrid_bolt.h"
+static void boltffi_jni_throw_runtime(JNIEnv *env, const char *message) {
+    jclass exception_class = (*env)->FindClass(env, "java/lang/RuntimeException");
+    if (exception_class == NULL) {
+        return;
+    }
+    (*env)->ThrowNew(env, exception_class, message);
+    (*env)->DeleteLocalRef(env, exception_class);
+}
+
+static void boltffi_jni_throw_illegal_argument(JNIEnv *env, const char *message) {
+    jclass exception_class = (*env)->FindClass(env, "java/lang/IllegalArgumentException");
+    if (exception_class == NULL) {
+        return;
+    }
+    (*env)->ThrowNew(env, exception_class, message);
+    (*env)->DeleteLocalRef(env, exception_class);
+}
+
+static void boltffi_jni_throw_status(JNIEnv *env, FfiStatus status) {
+    if (status.code != 0) {
+        boltffi_jni_throw_runtime(env, "BoltFFI call failed");
+    }
+}
+
+static void boltffi_jni_throw_error_buffer(JNIEnv *env, FfiBuf_u8 buffer) {
+    if (buffer.len > ((uintptr_t)INT32_MAX)) {
+        boltffi_free_buf(buffer);
+        boltffi_jni_throw_runtime(env, "BoltFFI error buffer was too large");
+        return;
+    }
+    jbyteArray bytes = (*env)->NewByteArray(env, (jsize)buffer.len);
+    if (bytes != NULL && buffer.len != 0) {
+        (*env)->SetByteArrayRegion(env, bytes, 0, (jsize)buffer.len, (const jbyte *)buffer.ptr);
+    }
+    boltffi_free_buf(buffer);
+    if (bytes == NULL || (*env)->ExceptionCheck(env)) {
+        return;
+    }
+    jclass exception_class = (*env)->FindClass(env, "ai/xybrid/BoltFfiErrorBufferException");
+    if (exception_class == NULL) {
+        (*env)->DeleteLocalRef(env, bytes);
+        return;
+    }
+    jmethodID constructor = (*env)->GetMethodID(env, exception_class, "<init>", "([B)V");
+    if (constructor == NULL) {
+        (*env)->DeleteLocalRef(env, exception_class);
+        (*env)->DeleteLocalRef(env, bytes);
+        return;
+    }
+    jthrowable exception = (jthrowable)(*env)->NewObject(env, exception_class, constructor, bytes);
+    if (exception != NULL) {
+        (*env)->Throw(env, exception);
+        (*env)->DeleteLocalRef(env, exception);
+    }
+    (*env)->DeleteLocalRef(env, exception_class);
+    (*env)->DeleteLocalRef(env, bytes);
+}
+
+static jbyteArray boltffi_jni_buffer_to_byte_array(JNIEnv *env, FfiBuf_u8 buffer) {
+    if (buffer.ptr == NULL) {
+        if (buffer.len != 0) {
+            boltffi_jni_throw_runtime(env, "BoltFFI buffer pointer was null with non-zero length");
+            return NULL;
+        }
+        return (*env)->NewByteArray(env, 0);
+    }
+    if (buffer.len > (uintptr_t)INT32_MAX) {
+        boltffi_free_buf(buffer);
+        boltffi_jni_throw_runtime(env, "BoltFFI buffer too large for Java byte array");
+        return NULL;
+    }
+    jbyteArray array = (*env)->NewByteArray(env, (jsize)buffer.len);
+    if (array == NULL) {
+        boltffi_free_buf(buffer);
+        return NULL;
+    }
+    (*env)->SetByteArrayRegion(env, array, 0, (jsize)buffer.len, (const jbyte *)buffer.ptr);
+    boltffi_free_buf(buffer);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->DeleteLocalRef(env, array);
+        return NULL;
+    }
+    return array;
+}
+
+static inline jbyteArray boltffi_jni_bytes_to_byte_array(JNIEnv *env, const uint8_t *bytes, uintptr_t len) {
+    if (bytes == NULL && len != 0) {
+        boltffi_jni_throw_runtime(env, "BoltFFI byte slice pointer was null with non-zero length");
+        return NULL;
+    }
+    if (len > (uintptr_t)INT32_MAX) {
+        boltffi_jni_throw_runtime(env, "BoltFFI byte slice too large for Java byte array");
+        return NULL;
+    }
+    jbyteArray array = (*env)->NewByteArray(env, (jsize)len);
+    if (array == NULL) {
+        return NULL;
+    }
+    if (len != 0) {
+        (*env)->SetByteArrayRegion(env, array, 0, (jsize)len, (const jbyte *)bytes);
+    }
+    return array;
+}
+
+static inline FfiBuf_u8 boltffi_jni_byte_array_to_buffer(JNIEnv *env, jbyteArray array) {
+    FfiBuf_u8 empty = {0};
+    if (array == NULL) {
+        boltffi_jni_throw_runtime(env, "BoltFFI byte array return was null");
+        return empty;
+    }
+    jsize len = (*env)->GetArrayLength(env, array);
+    if (len == 0) {
+        return empty;
+    }
+    FfiBuf_u8 buffer = boltffi_buf_with_len((uintptr_t)len);
+    if (buffer.ptr == NULL) {
+        boltffi_jni_throw_runtime(env, "failed to allocate BoltFFI byte array return");
+        return empty;
+    }
+    (*env)->GetByteArrayRegion(env, array, 0, len, (jbyte *)buffer.ptr);
+    return buffer;
+}
+
+static bool boltffi_jni_direct_buffer_address(JNIEnv *env, jobject buffer, jlong required_capacity, void **address) {
+    if (buffer == NULL) {
+        boltffi_jni_throw_illegal_argument(env, "BoltFFI direct buffer argument was null");
+        return false;
+    }
+    if (required_capacity < 0) {
+        boltffi_jni_throw_illegal_argument(env, "BoltFFI direct buffer length was negative");
+        return false;
+    }
+    jlong capacity = (*env)->GetDirectBufferCapacity(env, buffer);
+    if (capacity < 0) {
+        boltffi_jni_throw_illegal_argument(env, "BoltFFI argument was not a direct buffer");
+        return false;
+    }
+    if (capacity < required_capacity) {
+        boltffi_jni_throw_illegal_argument(env, "BoltFFI direct buffer capacity was too small");
+        return false;
+    }
+    *address = (*env)->GetDirectBufferAddress(env, buffer);
+    if (*address == NULL && required_capacity != 0) {
+        boltffi_jni_throw_illegal_argument(env, "BoltFFI direct buffer address was unavailable");
+        return false;
+    }
+    return true;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1release_1class_1xybrid_1bolt_1xybrid_1model(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_release_class_xybrid_bolt_xybrid_model(handle);
+
+    return;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1registry(JNIEnv *env, jclass cls, jobject id, jint __boltffi_id_len) {
+    (void)cls;
+
+    void *__boltffi_id_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, id, (jlong)__boltffi_id_len, &__boltffi_id_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_registry((const uint8_t *)__boltffi_id_ptr, (uintptr_t)__boltffi_id_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1registry_1speculative(JNIEnv *env, jclass cls, jobject id, jint __boltffi_id_len) {
+    (void)cls;
+
+    void *__boltffi_id_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, id, (jlong)__boltffi_id_len, &__boltffi_id_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_registry_speculative((const uint8_t *)__boltffi_id_ptr, (uintptr_t)__boltffi_id_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1directory(JNIEnv *env, jclass cls, jobject path, jint __boltffi_path_len) {
+    (void)cls;
+
+    void *__boltffi_path_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, path, (jlong)__boltffi_path_len, &__boltffi_path_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_directory((const uint8_t *)__boltffi_path_ptr, (uintptr_t)__boltffi_path_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1bundle(JNIEnv *env, jclass cls, jobject path, jint __boltffi_path_len) {
+    (void)cls;
+
+    void *__boltffi_path_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, path, (jlong)__boltffi_path_len, &__boltffi_path_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_bundle((const uint8_t *)__boltffi_path_ptr, (uintptr_t)__boltffi_path_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1huggingface(JNIEnv *env, jclass cls, jobject repo, jint __boltffi_repo_len) {
+    (void)cls;
+
+    void *__boltffi_repo_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, repo, (jlong)__boltffi_repo_len, &__boltffi_repo_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_huggingface((const uint8_t *)__boltffi_repo_ptr, (uintptr_t)__boltffi_repo_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1huggingface_1with_1revision(JNIEnv *env, jclass cls, jobject repo, jint __boltffi_repo_len, jobject revision, jint __boltffi_revision_len) {
+    (void)cls;
+
+    void *__boltffi_repo_ptr = NULL;
+    void *__boltffi_revision_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, repo, (jlong)__boltffi_repo_len, &__boltffi_repo_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, revision, (jlong)__boltffi_revision_len, &__boltffi_revision_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_huggingface_with_revision((const uint8_t *)__boltffi_repo_ptr, (uintptr_t)__boltffi_repo_len, (const uint8_t *)__boltffi_revision_ptr, (uintptr_t)__boltffi_revision_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1model_1from_1model_1file(JNIEnv *env, jclass cls, jobject path, jint __boltffi_path_len) {
+    (void)cls;
+
+    void *__boltffi_path_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, path, (jlong)__boltffi_path_len, &__boltffi_path_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_model_from_model_file((const uint8_t *)__boltffi_path_ptr, (uintptr_t)__boltffi_path_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1model_1id(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_model_id(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1version(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_version(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jint JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1output_1type(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    ___XybridOutputType __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_output_type(receiver);
+
+    return (jint)__boltffi_result;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1is_1loaded(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_is_loaded(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1is_1cloud_1serving(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_is_cloud_serving(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1download_1status(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_download_status(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1await_1download(JNIEnv *env, jclass cls, jlong receiver, jlong timeout_ms) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_await_download(receiver, timeout_ms);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1supports_1streaming(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_supports_streaming(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1supports_1token_1streaming(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_supports_token_streaming(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1default_1generation_1config(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_default_generation_config(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1is_1llm(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_is_llm(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1supports_1tool_1calling(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_supports_tool_calling(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1has_1voices(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_has_voices(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1voices(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_voices(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1default_1voice(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_default_voice(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1voice(JNIEnv *env, jclass cls, jlong receiver, jobject voice_id, jint __boltffi_voice_id_len) {
+    (void)cls;
+
+    void *__boltffi_voice_id_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, voice_id, (jlong)__boltffi_voice_id_len, &__boltffi_voice_id_ptr)) {
+        goto __boltffi_error;
+    }
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_model_voice(receiver, (const uint8_t *)__boltffi_voice_id_ptr, (uintptr_t)__boltffi_voice_id_len);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+__boltffi_error:
+    return NULL;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1run(JNIEnv *env, jclass cls, jlong receiver, jobject envelope, jint __boltffi_envelope_len, jobject options, jint __boltffi_options_len) {
+    (void)cls;
+
+    void *__boltffi_envelope_ptr = NULL;
+    void *__boltffi_options_ptr = NULL;
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, envelope, (jlong)__boltffi_envelope_len, &__boltffi_envelope_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, options, (jlong)__boltffi_options_len, &__boltffi_options_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_run(receiver, (const uint8_t *)__boltffi_envelope_ptr, (uintptr_t)__boltffi_envelope_len, (const uint8_t *)__boltffi_options_ptr, (uintptr_t)__boltffi_options_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+__boltffi_error:
+    return NULL;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1run_1stream(JNIEnv *env, jclass cls, jlong receiver, jobject envelope, jint __boltffi_envelope_len, jobject options, jint __boltffi_options_len) {
+    (void)cls;
+
+    void *__boltffi_envelope_ptr = NULL;
+    void *__boltffi_options_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, envelope, (jlong)__boltffi_envelope_len, &__boltffi_envelope_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, options, (jlong)__boltffi_options_len, &__boltffi_options_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_run_stream(receiver, (const uint8_t *)__boltffi_envelope_ptr, (uintptr_t)__boltffi_envelope_len, (const uint8_t *)__boltffi_options_ptr, (uintptr_t)__boltffi_options_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1stream_1next(JNIEnv *env, jclass cls, jlong receiver, jlong stream_id) {
+    (void)cls;
+
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_stream_next(receiver, stream_id, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1stream_1result(JNIEnv *env, jclass cls, jlong receiver, jlong stream_id) {
+    (void)cls;
+
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_stream_result(receiver, stream_id, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1stream_1close(JNIEnv *env, jclass cls, jlong receiver, jlong stream_id) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_model_stream_close(receiver, stream_id);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1run_1with_1context(JNIEnv *env, jclass cls, jlong receiver, jobject envelope, jint __boltffi_envelope_len, jlong context, jobject options, jint __boltffi_options_len) {
+    (void)cls;
+
+    void *__boltffi_envelope_ptr = NULL;
+    void *__boltffi_options_ptr = NULL;
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, envelope, (jlong)__boltffi_envelope_len, &__boltffi_envelope_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, options, (jlong)__boltffi_options_len, &__boltffi_options_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_run_with_context(receiver, (const uint8_t *)__boltffi_envelope_ptr, (uintptr_t)__boltffi_envelope_len, context, (const uint8_t *)__boltffi_options_ptr, (uintptr_t)__boltffi_options_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+__boltffi_error:
+    return NULL;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1run_1stream_1with_1context(JNIEnv *env, jclass cls, jlong receiver, jobject envelope, jint __boltffi_envelope_len, jlong context, jobject options, jint __boltffi_options_len) {
+    (void)cls;
+
+    void *__boltffi_envelope_ptr = NULL;
+    void *__boltffi_options_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, envelope, (jlong)__boltffi_envelope_len, &__boltffi_envelope_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, options, (jlong)__boltffi_options_len, &__boltffi_options_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_run_stream_with_context(receiver, (const uint8_t *)__boltffi_envelope_ptr, (uintptr_t)__boltffi_envelope_len, context, (const uint8_t *)__boltffi_options_ptr, (uintptr_t)__boltffi_options_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1warmup(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_warmup(receiver);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1model_1unload(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_model_unload(receiver);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1release_1class_1xybrid_1bolt_1xybrid_1conversation_1context(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_release_class_xybrid_bolt_xybrid_conversation_context(handle);
+
+    return;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1new(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    uint64_t __boltffi_result = boltffi_init_class_xybrid_bolt_xybrid_conversation_context_new();
+
+    return (jlong)__boltffi_result;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1with_1id(JNIEnv *env, jclass cls, jobject id, jint __boltffi_id_len) {
+    (void)cls;
+
+    void *__boltffi_id_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, id, (jlong)__boltffi_id_len, &__boltffi_id_ptr)) {
+        goto __boltffi_error;
+    }
+
+    (void)env;
+    uint64_t __boltffi_result = boltffi_init_class_xybrid_bolt_xybrid_conversation_context_with_id((const uint8_t *)__boltffi_id_ptr, (uintptr_t)__boltffi_id_len);
+
+    return (jlong)__boltffi_result;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1push(JNIEnv *env, jclass cls, jlong receiver, jobject envelope, jint __boltffi_envelope_len) {
+    (void)cls;
+
+    void *__boltffi_envelope_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, envelope, (jlong)__boltffi_envelope_len, &__boltffi_envelope_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_push(receiver, (const uint8_t *)__boltffi_envelope_ptr, (uintptr_t)__boltffi_envelope_len);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1set_1system(JNIEnv *env, jclass cls, jlong receiver, jobject envelope, jint __boltffi_envelope_len) {
+    (void)cls;
+
+    void *__boltffi_envelope_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, envelope, (jlong)__boltffi_envelope_len, &__boltffi_envelope_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_set_system(receiver, (const uint8_t *)__boltffi_envelope_ptr, (uintptr_t)__boltffi_envelope_len);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1clear(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_clear(receiver);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1id(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_id(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jint JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1history_1len(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    uint32_t __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_history_len(receiver);
+
+    return (jint)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1history(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_history(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1has_1system(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_has_system(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1conversation_1context_1set_1max_1history_1len(JNIEnv *env, jclass cls, jlong receiver, jint len) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_conversation_context_set_max_history_len(receiver, len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1release_1class_1xybrid_1bolt_1xybrid_1telemetry_1config(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_release_class_xybrid_bolt_xybrid_telemetry_config(handle);
+
+    return;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1new(JNIEnv *env, jclass cls, jobject api_key, jint __boltffi_api_key_len) {
+    (void)cls;
+
+    void *__boltffi_api_key_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, api_key, (jlong)__boltffi_api_key_len, &__boltffi_api_key_ptr)) {
+        goto __boltffi_error;
+    }
+
+    (void)env;
+    uint64_t __boltffi_result = boltffi_init_class_xybrid_bolt_xybrid_telemetry_config_new((const uint8_t *)__boltffi_api_key_ptr, (uintptr_t)__boltffi_api_key_len);
+
+    return (jlong)__boltffi_result;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1set_1endpoint(JNIEnv *env, jclass cls, jlong receiver, jobject endpoint, jint __boltffi_endpoint_len) {
+    (void)cls;
+
+    void *__boltffi_endpoint_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, endpoint, (jlong)__boltffi_endpoint_len, &__boltffi_endpoint_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_endpoint(receiver, (const uint8_t *)__boltffi_endpoint_ptr, (uintptr_t)__boltffi_endpoint_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1set_1app_1version(JNIEnv *env, jclass cls, jlong receiver, jobject version, jint __boltffi_version_len) {
+    (void)cls;
+
+    void *__boltffi_version_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, version, (jlong)__boltffi_version_len, &__boltffi_version_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_app_version(receiver, (const uint8_t *)__boltffi_version_ptr, (uintptr_t)__boltffi_version_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1set_1device_1label(JNIEnv *env, jclass cls, jlong receiver, jobject label, jint __boltffi_label_len) {
+    (void)cls;
+
+    void *__boltffi_label_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, label, (jlong)__boltffi_label_len, &__boltffi_label_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_device_label(receiver, (const uint8_t *)__boltffi_label_ptr, (uintptr_t)__boltffi_label_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1set_1device_1attribute(JNIEnv *env, jclass cls, jlong receiver, jobject key, jint __boltffi_key_len, jobject value, jint __boltffi_value_len) {
+    (void)cls;
+
+    void *__boltffi_key_ptr = NULL;
+    void *__boltffi_value_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, key, (jlong)__boltffi_key_len, &__boltffi_key_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, value, (jlong)__boltffi_value_len, &__boltffi_value_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_device_attribute(receiver, (const uint8_t *)__boltffi_key_ptr, (uintptr_t)__boltffi_key_len, (const uint8_t *)__boltffi_value_ptr, (uintptr_t)__boltffi_value_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1set_1batch_1size(JNIEnv *env, jclass cls, jlong receiver, jint batch_size) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_batch_size(receiver, batch_size);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1set_1flush_1interval_1secs(JNIEnv *env, jclass cls, jlong receiver, jint secs) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_flush_interval_secs(receiver, secs);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1telemetry_1config_1init(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_init(receiver);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1release_1class_1xybrid_1bolt_1xybrid_1bundle(JNIEnv *env, jclass cls, jlong handle) {
+    (void)cls;
+
+    (void)env;
+    boltffi_release_class_xybrid_bolt_xybrid_bundle(handle);
+
+    return;
+}
+
+JNIEXPORT jlong JNICALL Java_ai_xybrid_Native_boltffi_1init_1class_1xybrid_1bolt_1xybrid_1bundle_1open(JNIEnv *env, jclass cls, jobject path, jint __boltffi_path_len) {
+    (void)cls;
+
+    void *__boltffi_path_ptr = NULL;
+    uint64_t __boltffi_return = (uint64_t){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, path, (jlong)__boltffi_path_len, &__boltffi_path_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_init_class_xybrid_bolt_xybrid_bundle_open((const uint8_t *)__boltffi_path_ptr, (uintptr_t)__boltffi_path_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return 0;
+    }
+
+    return (jlong)__boltffi_return;
+__boltffi_error:
+    return 0;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1model_1id(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_model_id(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1version(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_version(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1target(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_target(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1hash(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_hash(receiver);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1has_1metadata(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_has_metadata(receiver);
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jint JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1file_1count(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    (void)env;
+    uint32_t __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_file_count(receiver);
+
+    return (jint)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1file_1name(JNIEnv *env, jclass cls, jlong receiver, jint index) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_method_class_xybrid_bolt_xybrid_bundle_file_name(receiver, index);
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1manifest_1json(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_bundle_manifest_json(receiver, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1metadata_1json(JNIEnv *env, jclass cls, jlong receiver) {
+    (void)cls;
+
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_bundle_metadata_json(receiver, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1method_1class_1xybrid_1bolt_1xybrid_1bundle_1extract(JNIEnv *env, jclass cls, jlong receiver, jobject output_dir, jint __boltffi_output_dir_len) {
+    (void)cls;
+
+    void *__boltffi_output_dir_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, output_dir, (jlong)__boltffi_output_dir_len, &__boltffi_output_dir_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_method_class_xybrid_bolt_xybrid_bundle_extract(receiver, (const uint8_t *)__boltffi_output_dir_ptr, (uintptr_t)__boltffi_output_dir_len);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1tool_1results_1envelope(JNIEnv *env, jclass cls, jobject user_text, jint __boltffi_user_text_len, jobject prior_assistant_text, jint __boltffi_prior_assistant_text_len, jobject results, jint __boltffi_results_len) {
+    (void)cls;
+
+    void *__boltffi_user_text_ptr = NULL;
+    void *__boltffi_prior_assistant_text_ptr = NULL;
+    void *__boltffi_results_ptr = NULL;
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, user_text, (jlong)__boltffi_user_text_len, &__boltffi_user_text_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, prior_assistant_text, (jlong)__boltffi_prior_assistant_text_len, &__boltffi_prior_assistant_text_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, results, (jlong)__boltffi_results_len, &__boltffi_results_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_function_xybrid_bolt_tool_results_envelope((const uint8_t *)__boltffi_user_text_ptr, (uintptr_t)__boltffi_user_text_len, (const uint8_t *)__boltffi_prior_assistant_text_ptr, (uintptr_t)__boltffi_prior_assistant_text_len, (const uint8_t *)__boltffi_results_ptr, (uintptr_t)__boltffi_results_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+__boltffi_error:
+    return NULL;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1json_1schema_1to_1gbnf(JNIEnv *env, jclass cls, jobject schema_json, jint __boltffi_schema_json_len) {
+    (void)cls;
+
+    void *__boltffi_schema_json_ptr = NULL;
+    FfiBuf_u8 __boltffi_return = (FfiBuf_u8){0};
+
+    if (!boltffi_jni_direct_buffer_address(env, schema_json, (jlong)__boltffi_schema_json_len, &__boltffi_schema_json_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiBuf_u8 error = boltffi_function_xybrid_bolt_json_schema_to_gbnf((const uint8_t *)__boltffi_schema_json_ptr, (uintptr_t)__boltffi_schema_json_len, &__boltffi_return);
+
+    if (error.ptr != NULL || error.len != 0) {
+        boltffi_jni_throw_error_buffer(env, error);
+        return NULL;
+    }
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_return);
+__boltffi_error:
+    return NULL;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1thermal_1state(JNIEnv *env, jclass cls, jint state) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_thermal_state((___XybridThermalState)state);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1clear_1thermal_1state(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    boltffi_function_xybrid_bolt_clear_thermal_state();
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1battery_1level(JNIEnv *env, jclass cls, jbyte percent) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_battery_level(percent);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1clear_1battery_1level(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    boltffi_function_xybrid_bolt_clear_battery_level();
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1configure_1runtime(JNIEnv *env, jclass cls, jobject api_key, jint __boltffi_api_key_len, jobject gateway_url, jint __boltffi_gateway_url_len, jobject ingest_url, jint __boltffi_ingest_url_len) {
+    (void)cls;
+
+    void *__boltffi_api_key_ptr = NULL;
+    void *__boltffi_gateway_url_ptr = NULL;
+    void *__boltffi_ingest_url_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, api_key, (jlong)__boltffi_api_key_len, &__boltffi_api_key_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, gateway_url, (jlong)__boltffi_gateway_url_len, &__boltffi_gateway_url_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, ingest_url, (jlong)__boltffi_ingest_url_len, &__boltffi_ingest_url_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_configure_runtime((const uint8_t *)__boltffi_api_key_ptr, (uintptr_t)__boltffi_api_key_len, (const uint8_t *)__boltffi_gateway_url_ptr, (uintptr_t)__boltffi_gateway_url_len, (const uint8_t *)__boltffi_ingest_url_ptr, (uintptr_t)__boltffi_ingest_url_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1init_1sdk_1cache_1dir(JNIEnv *env, jclass cls, jobject cache_dir, jint __boltffi_cache_dir_len) {
+    (void)cls;
+
+    void *__boltffi_cache_dir_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, cache_dir, (jlong)__boltffi_cache_dir_len, &__boltffi_cache_dir_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_init_sdk_cache_dir((const uint8_t *)__boltffi_cache_dir_ptr, (uintptr_t)__boltffi_cache_dir_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1binding(JNIEnv *env, jclass cls, jobject binding, jint __boltffi_binding_len) {
+    (void)cls;
+
+    void *__boltffi_binding_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, binding, (jlong)__boltffi_binding_len, &__boltffi_binding_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_binding((const uint8_t *)__boltffi_binding_ptr, (uintptr_t)__boltffi_binding_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1api_1key(JNIEnv *env, jclass cls, jobject api_key, jint __boltffi_api_key_len) {
+    (void)cls;
+
+    void *__boltffi_api_key_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, api_key, (jlong)__boltffi_api_key_len, &__boltffi_api_key_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_api_key((const uint8_t *)__boltffi_api_key_ptr, (uintptr_t)__boltffi_api_key_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1provider_1api_1key(JNIEnv *env, jclass cls, jobject provider, jint __boltffi_provider_len, jobject api_key, jint __boltffi_api_key_len) {
+    (void)cls;
+
+    void *__boltffi_provider_ptr = NULL;
+    void *__boltffi_api_key_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, provider, (jlong)__boltffi_provider_len, &__boltffi_provider_ptr)) {
+        goto __boltffi_error;
+    }
+    if (!boltffi_jni_direct_buffer_address(env, api_key, (jlong)__boltffi_api_key_len, &__boltffi_api_key_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_provider_api_key((const uint8_t *)__boltffi_provider_ptr, (uintptr_t)__boltffi_provider_len, (const uint8_t *)__boltffi_api_key_ptr, (uintptr_t)__boltffi_api_key_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1platform_1url(JNIEnv *env, jclass cls, jobject url, jint __boltffi_url_len) {
+    (void)cls;
+
+    void *__boltffi_url_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, url, (jlong)__boltffi_url_len, &__boltffi_url_ptr)) {
+        goto __boltffi_error;
+    }
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_platform_url((const uint8_t *)__boltffi_url_ptr, (uintptr_t)__boltffi_url_len);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+__boltffi_error:
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1speculative_1cloud(JNIEnv *env, jclass cls, jboolean enabled) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_speculative_cloud(enabled);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1has_1api_1key(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_function_xybrid_bolt_has_api_key();
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1is_1speculative_1cloud_1enabled(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_function_xybrid_bolt_is_speculative_cloud_enabled();
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1will_1speculate_1for_1model(JNIEnv *env, jclass cls, jobject model_id, jint __boltffi_model_id_len) {
+    (void)cls;
+
+    void *__boltffi_model_id_ptr = NULL;
+
+    if (!boltffi_jni_direct_buffer_address(env, model_id, (jlong)__boltffi_model_id_len, &__boltffi_model_id_ptr)) {
+        goto __boltffi_error;
+    }
+
+    (void)env;
+    bool __boltffi_result = boltffi_function_xybrid_bolt_will_speculate_for_model((const uint8_t *)__boltffi_model_id_ptr, (uintptr_t)__boltffi_model_id_len);
+
+    return (jboolean)__boltffi_result;
+__boltffi_error:
+    return JNI_FALSE;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1version(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_function_xybrid_bolt_version();
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT jint JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1release_1memory(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    uint32_t __boltffi_result = boltffi_function_xybrid_bolt_release_memory();
+
+    return (jint)__boltffi_result;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1set_1auto_1release(JNIEnv *env, jclass cls, jboolean enabled) {
+    (void)cls;
+
+    FfiStatus __boltffi_status = boltffi_function_xybrid_bolt_set_auto_release(enabled);
+
+    if (__boltffi_status.code != 0) {
+        boltffi_jni_throw_status(env, __boltffi_status);
+        return;
+    }
+
+    return;
+}
+
+JNIEXPORT jboolean JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1is_1auto_1release_1enabled(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    bool __boltffi_result = boltffi_function_xybrid_bolt_is_auto_release_enabled();
+
+    return (jboolean)__boltffi_result;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1telemetry_1default_1endpoint(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    FfiBuf_u8 __boltffi_result = boltffi_function_xybrid_bolt_telemetry_default_endpoint();
+
+    return boltffi_jni_buffer_to_byte_array(env, __boltffi_result);
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1telemetry_1flush(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    boltffi_function_xybrid_bolt_telemetry_flush();
+
+    return;
+}
+
+JNIEXPORT void JNICALL Java_ai_xybrid_Native_boltffi_1function_1xybrid_1bolt_1telemetry_1shutdown(JNIEnv *env, jclass cls) {
+    (void)cls;
+
+    (void)env;
+    boltffi_function_xybrid_bolt_telemetry_shutdown();
+
+    return;
+}

--- a/bindings/kotlin/bazel/jni/xybrid_bolt.h
+++ b/bindings/kotlin/bazel/jni/xybrid_bolt.h
@@ -1,0 +1,227 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdatomic.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int32_t code;
+} FfiStatus;
+
+#define FFI_STATUS_OK ((FfiStatus){0})
+#define FFI_STATUS_NULL_POINTER ((FfiStatus){1})
+#define FFI_STATUS_BUFFER_TOO_SMALL ((FfiStatus){2})
+#define FFI_STATUS_INVALID_ARG ((FfiStatus){3})
+#define FFI_STATUS_CANCELLED ((FfiStatus){4})
+#define FFI_STATUS_INTERNAL_ERROR ((FfiStatus){100})
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+    uintptr_t align;
+} FfiBuf_u8;
+
+typedef struct {
+    uint8_t *ptr;
+    uintptr_t len;
+    uintptr_t cap;
+} FfiString;
+
+typedef struct {
+    FfiString message;
+} FfiError;
+
+typedef struct {
+    const uint8_t *ptr;
+    uintptr_t len;
+} FfiSpan;
+
+typedef const void *RustFutureHandle;
+typedef int8_t StreamPollResult;
+typedef int32_t WaitResult;
+typedef void (*RustFutureContinuationCallback)(uint64_t callback_data, int8_t poll_result);
+typedef void (*StreamContinuationCallback)(uint64_t callback_data, StreamPollResult result);
+
+static inline bool boltffi_atomic_u8_cas(uint8_t *state, uint8_t expected, uint8_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint8_t *)state, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_exchange(uint64_t *slot, uint64_t value) {
+    return atomic_exchange_explicit((_Atomic uint64_t *)slot, value, memory_order_acq_rel);
+}
+
+static inline bool boltffi_atomic_u64_cas(uint64_t *slot, uint64_t expected, uint64_t desired) {
+    return atomic_compare_exchange_strong_explicit((_Atomic uint64_t *)slot, &expected, desired, memory_order_acq_rel, memory_order_acquire);
+}
+
+static inline uint64_t boltffi_atomic_u64_load(uint64_t *slot) {
+    return atomic_load_explicit((_Atomic uint64_t *)slot, memory_order_acquire);
+}
+
+typedef struct {
+    uint64_t handle;
+    const void *vtable;
+} BoltFFICallbackHandle;
+
+void boltffi_free_string(FfiString string);
+void boltffi_free_buf(FfiBuf_u8 buf);
+FfiBuf_u8 boltffi_buf_from_bytes(const uint8_t *ptr, uintptr_t len);
+FfiBuf_u8 boltffi_buf_with_len(uintptr_t len);
+FfiStatus boltffi_last_error_message(FfiString *out);
+void boltffi_clear_last_error(void);
+typedef uint32_t ___XybridError;
+#define XYBRID_ERROR_MODEL_NOT_FOUND ((___XybridError)0)
+#define XYBRID_ERROR_DIRECTORY_NOT_FOUND ((___XybridError)1)
+#define XYBRID_ERROR_METADATA_NOT_FOUND ((___XybridError)2)
+#define XYBRID_ERROR_METADATA_INVALID ((___XybridError)3)
+#define XYBRID_ERROR_LOAD_ERROR ((___XybridError)4)
+#define XYBRID_ERROR_INFERENCE_ERROR ((___XybridError)5)
+#define XYBRID_ERROR_ABORTED_FOR_CLOUD_FALLBACK ((___XybridError)6)
+#define XYBRID_ERROR_STREAMING_NOT_SUPPORTED ((___XybridError)7)
+#define XYBRID_ERROR_NOT_LOADED ((___XybridError)8)
+#define XYBRID_ERROR_CONFIG_ERROR ((___XybridError)9)
+#define XYBRID_ERROR_NETWORK_ERROR ((___XybridError)10)
+#define XYBRID_ERROR_OFFLINE ((___XybridError)11)
+#define XYBRID_ERROR_IO_ERROR ((___XybridError)12)
+#define XYBRID_ERROR_CACHE_ERROR ((___XybridError)13)
+#define XYBRID_ERROR_PIPELINE_ERROR ((___XybridError)14)
+#define XYBRID_ERROR_CIRCUIT_OPEN ((___XybridError)15)
+#define XYBRID_ERROR_RATE_LIMITED ((___XybridError)16)
+#define XYBRID_ERROR_TIMEOUT ((___XybridError)17)
+#define XYBRID_ERROR_MISSING_ARTIFACT ((___XybridError)18)
+#define XYBRID_ERROR_UNSUPPORTED_MODEL_CAPABILITY ((___XybridError)19)
+#define XYBRID_ERROR_UNSUPPORTED_BACKEND_CAPABILITY ((___XybridError)20)
+#define XYBRID_ERROR_INVALID_IMAGE ((___XybridError)21)
+typedef uint32_t ___XybridEnvelopeKind;
+#define XYBRID_ENVELOPE_KIND_TEXT ((___XybridEnvelopeKind)0)
+#define XYBRID_ENVELOPE_KIND_AUDIO ((___XybridEnvelopeKind)1)
+#define XYBRID_ENVELOPE_KIND_EMBEDDING ((___XybridEnvelopeKind)2)
+#define XYBRID_ENVELOPE_KIND_IMAGE ((___XybridEnvelopeKind)3)
+#define XYBRID_ENVELOPE_KIND_MULTI_PART ((___XybridEnvelopeKind)4)
+typedef int32_t ___XybridMessageRole;
+#define XYBRID_MESSAGE_ROLE_SYSTEM ((___XybridMessageRole)0)
+#define XYBRID_MESSAGE_ROLE_USER ((___XybridMessageRole)1)
+#define XYBRID_MESSAGE_ROLE_ASSISTANT ((___XybridMessageRole)2)
+typedef int32_t ___XybridAbortSignal;
+#define XYBRID_ABORT_SIGNAL_MEMORY_PRESSURE_WARN ((___XybridAbortSignal)0)
+#define XYBRID_ABORT_SIGNAL_MEMORY_PRESSURE_CRITICAL ((___XybridAbortSignal)1)
+#define XYBRID_ABORT_SIGNAL_THERMAL_HOT ((___XybridAbortSignal)2)
+#define XYBRID_ABORT_SIGNAL_THERMAL_CRITICAL ((___XybridAbortSignal)3)
+typedef int32_t ___XybridOutputType;
+#define XYBRID_OUTPUT_TYPE_TEXT ((___XybridOutputType)0)
+#define XYBRID_OUTPUT_TYPE_AUDIO ((___XybridOutputType)1)
+#define XYBRID_OUTPUT_TYPE_EMBEDDING ((___XybridOutputType)2)
+#define XYBRID_OUTPUT_TYPE_UNKNOWN ((___XybridOutputType)3)
+typedef int32_t ___XybridExecutionTarget;
+#define XYBRID_EXECUTION_TARGET_LOCAL ((___XybridExecutionTarget)0)
+#define XYBRID_EXECUTION_TARGET_CLOUD ((___XybridExecutionTarget)1)
+typedef int32_t ___XybridDownloadState;
+#define XYBRID_DOWNLOAD_STATE_DOWNLOADING ((___XybridDownloadState)0)
+#define XYBRID_DOWNLOAD_STATE_READY ((___XybridDownloadState)1)
+#define XYBRID_DOWNLOAD_STATE_FAILED ((___XybridDownloadState)2)
+typedef int32_t ___XybridStreamEventKind;
+#define XYBRID_STREAM_EVENT_KIND_TOKEN ((___XybridStreamEventKind)0)
+#define XYBRID_STREAM_EVENT_KIND_COMPLETE ((___XybridStreamEventKind)1)
+typedef int32_t ___XybridThermalState;
+#define XYBRID_THERMAL_STATE_NORMAL ((___XybridThermalState)0)
+#define XYBRID_THERMAL_STATE_WARM ((___XybridThermalState)1)
+#define XYBRID_THERMAL_STATE_HOT ((___XybridThermalState)2)
+#define XYBRID_THERMAL_STATE_CRITICAL ((___XybridThermalState)3)
+void boltffi_release_class_xybrid_bolt_xybrid_model(uint64_t handle);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_registry(const uint8_t *id_ptr, uintptr_t id_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_registry_speculative(const uint8_t *id_ptr, uintptr_t id_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_directory(const uint8_t *path_ptr, uintptr_t path_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_bundle(const uint8_t *path_ptr, uintptr_t path_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_huggingface(const uint8_t *repo_ptr, uintptr_t repo_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_huggingface_with_revision(const uint8_t *repo_ptr, uintptr_t repo_len, const uint8_t *revision_ptr, uintptr_t revision_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_model_from_model_file(const uint8_t *path_ptr, uintptr_t path_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_model_id(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_version(uint64_t receiver);
+___XybridOutputType boltffi_method_class_xybrid_bolt_xybrid_model_output_type(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_model_is_loaded(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_model_is_cloud_serving(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_download_status(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_await_download(uint64_t receiver, uint64_t timeout_ms);
+bool boltffi_method_class_xybrid_bolt_xybrid_model_supports_streaming(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_model_supports_token_streaming(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_default_generation_config(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_model_is_llm(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_supports_tool_calling(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_model_has_voices(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_voices(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_default_voice(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_voice(uint64_t receiver, const uint8_t *voice_id_ptr, uintptr_t voice_id_len);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_run(uint64_t receiver, const uint8_t *envelope_ptr, uintptr_t envelope_len, const uint8_t *options_ptr, uintptr_t options_len, FfiBuf_u8 *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_run_stream(uint64_t receiver, const uint8_t *envelope_ptr, uintptr_t envelope_len, const uint8_t *options_ptr, uintptr_t options_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_stream_next(uint64_t receiver, uint64_t stream_id, FfiBuf_u8 *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_stream_result(uint64_t receiver, uint64_t stream_id, FfiBuf_u8 *return_out);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_model_stream_close(uint64_t receiver, uint64_t stream_id);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_run_with_context(uint64_t receiver, const uint8_t *envelope_ptr, uintptr_t envelope_len, uint64_t context, const uint8_t *options_ptr, uintptr_t options_len, FfiBuf_u8 *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_run_stream_with_context(uint64_t receiver, const uint8_t *envelope_ptr, uintptr_t envelope_len, uint64_t context, const uint8_t *options_ptr, uintptr_t options_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_warmup(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_model_unload(uint64_t receiver);
+void boltffi_release_class_xybrid_bolt_xybrid_conversation_context(uint64_t handle);
+uint64_t boltffi_init_class_xybrid_bolt_xybrid_conversation_context_new(void);
+uint64_t boltffi_init_class_xybrid_bolt_xybrid_conversation_context_with_id(const uint8_t *id_ptr, uintptr_t id_len);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_conversation_context_push(uint64_t receiver, const uint8_t *envelope_ptr, uintptr_t envelope_len);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_conversation_context_set_system(uint64_t receiver, const uint8_t *envelope_ptr, uintptr_t envelope_len);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_conversation_context_clear(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_conversation_context_id(uint64_t receiver);
+uint32_t boltffi_method_class_xybrid_bolt_xybrid_conversation_context_history_len(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_conversation_context_history(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_conversation_context_has_system(uint64_t receiver);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_conversation_context_set_max_history_len(uint64_t receiver, uint32_t len);
+void boltffi_release_class_xybrid_bolt_xybrid_telemetry_config(uint64_t handle);
+uint64_t boltffi_init_class_xybrid_bolt_xybrid_telemetry_config_new(const uint8_t *api_key_ptr, uintptr_t api_key_len);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_endpoint(uint64_t receiver, const uint8_t *endpoint_ptr, uintptr_t endpoint_len);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_app_version(uint64_t receiver, const uint8_t *version_ptr, uintptr_t version_len);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_device_label(uint64_t receiver, const uint8_t *label_ptr, uintptr_t label_len);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_device_attribute(uint64_t receiver, const uint8_t *key_ptr, uintptr_t key_len, const uint8_t *value_ptr, uintptr_t value_len);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_batch_size(uint64_t receiver, uint32_t batch_size);
+FfiStatus boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_set_flush_interval_secs(uint64_t receiver, uint32_t secs);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_telemetry_config_init(uint64_t receiver);
+void boltffi_release_class_xybrid_bolt_xybrid_bundle(uint64_t handle);
+FfiBuf_u8 boltffi_init_class_xybrid_bolt_xybrid_bundle_open(const uint8_t *path_ptr, uintptr_t path_len, uint64_t *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_model_id(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_version(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_target(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_hash(uint64_t receiver);
+bool boltffi_method_class_xybrid_bolt_xybrid_bundle_has_metadata(uint64_t receiver);
+uint32_t boltffi_method_class_xybrid_bolt_xybrid_bundle_file_count(uint64_t receiver);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_file_name(uint64_t receiver, uint32_t index);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_manifest_json(uint64_t receiver, FfiBuf_u8 *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_metadata_json(uint64_t receiver, FfiBuf_u8 *return_out);
+FfiBuf_u8 boltffi_method_class_xybrid_bolt_xybrid_bundle_extract(uint64_t receiver, const uint8_t *output_dir_ptr, uintptr_t output_dir_len);
+FfiBuf_u8 boltffi_function_xybrid_bolt_tool_results_envelope(const uint8_t *user_text_ptr, uintptr_t user_text_len, const uint8_t *prior_assistant_text_ptr, uintptr_t prior_assistant_text_len, const uint8_t *results_ptr, uintptr_t results_len, FfiBuf_u8 *return_out);
+FfiBuf_u8 boltffi_function_xybrid_bolt_json_schema_to_gbnf(const uint8_t *schema_json_ptr, uintptr_t schema_json_len, FfiBuf_u8 *return_out);
+FfiStatus boltffi_function_xybrid_bolt_set_thermal_state(___XybridThermalState state);
+void boltffi_function_xybrid_bolt_clear_thermal_state(void);
+FfiStatus boltffi_function_xybrid_bolt_set_battery_level(uint8_t percent);
+void boltffi_function_xybrid_bolt_clear_battery_level(void);
+FfiStatus boltffi_function_xybrid_bolt_configure_runtime(const uint8_t *api_key_ptr, uintptr_t api_key_len, const uint8_t *gateway_url_ptr, uintptr_t gateway_url_len, const uint8_t *ingest_url_ptr, uintptr_t ingest_url_len);
+FfiStatus boltffi_function_xybrid_bolt_init_sdk_cache_dir(const uint8_t *cache_dir_ptr, uintptr_t cache_dir_len);
+FfiStatus boltffi_function_xybrid_bolt_set_binding(const uint8_t *binding_ptr, uintptr_t binding_len);
+FfiStatus boltffi_function_xybrid_bolt_set_api_key(const uint8_t *api_key_ptr, uintptr_t api_key_len);
+FfiStatus boltffi_function_xybrid_bolt_set_provider_api_key(const uint8_t *provider_ptr, uintptr_t provider_len, const uint8_t *api_key_ptr, uintptr_t api_key_len);
+FfiStatus boltffi_function_xybrid_bolt_set_platform_url(const uint8_t *url_ptr, uintptr_t url_len);
+FfiStatus boltffi_function_xybrid_bolt_set_speculative_cloud(bool enabled);
+bool boltffi_function_xybrid_bolt_has_api_key(void);
+bool boltffi_function_xybrid_bolt_is_speculative_cloud_enabled(void);
+bool boltffi_function_xybrid_bolt_will_speculate_for_model(const uint8_t *model_id_ptr, uintptr_t model_id_len);
+FfiBuf_u8 boltffi_function_xybrid_bolt_version(void);
+uint32_t boltffi_function_xybrid_bolt_release_memory(void);
+FfiStatus boltffi_function_xybrid_bolt_set_auto_release(bool enabled);
+bool boltffi_function_xybrid_bolt_is_auto_release_enabled(void);
+FfiBuf_u8 boltffi_function_xybrid_bolt_telemetry_default_endpoint(void);
+void boltffi_function_xybrid_bolt_telemetry_flush(void);
+void boltffi_function_xybrid_bolt_telemetry_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bindings/kotlin/consumer-smoke/app/build.gradle.kts
+++ b/bindings/kotlin/consumer-smoke/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "0.0.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -30,4 +31,7 @@ dependencies {
     // The AAR's transitive runtime dep. A Maven consumer gets this from the
     // POM; a local-file AAR carries no metadata, so declare it explicitly.
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    // Match the binding's existing Android test framework/version.
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test:runner:1.5.2")
 }

--- a/bindings/kotlin/consumer-smoke/app/src/androidTest/kotlin/ai/xybrid/smoke/NativeBindingTest.kt
+++ b/bindings/kotlin/consumer-smoke/app/src/androidTest/kotlin/ai/xybrid/smoke/NativeBindingTest.kt
@@ -1,0 +1,33 @@
+package ai.xybrid.smoke
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import ai.xybrid.Envelope
+import ai.xybrid.Xybrid
+import ai.xybrid.XybridConversationContext
+import ai.xybrid.version
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Executes the packaged JNI on Android without a model, credentials, or network. */
+@RunWith(AndroidJUnit4::class)
+class NativeBindingTest {
+    @Test
+    fun testPackagedNativeCalls() {
+        Xybrid.init(InstrumentationRegistry.getInstrumentation().targetContext)
+        assertTrue(Xybrid.isInitialized)
+        assertTrue(version().isNotBlank())
+
+        XybridConversationContext.withId("jni-smoke").use { context ->
+            assertEquals("jni-smoke", context.id())
+            assertEquals(0u, context.historyLen())
+            val input = Envelope.text("JNI round trip: ação 日本語")
+            context.push(input)
+            assertEquals(1u, context.historyLen())
+            assertEquals(input.kind, context.history().single().kind)
+            context.clear()
+            assertEquals(0u, context.historyLen())
+        }
+    }
+}

--- a/bindings/kotlin/consumer-smoke/gradle.properties
+++ b/bindings/kotlin/consumer-smoke/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx2g
+android.useAndroidX=true

--- a/bindings/kotlin/libs/.gitignore
+++ b/bindings/kotlin/libs/.gitignore
@@ -1,4 +1,4 @@
-# libxybrid-bolt.so is a build output produced from crates/xybrid-bolt via
+# libxybrid_bolt.so is a build output produced from crates/xybrid-bolt via
 # the Bazel AAR (see README) and built fresh by CI for releases. It is
 # not committed. The vendored ONNX Runtime libraries (libonnxruntime.so,
 # libc++_shared.so) and .gitkeep are intentionally tracked and not ignored.

--- a/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
+++ b/bindings/kotlin/src/main/kotlin/ai/xybrid/XybridBolt.kt
@@ -845,6 +845,9 @@ private object Native {
     @JvmStatic external fun boltffi_function_xybrid_bolt_is_speculative_cloud_enabled(): Boolean
     @JvmStatic external fun boltffi_function_xybrid_bolt_will_speculate_for_model(model_id: java.nio.ByteBuffer, __boltffi_model_id_len: Int): Boolean
     @JvmStatic external fun boltffi_function_xybrid_bolt_version(): ByteArray?
+    @JvmStatic external fun boltffi_function_xybrid_bolt_release_memory(): Int
+    @JvmStatic external fun boltffi_function_xybrid_bolt_set_auto_release(enabled: Boolean): Unit
+    @JvmStatic external fun boltffi_function_xybrid_bolt_is_auto_release_enabled(): Boolean
     @JvmStatic external fun boltffi_function_xybrid_bolt_telemetry_default_endpoint(): ByteArray?
     @JvmStatic external fun boltffi_function_xybrid_bolt_telemetry_flush(): Unit
     @JvmStatic external fun boltffi_function_xybrid_bolt_telemetry_shutdown(): Unit
@@ -2712,6 +2715,18 @@ fun version(): String {
     val __boltffi_result = Native.boltffi_function_xybrid_bolt_version() ?: throw IllegalStateException("null buffer returned")
     val __boltffi_reader = WireReader(__boltffi_result)
     return __boltffi_reader.readString()
+}
+
+fun releaseMemory(): UInt {
+    return Native.boltffi_function_xybrid_bolt_release_memory().toUInt()
+}
+
+fun setAutoRelease(enabled: Boolean) {
+    Native.boltffi_function_xybrid_bolt_set_auto_release(enabled)
+}
+
+fun isAutoReleaseEnabled(): Boolean {
+    return Native.boltffi_function_xybrid_bolt_is_auto_release_enabled()
 }
 
 fun telemetryDefaultEndpoint(): String {

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -31,7 +31,7 @@ The two platforms consume the bolt core differently:
   `//bindings/apple:XybridFFI` target the standalone Apple SDK ships from —
   see Local development below for the commands).
 - **Android** depends on the published `ai.xybrid:xybrid-kotlin` Maven AAR,
-  which bundles `libxybrid-bolt.so` + the ONNX Runtime alongside the
+  which bundles `libxybrid_bolt.so` + the ONNX Runtime alongside the
   `ai.xybrid.*` Kotlin classes. Nothing is staged per-package.
 
 No new Rust code — the bridge is purely a thin layer above the bolt bindings.

--- a/bindings/react-native/android/build.gradle
+++ b/bindings/react-native/android/build.gradle
@@ -4,7 +4,7 @@
 //
 // The bolt-generated Kotlin binding and its native artifacts come from the
 // published `ai.xybrid:xybrid-kotlin` AAR on Maven Central — it bundles
-// `libxybrid-bolt.so` + the ORT runtime alongside the `ai.xybrid.*`
+// `libxybrid_bolt.so` + the ORT runtime alongside the `ai.xybrid.*`
 // classes that `XybridModule.kt` calls into. No per-package native staging
 // is needed on Android; gradle resolves the AAR like any other dependency.
 
@@ -87,7 +87,7 @@ dependencies {
 
   // The bolt Kotlin SDK: provides the `ai.xybrid.*` classes XybridModule.kt
   // calls (Xybrid, XybridModel, Envelope, XybridError, …) and bundles
-  // `libxybrid-bolt.so` + the ORT runtime in the AAR. Bolt talks to the
+  // `libxybrid_bolt.so` + the ORT runtime in the AAR. Bolt talks to the
   // native layer over JNI directly, so there is no JNA dependency (unlike
   // the previous uniffi binding). Keep this version in lockstep with the
   // workspace SDK version (bindings/kotlin/build.gradle.kts `version`).

--- a/crates/xybrid-bolt/BUILD.bazel
+++ b/crates/xybrid-bolt/BUILD.bazel
@@ -37,8 +37,8 @@ _BOLTFFI_EXPANSION_FLAGS = [
 #   -llog                   -> android liblog (matches the relink's -llog)
 #   -z,max-page-size=16384  -> 16KB page alignment; must come after the NDK
 #                              toolchain's hardcoded 4096 (last -z wins with lld)
-# (Packaging note: Kotlin loads "xybrid-bolt" (hyphen); the AAR assembly renames
-# libxybrid_bolt.so -> libxybrid-bolt.so.)
+# The Kotlin AAR links its generated JNI layer against the staticlib target
+# below; this plain cdylib remains the direct C ABI artifact for other users.
 rust_shared_library(
     name = "xybrid_bolt_cdylib",
     srcs = glob(["src/**/*.rs"]),
@@ -113,6 +113,10 @@ cc_library(
 # staticlib — libxybrid_bolt.a (what `boltffi pack` relinks into the xcframework/aar)
 rust_static_library(
     name = "xybrid_bolt_staticlib",
+    # JNI glue references every public Bolt C symbol indirectly from C. Mark
+    # the archive always-link so Bazel mirrors boltffi's --whole-archive link
+    # and does not discard entry points before the generated wrappers use them.
+    alwayslink = True,
     srcs = glob(["src/**/*.rs"]),
     crate_name = "xybrid_bolt",
     edition = "2021",

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -36,7 +36,7 @@ unzip -o -q bazel-bin/bindings/kotlin/xybrid-kotlin.aar 'jni/*' -d /tmp/aar
 cp -r /tmp/aar/jni/* bindings/kotlin/libs/
 ```
 
-This stages `libxybrid-bolt.so`, `libonnxruntime.so`, and `libc++_shared.so` for each ABI (arm64-v8a, armeabi-v7a, x86_64) into `bindings/kotlin/libs/`.
+This stages `libxybrid_bolt.so`, `libonnxruntime.so`, and `libc++_shared.so` for each ABI (arm64-v8a, armeabi-v7a, x86_64) into `bindings/kotlin/libs/`.
 
 See [bindings/kotlin/README.md](../../bindings/kotlin/README.md) for detailed build instructions.
 

--- a/rules_android_ndk.patch
+++ b/rules_android_ndk.patch
@@ -1,3 +1,21 @@
+diff --color -ru a/BUILD.ndk_root.tpl b/BUILD.ndk_root.tpl
+--- a/BUILD.ndk_root.tpl	2026-07-08 11:15:00
++++ b/BUILD.ndk_root.tpl	2026-07-08 11:15:00
+@@ -11,6 +11,14 @@
+     actual = "//{clang_directory}:cc_toolchain_suite",
+ )
+
++# Host-independent aliases for consumers that need to link or package the
++# matching libc++_shared runtime. `{clang_directory}` differs between local
++# macOS builds and Linux RBE, so callers must not embed it in their labels.
++[alias(
++    name = "libcxx_shared_%s" % target_system_name,
++    actual = "//{clang_directory}/sysroot:libcxx_shared_%s" % target_system_name,
++) for target_system_name in TARGET_SYSTEM_NAMES]
++
+ # Loop over TARGET_SYSTEM_NAMES and define all toolchain targets.
+ [toolchain(
+     name = "toolchain_%s" % target_system_name,
 diff --color -ru a/BUILD.ndk_sysroot.tpl b/BUILD.ndk_sysroot.tpl
 --- a/BUILD.ndk_sysroot.tpl	2026-07-08 11:15:00
 +++ b/BUILD.ndk_sysroot.tpl	2026-07-08 11:15:00

--- a/tools/README.md
+++ b/tools/README.md
@@ -111,11 +111,11 @@ cp -r /tmp/aar/jni/* bindings/kotlin/libs/
 ```
 
 The NDK is a pinned Bazel download — no machine setup. Each
-`libxybrid-bolt.so` is a clean one-link output (16 KB-aligned,
+`libxybrid_bolt.so` is a clean one-link output (16 KB-aligned,
 `libc++_shared` in DT_NEEDED, no patchelf) with the ORT runtime bundled.
 
 **Output:**
-- `bindings/kotlin/libs/<abi>/libxybrid-bolt.so` (native library; 16 KB-aligned,
+- `bindings/kotlin/libs/<abi>/libxybrid_bolt.so` (native library; 16 KB-aligned,
   `libc++_shared` linked in — a clean linker output that survives a consumer's
   AGP strip, no patchelf)
 - `bindings/kotlin/libs/<abi>/{libonnxruntime.so,libc++_shared.so}` (bundled runtime)

--- a/tools/scripts/android-dlopen-gate.sh
+++ b/tools/scripts/android-dlopen-gate.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # android-dlopen-gate.sh — push the staged bolt .so + siblings + probe to a
-# booted emulator and assert libxybrid-bolt.so dlopens, both as built AND
+# booted emulator and assert libxybrid_bolt.so dlopens, both as built AND
 # after an AGP-style strip. This is the authoritative gate for the
 # strip-fragility / 16 KB-alignment bug: readelf can't prove a lib loads
 # (it reads section headers; the loader reads program headers), only an
 # on-device dlopen can.
 #
 # Expects a directory (default ./dlopen-gate) staged by build-android.yml
-# containing: libxybrid-bolt.so, libxybrid-bolt.stripped.so, libc++_shared.so,
+# containing: libxybrid_bolt.so, libxybrid_bolt.stripped.so, libc++_shared.so,
 # libonnxruntime.so, android-dlopen-probe. Run after the emulator is booted
 # (the emulator-runner action waits for boot before invoking this).
 set -euo pipefail
@@ -18,23 +18,23 @@ ADB="${ADB:-adb}"
 
 echo "==> Pushing gate artifacts to $DEVICE_DIR"
 "$ADB" shell "rm -rf $DEVICE_DIR && mkdir -p $DEVICE_DIR"
-for f in libxybrid-bolt.so libxybrid-bolt.stripped.so libc++_shared.so \
+for f in libxybrid_bolt.so libxybrid_bolt.stripped.so libc++_shared.so \
          libonnxruntime.so android-dlopen-probe; do
     "$ADB" push "$GATE_DIR/$f" "$DEVICE_DIR/$f" > /dev/null
 done
 "$ADB" shell "chmod 755 $DEVICE_DIR/android-dlopen-probe"
 
 # dlopen each candidate. RTLD_NOW + the siblings in LD_LIBRARY_PATH mirror an
-# app's per-ABI lib dir. `libxybrid-bolt.so` is renamed in place so the probe
+# app's per-ABI lib dir. `libxybrid_bolt.so` is renamed in place so the probe
 # always loads the same SONAME (the stripped copy is the same lib, AGP-stripped).
 probe() {
     local lib="$1" label="$2"
-    "$ADB" push "$GATE_DIR/$lib" "$DEVICE_DIR/libxybrid-bolt.so" > /dev/null
+    "$ADB" push "$GATE_DIR/$lib" "$DEVICE_DIR/libxybrid_bolt.so" > /dev/null
     # Capture stderr too (the probe prints DLOPEN-FAIL there) and `|| true` so
     # a failing probe doesn't trip `set -e` before we can report it — we want
     # the formatted message + an explicit `return 1`, not an abrupt exit.
     local out
-    out="$("$ADB" shell "cd $DEVICE_DIR && LD_LIBRARY_PATH=$DEVICE_DIR ./android-dlopen-probe $DEVICE_DIR/libxybrid-bolt.so" 2>&1 | tr -d '\r')" || true
+    out="$("$ADB" shell "cd $DEVICE_DIR && LD_LIBRARY_PATH=$DEVICE_DIR ./android-dlopen-probe $DEVICE_DIR/libxybrid_bolt.so" 2>&1 | tr -d '\r')" || true
     echo "    [$label] $out"
     case "$out" in
         DLOPEN-OK*) return 0 ;;
@@ -43,8 +43,8 @@ probe() {
 }
 
 echo "==> dlopen as built"
-probe libxybrid-bolt.so "as-built"
+probe libxybrid_bolt.so "as-built"
 echo "==> dlopen after AGP-style strip (the regression this gate guards)"
-probe libxybrid-bolt.stripped.so "stripped"
+probe libxybrid_bolt.stripped.so "stripped"
 
 echo "==> dlopen gate passed"

--- a/tools/scripts/android-dlopen-probe.c
+++ b/tools/scripts/android-dlopen-probe.c
@@ -1,6 +1,6 @@
 // android-dlopen-probe — load a .so the way System.loadLibrary (dlopen,
 // RTLD_NOW) does, print the dlerror() and exit non-zero on failure. Used by
-// the build-android CI gate to prove the shipped libxybrid-bolt.so actually
+// the build-android CI gate to prove the shipped libxybrid_bolt.so actually
 // loads on a device/emulator — both as built and after an AGP-style strip.
 //
 // Why this exists: `llvm-readelf` reads the ELF via *section* headers, but the
@@ -10,7 +10,7 @@
 // strip-corrupted copy with "empty/missing DT_HASH/DT_GNU_HASH".)
 //
 // Usage on device:
-//   LD_LIBRARY_PATH=<dir> ./android-dlopen-probe <dir>/libxybrid-bolt.so
+//   LD_LIBRARY_PATH=<dir> ./android-dlopen-probe <dir>/libxybrid_bolt.so
 //
 // RTLD_NOW forces eager symbol resolution, so an unresolved C++ ABI symbol
 // (missing libc++_shared DT_NEEDED) fails here exactly as at app launch. The

--- a/tools/scripts/gen_kotlin_bolt.py
+++ b/tools/scripts/gen_kotlin_bolt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regenerate the committed BoltFFI Kotlin binding for the Android SDK.
+"""Regenerate the committed BoltFFI Kotlin and JNI bindings for Android.
 
 Sibling of `bindings/apple/scripts/gen-bolt-bindings.sh`, `gen_unity_bolt_csharp.py`
 and `gen_python_bolt.py`. Until now Kotlin was the one binding refreshed by
@@ -24,6 +24,10 @@ The post-processes:
   tool calling landed. Its decoder probes for that tail before reading it and
   falls back to the existing reasoning metadata when the typed tail is absent.
 
+The generated JNI source and header are committed beside the Bazel AAR inputs.
+Keeping all three outputs in one drift check prevents the Kotlin declarations
+and native entry points from silently diverging.
+
 Usage:
     python3 tools/scripts/gen_kotlin_bolt.py            # regenerate + write
     python3 tools/scripts/gen_kotlin_bolt.py --check    # fail on drift
@@ -41,6 +45,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BOLT_DIR = REPO_ROOT / "crates" / "xybrid-bolt"
 RAW_FILE = BOLT_DIR / "dist" / "android" / "kotlin" / "ai" / "xybrid" / "XybridBolt.kt"
 DEST_FILE = REPO_ROOT / "bindings" / "kotlin" / "src" / "main" / "kotlin" / "ai" / "xybrid" / "XybridBolt.kt"
+RAW_JNI_DIR = BOLT_DIR / "dist" / "android" / "kotlin" / "jni"
+DEST_JNI_DIR = REPO_ROOT / "bindings" / "kotlin" / "bazel" / "jni"
+NATIVE_FILES = ("jni_glue.c", "xybrid_bolt.h")
 PINNED_BOLTFFI = "0.29.3"
 
 # `data class Foo(<params>) : XybridError() {` — payload lists carry no nested
@@ -140,10 +147,17 @@ def _add_result_wire_compatibility(source: str) -> str:
     return source.replace(decoder_target, decoder_replacement, 1)
 
 
-def render() -> str:
+def render() -> tuple[str, dict[str, bytes]]:
     subprocess.run(["boltffi", "generate", "kotlin"], cwd=BOLT_DIR, check=True)
     if not RAW_FILE.is_file():
         sys.exit(f"error: boltffi produced no Kotlin source at {RAW_FILE}")
+
+    native_files: dict[str, bytes] = {}
+    for name in NATIVE_FILES:
+        source = RAW_JNI_DIR / name
+        if not source.is_file():
+            sys.exit(f"error: boltffi produced no JNI input at {source}")
+        native_files[name] = source.read_bytes()
 
     source, overrides = _add_message_override(RAW_FILE.read_text())
     result_field = "    val reasoningContent: String?\n) {"
@@ -163,7 +177,8 @@ def render() -> str:
             "now emits it.",
             file=sys.stderr,
         )
-    return source if source.endswith("\n") else source + "\n"
+    kotlin = source if source.endswith("\n") else source + "\n"
+    return kotlin, native_files
 
 
 def main() -> int:
@@ -172,21 +187,32 @@ def main() -> int:
     args = parser.parse_args()
 
     check_boltffi_version()
-    rendered = render()
+    rendered, native_files = render()
 
     if args.check:
+        stale = []
         if not DEST_FILE.exists() or DEST_FILE.read_text() != rendered:
+            stale.append(DEST_FILE)
+        for name, content in native_files.items():
+            destination = DEST_JNI_DIR / name
+            if not destination.exists() or destination.read_bytes() != content:
+                stale.append(destination)
+        if stale:
+            paths = "\n".join(f"  - {path.relative_to(REPO_ROOT)}" for path in stale)
             print(
-                f"error: {DEST_FILE.relative_to(REPO_ROOT)} is out of date.\n"
+                f"error: generated Kotlin/JNI files are out of date:\n{paths}\n"
                 "Run: python3 tools/scripts/gen_kotlin_bolt.py",
                 file=sys.stderr,
             )
             return 1
-        print("Kotlin binding up to date")
+        print("Kotlin and JNI bindings up to date")
         return 0
 
     DEST_FILE.write_text(rendered)
-    print(f"Wrote {DEST_FILE.relative_to(REPO_ROOT)}")
+    DEST_JNI_DIR.mkdir(parents=True, exist_ok=True)
+    for name, content in native_files.items():
+        (DEST_JNI_DIR / name).write_bytes(content)
+    print(f"Wrote {DEST_FILE.relative_to(REPO_ROOT)} and {DEST_JNI_DIR.relative_to(REPO_ROOT)}")
     return 0
 
 

--- a/tools/scripts/tests/test_verify_android_jni.py
+++ b/tools/scripts/tests/test_verify_android_jni.py
@@ -1,0 +1,53 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "verify_android_jni", Path(__file__).resolve().parents[1] / "verify_android_jni.py"
+)
+jni = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(jni)
+
+
+def symbol(name, kind="FUNC", binding="GLOBAL", visibility="DEFAULT", index="12"):
+    return f"  1: 0000000120 32 {kind} {binding} {visibility} {index} {name}\n"
+
+
+class VerifyAndroidJniTest(unittest.TestCase):
+    def setUp(self):
+        self.name = jni.JNI_PREFIX + "run"
+        self.glue = f"JNIEXPORT void JNICALL {self.name}(JNIEnv *env) {{}}"
+        self.base = symbol(jni.BOLT_SYMBOL)
+
+    def test_matching_defined_symbols(self):
+        self.assertEqual(jni.verify(self.glue, self.base + symbol(self.name)), 1)
+
+    def test_same_count_with_wrong_name_fails(self):
+        with self.assertRaisesRegex(ValueError, "missing JNI exports"):
+            jni.verify(self.glue, self.base + symbol(jni.JNI_PREFIX + "wrong"))
+
+    def test_undefined_hidden_local_and_non_function_do_not_count(self):
+        for kwargs in [dict(index="UND"), dict(visibility="HIDDEN"),
+                       dict(binding="LOCAL"), dict(kind="OBJECT")]:
+            with self.subTest(kwargs=kwargs), self.assertRaisesRegex(ValueError, "missing JNI"):
+                jni.verify(self.glue, self.base + symbol(self.name, **kwargs))
+
+    def test_unexpected_extra_export_fails(self):
+        with self.assertRaisesRegex(ValueError, "unexpected JNI"):
+            jni.verify(self.glue, self.base + symbol(self.name) + symbol(jni.JNI_PREFIX + "stale"))
+
+    def test_no_generated_symbols_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "no entry points"):
+            jni.verify("", self.base)
+
+    def test_missing_or_undefined_bolt_abi_fails(self):
+        for base in ["", symbol(jni.BOLT_SYMBOL, index="UND")]:
+            with self.subTest(base=base), self.assertRaisesRegex(ValueError, "Bolt C ABI"):
+                jni.verify(self.glue, base + symbol(self.name))
+
+    def test_symbol_versions_and_protected_exports(self):
+        self.assertEqual(jni.verify(self.glue, self.base + symbol(self.name + "@@XYBRID", visibility="PROTECTED")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/verify_android_jni.py
+++ b/tools/scripts/verify_android_jni.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Check exact generated JNI exports in a linked (or stripped) Android ELF."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+JNI_PREFIX = "Java_ai_xybrid_Native_"
+BOLT_SYMBOL = "boltffi_function_xybrid_bolt_set_binding"
+
+
+def verify(glue: str, dynamic_symbols: str) -> int:
+    expected = set(re.findall(r"\bJNICALL\s+(Java_ai_xybrid_Native_\w+)\s*\(", glue))
+    if not expected:
+        raise ValueError("generated JNI source contains no entry points")
+
+    exported = set()
+    for line in dynamic_symbols.splitlines():
+        fields = line.split()
+        # readelf --dyn-syms --wide: Num Value Size Type Bind Vis Ndx Name
+        if (len(fields) >= 8 and fields[0].rstrip(":").isdigit()
+                and fields[3] == "FUNC" and fields[4] in {"GLOBAL", "WEAK"}
+                and fields[5] in {"DEFAULT", "PROTECTED"} and fields[6] != "UND"):
+            exported.add(fields[7].split("@", 1)[0])
+
+    actual = {symbol for symbol in exported if symbol.startswith(JNI_PREFIX)}
+    missing, unexpected = expected - actual, actual - expected
+    problems = []
+    if missing:
+        problems.append("missing JNI exports: " + ", ".join(sorted(missing)))
+    if unexpected:
+        problems.append("unexpected JNI exports: " + ", ".join(sorted(unexpected)))
+    if BOLT_SYMBOL not in exported:
+        problems.append("missing underlying Bolt C ABI: " + BOLT_SYMBOL)
+    if problems:
+        raise ValueError("\n".join(problems))
+    return len(expected)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--readelf", required=True)
+    parser.add_argument("--glue", type=Path, required=True)
+    parser.add_argument("library", type=Path)
+    args = parser.parse_args()
+    try:
+        symbols = subprocess.run(
+            [args.readelf, "--dyn-syms", "--wide", str(args.library)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        count = verify(args.glue.read_text(), symbols)
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"error: {args.library}: {error}", file=sys.stderr)
+        return 1
+    print(f"{args.library}: all {count} generated JNI exports match")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #530.

The published AAR had two independent native-loading failures: Kotlin calls System.loadLibrary("xybrid_bolt") while the package contained libxybrid-bolt.so, and the Bazel target packaged the Rust C ABI cdylib without BoltFFI's generated Java_ai_xybrid_Native_* JNI bridge.

This changes the Android artifact itself, not just the smoke test:

- generate and commit BoltFFI's Kotlin JNI C/header inputs alongside XybridBolt.kt, with one drift check for all generated outputs;
- link the JNI glue and Rust staticlib into libxybrid_bolt.so inside Bazel, preserving the Bolt C ABI and the generated Java entry points;
- expose host-independent NDK libc++_shared aliases so the same target works with local macOS builds and Linux RBE;
- update AAR/APK paths and documentation to the loadable filename;
- make Android CI compare the final ELF's JNI exports with the generated source, so a filename-only or C-ABI-only artifact cannot pass again.

I built the full three-ABI AAR and audited the packaged ELF files:

- arm64-v8a: 88/88 generated JNI exports, AArch64, 16 KB alignment;
- armeabi-v7a: 88/88 generated JNI exports, ARM, 16 KB alignment;
- x86_64: 88/88 generated JNI exports, x86-64, 16 KB alignment;
- all three have SONAME libxybrid_bolt.so, retain the underlying BoltFFI symbol, and declare libc++_shared.so in DT_NEEDED;
- the consumer-smoke app assembles successfully and its APK contains the underscore-named library for all three ABIs, with no hyphen-named copy.

Validation:

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --features ort-download
- python3 tools/scripts/gen_kotlin_bolt.py --check
- Kotlin release/debug compilation and unit tests
- full Bazel //bindings/kotlin:xybrid_kotlin_aar build
- Gradle consumer APK assembly
