### PR TITLE
fix: pin rules-rs Ubuntu zlib URLs

### DIFF
--- a/rules_rs.patch
+++ b/rules_rs.patch
@@ -164,3 +164,21 @@ diff -ru a/rs/toolchains/declare_rustc_toolchains.bzl b/rs/toolchains/declare_ru
              exec_triple = triple,
              target_triple = select(target_triple_select),
              visibility = ["//visibility:public"],
+
+diff -ru a/rs/private/rustc_repository.bzl b/rs/private/rustc_repository.bzl
+--- a/rs/private/rustc_repository.bzl
++++ b/rs/private/rustc_repository.bzl
+@@ -55,11 +55,11 @@ _LINUX_ZLIB = {
+     "aarch64": struct(
+         libdir = "usr/lib/aarch64-linux-gnu",
+         sha256 = "cbe3d39ec32d3cc27c021ae4af11e7c67bdf9d700d573207e0941d4038056278",
+-        url = "https://ports.ubuntu.com/ubuntu-ports/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_arm64.deb",
++        url = "https://snapshot.ubuntu.com/ubuntu/20260801T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_arm64.deb",
+     ),
+     "x86_64": struct(
+         libdir = "usr/lib/x86_64-linux-gnu",
+         sha256 = "7074b6a2f6367a10d280c00a1cb02e74277709180bab4f2491a2f355ab2d6c20",
+-        url = "https://archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb",
++        url = "https://snapshot.ubuntu.com/ubuntu/20260801T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb",
+     ),
+ }


### PR DESCRIPTION
## Summary

Pin the two Linux zlib package URLs in `rules_rs.patch` to the immutable Ubuntu snapshot used by the upstream `rules_rs` fix.

- Package bytes and existing SHA-256 checksums are unchanged.
- No cancellation code was changed.
- This PR changes only `rules_rs.patch`.

Upstream reference: https://github.com/hermeticbuild/rules_rs/commit/81336041f1c092b94ba0d35384c4dfc03ce45a07

## Validation

- `git diff --check -- rules_rs.patch` passed.
- Fresh-output-base `bazelisk build --nobuild --config=linux-vulkan -c opt //crates/xybrid-cli:xybrid //:llama_vulkan` passed with zero actions.
- The broader fresh-output-base graph reached analysis but was blocked on this macOS host because Bazel could not find Java for the Kotlin target. CI should run that Linux graph and the Android AAR target with its configured toolchain.
