### PR TITLE
ci(apple): run XybridTests on an iOS simulator after the wrapper build

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -162,22 +162,12 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Run Swift unit tests (iOS Simulator)
-        # The generic build above compiles + links the wrapper but cannot
-        # execute anything: `generic/platform=iOS Simulator` has no bootable
-        # device, so XybridTests never runs there. A concrete simulator
-        # destination compiles the test bundle and runs it on a booted device.
-        # Package.swift is already flipped to the locally built xcframework by
-        # the previous step, so this links the G4 simulator slice just built.
-        #
-        # iPhone 17 on iOS 26.5 is what the macos-26 image ships for the
-        # default Xcode (26.6); there is no "iPhone 16" simulator on that image
-        # (only iPhone 16e, and only under the iOS 26.2 runtime). DEVELOPER_DIR
-        # pins the Xcode whose bundled runtime the OS= below refers to. When
-        # the image rolls forward, bump both together (see
-        # actions/runner-images macos-26-Readme.md, "Installed Simulators").
-        #
-        # The timeout stops a simulator boot hang or a test deadlock from
-        # holding the runner for the job's full 6h default.
+        # The generic build above can't execute tests (no bootable device);
+        # a concrete simulator runs XybridTests against the xcframework the
+        # previous step already flipped Package.swift to. iPhone 17 / iOS 26.5
+        # is the pair macos-26 ships with its default Xcode 26.6 (no iPhone 16
+        # on that image); bump DEVELOPER_DIR and OS= together when the image
+        # rolls forward. Timeout guards against a simulator/test hang.
         timeout-minutes: 10
         env:
           DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -63,7 +63,9 @@ env:
 jobs:
   build-xcframework:
     name: Build XCFramework
-    runs-on: macos-14
+    # macos-26 (Xcode 26.6 default, iOS 26.5 simulator runtime) — the simulator
+    # test step below needs a bootable device, and macos-14 is on its way out.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -156,6 +158,34 @@ jobs:
           xcodebuild build \
             -scheme Xybrid \
             -destination 'generic/platform=iOS Simulator' \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Run Swift unit tests (iOS Simulator)
+        # The generic build above compiles + links the wrapper but cannot
+        # execute anything: `generic/platform=iOS Simulator` has no bootable
+        # device, so XybridTests never runs there. A concrete simulator
+        # destination compiles the test bundle and runs it on a booted device.
+        # Package.swift is already flipped to the locally built xcframework by
+        # the previous step, so this links the G4 simulator slice just built.
+        #
+        # iPhone 17 on iOS 26.5 is what the macos-26 image ships for the
+        # default Xcode (26.6); there is no "iPhone 16" simulator on that image
+        # (only iPhone 16e, and only under the iOS 26.2 runtime). DEVELOPER_DIR
+        # pins the Xcode whose bundled runtime the OS= below refers to. When
+        # the image rolls forward, bump both together (see
+        # actions/runner-images macos-26-Readme.md, "Installed Simulators").
+        #
+        # The timeout stops a simulator boot hang or a test deadlock from
+        # holding the runner for the job's full 6h default.
+        timeout-minutes: 10
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+        run: |
+          set -euo pipefail
+          xcodebuild test \
+            -scheme Xybrid \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO
 


### PR DESCRIPTION
## Summary

`Build Apple` compiled the Swift wrapper against `generic/platform=iOS Simulator`, which links but cannot execute anything, so `XybridTests` never ran in CI. This adds a `xcodebuild test` step on a concrete simulator right after that build (the generic build stays for its multi-arch compile/link coverage) and moves the job to `macos-26`.

- **Runner:** `macos-14` → `macos-26` (Xcode 26.6 default; macos-14 is nearing retirement).
- **Destination:** `iPhone 17, OS=26.5`. The macos-26 image has no "iPhone 16" simulator — only iPhone 16e, and only under the iOS 26.2 runtime — so this uses the device/runtime pair shipped with the default Xcode. `DEVELOPER_DIR` is pinned to `Xcode_26.6` so the `OS=` pin stays coherent with the Xcode that bundles that runtime. Source: [macos-26 runner image README](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md), "Installed Simulators".
- **Timeout:** `timeout-minutes: 10` so a simulator boot hang or a test deadlock can't hold the runner for the 6h default.

No extra setup is needed: the preceding step already flips `Package.swift` to the locally built xcframework, so the tests link the G4 simulator slice produced in the same job.

**Local verification** (macOS 26 / Xcode 26.6, same combo as the image): the exact `xcodebuild test` command runs `XybridTests` — 4 tests, 0 failures, `** TEST SUCCEEDED **`.

## Type of Change

- [x] Other: CI

## Checklist

- [x] Tests pass (`xcodebuild test`, see above; no Rust changes)
- [x] Code follows project style
- [ ] Documentation updated (n/a)
- [x] No breaking changes
