### PR TITLE
ci: run the sentence_ranker example's unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,10 +361,21 @@ jobs:
 
       # Skip examples — they statically link llama.cpp + ort and exhaust
       # runner disk during link. `clippy --all-targets` already verifies
-      # examples compile (it stops at .rmeta, so no link step).
+      # examples compile (it stops at .rmeta, so no link step) — but compiling
+      # is all it does: an example's `#[cfg(test)]` module never runs here.
+      # Examples that carry unit tests are opted in one at a time below.
       # `--doc` can't be combined with other target flags, so it runs separately.
       - name: Run tests (lib, bins, integration)
         run: cargo test --workspace --features ort-download --lib --bins --tests
+
+      # `sentence_ranker` unit-tests its cosine-similarity and ranking helpers.
+      # Selecting the single example keeps the no-examples policy above intact:
+      # it needs no llm-llamacpp, and ort is load-dynamic on Linux, so the link
+      # step is one small binary — not every example against llama.cpp. Add
+      # another `--example <name>` here when an example gains tests that run
+      # without llm-llamacpp; examples that need it belong in test-llm.
+      - name: Run tests (examples with unit tests)
+        run: cargo test -p xybrid-core --features ort-download --example sentence_ranker
 
       - name: Run doc tests
         run: cargo test --workspace --features ort-download --doc


### PR DESCRIPTION
## Summary

The `test` job passes `--lib --bins --tests`, so cargo never builds examples in test mode, and `clippy --all-targets` only proves they compile. The five cosine/ranking unit tests that landed with #550 in `crates/xybrid-core/examples/sentence_ranker.rs` therefore never run in CI: `cosine_similarity` or `rank_by_similarity` could break and CI would stay green.

This adds one targeted step to the `test` job:

```bash
cargo test -p xybrid-core --features ort-download --example sentence_ranker
```

It keeps the no-examples policy intact instead of lifting it. `sentence_ranker` needs no `llm-llamacpp`, and `ort` is `load-dynamic` on Linux, so the link step is one small binary rather than every example against llama.cpp. The existing "Skip examples" comment is extended to say that clippy only compiles examples and that examples carrying unit tests are opted in one at a time here (examples that need `llm-llamacpp` belong in `test-llm`).

Follow-up from the review of #550.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (describe below): CI

## Checklist

- [x] Tests pass: locally, `cargo test -p xybrid-core --features ort-download --example sentence_ranker` runs 5 tests, all passing
- [x] Code follows project style: `actionlint` clean; no Rust changes, so `fmt` / `clippy` are unaffected
- [x] Documentation updated: the workflow comment explaining the examples policy is updated in place
- [x] No breaking changes
