### PR TITLE
feat(routing): enforce policies across local and cloud inference

### DIFF
--- a/.github/workflows/test-policy-routing.yml
+++ b/.github/workflows/test-policy-routing.yml
@@ -1,0 +1,100 @@
+name: Test policy routing
+
+# Drives the real `xybrid` binary through a policy-routed hybrid stage: the
+# local leg is a real GGUF model (FunctionGemma 270M), the cloud leg is a
+# local fake DeepSeek endpoint. Compile-only lanes cannot prove that a policy
+# actually keeps a prompt on the device or actually sends it to the provider
+# with the right model, credential and options — this one does.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'crates/xybrid-core/**'
+      - 'crates/xybrid-cli/**'
+      - 'crates/xybrid-sdk/**'
+      - 'crates/llama-cpp-sys/**'
+      - 'crates/xybrid-llama/**'
+      - 'integration-tests/**'
+      - 'vendor/llama-cpp/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - '.github/workflows/test-policy-routing.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
+  pull_request:
+    branches: [master]
+    paths:
+      - 'crates/xybrid-core/**'
+      - 'crates/xybrid-cli/**'
+      - 'crates/xybrid-sdk/**'
+      - 'crates/llama-cpp-sys/**'
+      - 'crates/xybrid-llama/**'
+      - 'integration-tests/**'
+      - 'vendor/llama-cpp/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.cargo/**'
+      - '.github/workflows/test-policy-routing.yml'
+      # Markdown inside any path above cannot affect this build.
+      - "!**.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test-policy-routing:
+    name: Test policy routing (real local model, fake DeepSeek)
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: policy-routing-integration
+
+      - name: Ensure download tooling (jq, zstd)
+        run: |
+          for tool in jq zstd; do
+            command -v "$tool" >/dev/null || brew install "$tool"
+          done
+
+      # The checksum pins the exact Q8_0 weights the test is calibrated
+      # against (integration-tests/fixtures/models/models.json); a mutable
+      # artifact cannot silently redefine the test.
+      - name: Cache functiongemma-270m-it
+        id: cache-functiongemma
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: integration-tests/fixtures/models/functiongemma-270m-it
+          key: functiongemma-270m-it-${{ runner.os }}-83940d4dd9676710856f43523bed096164a595a96f6b34771610a03937de5270
+
+      - name: Download functiongemma-270m-it
+        if: steps.cache-functiongemma.outputs.cache-hit != 'true'
+        run: ./integration-tests/download.sh functiongemma-270m-it
+
+      - name: Verify weights (cache hit or miss)
+        run: |
+          echo '83940d4dd9676710856f43523bed096164a595a96f6b34771610a03937de5270  integration-tests/fixtures/models/functiongemma-270m-it/functiongemma-270m-it-q8_0.gguf' \
+            | shasum -a 256 -c -
+
+      - name: CLI routing helpers (unit)
+        run: cargo test -p xybrid-cli --bin xybrid commands::run
+
+      - name: Policy routing end to end
+        env:
+          XYBRID_REQUIRE_MODELS: 1
+        run: |
+          cargo test -p xybrid-cli --features llm-llamacpp --test policy_routing_cli_test -- --list
+          cargo test -p xybrid-cli --features llm-llamacpp --test policy_routing_cli_test -- --nocapture

--- a/.github/workflows/test-policy-routing.yml
+++ b/.github/workflows/test-policy-routing.yml
@@ -96,5 +96,32 @@ jobs:
         env:
           XYBRID_REQUIRE_MODELS: 1
         run: |
-          cargo test -p xybrid-cli --features llm-llamacpp --test policy_routing_cli_test -- --list
+          # Enumerate and assert the required tests: printing `--list` alone
+          # would still pass if every test were compiled out (cargo test exits
+          # 0 on an empty set).
+          LIST="$(cargo test -p xybrid-cli --features llm-llamacpp --test policy_routing_cli_test -- --list)"
+          printf '%s\n' "$LIST"
+          for test in \
+            local_only_policy_runs_the_gguf_model \
+            prefer_cloud_policy_calls_the_fake_deepseek_endpoint \
+            dry_run_loads_policy_without_inference \
+            cold_cache_hybrid_downloads_extracts_and_then_runs_offline; do
+            printf '%s\n' "$LIST" | grep -qE "^${test}: test$" \
+              || { echo "missing required test: ${test}" >&2; exit 1; }
+          done
           cargo test -p xybrid-cli --features llm-llamacpp --test policy_routing_cli_test -- --nocapture
+
+      - name: SDK streaming fast path (real GGUF fixture)
+        env:
+          XYBRID_REQUIRE_MODELS: 1
+        run: |
+          LIST="$(cargo test -p xybrid-sdk --features llm-llamacpp --test streaming_fast_path -- --list)"
+          printf '%s\n' "$LIST"
+          for test in \
+            yaml_max_tokens_caps_streaming_generation \
+            envelope_metadata_overrides_yaml_in_streaming \
+            invalid_yaml_option_fails_before_any_token; do
+            printf '%s\n' "$LIST" | grep -qE "^${test}: test$" \
+              || { echo "missing required test: ${test}" >&2; exit 1; }
+          done
+          cargo test -p xybrid-sdk --features llm-llamacpp --test streaming_fast_path -- --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Policy-routed hybrid inference: a pipeline stage can now carry a local GGUF
+model and an OpenAI-compatible cloud leg (DeepSeek, OpenAI, OpenRouter) at
+the same time, and a policy bundle decides which leg serves each request.
+
+### Added
+
+- **Policy DSL and cloud preference.** Bundles are compiled at load time and
+  support `input.kind`, `input.text` (`contains` / `matches` / `==` / `!=`),
+  `input.text_len`, `metrics.battery_level`, `metrics.cpu_pct`,
+  `metrics.memory_pressure`, `metrics.thermal_state` and bare `true` / `false`;
+  actions are `allow`, `deny`, `route_cloud` (alias `prefer_cloud`) and
+  `redact`, plus `deny_cloud_if` / `route_cloud_if` shorthand lists. Invalid
+  rules are rejected at load and a failed reload keeps the previous bundle.
+- **Hybrid stages in `xybrid run`.** `target: auto` with a `provider` resolves
+  the local bundle *and* keeps the cloud leg; `cloud_model` names the model
+  sent to the provider; shared `system_prompt` / `temperature` / `max_tokens`
+  / `top_p` apply to both legs with the same precedence (input metadata, then
+  YAML, then template defaults). Unknown targets or providers are errors.
+- **OpenAI-compatible direct providers and DeepSeek thinking mode.**
+  `backend: direct` for OpenAI, DeepSeek, OpenRouter and Custom uses the
+  gateway transport at the provider's documented base URL with
+  `$<PROVIDER>_API_KEY`; `thinking: enabled|disabled` is a typed request
+  option serialized as DeepSeek's `"thinking": {"type": ...}`. Batch and SSE
+  share one request-body builder.
+- **`Backend` in CLI results** (`template-executor` vs
+  `cloud:<provider>:gateway`) and `StageExecutionResult.adapter`, so a routing
+  label can be checked against what actually ran.
+- `OrchestrationAuthority::resolve_stage` and `load_policies`,
+  `StageResolution`, `PolicyAction`, `PolicyRoute`, `ThinkingMode`,
+  `CompletionRequest::with_thinking`, `MockRuntimeAdapter::with_name` /
+  `captured_inputs`.
+- Example pipeline `crates/xybrid-cli/examples/hybrid-deepseek.yaml` with
+  policies under `crates/xybrid-cli/examples/policies/`, and the
+  `test-policy-routing` workflow that drives the real binary through a policy
+  with a real local model and a local fake DeepSeek endpoint.
+
+### Changed
+
+- **Policy is a dispatch invariant.** Every stage decision evaluates the
+  policy once against the actual input and one device snapshot; a denial (or
+  a required transform) restricts the target to the device ahead of explicit
+  `cloud` / `server` targets, model availability, hysteresis, reliability
+  history, device stress and remote advice, and is re-applied immediately
+  before dispatch. A denied stage with no usable local leg fails locally
+  instead of running on cloud. `RemoteAuthority` consults advice only for
+  decisions the policy, an explicit target, availability or a policy
+  preference did not already settle, and never for a denied input.
+- **Credentials are scoped to the destination.** An explicit `api_key`
+  (literal or `$ENV`) always wins and never falls through; the Xybrid platform
+  key is sent only to the configured platform gateway origin (exact
+  scheme/host/port); a provider key only to that provider's origin; any other
+  endpoint — including a self-hosted gateway reached via `gateway_url` — is
+  anonymous unless `api_key` is set. Point the platform at such a gateway with
+  `XYBRID_GATEWAY_URL` / `set_platform_url` to keep the platform key flowing.
+- **The executor dispatches on the routing target**, not on the presence of a
+  provider. A hybrid stage routed local whose bundle is missing or invalid
+  errors instead of falling back to another adapter or to cloud; local
+  fallback never selects the cloud adapter and vice versa.
+- `--dry-run` decides the first stage through the same authority (and honours
+  `--policy`) at the current device snapshot; later stages print UNKNOWN
+  instead of fabricated outputs.
+- `Orchestrator::with_engines` removed; `Orchestrator::with_all` no longer
+  takes policy/routing engines; `PolicyRule.action` is a `PolicyAction`;
+  `PolicyResult` gains `route`; `CompletionRequest` gains `thinking`.
+
+### Fixed
+
+- `Orchestrator::load_policies` (and therefore `xybrid run --policy`) wrote
+  into an engine nothing consulted, so policies never affected routing.
+- The CLI mapped any provider other than openai/anthropic/google to OpenAI, so
+  `provider: deepseek` silently called the wrong API.
+- `Orchestrator::new()` / the SDK `Pipeline` served cloud stages from a fake
+  adapter that slept 50 ms and returned `cloud-output-<text>`; the real
+  OpenAI-compatible adapter is registered now, and a provider-less cloud stage
+  fails honestly.
+- `input.kind == "<v>"` matched a text payload equal to the literal.
+- Shared YAML generation options only reached the cloud leg; the local
+  template executor now receives them too.
+
 ### Planned
 
 - **Multimodal KV-prefix reuse**: the per-frame prefill cost lever for live vision — **deferred** from 0.2.0, not yet implemented.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ the same time, and a policy bundle decides which leg serves each request.
 - `Orchestrator::with_engines` removed; `Orchestrator::with_all` no longer
   takes policy/routing engines; `PolicyRule.action` is a `PolicyAction`;
   `PolicyResult` gains `route`; `CompletionRequest` gains `thinking`.
+- The SDK streaming fast path makes one `resolve_stage` decision (one policy
+  evaluation, one resource snapshot) instead of separate policy and target
+  calls.
 
 ### Fixed
 
@@ -85,6 +88,12 @@ the same time, and a policy bundle decides which leg serves each request.
 - `input.kind == "<v>"` matched a text payload equal to the literal.
 - Shared YAML generation options only reached the cloud leg; the local
   template executor now receives them too.
+- `backend: direct` with `anthropic` ignored the stage's `api_key` and
+  `gateway_url`; both now reach the native client. Google and ElevenLabs,
+  which have no native direct client, are rejected when the bundle loads
+  instead of failing at request time.
+- An HTTP 200 with no answer text (empty `content`, no choices) is a
+  non-retryable parse error instead of a silent empty success.
 
 ### Planned
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,10 @@ the same time, and a policy bundle decides which leg serves each request.
   `StageResolution`, `PolicyAction`, `PolicyRoute`, `ThinkingMode`,
   `CompletionRequest::with_thinking`, `MockRuntimeAdapter::with_name` /
   `captured_inputs`.
-- Example pipeline `crates/xybrid-cli/examples/hybrid-deepseek.yaml` with
-  policies under `crates/xybrid-cli/examples/policies/`, and the
+- Primary example `crates/xybrid-cli/examples/hybrid-platform.yaml` uses a
+  Xybrid API key and platform-held provider credentials. The separate
+  `hybrid-deepseek.yaml` example supports direct-provider testing. Both use
+  policies under `crates/xybrid-cli/examples/policies/`, alongside the
   `test-policy-routing` workflow that drives the real binary through a policy
   with a real local model and a local fake DeepSeek endpoint.
 

--- a/crates/xybrid-cli/examples/hybrid-deepseek.yaml
+++ b/crates/xybrid-cli/examples/hybrid-deepseek.yaml
@@ -1,0 +1,26 @@
+# One LLM stage with two legs: a local GGUF model and DeepSeek's API.
+# The policy passed with --policy (and the device state) decide which leg
+# serves each prompt. Export DEEPSEEK_API_KEY, then:
+#
+#   cargo run -p xybrid-cli --features llm-llamacpp -- run \
+#     -c crates/xybrid-cli/examples/hybrid-deepseek.yaml \
+#     --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
+#     --input-text "Summarise the plot of Dune in two sentences." -v
+#
+# Swap the policy for policies/local-only.yaml to keep the same prompt on
+# the device, or policies/privacy.yaml to route by content.
+name: hybrid-deepseek
+stages:
+  - id: llm
+    model: functiongemma-270m-it      # local leg (cache/registry id)
+    target: auto                      # hybrid: policy + device state pick the leg
+    provider: deepseek                # cloud leg
+    cloud_model: deepseek-flash       # model sent to the provider (defaults to `model`)
+    backend: direct                   # OpenAI-compatible call to https://api.deepseek.com/v1 with $DEEPSEEK_API_KEY
+    thinking: disabled                # DeepSeek: answer only; thinking is on by default and would eat max_tokens
+    # Explicit endpoint override — then select its credential explicitly too:
+    # gateway_url: "https://api.deepseek.com/v1"
+    # api_key: "$DEEPSEEK_API_KEY"
+    system_prompt: "You are a concise assistant."
+    max_tokens: 128
+    temperature: 0

--- a/crates/xybrid-cli/examples/hybrid-deepseek.yaml
+++ b/crates/xybrid-cli/examples/hybrid-deepseek.yaml
@@ -1,4 +1,7 @@
-# One LLM stage with two legs: a local GGUF model and DeepSeek's API.
+# Direct-provider example for testing: a local GGUF model and DeepSeek's API.
+# For the primary Xybrid Platform integration, use hybrid-platform.yaml.
+# This example calls DeepSeek directly with your provider key. Automated
+# policy-routing tests use a loopback fake DeepSeek endpoint instead.
 # The policy passed with --policy (and the device state) decide which leg
 # serves each prompt. Export DEEPSEEK_API_KEY, then:
 #

--- a/crates/xybrid-cli/examples/hybrid-platform.yaml
+++ b/crates/xybrid-cli/examples/hybrid-platform.yaml
@@ -1,0 +1,26 @@
+# Primary hybrid example: a local GGUF model and Xybrid Platform cloud inference.
+# Export XYBRID_API_KEY, then run from the repository root:
+#
+#   cargo run -p xybrid-cli --features llm-llamacpp -- run \
+#     -c crates/xybrid-cli/examples/hybrid-platform.yaml \
+#     --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
+#     --input-text "Summarise the plot of Dune in two sentences." -v
+#
+# The cloud request goes to https://api.xybrid.dev/v1 using the Xybrid key.
+# Provider credentials are configured on the platform, not on this device.
+# Use --platform-url <base-url> for a staging or self-hosted platform.
+# Swap in policies/local-only.yaml to forbid cloud inference, or
+# policies/privacy.yaml to route by content. A cold cache may download the
+# local model before inference; subsequent runs reuse the extracted model.
+# For direct-provider testing, see hybrid-deepseek.yaml.
+name: hybrid-platform
+stages:
+  - id: llm
+    model: functiongemma-270m-it     # local leg (cache/registry id)
+    target: auto                     # policy + device state choose the leg
+    provider: openai                 # upstream provider behind Xybrid Platform
+    cloud_model: gpt-4o-mini         # recognized by the platform model router
+    backend: gateway                # Xybrid Platform; resolves XYBRID_API_KEY
+    system_prompt: "You are a concise assistant."
+    max_tokens: 128
+    temperature: 0

--- a/crates/xybrid-cli/examples/policies/local-only.yaml
+++ b/crates/xybrid-cli/examples/policies/local-only.yaml
@@ -1,0 +1,4 @@
+# Cloud is forbidden for every input: the stage always runs on the device.
+version: "1.0.0"
+deny_cloud_if:
+  - "true"

--- a/crates/xybrid-cli/examples/policies/long-prompts-to-cloud.yaml
+++ b/crates/xybrid-cli/examples/policies/long-prompts-to-cloud.yaml
@@ -1,0 +1,4 @@
+# Long prompts go to the cloud leg; short ones stay local.
+version: "1.0.0"
+route_cloud_if:
+  - "input.text_len > 800"

--- a/crates/xybrid-cli/examples/policies/low-battery-to-cloud.yaml
+++ b/crates/xybrid-cli/examples/policies/low-battery-to-cloud.yaml
@@ -1,0 +1,4 @@
+# Offload when the battery is low (live reading at decision time).
+version: "1.0.0"
+route_cloud_if:
+  - "metrics.battery_level < 25"

--- a/crates/xybrid-cli/examples/policies/prefer-cloud.yaml
+++ b/crates/xybrid-cli/examples/policies/prefer-cloud.yaml
@@ -1,0 +1,4 @@
+# Prefer the cloud leg whenever the local model exists and nothing forbids it.
+version: "1.0.0"
+route_cloud_if:
+  - "true"

--- a/crates/xybrid-cli/examples/policies/privacy.yaml
+++ b/crates/xybrid-cli/examples/policies/privacy.yaml
@@ -1,0 +1,9 @@
+# Sensitive content never leaves the device. Everything else routes normally.
+version: "1.0.0"
+rules:
+  - id: keep_secrets_on_device
+    expression: 'input.text matches "(?i)confidential|ssn|password"'
+    action: deny
+  - id: keep_audio_on_device
+    expression: 'input.kind == "audio"'
+    action: deny

--- a/crates/xybrid-cli/examples/policy.yaml
+++ b/crates/xybrid-cli/examples/policy.yaml
@@ -1,13 +1,15 @@
-# Example Policy Bundle
+# Example policy bundle.
+# Rules are evaluated in order; the first match wins.
+# Actions: deny (cloud forbidden, stay local), route_cloud (prefer the cloud
+# leg when permitted), allow (stop evaluating, route normally).
 version: "1.0.0"
 rules:
-  - id: "audio_rule"
-    expression: "input.kind == \"AudioRaw\""
-    action: "deny"
-  - id: "high_rtt_rule"
-    expression: "metrics.network_rtt > 300"
-    action: "deny"
-  - id: "allow_all"
+  - id: keep_audio_on_device
+    expression: 'input.kind == "audio"'
+    action: deny
+  - id: offload_when_hot
+    expression: 'metrics.thermal_state == "hot"'
+    action: route_cloud
+  - id: default_allow
     expression: "true"
-    action: "allow"
-
+    action: allow

--- a/crates/xybrid-cli/src/commands/run.rs
+++ b/crates/xybrid-cli/src/commands/run.rs
@@ -217,10 +217,18 @@ fn resolve_device_stage(
         return Ok(());
     }
 
-    // Not cached locally — must fetch from the registry.
+    // Not cached locally — fetch and materialize the extracted bundle.
     download_model(desc, model_id, client)
 }
 
+/// Download and extract a model, setting `desc.bundle_path` only once the
+/// runtime-ready extraction directory exists.
+///
+/// `fetch_extracted` is the SDK entry point that turns a `.xyb` bundle into an
+/// extraction directory and, for passthrough variants (e.g. raw GGUF files),
+/// writes `model_metadata.json` alongside the model file. Plain `fetch`
+/// returns the downloaded bundle *file*, which the local executor cannot load,
+/// so a cold-cache hybrid stage must not stop there.
 fn download_model(
     desc: &mut StageDescriptor,
     model_id: &str,
@@ -230,13 +238,13 @@ fn download_model(
         Ok(resolved) => {
             let pb = ui::download_bar(resolved.size_bytes, model_id);
 
-            match client.fetch(model_id, None, |progress| {
+            match client.fetch_extracted(model_id, None, |progress| {
                 let bytes_done = (progress * resolved.size_bytes as f32) as u64;
                 pb.set_position(bytes_done);
             }) {
                 Ok(bundle_path) => {
                     pb.finish_and_clear();
-                    ui::ok(&format!("{} downloaded", model_id));
+                    ui::ok(&format!("{} downloaded and extracted", model_id));
                     desc.bundle_path = Some(bundle_path.to_string_lossy().to_string());
                 }
                 Err(e) => {

--- a/crates/xybrid-cli/src/commands/run.rs
+++ b/crates/xybrid-cli/src/commands/run.rs
@@ -5,13 +5,18 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
-use xybrid_core::context::{DeviceMetrics, StageDescriptor};
+use xybrid_core::context::{DeviceMetrics, StageDescriptor, DEVICE_CLASS_SCHEMA_VERSION};
+use xybrid_core::device::ResourceMonitor;
 use xybrid_core::execution_template::ModelMetadata;
+use xybrid_core::executor::prepare_stage_input;
 use xybrid_core::ir::{Envelope, EnvelopeKind};
-use xybrid_core::orchestrator::policy_engine::PolicyEngine;
-use xybrid_core::orchestrator::routing_engine::{LocalAvailability, RoutingEngine};
-use xybrid_core::orchestrator::Orchestrator;
-use xybrid_core::pipeline_config::PipelineConfig;
+use xybrid_core::orchestrator::routing_engine::LocalAvailability;
+use xybrid_core::orchestrator::{
+    LocalAuthority, OrchestrationAuthority, Orchestrator, PolicyOutcome, PolicyRequest,
+    ResolvedTarget, StageContext, StageResolution,
+};
+use xybrid_core::pipeline::{ExecutionTarget, IntegrationProvider, StageOptions};
+use xybrid_core::pipeline_config::{PipelineConfig, StageConfig};
 use xybrid_core::target::{Platform, TargetResolver};
 use xybrid_core::template_executor::TemplateExecutor;
 use xybrid_sdk::registry_client::RegistryClient;
@@ -60,7 +65,7 @@ pub(crate) fn run_pipeline(
     print_pipeline_config(&stages, &input, &metrics, target);
 
     if dry_run {
-        return run_dry_run(&stages, &input, &metrics, &availability_fn);
+        return run_dry_run(&stages, &input, &metrics, &availability_fn, policy_path);
     }
 
     execute_pipeline(
@@ -76,6 +81,57 @@ pub(crate) fn run_pipeline(
     )
 }
 
+/// How a YAML stage maps onto the local and cloud legs.
+#[derive(Debug, Clone, PartialEq)]
+enum StageShape {
+    /// Local only. `target` is the declared target (`device` / `auto`) or
+    /// `None` when the YAML omitted it.
+    Device { target: Option<ExecutionTarget> },
+    /// Cloud only: `target: cloud`, or a provider with no target.
+    CloudOnly { provider: IntegrationProvider },
+    /// `target: auto` with a provider: a local bundle *and* a cloud leg; the
+    /// policy and the device state pick one per request.
+    Hybrid { provider: IntegrationProvider },
+}
+
+/// Classify a YAML stage, rejecting unknown targets/providers instead of
+/// silently mapping them onto something else.
+fn classify_stage(stage_config: &StageConfig) -> Result<StageShape> {
+    let stage_id = stage_config.stage_id();
+    let target = stage_config
+        .target()
+        .map(|raw| {
+            raw.parse::<ExecutionTarget>()
+                .map_err(|e| anyhow::anyhow!("stage '{}': {}", stage_id, e))
+        })
+        .transpose()?;
+    let provider = stage_config
+        .provider()
+        .map(|raw| {
+            raw.parse::<IntegrationProvider>()
+                .map_err(|e| anyhow::anyhow!("stage '{}': {}", stage_id, e))
+        })
+        .transpose()?;
+
+    match (target, provider) {
+        (Some(ExecutionTarget::Server), _) => Err(anyhow::anyhow!(
+            "stage '{}': target 'server' is not supported by `xybrid run`; use device, cloud, or auto",
+            stage_id
+        )),
+        (Some(ExecutionTarget::Cloud), Some(provider)) => Ok(StageShape::CloudOnly { provider }),
+        (Some(ExecutionTarget::Cloud), None) => Err(anyhow::anyhow!(
+            "stage '{}': target 'cloud' requires a 'provider' (e.g. openai, deepseek)",
+            stage_id
+        )),
+        (None, Some(provider)) => Ok(StageShape::CloudOnly { provider }),
+        (Some(ExecutionTarget::Auto), Some(provider)) => Ok(StageShape::Hybrid { provider }),
+        (Some(ExecutionTarget::Device), Some(_)) => Ok(StageShape::Device {
+            target: Some(ExecutionTarget::Device),
+        }),
+        (target, None) => Ok(StageShape::Device { target }),
+    }
+}
+
 fn resolve_pipeline_stages(
     config: &PipelineConfig,
     client: &RegistryClient,
@@ -84,12 +140,37 @@ fn resolve_pipeline_stages(
 
     for stage_config in &config.stages {
         let model_id = stage_config.model_id();
-        let mut desc = StageDescriptor::new(&model_id);
+        // The stage keeps its YAML id; the model id travels separately so a
+        // hybrid stage can name a local bundle and a cloud model.
+        let mut desc = StageDescriptor::new(stage_config.stage_id()).with_model(model_id.clone());
 
-        if stage_config.is_cloud_stage() {
-            configure_cloud_stage(&mut desc, stage_config, &model_id);
-        } else {
-            resolve_device_stage(&mut desc, &model_id, client)?;
+        match classify_stage(stage_config)? {
+            StageShape::CloudOnly { provider } => {
+                configure_cloud_stage(&mut desc, stage_config, provider);
+            }
+            StageShape::Hybrid { provider } => {
+                if let Err(e) = resolve_device_stage(&mut desc, &model_id, client) {
+                    ui::warning(&format!(
+                        "stage '{}': local model '{}' is unavailable ({:#}); only the cloud leg \
+                         can serve it, subject to policy",
+                        desc.name, model_id, e
+                    ));
+                }
+                desc.target = Some(ExecutionTarget::Auto);
+                desc.provider = Some(provider);
+                apply_stage_options(&mut desc, stage_config);
+            }
+            StageShape::Device { target } => {
+                if stage_config.provider().is_some() {
+                    ui::warning(&format!(
+                        "stage '{}': 'provider' is ignored for target 'device'",
+                        desc.name
+                    ));
+                }
+                resolve_device_stage(&mut desc, &model_id, client)?;
+                desc.target = target;
+                apply_stage_options(&mut desc, stage_config);
+            }
         }
 
         stages.push(desc);
@@ -100,28 +181,26 @@ fn resolve_pipeline_stages(
 
 fn configure_cloud_stage(
     desc: &mut StageDescriptor,
-    stage_config: &xybrid_core::pipeline_config::StageConfig,
-    model_id: &str,
+    stage_config: &StageConfig,
+    provider: IntegrationProvider,
 ) {
-    if let Some(provider) = stage_config.provider() {
-        desc.provider = Some(match provider {
-            "openai" => xybrid_core::pipeline::IntegrationProvider::OpenAI,
-            "anthropic" => xybrid_core::pipeline::IntegrationProvider::Anthropic,
-            "google" => xybrid_core::pipeline::IntegrationProvider::Google,
-            _ => xybrid_core::pipeline::IntegrationProvider::OpenAI,
-        });
-    }
-    desc.target = Some(xybrid_core::pipeline::ExecutionTarget::Cloud);
-    desc.model = Some(model_id.to_string());
+    desc.provider = Some(provider);
+    desc.target = Some(ExecutionTarget::Cloud);
+    apply_stage_options(desc, stage_config);
+}
 
+/// Copy the flat YAML options (system_prompt, max_tokens, cloud_model,
+/// gateway_url, ...) onto the descriptor for both legs.
+fn apply_stage_options(desc: &mut StageDescriptor, stage_config: &StageConfig) {
     let opts = stage_config.options();
-    if !opts.is_empty() {
-        let mut stage_opts = xybrid_core::pipeline::StageOptions::new();
-        for (key, value) in opts {
-            stage_opts.values.insert(key, value);
-        }
-        desc.options = Some(stage_opts);
+    if opts.is_empty() {
+        return;
     }
+    let mut stage_opts = StageOptions::new();
+    for (key, value) in opts {
+        stage_opts.values.insert(key, value);
+    }
+    desc.options = Some(stage_opts);
 }
 
 fn resolve_device_stage(
@@ -326,20 +405,97 @@ fn print_pipeline_config(
     println!();
 }
 
+fn read_policy_bundle(policy_file: &Path) -> Result<Vec<u8>> {
+    fs::read(policy_file)
+        .with_context(|| format!("Failed to read policy file: {}", policy_file.display()))
+}
+
+/// Decide one stage exactly the way execution would, without running it:
+/// shared options applied, then one authority call for policy and target.
+fn simulate_stage(
+    authority: &dyn OrchestrationAuthority,
+    stage: &StageDescriptor,
+    input: &Envelope,
+    metrics: &DeviceMetrics,
+    availability: LocalAvailability,
+) -> Result<StageResolution> {
+    let prepared = prepare_stage_input(stage, input)
+        .map_err(|e| anyhow::anyhow!("stage '{}': {}", stage.name, e))?;
+    let request = PolicyRequest {
+        stage_id: stage.name.clone(),
+        envelope: prepared.clone(),
+        metrics: metrics.clone(),
+    };
+    let context = StageContext {
+        stage_id: stage.name.clone(),
+        model_id: stage.model.clone().unwrap_or_else(|| stage.name.clone()),
+        input_kind: prepared.kind.clone(),
+        metrics: metrics.clone(),
+        resource_monitor: ResourceMonitor::global(),
+        explicit_target: stage.target.clone(),
+        local_availability: Some(availability),
+        device_class: Some(metrics.canonical_device_class()),
+        device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
+    };
+    Ok(authority.resolve_stage(&request, &context).enforced())
+}
+
+fn route_label(target: &ResolvedTarget) -> String {
+    match target {
+        ResolvedTarget::Device => "local".to_string(),
+        ResolvedTarget::Cloud { .. } => "cloud".to_string(),
+        ResolvedTarget::Server { endpoint } => format!("fallback:{endpoint}"),
+    }
+}
+
+fn print_simulated_resolution(resolution: &StageResolution) {
+    let (status, reason) = match &resolution.policy.result {
+        PolicyOutcome::Allow => (
+            format!("{}", ui::success("ALLOWED")),
+            resolution.policy.reason.clone(),
+        ),
+        PolicyOutcome::Deny { reason } => (
+            format!("{}", ui::error("DENIED")),
+            format!("cloud forbidden, stays local: {reason}"),
+        ),
+        PolicyOutcome::Transform { transforms } => (
+            format!("{}", ui::warn("TRANSFORM REQUIRED")),
+            format!(
+                "cloud forbidden until transforms are implemented: {}",
+                transforms.join(",")
+            ),
+        ),
+    };
+    ui::kv("  Policy", &status);
+    ui::kv("  Reason", &reason);
+    let decision = &resolution.target.decision;
+    ui::kv(
+        "  Routing",
+        &format!("{} ({})", route_label(&decision.result), decision.reason),
+    );
+}
+
 fn run_dry_run(
     stages: &[StageDescriptor],
     input: &Envelope,
-    metrics: &xybrid_core::context::DeviceMetrics,
+    metrics: &DeviceMetrics,
     availability_fn: &dyn Fn(&str) -> LocalAvailability,
+    policy_path: Option<&PathBuf>,
 ) -> Result<()> {
     ui::section("Dry Run · Routing Simulation");
     println!();
 
-    let mut routing_engine = xybrid_core::orchestrator::routing_engine::DefaultRoutingEngine::new();
-    let policy_engine =
-        xybrid_core::orchestrator::policy_engine::DefaultPolicyEngine::with_default_policy();
-
-    let mut current_input = input.clone();
+    // Same decision path as a real run: one LocalAuthority, the same bundle.
+    let authority = LocalAuthority::new();
+    if let Some(policy_file) = policy_path {
+        ui::kv("Policy", &policy_file.display().to_string());
+        let policy_bytes = read_policy_bundle(policy_file)?;
+        authority
+            .load_policies(&policy_bytes)
+            .map_err(|e| anyhow::anyhow!("Failed to load policies: {}", e))?;
+        ui::ok("Policy bundle loaded");
+        println!();
+    }
 
     for (i, stage) in stages.iter().enumerate() {
         println!(
@@ -347,40 +503,39 @@ fn run_dry_run(
             ui::dim(&format!("Stage {}", i + 1)),
             ui::accent(display_stage_name(&stage.name))
         );
-
-        let policy_result = policy_engine.evaluate(&stage.name, &current_input, metrics);
-        let policy_status = if policy_result.allowed {
-            format!("{}", ui::success("ALLOWED"))
-        } else {
-            format!("{}", ui::error("DENIED"))
-        };
-        ui::kv("  Policy", &policy_status);
-        if let Some(ref reason) = policy_result.reason {
-            ui::kv("  Reason", reason);
+        if let Some(target) = &stage.target {
+            ui::kv("  Declared", &format!("target: {}", target));
+        }
+        if let Some(provider) = stage.provider {
+            ui::kv("  Provider", provider.as_str());
         }
 
-        let availability = availability_fn(&stage.name);
-        let routing_decision =
-            routing_engine.decide(&stage.name, metrics, &policy_result, &availability);
-        ui::kv(
-            "  Routing",
-            &format!("{} ({})", routing_decision.target, routing_decision.reason),
-        );
-
-        let new_kind = match &current_input.kind {
-            EnvelopeKind::Audio(_) => EnvelopeKind::Text("transcribed".to_string()),
-            EnvelopeKind::Text(t) => EnvelopeKind::Text(format!("{}-output", t)),
-            EnvelopeKind::Embedding(_) => EnvelopeKind::Text("result".to_string()),
-            EnvelopeKind::Image { .. } | EnvelopeKind::MultiPart(_) => {
-                EnvelopeKind::Text("vision-output".to_string())
-            }
-        };
-        current_input = Envelope::new(new_kind);
-        ui::kv("  Output", current_input.kind_str());
+        if i == 0 {
+            // The first stage sees the actual input and the current device
+            // snapshot; this is a prediction at that snapshot, not a promise.
+            let resolution = simulate_stage(
+                &authority,
+                stage,
+                input,
+                metrics,
+                availability_fn(&stage.name),
+            )?;
+            print_simulated_resolution(&resolution);
+        } else {
+            // Downstream input is whatever the previous stage produces; it
+            // does not exist without execution, so nothing is fabricated.
+            ui::kv("  Policy", &format!("{}", ui::dim("UNKNOWN")));
+            ui::kv("  Routing", &format!("{}", ui::dim("UNKNOWN")));
+            ui::kv("  Output", "upstream output unavailable without execution");
+        }
         println!();
     }
 
-    ui::ok("Dry run completed — no execution performed");
+    ui::hint(
+        "Dry run decides the first stage at the current device snapshot; later stages depend \
+         on upstream output and are not simulated.",
+    );
+    ui::ok("Dry run completed — no inference performed");
     println!();
     Ok(())
 }
@@ -400,14 +555,13 @@ fn execute_pipeline(
 
     if let Some(policy_file) = policy_path {
         ui::kv("Policy", &policy_file.display().to_string());
-        let policy_bytes = fs::read(policy_file)
-            .with_context(|| format!("Failed to read policy file: {}", policy_file.display()))?;
+        let policy_bytes = read_policy_bundle(policy_file)?;
 
         orchestrator
             .load_policies(policy_bytes)
             .map_err(|e| anyhow::anyhow!("Failed to load policies: {}", e))?;
 
-        ui::ok("Policy bundle loaded");
+        ui::ok("Policy bundle loaded — rules that deny cloud keep execution on this device");
         println!();
     }
 
@@ -451,6 +605,7 @@ fn print_pipeline_results(
         );
         ui::kv("  Routing", &result.routing_decision.target.to_string());
         ui::kv("  Reason", &result.routing_decision.reason);
+        ui::kv("  Backend", &result.adapter);
         ui::kv("  Time", &format!("{}ms", result.latency_ms));
         ui::kv("  Output", result.output.kind_str());
 
@@ -1407,6 +1562,7 @@ fn emit_pipeline_complete_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn png_image(width: u32, height: u32) -> Vec<u8> {
         let image = image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
@@ -1476,5 +1632,278 @@ mod tests {
         assert!(message.contains("Invalid image input"));
         assert!(message.contains("Image payload too large"));
         assert!(!message.contains("[0"));
+    }
+
+    // ── stage classification ────────────────────────────────────────────────
+
+    use std::time::Duration;
+    use xybrid_core::device::{MemoryPressure, ResourceSnapshot, ResourceSnapshotProvider};
+
+    fn first_stage(yaml: &str) -> StageConfig {
+        PipelineConfig::from_yaml(yaml)
+            .expect("yaml parses")
+            .stages
+            .into_iter()
+            .next()
+            .expect("one stage")
+    }
+
+    #[test]
+    fn classify_stage_deepseek_auto_is_hybrid() {
+        let stage = first_stage(
+            "stages:\n  - id: llm\n    model: functiongemma-270m-it\n    target: auto\n    provider: deepseek\n    cloud_model: deepseek-flash\n",
+        );
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::Hybrid {
+                provider: IntegrationProvider::DeepSeek
+            }
+        );
+    }
+
+    #[test]
+    fn classify_stage_provider_without_target_is_cloud_only() {
+        let stage = first_stage("stages:\n  - model: gpt-4o-mini\n    provider: openai\n");
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::CloudOnly {
+                provider: IntegrationProvider::OpenAI
+            }
+        );
+        let stage = first_stage(
+            "stages:\n  - model: deepseek-flash\n    target: cloud\n    provider: deepseek\n",
+        );
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::CloudOnly {
+                provider: IntegrationProvider::DeepSeek
+            }
+        );
+        // `integration` is an accepted alias for cloud.
+        let stage = first_stage(
+            "stages:\n  - model: gpt-4o-mini\n    target: integration\n    provider: openai\n",
+        );
+        assert!(matches!(
+            classify_stage(&stage).unwrap(),
+            StageShape::CloudOnly { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_stage_device_propagates_target() {
+        let stage = first_stage("stages:\n  - qwen2.5-0.5b-instruct\n");
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::Device { target: None }
+        );
+        let stage = first_stage("stages:\n  - model: m\n    target: device\n");
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::Device {
+                target: Some(ExecutionTarget::Device)
+            }
+        );
+        let stage = first_stage("stages:\n  - model: m\n    target: auto\n");
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::Device {
+                target: Some(ExecutionTarget::Auto)
+            }
+        );
+        // A provider under target: device is ignored (local only).
+        let stage =
+            first_stage("stages:\n  - model: m\n    target: device\n    provider: deepseek\n");
+        assert_eq!(
+            classify_stage(&stage).unwrap(),
+            StageShape::Device {
+                target: Some(ExecutionTarget::Device)
+            }
+        );
+    }
+
+    #[test]
+    fn classify_stage_rejects_unknown_provider_server_target_and_provider_less_cloud() {
+        let cases = [
+            (
+                "stages:\n  - model: m\n    target: cloud\n    provider: nope\n",
+                "Unknown provider",
+            ),
+            (
+                "stages:\n  - model: m\n    target: server\n",
+                "target 'server' is not supported",
+            ),
+            (
+                "stages:\n  - model: m\n    target: cloud\n",
+                "requires a 'provider'",
+            ),
+            (
+                "stages:\n  - model: m\n    target: sideways\n",
+                "Unknown execution target",
+            ),
+        ];
+        for (yaml, expected) in cases {
+            let err = classify_stage(&first_stage(yaml)).expect_err(yaml);
+            let message = format!("{err:#}");
+            assert!(message.contains(expected), "{yaml}\n{message}");
+            assert!(message.contains("stage 'm'"), "{message}");
+        }
+    }
+
+    #[test]
+    fn apply_stage_options_copies_flat_yaml_options() {
+        let stage = first_stage(
+            "stages:\n  - id: llm\n    model: m\n    target: auto\n    provider: deepseek\n    cloud_model: deepseek-flash\n    system_prompt: Be terse.\n    max_tokens: 16\n    thinking: disabled\n",
+        );
+        let mut desc = StageDescriptor::new(stage.stage_id()).with_model(stage.model_id());
+        apply_stage_options(&mut desc, &stage);
+        let options = desc.options.expect("options copied");
+        assert_eq!(
+            options.get::<String>("cloud_model").as_deref(),
+            Some("deepseek-flash")
+        );
+        assert_eq!(
+            options.get::<String>("system_prompt").as_deref(),
+            Some("Be terse.")
+        );
+        assert_eq!(options.get::<u32>("max_tokens"), Some(16));
+        assert_eq!(
+            options.get::<String>("thinking").as_deref(),
+            Some("disabled")
+        );
+        assert_eq!(desc.name, "llm");
+        assert_eq!(desc.model.as_deref(), Some("m"));
+    }
+
+    // ── dry-run simulation under a fixed snapshot ───────────────────────────
+
+    #[derive(Debug)]
+    struct FixedDevice(ResourceSnapshot);
+
+    impl ResourceSnapshotProvider for FixedDevice {
+        fn current_snapshot(&self, _max_age: Duration) -> ResourceSnapshot {
+            self.0
+        }
+    }
+
+    fn quiet_authority() -> LocalAuthority {
+        LocalAuthority::new()
+            .with_resource_provider(Arc::new(FixedDevice(ResourceSnapshot::unknown())))
+    }
+
+    fn hybrid_descriptor() -> StageDescriptor {
+        let mut options = StageOptions::new();
+        options.set("cloud_model", "deepseek-flash");
+        // `with_provider` forces `target: cloud`; the hybrid shape sets Auto after it.
+        StageDescriptor::new("llm")
+            .with_model("functiongemma-270m-it")
+            .with_provider(IntegrationProvider::DeepSeek)
+            .with_target(ExecutionTarget::Auto)
+            .with_options(options)
+    }
+
+    fn text(s: &str) -> Envelope {
+        Envelope::new(EnvelopeKind::Text(s.to_string()))
+    }
+
+    #[test]
+    fn simulate_stage_follows_policy_under_a_fixed_snapshot() {
+        let metrics = DeviceMetrics::default();
+        let stage = hybrid_descriptor();
+
+        let authority = quiet_authority();
+        authority
+            .load_policies(b"deny_cloud_if:\n  - 'input.kind == \"text\"'\n")
+            .unwrap();
+        let denied = simulate_stage(
+            &authority,
+            &stage,
+            &text("hi"),
+            &metrics,
+            LocalAvailability::new(true),
+        )
+        .unwrap();
+        assert!(matches!(denied.policy.result, PolicyOutcome::Deny { .. }));
+        assert_eq!(denied.target.decision.result, ResolvedTarget::Device);
+        assert!(
+            denied.target.decision.reason.starts_with("policy_deny"),
+            "{}",
+            denied.target.decision.reason
+        );
+        assert_eq!(route_label(&denied.target.decision.result), "local");
+
+        let authority = quiet_authority();
+        authority
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n")
+            .unwrap();
+        let preferred = simulate_stage(
+            &authority,
+            &stage,
+            &text("hi"),
+            &metrics,
+            LocalAvailability::new(true),
+        )
+        .unwrap();
+        assert!(matches!(
+            preferred.target.decision.result,
+            ResolvedTarget::Cloud { .. }
+        ));
+        assert!(
+            preferred
+                .target
+                .decision
+                .reason
+                .starts_with("policy_route_cloud"),
+            "{}",
+            preferred.target.decision.reason
+        );
+        assert_eq!(route_label(&preferred.target.decision.result), "cloud");
+
+        // No policy, quiet device: default local.
+        let plain = simulate_stage(
+            &quiet_authority(),
+            &stage,
+            &text("hi"),
+            &metrics,
+            LocalAvailability::new(true),
+        )
+        .unwrap();
+        assert_eq!(plain.policy.result, PolicyOutcome::Allow);
+        assert_eq!(plain.target.decision.result, ResolvedTarget::Device);
+        assert!(plain.target.decision.reason.contains("default_local"));
+
+        // No policy, stressed device: cloud.
+        let mut stressed = ResourceSnapshot::unknown();
+        stressed.memory_pressure = MemoryPressure::Critical;
+        let authority =
+            LocalAuthority::new().with_resource_provider(Arc::new(FixedDevice(stressed)));
+        let offloaded = simulate_stage(
+            &authority,
+            &stage,
+            &text("hi"),
+            &metrics,
+            LocalAvailability::new(true),
+        )
+        .unwrap();
+        assert!(matches!(
+            offloaded.target.decision.result,
+            ResolvedTarget::Cloud { .. }
+        ));
+        assert!(offloaded.target.decision.reason.contains("stress_memory"));
+    }
+
+    #[test]
+    fn simulate_stage_rejects_invalid_shared_options() {
+        let mut options = StageOptions::new();
+        options.set("max_tokens", 0);
+        let stage = StageDescriptor::new("llm").with_options(options);
+        let err = simulate_stage(
+            &quiet_authority(),
+            &stage,
+            &text("hi"),
+            &DeviceMetrics::default(),
+            LocalAvailability::new(true),
+        )
+        .expect_err("invalid option");
+        assert!(format!("{err:#}").contains("max_tokens"));
     }
 }

--- a/crates/xybrid-cli/src/commands/run.rs
+++ b/crates/xybrid-cli/src/commands/run.rs
@@ -488,7 +488,7 @@ fn run_dry_run(
     // Same decision path as a real run: one LocalAuthority, the same bundle.
     let authority = LocalAuthority::new();
     if let Some(policy_file) = policy_path {
-        ui::kv("Policy", &policy_file.display().to_string());
+        ui::kv("Policy file", &policy_file.display().to_string());
         let policy_bytes = read_policy_bundle(policy_file)?;
         authority
             .load_policies(&policy_bytes)
@@ -554,7 +554,7 @@ fn execute_pipeline(
     let mut orchestrator = Orchestrator::new();
 
     if let Some(policy_file) = policy_path {
-        ui::kv("Policy", &policy_file.display().to_string());
+        ui::kv("Policy file", &policy_file.display().to_string());
         let policy_bytes = read_policy_bundle(policy_file)?;
 
         orchestrator

--- a/crates/xybrid-cli/tests/anthropic_direct_credentials_test.rs
+++ b/crates/xybrid-cli/tests/anthropic_direct_credentials_test.rs
@@ -1,0 +1,309 @@
+//! Model-free end-to-end: `xybrid run` with a native-direct Anthropic stage.
+//!
+//! A loopback Anthropic surface records every request. The child environment
+//! carries a dummy `ANTHROPIC_API_KEY` and a dummy `XYBRID_API_KEY`, so the
+//! tests prove that neither ambient credential follows a custom `gateway_url`:
+//!
+//! - no explicit `api_key` + custom destination → configuration error, zero
+//!   requests;
+//! - explicit `api_key` → exactly one `/messages` request carrying that key
+//!   (and only that key), answered from a fake Anthropic response.
+//!
+//! Both cases are cloud-only stages, so this needs no model and runs in
+//! ordinary CI.
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+const DUMMY_ANTHROPIC_KEY: &str = "dummy-anthropic-key";
+const DUMMY_PLATFORM_KEY: &str = "dummy-platform-key";
+const FAKE_REPLY: &str = "FAKE_ANTHROPIC_REPLY";
+const CHILD_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn xybrid_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_xybrid"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Loopback Anthropic-compatible endpoint that records every request verbatim.
+struct FakeAnthropic {
+    url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl FakeAnthropic {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread = {
+            let requests = requests.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                while !stop.load(Ordering::SeqCst) {
+                    match listener.accept() {
+                        Ok((stream, _)) => Self::serve(stream, &requests),
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })
+        };
+        Self {
+            url: format!("http://{addr}"),
+            requests,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn serve(mut stream: TcpStream, requests: &Arc<Mutex<Vec<String>>>) {
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            let read = match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            request.extend_from_slice(&buf[..read]);
+            if let Some(header_end) = request
+                .windows(4)
+                .position(|w| w == b"\r\n\r\n")
+                .map(|pos| pos + 4)
+            {
+                let headers = String::from_utf8_lossy(&request[..header_end]).into_owned();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                while request.len() < header_end + content_length {
+                    match stream.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => request.extend_from_slice(&buf[..n]),
+                    }
+                }
+                break;
+            }
+        }
+        requests
+            .lock()
+            .unwrap()
+            .push(String::from_utf8_lossy(&request).into_owned());
+
+        let body = format!(
+            r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{{"type":"text","text":"{FAKE_REPLY}"}}],"stop_reason":"end_turn","usage":{{"input_tokens":3,"output_tokens":2}}}}"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+    }
+
+    fn requests(&self) -> Vec<String> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl Drop for FakeAnthropic {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+struct Run {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_cli(home: &Path, registry_url: &str, args: &[&str]) -> Run {
+    let mut child = Command::new(xybrid_bin())
+        .current_dir(workspace_root())
+        .env("HOME", home)
+        // Dummy ambient credentials the native client must not leak.
+        .env("ANTHROPIC_API_KEY", DUMMY_ANTHROPIC_KEY)
+        .env("XYBRID_API_KEY", DUMMY_PLATFORM_KEY)
+        // Point the registry at the same loopback recorder so an unexpected
+        // registry call would show up as a captured request too.
+        .env("XYBRID_REGISTRY_URL", registry_url)
+        .env("NO_COLOR", "1")
+        .env("XYBRID_TELEMETRY_OPTOUT", "1")
+        .env_remove("XYBRID_GATEWAY_URL")
+        .env_remove("XYBRID_PLATFORM_URL")
+        .env_remove("HTTP_PROXY")
+        .env_remove("HTTPS_PROXY")
+        .env_remove("http_proxy")
+        .env_remove("https_proxy")
+        .env_remove("ALL_PROXY")
+        .arg("run")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn xybrid");
+
+    let mut stdout_pipe = child.stdout.take().unwrap();
+    let mut stderr_pipe = child.stderr.take().unwrap();
+    let stdout_reader = thread::spawn(move || {
+        let mut out = String::new();
+        let _ = stdout_pipe.read_to_string(&mut out);
+        out
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut out = String::new();
+        let _ = stderr_pipe.read_to_string(&mut out);
+        out
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll child") {
+            break status;
+        }
+        if started.elapsed() > CHILD_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait().expect("reap killed child");
+            let stdout = stdout_reader.join().unwrap_or_default();
+            let stderr = stderr_reader.join().unwrap_or_default();
+            panic!("xybrid run exceeded {CHILD_TIMEOUT:?}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+
+    Run {
+        status,
+        stdout: stdout_reader.join().unwrap_or_default(),
+        stderr: stderr_reader.join().unwrap_or_default(),
+    }
+}
+
+fn write_pipeline(dir: &Path, fake: &FakeAnthropic, explicit_api_key: Option<&str>) -> PathBuf {
+    let api_key_line = explicit_api_key
+        .map(|key| format!("    api_key: \"{key}\"\n"))
+        .unwrap_or_default();
+    let yaml = format!(
+        r#"name: anthropic-direct-credentials
+stages:
+  - id: llm
+    model: claude-3-5-sonnet-20241022
+    target: cloud
+    provider: anthropic
+    backend: direct
+    gateway_url: "{url}"
+    max_tokens: 16
+    temperature: 0
+{api_key_line}"#,
+        url = fake.url,
+    );
+    let path = dir.join("anthropic-direct.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    path
+}
+
+#[test]
+fn custom_origin_without_explicit_key_fails_before_any_request() {
+    let temp = tempfile::tempdir().unwrap();
+    let fake = FakeAnthropic::start();
+    let pipeline = write_pipeline(temp.path(), &fake, None);
+
+    let run = run_cli(
+        temp.path(),
+        &fake.url,
+        &["-c", pipeline.to_str().unwrap(), "--input-text", "hello"],
+    );
+
+    assert!(
+        !run.status.success(),
+        "a custom destination without an explicit key must fail\nstdout:\n{}\nstderr:\n{}",
+        run.stdout,
+        run.stderr
+    );
+    let combined = format!("{}{}", run.stdout, run.stderr);
+    assert!(
+        combined.contains("explicit 'api_key'") || combined.contains("Configuration error"),
+        "error must identify the missing explicit key:\n{combined}"
+    );
+    assert!(
+        fake.requests().is_empty(),
+        "no credential may reach the endpoint: {:?}",
+        fake.requests()
+    );
+}
+
+#[test]
+fn explicit_key_reaches_only_the_configured_custom_origin() {
+    let temp = tempfile::tempdir().unwrap();
+    let fake = FakeAnthropic::start();
+    let pipeline = write_pipeline(temp.path(), &fake, Some(DUMMY_ANTHROPIC_KEY));
+
+    let run = run_cli(
+        temp.path(),
+        &fake.url,
+        &["-c", pipeline.to_str().unwrap(), "--input-text", "hello"],
+    );
+
+    assert!(
+        run.status.success(),
+        "explicit-key request must succeed\nstdout:\n{}\nstderr:\n{}",
+        run.stdout,
+        run.stderr
+    );
+    assert!(
+        run.stdout.contains(FAKE_REPLY),
+        "fake Anthropic reply must surface:\n{}",
+        run.stdout
+    );
+
+    let requests = fake.requests();
+    assert_eq!(
+        requests.len(),
+        1,
+        "exactly one request (no registry call): {requests:?}"
+    );
+    let request = &requests[0];
+    assert!(request.starts_with("POST /messages "), "{request}");
+    let lower = request.to_ascii_lowercase();
+    assert!(
+        lower.contains(&format!("x-api-key: {DUMMY_ANTHROPIC_KEY}")),
+        "explicit key must be the one presented: {request}"
+    );
+    assert!(
+        !request.contains(DUMMY_PLATFORM_KEY),
+        "platform key must never reach a provider: {request}"
+    );
+}

--- a/crates/xybrid-cli/tests/anthropic_direct_credentials_test.rs
+++ b/crates/xybrid-cli/tests/anthropic_direct_credentials_test.rs
@@ -10,7 +10,8 @@
 //!   (and only that key), answered from a fake Anthropic response.
 //!
 //! Both cases are cloud-only stages, so this needs no model and runs in
-//! ordinary CI.
+//! ordinary CI. The captured-request assertions verify what reached this
+//! loopback endpoint, not process-wide network isolation.
 #![cfg(unix)]
 
 use std::io::{Read, Write};

--- a/crates/xybrid-cli/tests/policy_routing_cli_test.rs
+++ b/crates/xybrid-cli/tests/policy_routing_cli_test.rs
@@ -201,6 +201,202 @@ impl Drop for FakeDeepSeek {
     }
 }
 
+/// Loopback registry that serves a passthrough resolve response and the real
+/// GGUF bytes, so the cold-cache download/extraction path can be exercised
+/// end to end without touching the network. Once `reject_unexpected_requests`
+/// is set, every further request is answered with 503 (and still recorded).
+struct FakeRegistry {
+    url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    reject: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl FakeRegistry {
+    fn start(model_id: &str, fixture_dir: &Path) -> Self {
+        let metadata: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(fixture_dir.join("model_metadata.json")).unwrap(),
+        )
+        .unwrap();
+        let model_file_name = metadata["files"]
+            .as_array()
+            .expect("metadata.files")
+            .iter()
+            .filter_map(|file| file.as_str())
+            .find(|name| name.ends_with(".gguf"))
+            .expect("fixture declares a GGUF")
+            .to_string();
+        let model_file = fixture_dir.join(&model_file_name);
+
+        let sha256 = {
+            use sha2::{Digest, Sha256};
+            let mut file = std::fs::File::open(&model_file).unwrap();
+            let mut hasher = Sha256::new();
+            let mut buf = [0u8; 64 * 1024];
+            loop {
+                let read = file.read(&mut buf).unwrap();
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buf[..read]);
+            }
+            format!("{:x}", hasher.finalize())
+        };
+        let size_bytes = std::fs::metadata(&model_file).unwrap().len();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base = format!("http://{addr}");
+        let resolve_body = serde_json::json!({
+            "mask": model_id,
+            "platform": "e2e",
+            "resolved": {
+                "hf_repo": "ggml-org/functiongemma-270m-it-GGUF",
+                "file": model_file_name,
+                "download_url": format!("{base}/files/{model_file_name}"),
+                "format": "gguf",
+                "quantization": "Q8_0",
+                "size_bytes": size_bytes,
+                "sha256": sha256,
+                "passthrough": true,
+                "model_metadata": metadata,
+            }
+        });
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let reject = Arc::new(AtomicBool::new(false));
+        let thread = {
+            let requests = requests.clone();
+            let stop = stop.clone();
+            let reject = reject.clone();
+            let resolve_body = resolve_body.clone();
+            let model_file = model_file.clone();
+            thread::spawn(move || {
+                while !stop.load(Ordering::SeqCst) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            Self::serve(stream, &requests, &reject, &resolve_body, &model_file)
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })
+        };
+
+        Self {
+            url: base,
+            requests,
+            stop,
+            reject,
+            thread: Some(thread),
+        }
+    }
+
+    fn serve(
+        mut stream: TcpStream,
+        requests: &Arc<Mutex<Vec<String>>>,
+        reject: &Arc<AtomicBool>,
+        resolve_body: &serde_json::Value,
+        model_file: &Path,
+    ) {
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(30)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut buf = [0u8; 8192];
+        while request.windows(4).position(|w| w == b"\r\n\r\n").is_none() {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => request.extend_from_slice(&buf[..n]),
+            }
+        }
+        let request_text = String::from_utf8_lossy(&request).into_owned();
+        let path = request_text
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("/")
+            .to_string();
+        requests.lock().unwrap().push(request_text);
+
+        if reject.load(Ordering::SeqCst) {
+            let _ = write_http_response(&mut stream, 503, "text/plain", b"unexpected request");
+            return;
+        }
+
+        if path.contains("/v1/models/") && path.contains("/resolve") {
+            let body = serde_json::to_vec(resolve_body).unwrap();
+            let _ = write_http_response(&mut stream, 200, "application/json", &body);
+            return;
+        }
+
+        if let Some(name) = path.strip_prefix("/files/") {
+            let expected = model_file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            if name == expected {
+                match std::fs::File::open(model_file) {
+                    Ok(mut file) => {
+                        let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+                        let header = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {size}\r\nConnection: close\r\n\r\n"
+                        );
+                        if stream.write_all(header.as_bytes()).is_ok() {
+                            let _ = std::io::copy(&mut file, &mut stream);
+                        }
+                    }
+                    Err(_) => {
+                        let _ = write_http_response(&mut stream, 404, "text/plain", b"missing");
+                    }
+                }
+                return;
+            }
+        }
+
+        let _ = write_http_response(&mut stream, 404, "text/plain", b"not found");
+    }
+
+    fn requests(&self) -> Vec<String> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    fn reject_unexpected_requests(&self) {
+        self.reject.store(true, Ordering::SeqCst);
+    }
+}
+
+impl Drop for FakeRegistry {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    status: u16,
+    content_type: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let reason = if status == 200 { "OK" } else { "Error" };
+    let header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(header.as_bytes())?;
+    stream.write_all(body)
+}
+
 struct Run {
     status: std::process::ExitStatus,
     stdout: String,
@@ -208,7 +404,15 @@ struct Run {
 }
 
 fn run_cli(home: &Path, args: &[&str]) -> Run {
-    let mut child = Command::new(xybrid_bin())
+    run_cli_with_env(home, args, &[])
+}
+
+/// Spawn `xybrid run` with an isolated child environment. `env_overrides` are
+/// applied after the removals, so an explicit loopback registry URL wins over
+/// the "never leak the developer's env" cleanup.
+fn run_cli_with_env(home: &Path, args: &[&str], env_overrides: &[(&str, &str)]) -> Run {
+    let mut command = Command::new(xybrid_bin());
+    command
         .current_dir(workspace_root())
         .env("HOME", home)
         .env("DEEPSEEK_API_KEY", DUMMY_DEEPSEEK_KEY)
@@ -223,7 +427,12 @@ fn run_cli(home: &Path, args: &[&str]) -> Run {
         .env_remove("HTTPS_PROXY")
         .env_remove("http_proxy")
         .env_remove("https_proxy")
-        .env_remove("ALL_PROXY")
+        .env_remove("ALL_PROXY");
+    for (key, value) in env_overrides {
+        command.env(key, value);
+    }
+
+    let mut child = command
         .arg("run")
         .args(args)
         .stdout(Stdio::piped())
@@ -560,4 +769,148 @@ fn dry_run_loads_policy_without_inference() {
         env.fake.requests()
     );
     assert!(!denied.stdout.contains(FAKE_REPLY) && !preferred.stdout.contains(FAKE_REPLY));
+}
+
+/// Cold cache: the hybrid local leg must download, extract (metadata included),
+/// and run locally; the next run must reuse the extracted copy without
+/// touching the registry.
+#[test]
+fn cold_cache_hybrid_downloads_extracts_and_then_runs_offline() {
+    let model_id = model_id();
+    let Some(fixture_dir) = fixture_dir_or_skip(&model_id) else {
+        return;
+    };
+
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    let registry = FakeRegistry::start(&model_id, &fixture_dir);
+    let fake = FakeDeepSeek::start();
+
+    let stage = format!(
+        r#"  - id: llm
+    model: {model_id}
+    target: auto
+    provider: deepseek
+    cloud_model: deepseek-flash
+    gateway_url: "{url}"
+    api_key: "$DEEPSEEK_API_KEY"
+    thinking: disabled
+    system_prompt: "{SYSTEM_PROMPT}"
+    temperature: 0
+    max_tokens: 16
+"#,
+        url = fake.url
+    );
+    let pipeline = temp.path().join("hybrid-cold.yaml");
+    std::fs::write(
+        &pipeline,
+        format!("name: policy-e2e-cold\nstages:\n{stage}"),
+    )
+    .unwrap();
+    let local_only = temp.path().join("local-only.yaml");
+    std::fs::write(
+        &local_only,
+        "version: \"1.0.0\"\ndeny_cloud_if:\n  - \"true\"\n",
+    )
+    .unwrap();
+
+    let args = [
+        "-c",
+        pipeline.to_str().unwrap(),
+        "--input-text",
+        PROMPT,
+        "--policy",
+        local_only.to_str().unwrap(),
+    ];
+    let registry_env = [("XYBRID_REGISTRY_URL", registry.url.as_str())];
+
+    // First run: cold cache -> registry resolve + passthrough download.
+    let run = run_cli_with_env(&home, &args, &registry_env);
+    assert_success(&run);
+    assert_eq!(
+        kv_value(&run.stdout, "Routing").as_deref(),
+        Some("local"),
+        "{}",
+        run.stdout
+    );
+    assert_eq!(
+        kv_value(&run.stdout, "Backend").as_deref(),
+        Some("template-executor"),
+        "{}",
+        run.stdout
+    );
+
+    let extracted = home
+        .join(".xybrid")
+        .join("cache")
+        .join("extracted")
+        .join(&model_id);
+    assert!(
+        extracted.join("model_metadata.json").is_file(),
+        "extraction must materialize model_metadata.json: {}",
+        extracted.display()
+    );
+    let metadata: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(extracted.join("model_metadata.json")).unwrap(),
+    )
+    .unwrap();
+    for file in metadata["files"].as_array().expect("metadata.files") {
+        let name = file.as_str().unwrap();
+        assert!(
+            extracted.join(name).is_file(),
+            "extraction must materialize {name}"
+        );
+    }
+
+    let first_requests = registry.requests();
+    assert!(
+        first_requests
+            .iter()
+            .any(|request| request.contains("/v1/models/")),
+        "cold run must resolve through the registry: {first_requests:?}"
+    );
+    assert!(
+        first_requests
+            .iter()
+            .any(|request| request.contains("/files/")),
+        "cold run must download the model file: {first_requests:?}"
+    );
+    assert!(
+        fake.requests().is_empty(),
+        "local-only policy must make no cloud request: {:?}",
+        fake.requests()
+    );
+
+    // Second run: the extracted copy is reused; the registry rejects
+    // everything from here on, so any request is a failure.
+    registry.reject_unexpected_requests();
+    let request_count = registry.requests().len();
+
+    let offline = run_cli_with_env(&home, &args, &registry_env);
+    assert_success(&offline);
+    assert_eq!(
+        kv_value(&offline.stdout, "Routing").as_deref(),
+        Some("local"),
+        "{}",
+        offline.stdout
+    );
+    assert_eq!(
+        kv_value(&offline.stdout, "Backend").as_deref(),
+        Some("template-executor"),
+        "{}",
+        offline.stdout
+    );
+    assert_eq!(
+        registry.requests().len(),
+        request_count,
+        "a warm extracted cache must not call the registry again: {:?}",
+        registry.requests()
+    );
+    assert!(
+        fake.requests().is_empty(),
+        "offline run must still make no cloud request: {:?}",
+        fake.requests()
+    );
 }

--- a/crates/xybrid-cli/tests/policy_routing_cli_test.rs
+++ b/crates/xybrid-cli/tests/policy_routing_cli_test.rs
@@ -11,6 +11,9 @@
 //! No test here asserts what a *policy-free* run chooses: live device stress
 //! can legitimately pick the cloud leg. Those cases are pinned under fixed
 //! snapshots in the core and CLI unit tests.
+//!
+//! The request logs below verify what reached these loopback endpoints; they
+//! are not a claim of process-wide network isolation.
 #![cfg(all(feature = "llm-llamacpp", unix))]
 
 use std::io::{Read, Write};

--- a/crates/xybrid-cli/tests/policy_routing_cli_test.rs
+++ b/crates/xybrid-cli/tests/policy_routing_cli_test.rs
@@ -1,0 +1,563 @@
+//! End-to-end: `xybrid run --policy` routes one hybrid LLM stage between a
+//! real local GGUF model and a (fake) DeepSeek endpoint.
+//!
+//! The local leg is the real `functiongemma-270m-it` fixture (override with
+//! `XYBRID_POLICY_E2E_MODEL_ID`), staged into a temporary `HOME` so the CLI
+//! resolves it offline. The cloud leg is a loopback HTTP server that speaks
+//! OpenAI chat-completions and records every request, so the assertions are
+//! about what actually crossed the wire: the path, the bearer credential, the
+//! model, the thinking mode and the shared generation options.
+//!
+//! No test here asserts what a *policy-free* run chooses: live device stress
+//! can legitimately pick the cloud leg. Those cases are pinned under fixed
+//! snapshots in the core and CLI unit tests.
+#![cfg(all(feature = "llm-llamacpp", unix))]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+use xybrid_core::testing::model_fixtures;
+
+const DEFAULT_MODEL_ID: &str = "functiongemma-270m-it";
+const PROMPT: &str = "Reply with the single word hello.";
+const SYSTEM_PROMPT: &str = "You are a terse assistant for the policy routing test.";
+const FAKE_REPLY: &str = "FAKE_DEEPSEEK_REPLY";
+const DUMMY_DEEPSEEK_KEY: &str = "dummy-deepseek-key";
+const DUMMY_PLATFORM_KEY: &str = "dummy-platform-key";
+const CHILD_TIMEOUT: Duration = Duration::from_secs(600);
+
+fn xybrid_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_xybrid"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn model_id() -> String {
+    std::env::var("XYBRID_POLICY_E2E_MODEL_ID").unwrap_or_else(|_| DEFAULT_MODEL_ID.to_string())
+}
+
+/// The fixture directory, or `None` to skip. When `XYBRID_REQUIRE_MODELS` is
+/// set a missing model is a failure, never a silent skip.
+fn fixture_dir_or_skip(model_id: &str) -> Option<PathBuf> {
+    match model_fixtures::model_or_skip(model_id) {
+        Some(dir) => Some(dir),
+        None => {
+            assert!(
+                std::env::var_os("XYBRID_REQUIRE_MODELS").is_none(),
+                "XYBRID_REQUIRE_MODELS is set but model '{model_id}' is not available"
+            );
+            None
+        }
+    }
+}
+
+fn link_or_copy(source: &Path, destination: &Path) {
+    if std::fs::hard_link(source, destination).is_ok() {
+        return;
+    }
+    if std::os::unix::fs::symlink(source, destination).is_ok() {
+        return;
+    }
+    std::fs::copy(source, destination)
+        .unwrap_or_else(|err| panic!("failed to materialize {}: {err}", source.display()));
+}
+
+/// Stage the fixture byte-for-byte into `<home>/.xybrid/cache/extracted/<id>/`,
+/// which is what `RegistryClient::resolve_offline` checks (metadata plus
+/// every file the metadata lists). Generation params are NOT rewritten.
+fn seed_home(home: &Path, model_id: &str, fixture_dir: &Path) {
+    let extracted = home
+        .join(".xybrid")
+        .join("cache")
+        .join("extracted")
+        .join(model_id);
+    std::fs::create_dir_all(&extracted).unwrap();
+    std::fs::create_dir_all(home.join(".xybrid").join("cache").join("models")).unwrap();
+
+    let metadata_path = fixture_dir.join("model_metadata.json");
+    std::fs::copy(&metadata_path, extracted.join("model_metadata.json")).unwrap();
+    let metadata: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&metadata_path).unwrap()).unwrap();
+    for file in metadata["files"].as_array().expect("metadata.files") {
+        let name = file.as_str().expect("file name");
+        link_or_copy(&fixture_dir.join(name), &extracted.join(name));
+    }
+}
+
+/// Loopback OpenAI-compatible endpoint that records every request verbatim.
+struct FakeDeepSeek {
+    url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl FakeDeepSeek {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread = {
+            let requests = requests.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                while !stop.load(Ordering::SeqCst) {
+                    match listener.accept() {
+                        Ok((stream, _)) => Self::serve(stream, &requests),
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })
+        };
+        Self {
+            url: format!("http://{}/v1", addr),
+            requests,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn serve(mut stream: TcpStream, requests: &Arc<Mutex<Vec<String>>>) {
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            let read = match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            request.extend_from_slice(&buf[..read]);
+            if let Some(header_end) = request
+                .windows(4)
+                .position(|w| w == b"\r\n\r\n")
+                .map(|pos| pos + 4)
+            {
+                let headers = String::from_utf8_lossy(&request[..header_end]).into_owned();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                while request.len() < header_end + content_length {
+                    match stream.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => request.extend_from_slice(&buf[..n]),
+                    }
+                }
+                break;
+            }
+        }
+        requests
+            .lock()
+            .unwrap()
+            .push(String::from_utf8_lossy(&request).into_owned());
+
+        let body = format!(
+            r#"{{"id":"chatcmpl-1","model":"deepseek-flash","choices":[{{"index":0,"message":{{"role":"assistant","content":"{FAKE_REPLY}"}},"finish_reason":"stop"}}],"usage":{{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}}}"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+    }
+
+    fn requests(&self) -> Vec<String> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl Drop for FakeDeepSeek {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+struct Run {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_cli(home: &Path, args: &[&str]) -> Run {
+    let mut child = Command::new(xybrid_bin())
+        .current_dir(workspace_root())
+        .env("HOME", home)
+        .env("DEEPSEEK_API_KEY", DUMMY_DEEPSEEK_KEY)
+        .env("XYBRID_API_KEY", DUMMY_PLATFORM_KEY)
+        .env("NO_COLOR", "1")
+        .env("XYBRID_TELEMETRY_OPTOUT", "1")
+        // Never let a developer's configured platform/gateway/proxy leak in.
+        .env_remove("XYBRID_GATEWAY_URL")
+        .env_remove("XYBRID_PLATFORM_URL")
+        .env_remove("XYBRID_REGISTRY_URL")
+        .env_remove("HTTP_PROXY")
+        .env_remove("HTTPS_PROXY")
+        .env_remove("http_proxy")
+        .env_remove("https_proxy")
+        .env_remove("ALL_PROXY")
+        .arg("run")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn xybrid");
+
+    let mut stdout_pipe = child.stdout.take().unwrap();
+    let mut stderr_pipe = child.stderr.take().unwrap();
+    let stdout_reader = thread::spawn(move || {
+        let mut out = String::new();
+        let _ = stdout_pipe.read_to_string(&mut out);
+        out
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut out = String::new();
+        let _ = stderr_pipe.read_to_string(&mut out);
+        out
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("poll child") {
+            break status;
+        }
+        if started.elapsed() > CHILD_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait().expect("reap killed child");
+            let stdout = stdout_reader.join().unwrap_or_default();
+            let stderr = stderr_reader.join().unwrap_or_default();
+            panic!("xybrid run exceeded {CHILD_TIMEOUT:?}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+    Run {
+        status,
+        stdout: stdout_reader.join().unwrap_or_default(),
+        stderr: stderr_reader.join().unwrap_or_default(),
+    }
+}
+
+/// Value of a `ui::kv` line whose key is exactly `key`.
+///
+/// The format is `"  {:<16} {}"`: the key is padded to 16 columns, so a
+/// real match is followed by at least two spaces. That also keeps `Policy`
+/// from matching the `Policy file` line.
+fn kv_line_value(line: &str, key: &str) -> Option<String> {
+    let rest = line.trim_start().strip_prefix(key)?;
+    rest.starts_with("  ").then(|| rest.trim().to_string())
+}
+
+/// Value of the first `ui::kv` line whose key is `key`.
+fn kv_value(stdout: &str, key: &str) -> Option<String> {
+    stdout.lines().find_map(|line| kv_line_value(line, key))
+}
+
+struct TestEnv {
+    _temp: tempfile::TempDir,
+    home: PathBuf,
+    pipeline: PathBuf,
+    local_only: PathBuf,
+    prefer_cloud: PathBuf,
+    two_stage: PathBuf,
+    fake: FakeDeepSeek,
+}
+
+fn setup() -> Option<TestEnv> {
+    let model_id = model_id();
+    let fixture_dir = fixture_dir_or_skip(&model_id)?;
+    let temp = tempfile::tempdir().expect("temp dir");
+    let home = temp.path().join("home");
+    seed_home(&home, &model_id, &fixture_dir);
+
+    let fake = FakeDeepSeek::start();
+    let stage = format!(
+        r#"  - id: llm
+    model: {model_id}
+    target: auto
+    provider: deepseek
+    cloud_model: deepseek-flash
+    gateway_url: "{url}"
+    api_key: "$DEEPSEEK_API_KEY"
+    thinking: disabled
+    system_prompt: "{SYSTEM_PROMPT}"
+    temperature: 0
+    max_tokens: 16
+"#,
+        url = fake.url
+    );
+    let pipeline = temp.path().join("hybrid.yaml");
+    std::fs::write(&pipeline, format!("name: policy-e2e\nstages:\n{stage}")).unwrap();
+    let two_stage = temp.path().join("two-stage.yaml");
+    std::fs::write(
+        &two_stage,
+        format!("name: policy-e2e-two\nstages:\n{stage}{stage}").replacen(
+            "id: llm",
+            "id: first",
+            1,
+        ),
+    )
+    .unwrap();
+    let local_only = temp.path().join("local-only.yaml");
+    std::fs::write(
+        &local_only,
+        "version: \"1.0.0\"\ndeny_cloud_if:\n  - \"true\"\n",
+    )
+    .unwrap();
+    let prefer_cloud = temp.path().join("prefer-cloud.yaml");
+    std::fs::write(
+        &prefer_cloud,
+        "version: \"1.0.0\"\nroute_cloud_if:\n  - \"true\"\n",
+    )
+    .unwrap();
+
+    Some(TestEnv {
+        _temp: temp,
+        home,
+        pipeline,
+        local_only,
+        prefer_cloud,
+        two_stage,
+        fake,
+    })
+}
+
+fn assert_success(run: &Run) {
+    assert!(
+        run.status.success(),
+        "xybrid run failed ({:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        run.stdout,
+        run.stderr
+    );
+}
+
+#[test]
+fn local_only_policy_runs_the_gguf_model() {
+    let Some(env) = setup() else { return };
+
+    let run = run_cli(
+        &env.home,
+        &[
+            "-c",
+            env.pipeline.to_str().unwrap(),
+            "--input-text",
+            PROMPT,
+            "--policy",
+            env.local_only.to_str().unwrap(),
+        ],
+    );
+    assert_success(&run);
+
+    assert_eq!(
+        kv_value(&run.stdout, "Routing").as_deref(),
+        Some("local"),
+        "{}",
+        run.stdout
+    );
+    let reason = kv_value(&run.stdout, "Reason").unwrap_or_default();
+    assert!(reason.contains("policy_deny"), "{reason}");
+    assert_eq!(
+        kv_value(&run.stdout, "Backend").as_deref(),
+        Some("template-executor"),
+        "{}",
+        run.stdout
+    );
+    assert!(
+        run.stdout.contains("Pipeline completed successfully"),
+        "{}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains(FAKE_REPLY),
+        "local run must not show the fake cloud reply"
+    );
+    assert!(
+        env.fake.requests().is_empty(),
+        "a denied stage must make zero cloud requests: {:?}",
+        env.fake.requests()
+    );
+}
+
+#[test]
+fn prefer_cloud_policy_calls_the_fake_deepseek_endpoint() {
+    let Some(env) = setup() else { return };
+
+    let run = run_cli(
+        &env.home,
+        &[
+            "-c",
+            env.pipeline.to_str().unwrap(),
+            "--input-text",
+            PROMPT,
+            "--policy",
+            env.prefer_cloud.to_str().unwrap(),
+        ],
+    );
+    assert_success(&run);
+
+    assert_eq!(
+        kv_value(&run.stdout, "Routing").as_deref(),
+        Some("cloud"),
+        "{}",
+        run.stdout
+    );
+    let reason = kv_value(&run.stdout, "Reason").unwrap_or_default();
+    assert!(reason.contains("policy_route_cloud"), "{reason}");
+    assert_eq!(
+        kv_value(&run.stdout, "Backend").as_deref(),
+        Some("cloud:deepseek:gateway"),
+        "{}",
+        run.stdout
+    );
+    assert!(run.stdout.contains(FAKE_REPLY), "{}", run.stdout);
+
+    let requests = env.fake.requests();
+    assert_eq!(requests.len(), 1, "exactly one cloud request: {requests:?}");
+    let request = &requests[0];
+    assert!(
+        request.starts_with("POST /v1/chat/completions "),
+        "{request}"
+    );
+    let lower = request.to_ascii_lowercase();
+    assert!(
+        lower.contains(&format!("authorization: bearer {DUMMY_DEEPSEEK_KEY}")),
+        "{request}"
+    );
+    assert!(
+        !request.contains(DUMMY_PLATFORM_KEY),
+        "platform key must never reach a provider: {request}"
+    );
+    let body_start = request.find("\r\n\r\n").unwrap() + 4;
+    let body: serde_json::Value = serde_json::from_str(&request[body_start..]).unwrap();
+    assert_eq!(body["model"], "deepseek-flash");
+    assert_eq!(body["thinking"], serde_json::json!({"type": "disabled"}));
+    assert_eq!(body["max_tokens"], 16);
+    assert_eq!(body["temperature"], 0.0);
+    assert_eq!(body["messages"][0]["role"], "system");
+    assert_eq!(body["messages"][0]["content"], SYSTEM_PROMPT);
+    assert_eq!(body["messages"][1]["role"], "user");
+    assert_eq!(body["messages"][1]["content"], PROMPT);
+}
+
+#[test]
+fn dry_run_loads_policy_without_inference() {
+    let Some(env) = setup() else { return };
+
+    let denied = run_cli(
+        &env.home,
+        &[
+            "-c",
+            env.pipeline.to_str().unwrap(),
+            "--input-text",
+            PROMPT,
+            "--dry-run",
+            "--policy",
+            env.local_only.to_str().unwrap(),
+        ],
+    );
+    assert_success(&denied);
+    assert_eq!(
+        kv_value(&denied.stdout, "Policy").as_deref(),
+        Some("DENIED"),
+        "{}",
+        denied.stdout
+    );
+    let routing = kv_value(&denied.stdout, "Routing").unwrap_or_default();
+    assert!(routing.starts_with("local (policy_deny"), "{routing}");
+    assert!(
+        !denied.stdout.contains("Backend"),
+        "dry-run must not claim an executed backend"
+    );
+
+    let preferred = run_cli(
+        &env.home,
+        &[
+            "-c",
+            env.pipeline.to_str().unwrap(),
+            "--input-text",
+            PROMPT,
+            "--dry-run",
+            "--policy",
+            env.prefer_cloud.to_str().unwrap(),
+        ],
+    );
+    assert_success(&preferred);
+    assert_eq!(
+        kv_value(&preferred.stdout, "Policy").as_deref(),
+        Some("ALLOWED"),
+        "{}",
+        preferred.stdout
+    );
+    let routing = kv_value(&preferred.stdout, "Routing").unwrap_or_default();
+    assert!(
+        routing.starts_with("cloud (policy_route_cloud"),
+        "{routing}"
+    );
+
+    // Two stages: the second depends on upstream output and is not simulated.
+    let two = run_cli(
+        &env.home,
+        &[
+            "-c",
+            env.two_stage.to_str().unwrap(),
+            "--input-text",
+            PROMPT,
+            "--dry-run",
+            "--policy",
+            env.prefer_cloud.to_str().unwrap(),
+        ],
+    );
+    assert_success(&two);
+    let policies: Vec<String> = two
+        .stdout
+        .lines()
+        .filter_map(|line| kv_line_value(line, "Policy"))
+        .collect();
+    assert_eq!(
+        policies,
+        vec!["ALLOWED".to_string(), "UNKNOWN".to_string()],
+        "{}",
+        two.stdout
+    );
+    assert!(
+        two.stdout
+            .contains("upstream output unavailable without execution"),
+        "{}",
+        two.stdout
+    );
+
+    assert!(
+        env.fake.requests().is_empty(),
+        "dry-run must perform no inference: {:?}",
+        env.fake.requests()
+    );
+    assert!(!denied.stdout.contains(FAKE_REPLY) && !preferred.stdout.contains(FAKE_REPLY));
+}

--- a/crates/xybrid-core/README.md
+++ b/crates/xybrid-core/README.md
@@ -63,26 +63,32 @@ let results = orchestrator.execute_pipeline(&stages, &input, &metrics, &|s| {
 Evaluates policies to determine if requests are allowed and what constraints apply.
 
 ```rust
-use xybrid_core::policy_engine::{PolicyEngine, DefaultPolicyEngine};
+use xybrid_core::orchestrator::policy_engine::{DefaultPolicyEngine, PolicyEngine};
 
 let mut engine = DefaultPolicyEngine::new();
 
-// Load policies from YAML or JSON
+// Load policies from YAML or JSON. Rules are compiled at load time; an
+// unsupported operand, operator, literal or action is rejected here.
 let policy_yaml = r#"
-version: "0.1.0"
+version: "1.0.0"
 rules:
-  - id: "audio_rule"
-    expression: "input.kind == \"AudioRaw\""
-    action: "deny"
-signature: "test-signature"
+  - id: keep_audio_on_device
+    expression: 'input.kind == "audio"'
+    action: deny
+  - id: offload_when_hot
+    expression: 'metrics.thermal_state == "hot"'
+    action: route_cloud
 "#;
 
 engine.load_policies(policy_yaml.as_bytes().to_vec())?;
 
-// Evaluate policy for a request
+// Evaluate policy for a request: `deny` forbids cloud (the stage stays on
+// the device), `route_cloud` prefers the cloud leg when it is permitted.
 let result = engine.evaluate("asr", &input, &metrics);
-if !result.allowed {
-    println!("Request denied: {:?}", result.reason);
+if result.requires_local() {
+    println!("Cloud forbidden: {:?}", result.reason);
+} else if result.prefers_cloud() {
+    println!("Cloud preferred: {:?}", result.reason);
 }
 ```
 
@@ -91,7 +97,9 @@ if !result.allowed {
 Makes intelligent routing decisions based on device metrics, policy results, and model availability.
 
 ```rust
-use xybrid_core::routing_engine::{RoutingEngine, DefaultRoutingEngine, LocalAvailability};
+use xybrid_core::orchestrator::routing_engine::{
+    DefaultRoutingEngine, LocalAvailability, RouteTarget, RoutingEngine,
+};
 
 let mut routing_engine = DefaultRoutingEngine::new();
 

--- a/crates/xybrid-core/README.md
+++ b/crates/xybrid-core/README.md
@@ -31,27 +31,23 @@ The main entry point that coordinates pipeline execution.
 ```rust
 use xybrid_core::orchestrator::Orchestrator;
 use xybrid_core::context::{Envelope, EnvelopeKind, DeviceMetrics, StageDescriptor};
-use xybrid_core::routing_engine::LocalAvailability;
+use xybrid_core::orchestrator::routing_engine::LocalAvailability;
 
 // Create a new orchestrator
 let mut orchestrator = Orchestrator::new();
 
 // Execute a single stage
-let stage = StageDescriptor { name: "asr".to_string() };
+let stage = StageDescriptor::new("asr");
 let input = Envelope::new(EnvelopeKind::Audio(vec![0u8; 1600]));
-let metrics = DeviceMetrics {
-    network_rtt: 100,
-    battery: 80,
-    temperature: 25.0,
-};
+let metrics = DeviceMetrics::default();
 let availability = LocalAvailability::new(true);
 
 let result = orchestrator.execute_stage(&stage, &input, &metrics, &availability)?;
 
 // Execute a multi-stage pipeline
 let stages = vec![
-    StageDescriptor { name: "asr".to_string() },
-    StageDescriptor { name: "tts".to_string() },
+    StageDescriptor::new("asr"),
+    StageDescriptor::new("tts"),
 ];
 let results = orchestrator.execute_pipeline(&stages, &input, &metrics, &|s| {
     LocalAvailability::new(s == "asr") // ASR available locally, TTS in cloud

--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -1,6 +1,6 @@
 //! Cloud client implementation.
 
-use super::completion::{CompletionRequest, CompletionResponse};
+use super::completion::{CompletionRequest, CompletionResponse, Role};
 use super::config::{CloudBackend, CloudConfig};
 use super::error::CloudError;
 use crate::http::{with_retry, CircuitBreaker, CircuitConfig, RetryPolicy, RetryResult};
@@ -150,61 +150,22 @@ impl Cloud {
         Ok(response.text)
     }
 
-    /// Complete through Xybrid Gateway.
+    /// Complete through an OpenAI-compatible `/chat/completions` endpoint
+    /// (the Xybrid gateway or a provider reached over the same transport).
     fn call_gateway(&self, request: CompletionRequest) -> Result<CompletionResponse, CloudError> {
         let api_key = self.config.resolve_api_key();
-
-        // Build OpenAI-compatible request body
-        let messages = request.to_messages();
-        let openai_messages: Vec<serde_json::Value> = messages
-            .iter()
-            .map(|m| {
-                json!({
-                    "role": match m.role {
-                        super::completion::Role::System => "system",
-                        super::completion::Role::User => "user",
-                        super::completion::Role::Assistant => "assistant",
-                    },
-                    "content": &m.content
-                })
-            })
-            .collect();
 
         // No silent default: falling back to a hosted model here would route a
         // caller who merely forgot to set `model` to OpenAI, quietly billing a
         // third-party provider instead of running the model they asked for.
-        let model = request
-            .model
-            .clone()
-            .or_else(|| self.config.default_model.clone())
-            .ok_or_else(|| {
+        let body =
+            openai_chat_body(&request, &self.config, request.stream).map_err(|MissingModel| {
                 CloudError::GatewayError(
                     "no model specified for the gateway request: set CompletionRequest::model or \
                      CloudConfig::default_model"
                         .to_string(),
                 )
             })?;
-
-        let mut body = json!({
-            "model": model,
-            "messages": openai_messages,
-        });
-
-        if let Some(max_tokens) = request.max_tokens {
-            body["max_tokens"] = json!(max_tokens);
-        }
-        if let Some(temperature) = request.temperature {
-            body["temperature"] = json!(temperature);
-        }
-        if let Some(top_p) = request.top_p {
-            body["top_p"] = json!(top_p);
-        }
-        if let Some(ref stop) = request.stop {
-            body["stop"] = json!(stop);
-        }
-        if request.stream {
-            body["stream"] = json!(true);
-        }
 
         let url = format!("{}/chat/completions", self.config.gateway_url);
 
@@ -241,16 +202,13 @@ impl Cloud {
                 }
 
                 // Parse OpenAI-format response
-                let text = json_resp["choices"][0]["message"]["content"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string();
-
                 let model = json_resp["model"].as_str().unwrap_or("unknown").to_string();
 
                 let finish_reason = json_resp["choices"][0]["finish_reason"]
                     .as_str()
                     .map(|s| s.to_string());
+
+                let text = assistant_content(&json_resp, finish_reason.as_deref())?;
 
                 let usage = json_resp.get("usage").map(parse_gateway_usage);
 
@@ -332,6 +290,101 @@ impl Default for Cloud {
     fn default() -> Self {
         Self::new().expect("Failed to create default Cloud client")
     }
+}
+
+/// Extract `choices[0].message.content` from an OpenAI-shaped 200 response.
+///
+/// An HTTP 200 is not an answer. A body with no choices, a non-string
+/// content, or an empty string (typically `finish_reason: length` after hidden
+/// reasoning consumed the whole output budget) is reported as
+/// [`CloudError::ParseError`] — non-retryable, so the caller sees the failure
+/// instead of an empty "success".
+fn assistant_content(
+    response: &serde_json::Value,
+    finish_reason: Option<&str>,
+) -> Result<String, CloudError> {
+    match response["choices"][0]["message"]["content"].as_str() {
+        Some(content) if !content.is_empty() => Ok(content.to_string()),
+        Some(_) => Err(CloudError::ParseError(format!(
+            "completion returned empty content (finish_reason: {}); the output budget may have \
+             been exhausted before an answer was produced",
+            finish_reason.unwrap_or("none")
+        ))),
+        None => Err(CloudError::ParseError(
+            "response has no choices[0].message.content string".to_string(),
+        )),
+    }
+}
+
+/// The request names no model and the config has no `default_model`.
+///
+/// Returned by [`openai_chat_body`] so each transport can map it to its own
+/// error type and message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MissingModel;
+
+/// Build the OpenAI-compatible `/chat/completions` request body.
+///
+/// The single body builder shared by the batch transport
+/// (`Cloud::call_gateway`) and the SSE transport
+/// (`CloudRuntimeAdapter::execute_streaming`), so the two wire bodies are
+/// identical except for `stream`. Carries `model`, `messages`, `max_tokens`,
+/// `temperature`, `top_p`, `stop`, `stream` (only when `true`), and DeepSeek's
+/// `"thinking": {"type": ...}` when [`CompletionRequest::thinking`] is set.
+///
+/// The model is `request.model`, then `config.default_model`; with neither,
+/// [`MissingModel`] is returned rather than guessing a hosted default.
+pub(crate) fn openai_chat_body(
+    request: &CompletionRequest,
+    config: &CloudConfig,
+    stream: bool,
+) -> Result<serde_json::Value, MissingModel> {
+    let model = request
+        .model
+        .clone()
+        .or_else(|| config.default_model.clone())
+        .ok_or(MissingModel)?;
+
+    let messages: Vec<serde_json::Value> = request
+        .to_messages()
+        .into_iter()
+        .map(|m| {
+            json!({
+                "role": match m.role {
+                    Role::System => "system",
+                    Role::User => "user",
+                    Role::Assistant => "assistant",
+                },
+                "content": m.content,
+            })
+        })
+        .collect();
+
+    let mut body = json!({
+        "model": model,
+        "messages": messages,
+    });
+
+    if let Some(max_tokens) = request.max_tokens {
+        body["max_tokens"] = json!(max_tokens);
+    }
+    if let Some(temperature) = request.temperature {
+        body["temperature"] = json!(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        body["top_p"] = json!(top_p);
+    }
+    if let Some(stop) = request.stop.as_ref() {
+        body["stop"] = json!(stop);
+    }
+    if stream {
+        body["stream"] = json!(true);
+    }
+    if let Some(thinking) = request.thinking {
+        body["thinking"] = json!({ "type": thinking.as_str() });
+    }
+
+    Ok(body)
 }
 
 /// Parse a raw gateway `usage` JSON value into canonical `Usage`.
@@ -459,6 +512,93 @@ mod tests {
         let usage = parse_gateway_usage(&blob);
         assert_eq!(usage.cache_read_input_tokens, None);
         assert_eq!(usage.cache_creation_input_tokens, None);
+    }
+
+    #[test]
+    fn openai_chat_body_serializes_thinking_as_typed_object() {
+        use super::super::completion::ThinkingMode;
+
+        let config = CloudConfig::gateway();
+        let request = CompletionRequest::new("hello")
+            .with_model("deepseek-flash")
+            .with_thinking(ThinkingMode::Disabled);
+
+        let body = openai_chat_body(&request, &config, false).expect("model is set");
+
+        assert_eq!(body["thinking"], json!({ "type": "disabled" }));
+        assert!(body.get("stream").is_none(), "stream is omitted when false");
+
+        let plain = CompletionRequest::new("hello").with_model("deepseek-flash");
+        let body = openai_chat_body(&plain, &config, false).expect("model is set");
+        assert!(body.get("thinking").is_none(), "unset thinking is omitted");
+    }
+
+    #[test]
+    fn openai_chat_body_reports_missing_model() {
+        let config = CloudConfig::gateway();
+        assert!(config.default_model.is_none(), "guard the premise");
+
+        assert_eq!(
+            openai_chat_body(&CompletionRequest::new("hello"), &config, false),
+            Err(MissingModel)
+        );
+
+        let with_default = CloudConfig::gateway().with_default_model("lfm2.5-350m");
+        let body = openai_chat_body(&CompletionRequest::new("hello"), &with_default, true)
+            .expect("config supplies the model");
+        assert_eq!(body["model"], "lfm2.5-350m");
+        assert_eq!(body["stream"], true);
+    }
+
+    #[test]
+    fn assistant_content_rejects_missing_and_empty_answers() {
+        let ok = json!({"choices":[{"message":{"content":"hi"},"finish_reason":"stop"}]});
+        assert_eq!(assistant_content(&ok, Some("stop")).unwrap(), "hi");
+
+        let no_choices = json!({"choices":[]});
+        assert!(matches!(
+            assistant_content(&no_choices, None),
+            Err(CloudError::ParseError(_))
+        ));
+
+        let empty = json!({"choices":[{"message":{"content":""},"finish_reason":"length"}]});
+        match assistant_content(&empty, Some("length")) {
+            Err(CloudError::ParseError(msg)) => {
+                assert!(msg.contains("empty content"), "got {msg}");
+                assert!(msg.contains("length"), "got {msg}");
+            }
+            other => panic!("expected ParseError, got {other:?}"),
+        }
+
+        let non_string = json!({"choices":[{"message":{"content":null}}]});
+        assert!(matches!(
+            assistant_content(&non_string, None),
+            Err(CloudError::ParseError(_))
+        ));
+    }
+
+    /// 401 is permanent; 429 is retryable with the server's `Retry-After`.
+    /// The retry loop itself sleeps for the policy delay, so classification is
+    /// what keeps a rate-limited request bounded, not wall-clock assertions.
+    #[test]
+    fn status_errors_classify_for_retry() {
+        use crate::http::RetryableError;
+
+        let unauthorized = CloudError::ApiError {
+            status: 401,
+            message: "bad key".to_string(),
+        };
+        assert!(!unauthorized.is_retryable());
+        assert_eq!(unauthorized.retry_after(), None);
+
+        let limited = CloudError::RateLimited {
+            retry_after_secs: 7,
+        };
+        assert!(limited.is_retryable());
+        assert_eq!(limited.retry_after(), Some(Duration::from_secs(7)));
+
+        let empty_answer = CloudError::ParseError("empty".to_string());
+        assert!(!empty_answer.is_retryable());
     }
 
     #[test]

--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -265,12 +265,14 @@ impl Cloud {
                 CloudError::ConfigError("Direct provider not configured".to_string())
             })?;
 
-        // Use cloud_llm for direct API calls
-        let llm_provider: crate::pipeline::IntegrationProvider = provider
-            .parse()
-            .map_err(|e: String| CloudError::ConfigError(e))?;
-
-        let client = crate::cloud_llm::LlmClient::new(llm_provider)?;
+        // Use cloud_llm for direct API calls. The explicit `api_key` (literal
+        // or `$VAR`) and `direct_base_url` reach the native client; absent
+        // values fall back to the provider's own environment variable and
+        // documented base URL.
+        let client = crate::cloud_llm::LlmClient::with_config(direct_provider_config(
+            provider,
+            &self.config,
+        )?)?;
         let llm_request: crate::cloud_llm::LlmRequest = request.into();
         let response = client.complete(llm_request)?;
 
@@ -290,6 +292,28 @@ impl Default for Cloud {
     fn default() -> Self {
         Self::new().expect("Failed to create default Cloud client")
     }
+}
+
+/// Build the native-client [`crate::pipeline::ProviderConfig`] for a
+/// `backend: direct` call.
+///
+/// Threads the stage's explicit `api_key` (literal or `$VAR` reference, kept
+/// as a reference so the client resolves it at request time) and
+/// `direct_base_url` into the native client. When either is absent the
+/// provider's own environment variable and documented base URL apply, as
+/// before.
+fn direct_provider_config(
+    provider: &str,
+    config: &CloudConfig,
+) -> Result<crate::pipeline::ProviderConfig, CloudError> {
+    let llm_provider: crate::pipeline::IntegrationProvider = provider
+        .parse()
+        .map_err(|e: String| CloudError::ConfigError(e))?;
+    let mut provider_config = crate::pipeline::ProviderConfig::new(llm_provider);
+    provider_config.base_url = config.direct_base_url.clone();
+    provider_config.api_key = config.api_key.clone();
+    provider_config.timeout_ms = config.timeout_ms;
+    Ok(provider_config)
 }
 
 /// Extract `choices[0].message.content` from an OpenAI-shaped 200 response.
@@ -453,6 +477,64 @@ mod tests {
         let cloud = Cloud::direct("openai");
         assert!(cloud.is_ok());
         std::env::remove_var("OPENAI_API_KEY");
+    }
+
+    #[test]
+    fn direct_provider_config_threads_explicit_key_url_and_timeout() {
+        use crate::cloud::config::CloudBackend;
+
+        let config = CloudConfig {
+            backend: CloudBackend::Direct,
+            direct_provider: Some("anthropic".to_string()),
+            direct_base_url: Some("http://127.0.0.1:8080/v1".to_string()),
+            api_key: Some("sk-ant-explicit".to_string()),
+            timeout_ms: 1234,
+            ..Default::default()
+        };
+
+        let provider_config = direct_provider_config("anthropic", &config).expect("valid provider");
+
+        assert_eq!(
+            provider_config.base_url.as_deref(),
+            Some("http://127.0.0.1:8080/v1")
+        );
+        assert_eq!(provider_config.api_key.as_deref(), Some("sk-ant-explicit"));
+        assert_eq!(provider_config.timeout_ms, 1234);
+        // The explicit key is what the client resolves, whatever the origin.
+        assert_eq!(
+            provider_config.resolve_api_key().as_deref(),
+            Some("sk-ant-explicit")
+        );
+    }
+
+    #[test]
+    fn direct_provider_config_keeps_env_reference_and_provider_defaults() {
+        let config = CloudConfig {
+            api_key: Some("$ANTHROPIC_API_KEY".to_string()),
+            ..CloudConfig::direct("anthropic")
+        };
+
+        let provider_config = direct_provider_config("anthropic", &config).expect("valid provider");
+
+        assert!(
+            provider_config.base_url.is_none(),
+            "None must fall back to the provider's documented base URL"
+        );
+        assert_eq!(
+            provider_config.effective_base_url(),
+            "https://api.anthropic.com/v1"
+        );
+        assert_eq!(
+            provider_config.api_key.as_deref(),
+            Some("$ANTHROPIC_API_KEY")
+        );
+    }
+
+    #[test]
+    fn direct_provider_config_rejects_unknown_provider() {
+        let config = CloudConfig::direct("nope");
+        let err = direct_provider_config("nope", &config).expect_err("unknown provider");
+        assert!(matches!(err, CloudError::ConfigError(_)), "{err:?}");
     }
 
     #[test]

--- a/crates/xybrid-core/src/cloud/client.rs
+++ b/crates/xybrid-core/src/cloud/client.rs
@@ -1,7 +1,7 @@
 //! Cloud client implementation.
 
 use super::completion::{CompletionRequest, CompletionResponse, Role};
-use super::config::{CloudBackend, CloudConfig};
+use super::config::{same_origin, CloudBackend, CloudConfig};
 use super::error::CloudError;
 use crate::http::{with_retry, CircuitBreaker, CircuitConfig, RetryPolicy, RetryResult};
 use serde_json::json;
@@ -297,23 +297,109 @@ impl Default for Cloud {
 /// Build the native-client [`crate::pipeline::ProviderConfig`] for a
 /// `backend: direct` call.
 ///
-/// Threads the stage's explicit `api_key` (literal or `$VAR` reference, kept
-/// as a reference so the client resolves it at request time) and
-/// `direct_base_url` into the native client. When either is absent the
-/// provider's own environment variable and documented base URL apply, as
-/// before.
+/// Threads the stage's explicit `api_key` (literal or `$VAR` reference) and
+/// `direct_base_url` into the native client. Credential selection is
+/// destination-scoped: an explicit key always wins; without one, the
+/// provider's own environment variable is used only when the effective
+/// destination is the provider's documented origin. A custom (loopback,
+/// staging, lookalike) destination requires an explicit key and fails here —
+/// before any HTTP — so the native client can never attach an ambient
+/// provider credential to an unrelated endpoint.
 fn direct_provider_config(
     provider: &str,
     config: &CloudConfig,
 ) -> Result<crate::pipeline::ProviderConfig, CloudError> {
+    direct_provider_config_with_env(provider, config, |var| std::env::var(var).ok())
+}
+
+/// [`direct_provider_config`] with an injected environment lookup, so the
+/// credential matrix is testable without touching process environment.
+fn direct_provider_config_with_env(
+    provider: &str,
+    config: &CloudConfig,
+    env: impl Fn(&str) -> Option<String>,
+) -> Result<crate::pipeline::ProviderConfig, CloudError> {
     let llm_provider: crate::pipeline::IntegrationProvider = provider
         .parse()
         .map_err(|e: String| CloudError::ConfigError(e))?;
+    let destination = config
+        .direct_base_url
+        .as_deref()
+        .unwrap_or_else(|| llm_provider.default_base_url());
+    let api_key =
+        resolve_direct_api_key(llm_provider, config.api_key.as_deref(), destination, env)?;
+
     let mut provider_config = crate::pipeline::ProviderConfig::new(llm_provider);
     provider_config.base_url = config.direct_base_url.clone();
-    provider_config.api_key = config.api_key.clone();
     provider_config.timeout_ms = config.timeout_ms;
+    // Always concrete: `ProviderConfig::resolve_api_key` falls back to the
+    // provider's environment variable when this is `None`, which would
+    // re-open the ambient credential path the destination check just closed.
+    provider_config.api_key = Some(api_key);
     Ok(provider_config)
+}
+
+/// Destination-scoped credential for a `backend: direct` native call.
+///
+/// Rules, in order:
+/// 1. An explicit key wins. A literal is used as-is; a `$VAR` reference reads
+///    only that variable.
+/// 2. An empty explicit key, or a reference that resolves to nothing, is an
+///    error — never a fall-through to another credential.
+/// 3. With no explicit key, the provider's own environment variable is used
+///    only when `destination` has the provider's documented origin.
+/// 4. Any other destination demands an explicit key; the Xybrid platform key
+///    (`XYBRID_API_KEY`) is never substituted for a provider key.
+///
+/// Errors name the configuration problem, never a secret value.
+fn resolve_direct_api_key(
+    provider: crate::pipeline::IntegrationProvider,
+    explicit: Option<&str>,
+    destination: &str,
+    env: impl Fn(&str) -> Option<String>,
+) -> Result<String, CloudError> {
+    fn non_empty(value: Option<String>) -> Option<String> {
+        value.filter(|v| !v.trim().is_empty())
+    }
+
+    if let Some(key) = explicit {
+        if key.trim().is_empty() {
+            return Err(CloudError::ConfigError(format!(
+                "backend 'direct' for {}: 'api_key' is empty; set a literal key or a '${}' \
+                 reference",
+                provider,
+                provider.api_key_env_var()
+            )));
+        }
+        if let Some(var) = key.strip_prefix('$') {
+            return non_empty(env(var)).ok_or_else(|| {
+                CloudError::ConfigError(format!(
+                    "backend 'direct' for {}: 'api_key' references ${}, which is unset or \
+                     empty; refusing to fall back to another credential",
+                    provider, var
+                ))
+            });
+        }
+        return Ok(key.to_string());
+    }
+
+    if same_origin(destination, provider.default_base_url()) {
+        return non_empty(env(provider.api_key_env_var())).ok_or_else(|| {
+            CloudError::ConfigError(format!(
+                "no API key for {}: set {} or the stage's 'api_key'",
+                provider,
+                provider.api_key_env_var()
+            ))
+        });
+    }
+
+    Err(CloudError::ConfigError(format!(
+        "backend 'direct' for {} at a custom destination ('{}') requires an explicit \
+         'api_key'; refusing to send {} to a different origin",
+        provider,
+        destination,
+        provider.api_key_env_var()
+    )))
 }
 
 /// Extract `choices[0].message.content` from an OpenAI-shaped 200 response.
@@ -479,10 +565,252 @@ mod tests {
         std::env::remove_var("OPENAI_API_KEY");
     }
 
+    /// Environment lookup backed by a literal list, so credential selection
+    /// is tested without touching process environment.
+    fn env_with<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |var| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == var)
+                .map(|(_, value)| value.to_string())
+        }
+    }
+
+    /// Minimal loopback Anthropic `/messages` responder that records every
+    /// request verbatim, for exercising the public `Cloud` entry point.
+    struct FakeAnthropic {
+        base_url: String,
+        requests: Arc<std::sync::Mutex<Vec<String>>>,
+        stop: Arc<std::sync::atomic::AtomicBool>,
+        thread: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl FakeAnthropic {
+        fn start() -> Self {
+            use std::io::ErrorKind;
+            use std::net::TcpListener;
+
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let thread = {
+                let requests = requests.clone();
+                let stop = stop.clone();
+                std::thread::spawn(move || {
+                    while !stop.load(std::sync::atomic::Ordering::SeqCst) {
+                        match listener.accept() {
+                            Ok((stream, _)) => Self::serve(stream, &requests),
+                            Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                                std::thread::sleep(Duration::from_millis(10));
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                })
+            };
+            Self {
+                base_url: format!("http://{addr}"),
+                requests,
+                stop,
+                thread: Some(thread),
+            }
+        }
+
+        fn serve(mut stream: std::net::TcpStream, requests: &Arc<std::sync::Mutex<Vec<String>>>) {
+            use std::io::{Read, Write};
+
+            stream.set_nonblocking(false).unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                let read = match stream.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => n,
+                };
+                request.extend_from_slice(&buf[..read]);
+                if let Some(header_end) = request
+                    .windows(4)
+                    .position(|w| w == b"\r\n\r\n")
+                    .map(|pos| pos + 4)
+                {
+                    let headers = String::from_utf8_lossy(&request[..header_end]).into_owned();
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    while request.len() < header_end + content_length {
+                        match stream.read(&mut buf) {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => request.extend_from_slice(&buf[..n]),
+                        }
+                    }
+                    break;
+                }
+            }
+            requests
+                .lock()
+                .unwrap()
+                .push(String::from_utf8_lossy(&request).into_owned());
+
+            let body = r#"{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"FAKE_ANTHROPIC_REPLY"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+
+        fn requests(&self) -> Vec<String> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    impl Drop for FakeAnthropic {
+        fn drop(&mut self) {
+            self.stop.store(true, std::sync::atomic::Ordering::SeqCst);
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    #[test]
+    fn direct_credential_explicit_literal_wins_for_any_destination() {
+        let env = env_with(&[
+            ("ANTHROPIC_API_KEY", "env-anthropic"),
+            ("XYBRID_API_KEY", "env-platform"),
+        ]);
+
+        for destination in ["https://api.anthropic.com/v1", "http://127.0.0.1:8080/v1"] {
+            let key = resolve_direct_api_key(
+                crate::pipeline::IntegrationProvider::Anthropic,
+                Some("literal-key"),
+                destination,
+                &env,
+            )
+            .expect("literal key wins");
+            assert_eq!(key, "literal-key");
+        }
+    }
+
+    #[test]
+    fn direct_credential_env_reference_reads_only_that_variable() {
+        let env = env_with(&[
+            ("ANTHROPIC_API_KEY", "env-anthropic"),
+            ("MY_KEY", "my-key"),
+            ("EMPTY_KEY", "   "),
+            ("XYBRID_API_KEY", "env-platform"),
+        ]);
+
+        let key = resolve_direct_api_key(
+            crate::pipeline::IntegrationProvider::Anthropic,
+            Some("$MY_KEY"),
+            "https://api.anthropic.com/v1",
+            &env,
+        )
+        .expect("reference resolves");
+        assert_eq!(key, "my-key");
+
+        for destination in ["https://api.anthropic.com/v1", "http://127.0.0.1:8080/v1"] {
+            for reference in ["$MISSING_KEY", "$EMPTY_KEY"] {
+                let err = resolve_direct_api_key(
+                    crate::pipeline::IntegrationProvider::Anthropic,
+                    Some(reference),
+                    destination,
+                    &env,
+                )
+                .expect_err("unresolved reference must fail");
+                assert!(matches!(err, CloudError::ConfigError(_)), "{err:?}");
+                assert!(err.to_string().contains("unset or empty"), "{err}");
+            }
+
+            let err = resolve_direct_api_key(
+                crate::pipeline::IntegrationProvider::Anthropic,
+                Some("   "),
+                destination,
+                &env,
+            )
+            .expect_err("whitespace literal is empty");
+            assert!(err.to_string().contains("is empty"), "{err}");
+        }
+    }
+
+    #[test]
+    fn direct_credential_provider_env_only_at_provider_origin() {
+        let env = env_with(&[
+            ("ANTHROPIC_API_KEY", "env-anthropic"),
+            ("XYBRID_API_KEY", "env-platform"),
+        ]);
+
+        for destination in [
+            "https://api.anthropic.com/v1",
+            "https://api.anthropic.com:443/v1/",
+        ] {
+            let key = resolve_direct_api_key(
+                crate::pipeline::IntegrationProvider::Anthropic,
+                None,
+                destination,
+                &env,
+            )
+            .expect("provider origin may use the provider env var");
+            assert_eq!(key, "env-anthropic");
+        }
+
+        // Custom, loopback, different port, downgraded scheme, and lookalike
+        // hosts must all demand an explicit key and must never receive the
+        // platform key or the provider env var.
+        for destination in [
+            "http://127.0.0.1:8080/v1",
+            "http://api.anthropic.com/v1",
+            "https://api.anthropic.com:8443/v1",
+            "https://api.anthropic.com.evil.example/v1",
+            "https://evil.example/api.anthropic.com/v1",
+        ] {
+            let err = resolve_direct_api_key(
+                crate::pipeline::IntegrationProvider::Anthropic,
+                None,
+                destination,
+                &env,
+            )
+            .expect_err("custom destination must require an explicit key");
+            assert!(matches!(err, CloudError::ConfigError(_)), "{err:?}");
+            let message = err.to_string();
+            assert!(
+                message.contains("explicit 'api_key'"),
+                "{destination}: {message}"
+            );
+            assert!(!message.contains("env-anthropic"), "{message}");
+            assert!(!message.contains("env-platform"), "{message}");
+        }
+
+        // The provider origin with no provider env var fails instead of
+        // reaching for the platform key.
+        let platform_only = env_with(&[("XYBRID_API_KEY", "env-platform")]);
+        let err = resolve_direct_api_key(
+            crate::pipeline::IntegrationProvider::Anthropic,
+            None,
+            "https://api.anthropic.com/v1",
+            &platform_only,
+        )
+        .expect_err("missing provider key");
+        let message = err.to_string();
+        assert!(message.contains("ANTHROPIC_API_KEY"), "{message}");
+        assert!(!message.contains("XYBRID"), "{message}");
+    }
+
     #[test]
     fn direct_provider_config_threads_explicit_key_url_and_timeout() {
-        use crate::cloud::config::CloudBackend;
-
         let config = CloudConfig {
             backend: CloudBackend::Direct,
             direct_provider: Some("anthropic".to_string()),
@@ -492,7 +820,9 @@ mod tests {
             ..Default::default()
         };
 
-        let provider_config = direct_provider_config("anthropic", &config).expect("valid provider");
+        let env = env_with(&[("ANTHROPIC_API_KEY", "env-anthropic")]);
+        let provider_config =
+            direct_provider_config_with_env("anthropic", &config, &env).expect("valid provider");
 
         assert_eq!(
             provider_config.base_url.as_deref(),
@@ -508,13 +838,12 @@ mod tests {
     }
 
     #[test]
-    fn direct_provider_config_keeps_env_reference_and_provider_defaults() {
-        let config = CloudConfig {
-            api_key: Some("$ANTHROPIC_API_KEY".to_string()),
-            ..CloudConfig::direct("anthropic")
-        };
+    fn direct_provider_config_resolves_provider_env_at_its_own_origin() {
+        let config = CloudConfig::direct("anthropic");
+        let env = env_with(&[("ANTHROPIC_API_KEY", "sk-ant-env")]);
 
-        let provider_config = direct_provider_config("anthropic", &config).expect("valid provider");
+        let provider_config =
+            direct_provider_config_with_env("anthropic", &config, &env).expect("valid provider");
 
         assert!(
             provider_config.base_url.is_none(),
@@ -524,9 +853,77 @@ mod tests {
             provider_config.effective_base_url(),
             "https://api.anthropic.com/v1"
         );
-        assert_eq!(
-            provider_config.api_key.as_deref(),
-            Some("$ANTHROPIC_API_KEY")
+        // Resolved eagerly to a literal; the native client must not re-read
+        // the environment at request time.
+        assert_eq!(provider_config.api_key.as_deref(), Some("sk-ant-env"));
+    }
+
+    #[test]
+    fn direct_provider_config_rejects_custom_destination_without_explicit_key() {
+        let config = CloudConfig {
+            backend: CloudBackend::Direct,
+            direct_provider: Some("anthropic".to_string()),
+            direct_base_url: Some("http://127.0.0.1:9/v1".to_string()),
+            ..Default::default()
+        };
+        let env = env_with(&[("ANTHROPIC_API_KEY", "env-anthropic")]);
+
+        let err = direct_provider_config_with_env("anthropic", &config, &env)
+            .expect_err("custom destination without an explicit key");
+
+        assert!(matches!(err, CloudError::ConfigError(_)), "{err:?}");
+        assert!(err.to_string().contains("custom destination"), "{err}");
+    }
+
+    #[test]
+    fn direct_cloud_refuses_custom_origin_without_explicit_key_and_makes_no_request() {
+        let server = FakeAnthropic::start();
+        let config = CloudConfig {
+            backend: CloudBackend::Direct,
+            direct_provider: Some("anthropic".to_string()),
+            direct_base_url: Some(format!("{}/v1", server.base_url)),
+            ..Default::default()
+        };
+
+        let cloud = Cloud::with_config(config).expect("client construction");
+        let err = cloud
+            .complete(CompletionRequest::new("hello"))
+            .expect_err("custom destination without a key must fail");
+
+        assert!(matches!(err, CloudError::ConfigError(_)), "{err:?}");
+        assert!(
+            server.requests().is_empty(),
+            "no HTTP before the configuration error: {:?}",
+            server.requests()
+        );
+    }
+
+    #[test]
+    fn direct_cloud_sends_only_the_explicit_key_to_a_custom_origin() {
+        let server = FakeAnthropic::start();
+        let config = CloudConfig {
+            backend: CloudBackend::Direct,
+            direct_provider: Some("anthropic".to_string()),
+            direct_base_url: Some(server.base_url.clone()),
+            api_key: Some("sk-ant-explicit".to_string()),
+            ..Default::default()
+        };
+
+        let cloud = Cloud::with_config(config).expect("client construction");
+        let response = cloud
+            .complete(CompletionRequest::new("hello").with_max_tokens(16))
+            .expect("explicit key request");
+
+        assert_eq!(response.text, "FAKE_ANTHROPIC_REPLY");
+        let requests = server.requests();
+        assert_eq!(requests.len(), 1, "{requests:?}");
+        let request = &requests[0];
+        assert!(request.starts_with("POST /messages "), "{request}");
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("x-api-key: sk-ant-explicit"),
+            "{request}"
         );
     }
 

--- a/crates/xybrid-core/src/cloud/completion.rs
+++ b/crates/xybrid-core/src/cloud/completion.rs
@@ -97,6 +97,59 @@ pub struct Usage {
     pub cache_creation_input_tokens: Option<u32>,
 }
 
+/// Whether a reasoning-capable model may think before it answers.
+///
+/// DeepSeek enables thinking by default and returns the reasoning in a separate
+/// `reasoning_content` field; hidden reasoning still consumes the output token
+/// budget, so a small `max_tokens` can be exhausted before any answer appears.
+/// [`ThinkingMode::Disabled`] requests answer-only generation.
+///
+/// On the OpenAI-compatible wire the mode is serialized as
+/// `"thinking": {"type": "enabled" | "disabled"}`. A `None` on
+/// [`CompletionRequest::thinking`] omits the field so the provider default
+/// applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThinkingMode {
+    /// The model may emit hidden reasoning before its answer.
+    Enabled,
+    /// Answer-only generation; no reasoning budget is spent.
+    Disabled,
+}
+
+impl ThinkingMode {
+    /// Wire value: `"enabled"` or `"disabled"`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ThinkingMode::Enabled => "enabled",
+            ThinkingMode::Disabled => "disabled",
+        }
+    }
+}
+
+impl std::fmt::Display for ThinkingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ThinkingMode {
+    type Err = String;
+
+    /// Parse `enabled` / `disabled`, case-insensitively and ignoring
+    /// surrounding whitespace. Any other value is an error.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "enabled" => Ok(ThinkingMode::Enabled),
+            "disabled" => Ok(ThinkingMode::Disabled),
+            _ => Err(format!(
+                "invalid thinking mode '{}': expected 'enabled' or 'disabled'",
+                s.trim()
+            )),
+        }
+    }
+}
+
 /// Request for cloud completion.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CompletionRequest {
@@ -138,6 +191,14 @@ pub struct CompletionRequest {
     /// Stream the response (token-by-token).
     #[serde(default)]
     pub stream: bool,
+
+    /// Thinking mode for reasoning-capable providers (DeepSeek).
+    ///
+    /// `None` omits the field from the request body so the provider default
+    /// applies. Honored by the OpenAI-compatible transport; the native direct
+    /// clients in `cloud_llm` have no equivalent and ignore it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingMode>,
 }
 
 impl CompletionRequest {
@@ -196,6 +257,12 @@ impl CompletionRequest {
     /// Enable streaming.
     pub fn with_stream(mut self, stream: bool) -> Self {
         self.stream = stream;
+        self
+    }
+
+    /// Set the thinking mode (DeepSeek `"thinking": {"type": ...}`).
+    pub fn with_thinking(mut self, mode: ThinkingMode) -> Self {
+        self.thinking = Some(mode);
         self
     }
 
@@ -332,6 +399,9 @@ impl From<CompletionRequest> for crate::cloud_llm::LlmRequest {
         if let Some(stop) = req.stop {
             llm_req = llm_req.with_stop(stop);
         }
+        // `thinking` has no `LlmRequest` equivalent: the native direct clients
+        // are not reasoning-mode aware, and the adapter only accepts the option
+        // for DeepSeek, which rides the OpenAI-compatible transport instead.
 
         llm_req
     }
@@ -378,5 +448,44 @@ mod tests {
 
         resp.finish_reason = Some("length".into());
         assert!(resp.truncated());
+    }
+
+    #[test]
+    fn thinking_defaults_to_none_and_is_omitted_from_json() {
+        let req = CompletionRequest::new("Hello");
+        assert_eq!(req.thinking, None);
+
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("thinking").is_none(), "got {json}");
+    }
+
+    #[test]
+    fn with_thinking_sets_the_mode() {
+        let req = CompletionRequest::new("Hello").with_thinking(ThinkingMode::Disabled);
+        assert_eq!(req.thinking, Some(ThinkingMode::Disabled));
+        assert_eq!(ThinkingMode::Disabled.as_str(), "disabled");
+        assert_eq!(ThinkingMode::Enabled.to_string(), "enabled");
+    }
+
+    #[test]
+    fn thinking_mode_parses_case_insensitively_and_rejects_other_values() {
+        assert_eq!(
+            "disabled".parse::<ThinkingMode>(),
+            Ok(ThinkingMode::Disabled)
+        );
+        assert_eq!(
+            " Enabled ".parse::<ThinkingMode>(),
+            Ok(ThinkingMode::Enabled)
+        );
+        assert_eq!(
+            "DISABLED".parse::<ThinkingMode>(),
+            Ok(ThinkingMode::Disabled)
+        );
+
+        let err = "maybe".parse::<ThinkingMode>().unwrap_err();
+        assert!(err.contains("maybe"), "got {err}");
+        assert!(err.contains("'enabled' or 'disabled'"), "got {err}");
+        assert!("".parse::<ThinkingMode>().is_err());
+        assert!("true".parse::<ThinkingMode>().is_err());
     }
 }

--- a/crates/xybrid-core/src/cloud/config.rs
+++ b/crates/xybrid-core/src/cloud/config.rs
@@ -124,6 +124,15 @@ pub struct CloudConfig {
     /// Direct provider (for Direct backend - development only).
     #[serde(default)]
     pub direct_provider: Option<String>,
+
+    /// Base URL for the native direct client (`backend: direct`).
+    ///
+    /// `None` uses the provider's documented default. The cloud adapter sets
+    /// this from a stage's explicit `gateway_url`; unlike `gateway_url` it is
+    /// never defaulted to the platform gateway, so a native direct call
+    /// cannot accidentally target the Xybrid platform.
+    #[serde(default)]
+    pub direct_base_url: Option<String>,
 }
 
 /// The configured Xybrid platform gateway URL (base + `/v1`).
@@ -231,6 +240,7 @@ impl Default for CloudConfig {
             timeout_ms: default_timeout_ms(),
             debug: false,
             direct_provider: None,
+            direct_base_url: None,
         }
     }
 }

--- a/crates/xybrid-core/src/cloud/config.rs
+++ b/crates/xybrid-core/src/cloud/config.rs
@@ -126,6 +126,71 @@ pub struct CloudConfig {
     pub direct_provider: Option<String>,
 }
 
+/// The configured Xybrid platform gateway URL (base + `/v1`).
+///
+/// Resolution order: `XYBRID_GATEWAY_URL`, the in-memory platform URL set via
+/// [`set_xybrid_platform_url`] + `/v1`, `XYBRID_PLATFORM_URL` + `/v1`, then
+/// the production default. This is also the only origin that may receive the
+/// Xybrid platform API key automatically — see [`CloudConfig::resolve_api_key`].
+pub fn platform_gateway_url() -> String {
+    default_gateway_url()
+}
+
+/// Scheme, lowercase host and effective port of an `http(s)` URL, for
+/// comparing destinations. `None` for anything unparsable or non-HTTP.
+///
+/// Comparing origins (never substrings or suffixes) is what stops
+/// `api.xybrid.dev.evil.example` or a different port from looking like the
+/// platform gateway.
+pub fn url_origin(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    let port = parsed.port_or_known_default()?;
+    Some(format!("{}://{}:{}", parsed.scheme(), host, port))
+}
+
+/// True when both URLs parse to the same `http(s)` origin.
+pub fn same_origin(a: &str, b: &str) -> bool {
+    matches!((url_origin(a), url_origin(b)), (Some(x), Some(y)) if x == y)
+}
+
+/// Pure credential resolution for one destination.
+///
+/// Precedence:
+/// 1. An explicit key wins. A literal is used as-is; a `$VAR` reference reads
+///    `VAR` through `env` and, if it is unset or empty, yields `None` — it
+///    never falls through to another credential.
+/// 2. With no explicit key, the Xybrid platform key (`programmatic_platform_key`,
+///    then `XYBRID_API_KEY` from `env`) is used **only** when `destination_url`
+///    has the same origin as `platform_gateway_url`.
+/// 3. Any other destination gets no automatic credential.
+///
+/// `env` is injected so tests never touch process environment.
+pub fn resolve_api_key_for(
+    explicit: Option<&str>,
+    destination_url: &str,
+    platform_gateway_url: &str,
+    programmatic_platform_key: Option<String>,
+    env: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    fn non_empty(value: Option<String>) -> Option<String> {
+        value.filter(|v| !v.trim().is_empty())
+    }
+    if let Some(key) = explicit {
+        if let Some(var) = key.strip_prefix('$') {
+            return non_empty(env(var));
+        }
+        return non_empty(Some(key.to_string()));
+    }
+    if same_origin(destination_url, platform_gateway_url) {
+        return non_empty(programmatic_platform_key).or_else(|| non_empty(env("XYBRID_API_KEY")));
+    }
+    None
+}
+
 fn default_gateway_url() -> String {
     // Priority:
     // 1. XYBRID_GATEWAY_URL env var (explicit override, should include /v1)
@@ -218,20 +283,23 @@ impl CloudConfig {
         self
     }
 
-    /// Resolve the API key from environment or config.
+    /// Resolve the API key for this config's destination.
+    ///
+    /// An explicit `api_key` (literal or `$ENV_VAR` reference) always wins and
+    /// never falls through. Without one, the Xybrid platform key — the
+    /// programmatic key set via the SDK first, then the ambient
+    /// `XYBRID_API_KEY` — is supplied only when `gateway_url` has the same
+    /// origin as the configured platform gateway. A provider endpoint or a
+    /// custom/loopback gateway never inherits the platform credential. See
+    /// [`resolve_api_key_for`].
     pub fn resolve_api_key(&self) -> Option<String> {
-        if let Some(ref key) = self.api_key {
-            if let Some(env_var) = key.strip_prefix('$') {
-                return std::env::var(env_var).ok();
-            }
-            return Some(key.clone());
-        }
-
-        // Programmatic key (set via the SDK, held in memory — not the
-        // environment) takes precedence over the ambient `XYBRID_API_KEY` env
-        // var, which remains the fallback for externally-configured keys
-        // (CLI `--env`, Flutter `--dart-define`, iOS `ProcessInfo`).
-        xybrid_api_key().or_else(|| std::env::var("XYBRID_API_KEY").ok())
+        resolve_api_key_for(
+            self.api_key.as_deref(),
+            &self.gateway_url,
+            &default_gateway_url(),
+            xybrid_api_key(),
+            |var| std::env::var(var).ok(),
+        )
     }
 }
 
@@ -346,5 +414,169 @@ mod tests {
         set_xybrid_platform_url(Some("https://staging.example.com".to_string()));
         std::env::set_var("XYBRID_GATEWAY_URL", "https://explicit.example.com/v1");
         assert_eq!(default_gateway_url(), "https://explicit.example.com/v1");
+    }
+
+    // ── destination-scoped credentials ──────────────────────────────────────
+
+    const PLATFORM: &str = "https://api.xybrid.dev/v1";
+
+    fn env_with<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |var| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == var)
+                .map(|(_, value)| value.to_string())
+        }
+    }
+
+    #[test]
+    fn url_origin_normalizes_host_and_default_port() {
+        assert_eq!(
+            url_origin("https://API.xybrid.dev/v1/chat").as_deref(),
+            Some("https://api.xybrid.dev:443")
+        );
+        assert_eq!(
+            url_origin("http://127.0.0.1:3001/v1").as_deref(),
+            Some("http://127.0.0.1:3001")
+        );
+        assert_eq!(url_origin("ftp://api.xybrid.dev").as_deref(), None);
+        assert_eq!(url_origin("not a url").as_deref(), None);
+        assert!(same_origin(PLATFORM, "https://api.xybrid.dev/"));
+        assert!(same_origin(PLATFORM, "https://api.xybrid.dev:443/v1/"));
+        assert!(!same_origin(PLATFORM, "https://api.xybrid.dev:8443/v1"));
+        assert!(!same_origin(PLATFORM, "http://api.xybrid.dev/v1"));
+        assert!(!same_origin(
+            PLATFORM,
+            "https://api.xybrid.dev.evil.example/v1"
+        ));
+        assert!(!same_origin(
+            PLATFORM,
+            "https://evil.example/api.xybrid.dev/v1"
+        ));
+    }
+
+    #[test]
+    fn explicit_literal_key_wins_for_any_destination() {
+        let key = resolve_api_key_for(
+            Some("literal-key"),
+            "https://api.deepseek.com/v1",
+            PLATFORM,
+            Some("platform-key".to_string()),
+            env_with(&[("XYBRID_API_KEY", "env-platform-key")]),
+        );
+        assert_eq!(key.as_deref(), Some("literal-key"));
+    }
+
+    #[test]
+    fn explicit_env_reference_reads_that_variable_only() {
+        let env = env_with(&[
+            ("DEEPSEEK_API_KEY", "ds-key"),
+            ("XYBRID_API_KEY", "env-platform-key"),
+        ]);
+        let key = resolve_api_key_for(
+            Some("$DEEPSEEK_API_KEY"),
+            "https://api.deepseek.com/v1",
+            PLATFORM,
+            Some("platform-key".to_string()),
+            &env,
+        );
+        assert_eq!(key.as_deref(), Some("ds-key"));
+
+        // Unset or empty reference: no fall-through to any other credential,
+        // not even at the platform origin.
+        for destination in ["https://api.deepseek.com/v1", PLATFORM] {
+            assert_eq!(
+                resolve_api_key_for(
+                    Some("$MISSING_KEY"),
+                    destination,
+                    PLATFORM,
+                    Some("platform-key".to_string()),
+                    &env,
+                ),
+                None
+            );
+            assert_eq!(
+                resolve_api_key_for(
+                    Some("$EMPTY_KEY"),
+                    destination,
+                    PLATFORM,
+                    Some("platform-key".to_string()),
+                    env_with(&[("EMPTY_KEY", "   ")]),
+                ),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn platform_key_is_automatic_only_for_the_platform_origin() {
+        let env = env_with(&[("XYBRID_API_KEY", "env-platform-key")]);
+
+        // Programmatic key first, then the ambient env var.
+        assert_eq!(
+            resolve_api_key_for(
+                None,
+                PLATFORM,
+                PLATFORM,
+                Some("platform-key".to_string()),
+                &env
+            )
+            .as_deref(),
+            Some("platform-key")
+        );
+        assert_eq!(
+            resolve_api_key_for(None, "https://api.xybrid.dev/v1/", PLATFORM, None, &env)
+                .as_deref(),
+            Some("env-platform-key")
+        );
+        // A reconfigured platform origin (staging, self-hosted) still gets it.
+        assert_eq!(
+            resolve_api_key_for(
+                None,
+                "http://localhost:3000/v1",
+                "http://localhost:3000/v1",
+                None,
+                &env
+            )
+            .as_deref(),
+            Some("env-platform-key")
+        );
+
+        // Provider, custom, loopback and lookalike origins never do.
+        for destination in [
+            "https://api.deepseek.com/v1",
+            "https://api.openai.com/v1",
+            "http://127.0.0.1:3001/v1",
+            "https://api.xybrid.dev.evil.example/v1",
+            "https://api.xybrid.dev:8443/v1",
+            "http://api.xybrid.dev/v1",
+        ] {
+            assert_eq!(
+                resolve_api_key_for(
+                    None,
+                    destination,
+                    PLATFORM,
+                    Some("platform-key".to_string()),
+                    &env
+                ),
+                None,
+                "{destination} must not receive the platform key"
+            );
+        }
+    }
+
+    #[test]
+    fn config_resolve_api_key_uses_its_gateway_url_as_destination() {
+        // Explicit literal on any destination.
+        let config = CloudConfig::gateway()
+            .with_gateway_url("https://api.deepseek.com/v1")
+            .with_api_key("ds-literal");
+        assert_eq!(config.resolve_api_key().as_deref(), Some("ds-literal"));
+
+        // Explicit reference to a variable that is certainly unset.
+        let config = CloudConfig::gateway()
+            .with_gateway_url("https://api.deepseek.com/v1")
+            .with_api_key("$XYBRID_TEST_SURELY_UNSET_KEY_7f3a");
+        assert_eq!(config.resolve_api_key(), None);
     }
 }

--- a/crates/xybrid-core/src/cloud/mod.rs
+++ b/crates/xybrid-core/src/cloud/mod.rs
@@ -60,9 +60,9 @@ mod completion;
 mod config;
 mod error;
 
-pub(crate) use client::parse_gateway_usage;
 pub use client::Cloud;
-pub use completion::{CompletionRequest, CompletionResponse, Message, Role, Usage};
+pub(crate) use client::{openai_chat_body, parse_gateway_usage, MissingModel};
+pub use completion::{CompletionRequest, CompletionResponse, Message, Role, ThinkingMode, Usage};
 pub use config::{
     has_xybrid_api_key, set_xybrid_api_key, set_xybrid_platform_url, xybrid_api_key,
     xybrid_platform_url, CloudBackend, CloudConfig,

--- a/crates/xybrid-core/src/cloud/mod.rs
+++ b/crates/xybrid-core/src/cloud/mod.rs
@@ -67,4 +67,5 @@ pub use config::{
     has_xybrid_api_key, set_xybrid_api_key, set_xybrid_platform_url, xybrid_api_key,
     xybrid_platform_url, CloudBackend, CloudConfig,
 };
+pub use config::{platform_gateway_url, resolve_api_key_for, same_origin, url_origin};
 pub use error::CloudError;

--- a/crates/xybrid-core/src/executor.rs
+++ b/crates/xybrid-core/src/executor.rs
@@ -962,10 +962,11 @@ mod tests {
         options.set("thinking", "disabled");
         options.set("gateway_url", "http://127.0.0.1:9/v1");
         options.set("api_key", "$DEEPSEEK_API_KEY");
+        // `with_provider` forces `target: cloud`; the hybrid shape sets Auto after it.
         let mut stage = StageDescriptor::new("llm")
             .with_model("functiongemma-270m-it")
-            .with_target(crate::pipeline::ExecutionTarget::Auto)
             .with_provider(crate::pipeline::IntegrationProvider::DeepSeek)
+            .with_target(crate::pipeline::ExecutionTarget::Auto)
             .with_options(options);
         stage.bundle_path = bundle_path.map(str::to_string);
         stage

--- a/crates/xybrid-core/src/executor.rs
+++ b/crates/xybrid-core/src/executor.rs
@@ -213,35 +213,88 @@ impl Executor {
         input: &Envelope,
         target: &str,
     ) -> ExecutorResult<(Envelope, StageMetadata)> {
+        let prepared = prepare_stage_input(stage, input)?;
+        self.execute_prepared(stage, &prepared, target)
+    }
+
+    /// Executes a stage whose input has already been through
+    /// [`prepare_stage_input`].
+    ///
+    /// The orchestrator prepares once, evaluates policy against the prepared
+    /// envelope, and then calls this so the merge is not repeated. Dispatch
+    /// is driven by `target` alone — the routing decision is authoritative.
+    /// A stage carrying a `provider` is *not* automatically a cloud stage:
+    /// when it is routed `local` it must have a usable local bundle, and it
+    /// never falls through to a different model or to cloud.
+    pub fn execute_prepared(
+        &mut self,
+        stage: &StageDescriptor,
+        input: &Envelope,
+        target: &str,
+    ) -> ExecutorResult<(Envelope, StageMetadata)> {
         let start_time = Instant::now();
-
-        // Check if this is a cloud stage (third-party API like OpenAI/Anthropic)
-        if stage.is_cloud() {
-            return self.execute_cloud(stage, input, start_time);
+        match target {
+            "cloud" => {
+                if stage.provider.is_some() {
+                    return self.execute_cloud(stage, input, start_time);
+                }
+                self.execute_registered_cloud_adapter(stage, input, target, start_time)
+            }
+            "local" | "edge" => self.execute_local(stage, input, target, start_time),
+            other => Err(ExecutorError::InvalidTarget(format!(
+                "Unknown target: {}",
+                other
+            ))),
         }
+    }
 
-        // Select adapter based on target
-        let adapter_name = self.select_adapter(target)?;
+    /// Provider-free stage routed to cloud: only an explicitly registered
+    /// cloud adapter may serve it. This never falls back to a local adapter.
+    fn execute_registered_cloud_adapter(
+        &self,
+        stage: &StageDescriptor,
+        input: &Envelope,
+        target: &str,
+        start_time: Instant,
+    ) -> ExecutorResult<(Envelope, StageMetadata)> {
+        let adapter_name = self
+            .default_cloud_adapter
+            .clone()
+            .filter(|name| self.adapters.contains_key(name))
+            .ok_or_else(|| {
+                ExecutorError::AdapterNotFound(format!(
+                    "stage '{}' was routed to cloud but has no provider and no cloud adapter \
+                     is registered",
+                    stage.name
+                ))
+            })?;
+        let adapter = self
+            .get_adapter(&adapter_name)
+            .ok_or_else(|| ExecutorError::AdapterNotFound(adapter_name.clone()))?;
 
-        // For cloud adapter, skip model loading (legacy path - prefer integration)
-        if adapter_name == "cloud" {
-            let adapter = self
-                .get_adapter(&adapter_name)
-                .ok_or_else(|| ExecutorError::AdapterNotFound(adapter_name.clone()))?;
+        let output = adapter
+            .execute(input)
+            .map_err(ExecutorError::AdapterError)?;
 
-            let output = adapter
-                .execute(input)
-                .map_err(ExecutorError::AdapterError)?;
+        let latency_ms = start_time.elapsed().as_millis();
+        let metadata = StageMetadata {
+            adapter: adapter_name,
+            target: target.to_string(),
+            latency_ms,
+        };
+        Ok((output, metadata))
+    }
 
-            let latency_ms = start_time.elapsed().as_millis();
-            let metadata = StageMetadata {
-                adapter: adapter_name,
-                target: target.to_string(),
-                latency_ms,
-            };
-            return Ok((output, metadata));
-        }
-
+    /// Local execution: an extracted model directory drives the
+    /// [`TemplateExecutor`]; provider-free stages without a bundle may fall
+    /// back to a pre-loaded raw adapter.
+    fn execute_local(
+        &mut self,
+        stage: &StageDescriptor,
+        input: &Envelope,
+        target: &str,
+        start_time: Instant,
+    ) -> ExecutorResult<(Envelope, StageMetadata)> {
         // Try bundle_path for metadata-driven execution
         // IMPORTANT: Core only accepts directories, not .xyb files.
         // Bundle extraction must be done by SDK's CacheManager.ensure_extracted() before calling Core.
@@ -351,12 +404,32 @@ impl Executor {
                     bundle_path
                 );
             }
+
+            // A hybrid stage (local bundle + cloud provider) must not fall
+            // through to an unrelated adapter when its bundle is unusable —
+            // that would silently run a different model.
+            if stage.provider.is_some() {
+                return Err(ExecutorError::ExecutionFailed(format!(
+                    "stage '{}' was routed local but its bundle at '{}' is not an extracted \
+                     model directory (missing model_metadata.json); not falling back to \
+                     another model or to cloud",
+                    stage.name,
+                    bundle_path.display()
+                )));
+            }
         } else {
             debug!(
                 target: "xybrid_core",
                 "Stage '{}' has no bundle_path set",
                 stage.name
             );
+            if stage.provider.is_some() {
+                return Err(ExecutorError::ExecutionFailed(format!(
+                    "stage '{}' was routed local but has no local bundle (cloud leg denied by \
+                     policy?)",
+                    stage.name
+                )));
+            }
         }
 
         // Raw adapter fallback for externally-preloaded adapters (test
@@ -366,6 +439,7 @@ impl Executor {
         // envelope. If the adapter isn't pre-loaded the real
         // `ModelNotLoaded` error propagates — the user must call
         // `Pipeline::load_models()` first (or pre-load the adapter).
+        let adapter_name = self.select_local_adapter()?;
         debug!(
             target: "xybrid_core",
             "Stage '{}' has no bundle_path; falling back to raw adapter '{}' (adapter must be pre-loaded)",
@@ -455,12 +529,14 @@ impl Executor {
     /// a remote cloud provider rather than locally on-device.
     ///
     /// Delegates to [`CloudRuntimeAdapter`] after enriching the envelope with
-    /// stage configuration metadata.
+    /// the stage's *transport* configuration. Shared generation options
+    /// (`system_prompt`, `temperature`, `max_tokens`, `top_p`) were already
+    /// applied by [`prepare_stage_input`] and are not overwritten here.
     ///
     /// # Arguments
     ///
     /// * `stage` - Stage descriptor with provider info
-    /// * `input` - Input envelope (expects Text)
+    /// * `input` - Prepared input envelope (expects Text)
     /// * `start_time` - Timer for latency measurement
     ///
     /// # Returns
@@ -477,43 +553,40 @@ impl Executor {
             ExecutorError::ProviderNotConfigured("Integration stage requires provider".to_string())
         })?;
 
+        // The model sent to the provider. A hybrid stage names its local
+        // bundle in `model` and its cloud model in the `cloud_model` option.
+        let effective_model = stage
+            .options
+            .as_ref()
+            .and_then(|options| options.get::<String>("cloud_model"))
+            .or_else(|| stage.model.clone());
+
         // Start tracing span for cloud execution
-        let model_name = stage.model.clone().unwrap_or_else(|| "unknown".to_string());
+        let model_name = effective_model
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
         let _exec_span = trace::SpanGuard::new(format!("execute:{}", model_name));
         trace::add_metadata("provider", provider.as_str());
         trace::add_metadata("target", "cloud");
-        if let Some(ref model) = stage.model {
+        if let Some(ref model) = effective_model {
             trace::add_metadata("model", model);
         }
 
-        // Enrich envelope with stage configuration for CloudRuntimeAdapter
+        // Enrich envelope with transport configuration for CloudRuntimeAdapter
         let mut enriched_input = input.clone();
         enriched_input
             .metadata
             .insert("provider".to_string(), provider.as_str().to_string());
 
-        if let Some(ref model) = stage.model {
-            enriched_input
-                .metadata
-                .insert("model".to_string(), model.clone());
+        if let Some(model) = effective_model {
+            enriched_input.metadata.insert("model".to_string(), model);
         }
 
-        // Apply stage options to metadata
         if let Some(ref options) = stage.options {
-            if let Some(backend) = options.get::<String>("backend") {
-                enriched_input
-                    .metadata
-                    .insert("backend".to_string(), backend);
-            }
-            if let Some(gateway_url) = options.get::<String>("gateway_url") {
-                enriched_input
-                    .metadata
-                    .insert("gateway_url".to_string(), gateway_url);
-            }
-            if let Some(api_key) = options.get::<String>("api_key") {
-                enriched_input
-                    .metadata
-                    .insert("api_key".to_string(), api_key);
+            for key in ["backend", "gateway_url", "api_key"] {
+                if let Some(value) = options.get::<String>(key) {
+                    enriched_input.metadata.insert(key.to_string(), value);
+                }
             }
             if let Some(timeout) = options.timeout_ms() {
                 enriched_input
@@ -525,20 +598,21 @@ impl Executor {
                     .metadata
                     .insert("debug".to_string(), debug.to_string());
             }
-            if let Some(system) = options.system_prompt() {
-                enriched_input
-                    .metadata
-                    .insert("system_prompt".to_string(), system);
-            }
-            if let Some(temp) = options.temperature() {
-                enriched_input
-                    .metadata
-                    .insert("temperature".to_string(), temp.to_string());
-            }
-            if let Some(max) = options.max_tokens() {
-                enriched_input
-                    .metadata
-                    .insert("max_tokens".to_string(), max.to_string());
+            // Provider-specific request capability; the adapter validates
+            // the value and the provider it is used with.
+            match options.values.get("thinking") {
+                None => {}
+                Some(serde_json::Value::String(mode)) => {
+                    enriched_input
+                        .metadata
+                        .insert("thinking".to_string(), mode.clone());
+                }
+                Some(other) => {
+                    return Err(ExecutorError::Other(format!(
+                        "stage '{}': option 'thinking' must be a string (enabled|disabled), got {}",
+                        stage.name, other
+                    )));
+                }
             }
         }
 
@@ -573,69 +647,33 @@ impl Executor {
         Ok((output, metadata))
     }
 
-    /// Selects an adapter name based on the target.
+    /// Selects the adapter for local execution when no bundle drives a
+    /// [`TemplateExecutor`].
     ///
-    /// # Arguments
-    ///
-    /// * `target` - Target string ("local", "edge", "cloud")
-    ///
-    /// # Returns
-    ///
-    /// Adapter name to use
-    fn select_adapter(&self, target: &str) -> ExecutorResult<String> {
-        match target {
-            "local" => {
-                // Prefer ONNX for local execution
-                if let Some(name) = &self.default_local_adapter {
-                    if self.adapters.contains_key(name) {
-                        return Ok(name.clone());
-                    }
-                }
-                // Fallback to first available adapter
-                self.adapters
-                    .keys()
-                    .next()
-                    .ok_or_else(|| {
-                        ExecutorError::AdapterNotFound("No adapters registered".to_string())
-                    })
-                    .cloned()
+    /// Prefers the default local adapter (`onnx`); otherwise the
+    /// alphabetically first registered adapter that is not the cloud adapter,
+    /// so the choice is deterministic and a cloud adapter never serves a
+    /// local route.
+    fn select_local_adapter(&self) -> ExecutorResult<String> {
+        if let Some(name) = &self.default_local_adapter {
+            if self.adapters.contains_key(name) {
+                return Ok(name.clone());
             }
-            "cloud" => {
-                // Prefer cloud adapter if available
-                if let Some(name) = &self.default_cloud_adapter {
-                    if self.adapters.contains_key(name) {
-                        return Ok(name.clone());
-                    }
-                }
-                // Fallback to first available adapter
-                self.adapters
-                    .keys()
-                    .next()
-                    .ok_or_else(|| {
-                        ExecutorError::AdapterNotFound("No adapters registered".to_string())
-                    })
-                    .cloned()
-            }
-            "edge" => {
-                // Edge is similar to local, prefer ONNX
-                if let Some(name) = &self.default_local_adapter {
-                    if self.adapters.contains_key(name) {
-                        return Ok(name.clone());
-                    }
-                }
-                self.adapters
-                    .keys()
-                    .next()
-                    .ok_or_else(|| {
-                        ExecutorError::AdapterNotFound("No adapters registered".to_string())
-                    })
-                    .cloned()
-            }
-            _ => Err(ExecutorError::InvalidTarget(format!(
-                "Unknown target: {}",
-                target
-            ))),
         }
+        let mut candidates: Vec<&String> = self
+            .adapters
+            .keys()
+            .filter(|name| {
+                name.as_str() != "cloud" && Some(*name) != self.default_cloud_adapter.as_ref()
+            })
+            .collect();
+        candidates.sort();
+        candidates
+            .first()
+            .map(|name| (*name).clone())
+            .ok_or_else(|| {
+                ExecutorError::AdapterNotFound("No local adapters registered".to_string())
+            })
     }
 
     /// Lists all registered adapter names.
@@ -645,6 +683,64 @@ impl Executor {
     /// Vector of adapter names
     pub fn list_adapters(&self) -> Vec<String> {
         self.adapters.keys().cloned().collect()
+    }
+}
+
+/// Generation options a stage may declare in pipeline YAML that apply to
+/// *both* legs of a hybrid stage, and the string form the backends parse
+/// from envelope metadata.
+const SHARED_GENERATION_OPTIONS: [&str; 4] =
+    ["system_prompt", "temperature", "max_tokens", "top_p"];
+
+/// Apply a stage's shared generation options to the input envelope.
+///
+/// Precedence, highest first: metadata already on the input (caller or CLI
+/// overrides), then the stage's YAML options, then the model template's own
+/// defaults (left to the backend). Unrelated metadata and the payload are
+/// preserved. A recognised option with an invalid value is an error, never
+/// silently dropped. Both the local [`TemplateExecutor`] and the cloud
+/// adapter read the resulting metadata keys, so a hybrid stage generates
+/// with the same settings on either leg.
+pub fn prepare_stage_input(stage: &StageDescriptor, input: &Envelope) -> ExecutorResult<Envelope> {
+    let Some(options) = stage.options.as_ref() else {
+        return Ok(input.clone());
+    };
+    let mut prepared = input.clone();
+    for key in SHARED_GENERATION_OPTIONS {
+        let Some(value) = options.values.get(key) else {
+            continue;
+        };
+        let rendered = render_generation_option(&stage.name, key, value)?;
+        prepared.metadata.entry(key.to_string()).or_insert(rendered);
+    }
+    Ok(prepared)
+}
+
+fn render_generation_option(
+    stage: &str,
+    key: &str,
+    value: &serde_json::Value,
+) -> ExecutorResult<String> {
+    use serde_json::Value;
+    let invalid = |expected: &str| {
+        ExecutorError::Other(format!(
+            "stage '{stage}': option '{key}' must be {expected}, got {value}"
+        ))
+    };
+    match key {
+        "system_prompt" => match value {
+            Value::String(text) => Ok(text.clone()),
+            _ => Err(invalid("a string")),
+        },
+        "temperature" | "top_p" => match value.as_f64() {
+            Some(number) if number.is_finite() && number >= 0.0 => Ok(number.to_string()),
+            _ => Err(invalid("a non-negative number")),
+        },
+        "max_tokens" => match value.as_u64() {
+            Some(count) if count > 0 => Ok(count.to_string()),
+            _ => Err(invalid("a positive integer")),
+        },
+        other => Err(invalid(&format!("a known option (internal: '{other}')"))),
     }
 }
 
@@ -774,8 +870,9 @@ mod tests {
     fn test_execute_stage_cloud_target() -> ExecutorResult<()> {
         let mut executor = Executor::new();
 
-        // Create and register mock adapter
-        let mut adapter = MockRuntimeAdapter::with_text_output("cloud response");
+        // A provider-free cloud route is served only by an adapter registered
+        // under the "cloud" name.
+        let mut adapter = MockRuntimeAdapter::with_text_output("cloud response").with_name("cloud");
         adapter.load_model("/mock/model.onnx")?;
         executor.register_adapter(Arc::new(adapter));
 
@@ -784,10 +881,316 @@ mod tests {
 
         let (_output, metadata) = executor.execute_stage(&stage, &input, "cloud")?;
 
-        // Cloud target still routes through the adapter (no provider set = not integration)
         assert_eq!(metadata.target, "cloud");
+        assert_eq!(metadata.adapter, "cloud");
 
         Ok(())
+    }
+
+    #[test]
+    fn cloud_target_without_provider_requires_registered_cloud_adapter() {
+        // Only a local adapter is registered: a provider-free cloud route must
+        // error rather than quietly run on the local adapter.
+        let mut executor = Executor::new();
+        let mut local = MockRuntimeAdapter::with_text_output("local").with_name("onnx");
+        local.load_model("/mock/model.onnx").unwrap();
+        let local = Arc::new(local);
+        executor.register_adapter(local.clone());
+
+        let stage = StageDescriptor::new("motivator");
+        let input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+
+        let result = executor.execute_stage(&stage, &input, "cloud");
+
+        assert!(
+            matches!(result, Err(ExecutorError::AdapterNotFound(_))),
+            "got {result:?}"
+        );
+        assert_eq!(
+            local.call_count(),
+            0,
+            "local adapter must not serve a cloud route"
+        );
+    }
+
+    #[test]
+    fn local_selection_never_picks_the_cloud_adapter() {
+        let mut executor = Executor::new();
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        executor.register_adapter(cloud.clone());
+
+        let stage = StageDescriptor::new("asr");
+        let input = Envelope::new(EnvelopeKind::Audio(vec![0u8; 16]));
+
+        let result = executor.execute_stage(&stage, &input, "local");
+
+        assert!(
+            matches!(result, Err(ExecutorError::AdapterNotFound(_))),
+            "got {result:?}"
+        );
+        assert_eq!(cloud.call_count(), 0);
+    }
+
+    #[test]
+    fn local_fallback_adapter_selection_is_deterministic() {
+        // No "onnx" adapter: the alphabetically-first non-cloud adapter wins,
+        // regardless of HashMap iteration order.
+        let mut executor = Executor::new();
+        for name in ["zeta", "alpha", "cloud", "mid"] {
+            let mut adapter = MockRuntimeAdapter::with_text_output(name).with_name(name);
+            adapter.load_model("/mock/model").unwrap();
+            executor.register_adapter(Arc::new(adapter));
+        }
+
+        assert_eq!(executor.select_local_adapter().unwrap(), "alpha");
+
+        let stage = StageDescriptor::new("asr");
+        let input = Envelope::new(EnvelopeKind::Audio(vec![0u8; 16]));
+        let (output, metadata) = executor.execute_stage(&stage, &input, "local").unwrap();
+        assert_eq!(metadata.adapter, "alpha");
+        assert_eq!(output.as_text(), Some("alpha"));
+    }
+
+    fn hybrid_stage(bundle_path: Option<&str>) -> StageDescriptor {
+        let mut options = crate::pipeline::StageOptions::new();
+        options.set("cloud_model", "deepseek-flash");
+        options.set("system_prompt", "Be terse.");
+        options.set("temperature", 0.0);
+        options.set("max_tokens", 16);
+        options.set("thinking", "disabled");
+        options.set("gateway_url", "http://127.0.0.1:9/v1");
+        options.set("api_key", "$DEEPSEEK_API_KEY");
+        let mut stage = StageDescriptor::new("llm")
+            .with_model("functiongemma-270m-it")
+            .with_target(crate::pipeline::ExecutionTarget::Auto)
+            .with_provider(crate::pipeline::IntegrationProvider::DeepSeek)
+            .with_options(options);
+        stage.bundle_path = bundle_path.map(str::to_string);
+        stage
+    }
+
+    #[test]
+    fn cloud_target_with_provider_uses_cloud_adapter_and_cloud_model() {
+        let mut executor = Executor::new();
+        let mut cloud =
+            MockRuntimeAdapter::with_text_output("FAKE_DEEPSEEK_REPLY").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        executor.register_adapter(cloud.clone());
+        let mut local = MockRuntimeAdapter::with_text_output("local").with_name("onnx");
+        local.load_model("/mock/model.onnx").unwrap();
+        let local = Arc::new(local);
+        executor.register_adapter(local.clone());
+
+        let stage = hybrid_stage(None);
+        let input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+
+        let (output, metadata) = executor.execute_stage(&stage, &input, "cloud").unwrap();
+
+        assert_eq!(output.as_text(), Some("FAKE_DEEPSEEK_REPLY"));
+        assert_eq!(metadata.adapter, "cloud:deepseek:gateway");
+        assert_eq!(metadata.target, "cloud");
+        assert_eq!(local.call_count(), 0);
+
+        let sent = cloud.captured_inputs();
+        assert_eq!(sent.len(), 1);
+        let meta = &sent[0].metadata;
+        // Effective cloud model, not the local bundle id.
+        assert_eq!(
+            meta.get("model").map(String::as_str),
+            Some("deepseek-flash")
+        );
+        assert_eq!(meta.get("provider").map(String::as_str), Some("deepseek"));
+        assert_eq!(meta.get("thinking").map(String::as_str), Some("disabled"));
+        assert_eq!(
+            meta.get("gateway_url").map(String::as_str),
+            Some("http://127.0.0.1:9/v1")
+        );
+        assert_eq!(
+            meta.get("api_key").map(String::as_str),
+            Some("$DEEPSEEK_API_KEY")
+        );
+        // Shared generation options arrive via prepare_stage_input.
+        assert_eq!(
+            meta.get("system_prompt").map(String::as_str),
+            Some("Be terse.")
+        );
+        assert_eq!(meta.get("temperature").map(String::as_str), Some("0"));
+        assert_eq!(meta.get("max_tokens").map(String::as_str), Some("16"));
+    }
+
+    #[test]
+    fn local_target_with_provider_but_no_bundle_errors_without_calling_adapters() {
+        let mut executor = Executor::new();
+        let mut local = MockRuntimeAdapter::with_text_output("local").with_name("onnx");
+        local.load_model("/mock/model.onnx").unwrap();
+        let local = Arc::new(local);
+        executor.register_adapter(local.clone());
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        executor.register_adapter(cloud.clone());
+
+        let stage = hybrid_stage(None);
+        let input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+
+        let err = executor
+            .execute_stage(&stage, &input, "local")
+            .expect_err("hybrid stage without a bundle cannot run locally");
+
+        assert!(
+            matches!(err, ExecutorError::ExecutionFailed(_)),
+            "got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("routed local but has no local bundle"),
+            "{msg}"
+        );
+        assert!(msg.contains("llm"), "{msg}");
+        assert_eq!(
+            local.call_count(),
+            0,
+            "raw adapter must not substitute for the bundle"
+        );
+        assert_eq!(cloud.call_count(), 0, "cloud must not be retried");
+    }
+
+    #[test]
+    fn local_target_with_provider_and_invalid_bundle_errors() {
+        let mut executor = Executor::new();
+        let mut local = MockRuntimeAdapter::with_text_output("local").with_name("onnx");
+        local.load_model("/mock/model.onnx").unwrap();
+        let local = Arc::new(local);
+        executor.register_adapter(local.clone());
+
+        // An existing directory with no model_metadata.json is not a bundle.
+        let empty_dir = tempfile::tempdir().unwrap();
+        let stage = hybrid_stage(Some(empty_dir.path().to_str().unwrap()));
+        let input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+
+        let err = executor
+            .execute_stage(&stage, &input, "local")
+            .expect_err("invalid hybrid bundle must not fall through");
+        assert!(
+            matches!(err, ExecutorError::ExecutionFailed(_)),
+            "got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("missing model_metadata.json"),
+            "{err}"
+        );
+        assert_eq!(local.call_count(), 0);
+
+        // A missing directory is rejected the same way.
+        let stage = hybrid_stage(Some("/definitely/not/here"));
+        let err = executor
+            .execute_stage(&stage, &input, "local")
+            .expect_err("missing hybrid bundle must not fall through");
+        assert!(
+            matches!(err, ExecutorError::ExecutionFailed(_)),
+            "got {err:?}"
+        );
+        assert_eq!(local.call_count(), 0);
+    }
+
+    #[test]
+    fn prepare_stage_input_applies_stage_options_when_input_is_silent() {
+        let stage = hybrid_stage(None);
+        let input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+
+        let prepared = prepare_stage_input(&stage, &input).unwrap();
+
+        assert_eq!(prepared.as_text(), Some("Hello"));
+        assert_eq!(
+            prepared.metadata.get("system_prompt").map(String::as_str),
+            Some("Be terse.")
+        );
+        assert_eq!(
+            prepared.metadata.get("temperature").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            prepared.metadata.get("max_tokens").map(String::as_str),
+            Some("16")
+        );
+        // Transport keys are NOT shared generation options.
+        assert!(!prepared.metadata.contains_key("gateway_url"));
+        assert!(!prepared.metadata.contains_key("cloud_model"));
+        assert!(!prepared.metadata.contains_key("thinking"));
+        // The prepared values are what the local LLM strategy parses.
+        let params = crate::execution::strategies::LlmGenerationParams::from_envelope_metadata(
+            &prepared.metadata,
+        );
+        assert_eq!(params.max_tokens, 16);
+        assert_eq!(params.temperature, 0.0);
+        assert_eq!(params.system_prompt.as_deref(), Some("Be terse."));
+    }
+
+    #[test]
+    fn prepare_stage_input_keeps_explicit_input_metadata() {
+        let stage = hybrid_stage(None);
+        let mut input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+        input
+            .metadata
+            .insert("max_tokens".to_string(), "512".to_string());
+        input
+            .metadata
+            .insert("unrelated".to_string(), "kept".to_string());
+
+        let prepared = prepare_stage_input(&stage, &input).unwrap();
+
+        // Caller/CLI override wins over YAML.
+        assert_eq!(
+            prepared.metadata.get("max_tokens").map(String::as_str),
+            Some("512")
+        );
+        // YAML still fills the keys the caller left unset.
+        assert_eq!(
+            prepared.metadata.get("temperature").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            prepared.metadata.get("unrelated").map(String::as_str),
+            Some("kept")
+        );
+
+        // No options at all: the input is returned untouched.
+        let bare = StageDescriptor::new("bare");
+        let untouched = prepare_stage_input(&bare, &input).unwrap();
+        assert_eq!(untouched.metadata, input.metadata);
+    }
+
+    #[test]
+    fn prepare_stage_input_rejects_invalid_options() {
+        let cases: [(&str, serde_json::Value, &str); 6] = [
+            (
+                "temperature",
+                serde_json::json!("hot"),
+                "non-negative number",
+            ),
+            (
+                "temperature",
+                serde_json::json!(-0.5),
+                "non-negative number",
+            ),
+            ("top_p", serde_json::json!(true), "non-negative number"),
+            ("max_tokens", serde_json::json!(0), "positive integer"),
+            ("max_tokens", serde_json::json!(1.5), "positive integer"),
+            ("system_prompt", serde_json::json!(42), "a string"),
+        ];
+        let input = Envelope::new(EnvelopeKind::Text("Hello".to_string()));
+        for (key, value, expected) in cases {
+            let mut options = crate::pipeline::StageOptions::new();
+            options.values.insert(key.to_string(), value.clone());
+            let stage = StageDescriptor::new("llm").with_options(options);
+            let err = prepare_stage_input(&stage, &input)
+                .expect_err(&format!("{key}={value} must be rejected"));
+            let msg = err.to_string();
+            assert!(msg.contains(key) && msg.contains(expected), "{msg}");
+        }
     }
 
     #[test]
@@ -822,22 +1225,20 @@ mod tests {
     }
 
     #[test]
-    fn test_select_adapter() {
+    fn test_select_local_adapter_prefers_onnx() {
         let mut executor = Executor::new();
-        let adapter = Arc::new(OnnxRuntimeAdapter::new());
-        executor.register_adapter(adapter);
+        executor.register_adapter(Arc::new(OnnxRuntimeAdapter::new()));
+        let mut other = MockRuntimeAdapter::with_text_output("x").with_name("aaa");
+        other.load_model("/mock").unwrap();
+        executor.register_adapter(Arc::new(other));
 
-        // Test local target
-        let adapter_name = executor.select_adapter("local").unwrap();
-        assert_eq!(adapter_name, "onnx");
+        assert_eq!(executor.select_local_adapter().unwrap(), "onnx");
 
-        // Test cloud target
-        let adapter_name = executor.select_adapter("cloud").unwrap();
-        assert_eq!(adapter_name, "onnx");
-
-        // Test invalid target
-        let result = executor.select_adapter("invalid");
-        assert!(matches!(result, Err(ExecutorError::InvalidTarget(_))));
+        let empty = Executor::new();
+        assert!(matches!(
+            empty.select_local_adapter(),
+            Err(ExecutorError::AdapterNotFound(_))
+        ));
     }
 
     // ============================================================================

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -270,19 +270,23 @@ impl Orchestrator {
     ) -> OrchestratorResult<StageExecutionResult> {
         let _start_time = std::time::Instant::now();
 
-        // Step 1: Receive input envelope
+        // Step 1: Prepare the input once (shared generation options), then
+        // evaluate policy and resolve the target in ONE authority call so the
+        // policy event, the routing event and the dispatch target agree.
+        //
+        // Preparation runs before `StageStart`: a validation failure must not
+        // publish a stage start that never gets a terminal event, and
+        // `ExecutionFailed` carries a routed target that does not exist yet.
+        let prepared_input = prepare_stage_input(stage, input)
+            .map_err(|e| OrchestratorError::ExecutionFailed(e.to_string()))?;
+
+        // Step 2: Receive input envelope
         // Emit stage start event
         self.event_bus.publish(OrchestratorEvent::StageStart {
             stage_name: stage.name.clone(),
             context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_stage_start(&stage.name);
-
-        // Step 2: Prepare the input once (shared generation options), then
-        // evaluate policy and resolve the target in ONE authority call so the
-        // policy event, the routing event and the dispatch target agree.
-        let prepared_input = prepare_stage_input(stage, input)
-            .map_err(|e| OrchestratorError::ExecutionFailed(e.to_string()))?;
         let policy_request = PolicyRequest {
             stage_id: stage.name.clone(),
             envelope: prepared_input.clone(),
@@ -518,18 +522,18 @@ impl Orchestrator {
         metrics: &DeviceMetrics,
         availability: &LocalAvailability,
     ) -> OrchestratorResult<StageExecutionResult> {
+        // Prepare before `StageStart` (consistent with sync execute_stage): a
+        // validation failure must not leave a start event without a terminal
+        // counterpart, and no target exists yet to attach to `ExecutionFailed`.
+        let prepared_input = prepare_stage_input(stage, input)
+            .map_err(|e| OrchestratorError::ExecutionFailed(e.to_string()))?;
+
         // Emit stage start event (consistent with sync execute_stage)
         self.event_bus.publish(OrchestratorEvent::StageStart {
             stage_name: stage.name.clone(),
             context: Self::event_context_for_stage(stage),
         });
         self.telemetry.log_stage_start(&stage.name);
-
-        // Step 2: Prepare the input once (shared generation options), then
-        // evaluate policy and resolve the target in ONE authority call so the
-        // policy event, the routing event and the dispatch target agree.
-        let prepared_input = prepare_stage_input(stage, input)
-            .map_err(|e| OrchestratorError::ExecutionFailed(e.to_string()))?;
         let policy_request = PolicyRequest {
             stage_id: stage.name.clone(),
             envelope: prepared_input.clone(),
@@ -1275,6 +1279,64 @@ mod tests {
         let orchestrator = Orchestrator::new();
         let _bus = orchestrator.event_bus();
         // Just verify we can access the event bus
+    }
+
+    /// A stage whose declared options fail `prepare_stage_input`.
+    fn invalid_generation_options_stage() -> StageDescriptor {
+        let mut options = crate::pipeline::StageOptions::new();
+        options.set("max_tokens", 0_u32);
+        StageDescriptor::new("llm")
+            .with_model("functiongemma-270m-it")
+            .with_target(ExecutionTarget::Device)
+            .with_options(options)
+    }
+
+    #[test]
+    fn prepare_failure_publishes_no_stage_start_sync() {
+        let mut orchestrator = Orchestrator::new();
+        let subscription = orchestrator.event_bus().subscribe();
+        let stage = invalid_generation_options_stage();
+        let input = text_envelope("hello");
+        let availability = LocalAvailability::new(true);
+
+        let result =
+            orchestrator.execute_stage(&stage, &input, &local_routing_metrics(), &availability);
+
+        assert!(matches!(result, Err(OrchestratorError::ExecutionFailed(_))));
+        assert!(
+            matches!(
+                subscription.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ),
+            "a stage that never starts must not publish StageStart (or any other event)"
+        );
+    }
+
+    #[test]
+    fn prepare_failure_publishes_no_stage_start_async() {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let mut orchestrator = Orchestrator::new();
+                let subscription = orchestrator.event_bus().subscribe();
+                let stage = invalid_generation_options_stage();
+                let input = text_envelope("hello");
+                let availability = LocalAvailability::new(true);
+
+                let result = orchestrator
+                    .execute_stage_async(&stage, &input, &local_routing_metrics(), &availability)
+                    .await;
+
+                assert!(matches!(result, Err(OrchestratorError::ExecutionFailed(_))));
+                assert!(
+                    matches!(
+                        subscription.try_recv(),
+                        Err(std::sync::mpsc::TryRecvError::Empty)
+                    ),
+                    "async prep failure must not publish StageStart (or any other event)"
+                );
+            });
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -1058,12 +1058,22 @@ mod tests {
             )),
         };
 
-        // Register a mock adapter that returns text output
-        let mut adapter = MockRuntimeAdapter::with_text_output("mock output");
-        adapter.load_model("/mock/model.onnx").unwrap();
+        // Register named mock adapters for both legs. The executor keys its
+        // default local/cloud adapters on "onnx"/"cloud" and never serves a
+        // local route from the cloud adapter (or vice versa), so both must
+        // be present for pipelines that mix local and cloud-routed stages.
+        let mut local_adapter =
+            MockRuntimeAdapter::with_text_output("mock output").with_name("onnx");
+        local_adapter.load_model("/mock/model.onnx").unwrap();
         orchestrator
             .executor_mut()
-            .register_adapter(Arc::new(adapter));
+            .register_adapter(Arc::new(local_adapter));
+        let mut cloud_adapter =
+            MockRuntimeAdapter::with_text_output("mock cloud output").with_name("cloud");
+        cloud_adapter.load_model("/mock/cloud").unwrap();
+        orchestrator
+            .executor_mut()
+            .register_adapter(Arc::new(cloud_adapter));
 
         orchestrator
     }

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -16,9 +16,10 @@
 //!
 //! ## Runtime Flow
 //!
-//! 1. Receive input envelope
-//! 2. Evaluate policy
-//! 3. Decide route
+//! 1. Receive input envelope and apply the stage's shared generation options
+//! 2. Evaluate policy and decide the route in one authority call
+//!    (one policy evaluation, one resource snapshot; policy restricts the target)
+//! 3. Re-check the policy/target consistency at dispatch
 //! 4. Execute model (delegates to [`Executor`])
 //! 5. Emit telemetry
 //!
@@ -40,7 +41,7 @@ pub use authority::{
     AbortReason, AuthorityDecision, DecisionSource, ExecutionOutcome, LocalAuthority,
     ModelConstraints, ModelRequest, ModelSelection, ModelSource, OrchestrationAuthority,
     OutcomeCategory, PolicyOutcome, PolicyRequest, RemoteAuthority, ResolvedTarget, SignalContext,
-    StageContext, TargetResolution,
+    StageContext, StageResolution, TargetResolution,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -51,15 +52,13 @@ use crate::context::{DeviceMetrics, StageDescriptor};
 use crate::control_sync::ControlSync;
 use crate::device::ResourceMonitor;
 use crate::event_bus::{EventBus, EventContext, OrchestratorEvent};
+use crate::executor::prepare_stage_input;
 use crate::executor::{Executor, ExecutorError};
 use crate::ir::Envelope;
 use crate::streaming::manager::{StreamManager, StreamManagerConfig as StreamConfig};
 use crate::telemetry::Telemetry;
 use crate::tracing as trace;
-use policy_engine::{DefaultPolicyEngine, PolicyEngine};
-use routing_engine::{
-    DefaultRoutingEngine, LocalAvailability, RouteTarget, RoutingDecision, RoutingEngine,
-};
+use routing_engine::{LocalAvailability, RouteTarget, RoutingDecision};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::task;
@@ -91,6 +90,10 @@ pub struct StageExecutionResult {
     pub output: Envelope,
     pub routing_decision: RoutingDecision,
     pub latency_ms: u32,
+    /// Adapter that actually served the stage (e.g. `template-executor`,
+    /// `cloud:deepseek:gateway`). The routing decision is what was chosen;
+    /// this is what ran.
+    pub adapter: String,
 }
 
 /// Execution mode for the orchestrator.
@@ -126,10 +129,6 @@ pub struct Orchestrator {
     /// The orchestration authority for routing and policy decisions.
     /// Default: LocalAuthority (offline, no phone-home).
     authority: Box<dyn OrchestrationAuthority>,
-    /// Policy engine for backward compatibility (load_policies, redact).
-    policy_engine: Box<dyn PolicyEngine>,
-    /// Routing engine for backward compatibility (record_feedback).
-    routing_engine: Box<dyn RoutingEngine>,
     executor: Executor,
     stream_manager: StreamManager,
     event_bus: EventBus,
@@ -177,8 +176,6 @@ impl Orchestrator {
     /// Creates a new orchestrator with custom components.
     pub fn with_all(
         authority: Box<dyn OrchestrationAuthority>,
-        policy_engine: Box<dyn PolicyEngine>,
-        routing_engine: Box<dyn RoutingEngine>,
         executor: Executor,
         stream_manager: StreamManager,
         event_bus: EventBus,
@@ -189,8 +186,6 @@ impl Orchestrator {
     ) -> Self {
         Self {
             authority,
-            policy_engine,
-            routing_engine,
             executor,
             stream_manager,
             event_bus,
@@ -226,32 +221,6 @@ impl Orchestrator {
         let resource_monitor = ResourceMonitor::global();
         Self {
             authority,
-            policy_engine: Box::new(DefaultPolicyEngine::with_default_policy()),
-            routing_engine: Box::new(DefaultRoutingEngine::new()),
-            executor: Executor::new(),
-            stream_manager: StreamManager::new(),
-            event_bus: EventBus::new(),
-            telemetry,
-            resource_monitor,
-            control_sync: None,
-            execution_mode: ExecutionMode::Batch,
-        }
-    }
-
-    /// Creates a new orchestrator with custom policy and routing engines.
-    ///
-    /// Note: This uses `LocalAuthority` internally. For custom authority,
-    /// use `with_authority()` instead.
-    pub fn with_engines(
-        policy_engine: Box<dyn PolicyEngine>,
-        routing_engine: Box<dyn RoutingEngine>,
-    ) -> Self {
-        let telemetry = Arc::new(Telemetry::new());
-        let resource_monitor = ResourceMonitor::global();
-        Self {
-            authority: Box::new(LocalAuthority::new()),
-            policy_engine,
-            routing_engine,
             executor: Executor::new(),
             stream_manager: StreamManager::new(),
             event_bus: EventBus::new(),
@@ -270,8 +239,6 @@ impl Orchestrator {
         let resource_monitor = ResourceMonitor::global();
         Self {
             authority: Box::new(LocalAuthority::new()),
-            policy_engine: Box::new(DefaultPolicyEngine::with_default_policy()),
-            routing_engine: Box::new(DefaultRoutingEngine::new()),
             executor: Executor::new(),
             stream_manager: StreamManager::with_config(config),
             event_bus: EventBus::new(),
@@ -311,15 +278,37 @@ impl Orchestrator {
         });
         self.telemetry.log_stage_start(&stage.name);
 
-        // Step 2: Evaluate policy via OrchestrationAuthority
+        // Step 2: Prepare the input once (shared generation options), then
+        // evaluate policy and resolve the target in ONE authority call so the
+        // policy event, the routing event and the dispatch target agree.
+        let prepared_input = prepare_stage_input(stage, input)
+            .map_err(|e| OrchestratorError::ExecutionFailed(e.to_string()))?;
         let policy_request = PolicyRequest {
             stage_id: stage.name.clone(),
-            envelope: input.clone(),
+            envelope: prepared_input.clone(),
             metrics: metrics.clone(),
         };
-        let policy_decision = self.authority.apply_policy(&policy_request);
+        let stage_context = StageContext {
+            stage_id: stage.name.clone(),
+            model_id: Self::effective_model_id(stage),
+            input_kind: prepared_input.kind.clone(),
+            metrics: metrics.clone(),
+            resource_monitor: self.resource_monitor.clone(),
+            explicit_target: stage.target.clone(),
+            local_availability: Some(availability.clone()),
+            device_class: Some(metrics.canonical_device_class()),
+            device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
+        };
+        // Defense in depth: re-apply the policy restriction right before
+        // dispatch, even though the built-in authorities already did.
+        let StageResolution {
+            policy: policy_decision,
+            target: target_resolution,
+        } = self
+            .authority
+            .resolve_stage(&policy_request, &stage_context)
+            .enforced();
         let policy_allowed = policy_decision.result.is_allowed();
-        let needs_transform = matches!(&policy_decision.result, PolicyOutcome::Transform { .. });
 
         // Emit policy evaluation event
         self.event_bus.publish(OrchestratorEvent::PolicyEvaluated {
@@ -333,26 +322,6 @@ impl Orchestrator {
             policy_allowed,
             Some(&policy_decision.reason),
         );
-
-        // Apply redaction if transforms needed (use policy_engine for actual redaction)
-        let mut redacted_input = input.clone();
-        if needs_transform {
-            self.policy_engine.redact(&mut redacted_input);
-        }
-
-        // Step 3: Resolve target via OrchestrationAuthority
-        let stage_context = StageContext {
-            stage_id: stage.name.clone(),
-            model_id: Self::effective_model_id(stage),
-            input_kind: input.kind.clone(),
-            metrics: metrics.clone(),
-            resource_monitor: self.resource_monitor.clone(),
-            explicit_target: stage.target.clone(),
-            local_availability: Some(availability.clone()),
-            device_class: Some(metrics.canonical_device_class()),
-            device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
-        };
-        let target_resolution = self.authority.resolve_target_with_feedback(&stage_context);
 
         // Convert ResolvedTarget to RoutingDecision for backward compatibility
         let routing_decision =
@@ -385,7 +354,9 @@ impl Orchestrator {
             .log_execution_start(&stage.name, &routing_decision.target.to_json_string());
 
         let target = routing_decision.target.to_json_string();
-        let execution_result = self.executor.execute_stage(stage, &redacted_input, &target);
+        let execution_result = self
+            .executor
+            .execute_prepared(stage, &prepared_input, &target);
 
         let (output, stage_metadata, success, error_msg) = match execution_result {
             Ok((out, meta)) => (out, meta, true, None),
@@ -453,10 +424,6 @@ impl Orchestrator {
         );
         self.authority.record_outcome(&outcome);
 
-        // Also record feedback for backward compatibility with routing engine
-        self.routing_engine
-            .record_feedback(&routing_decision, latency_ms);
-
         // Emit stage completion event and telemetry
         self.event_bus.publish(OrchestratorEvent::StageComplete {
             stage_name: stage.name.clone(),
@@ -476,6 +443,7 @@ impl Orchestrator {
             output,
             routing_decision,
             latency_ms,
+            adapter: stage_metadata.adapter,
         })
     }
 
@@ -557,15 +525,37 @@ impl Orchestrator {
         });
         self.telemetry.log_stage_start(&stage.name);
 
-        // Step 2: Evaluate policy via OrchestrationAuthority
+        // Step 2: Prepare the input once (shared generation options), then
+        // evaluate policy and resolve the target in ONE authority call so the
+        // policy event, the routing event and the dispatch target agree.
+        let prepared_input = prepare_stage_input(stage, input)
+            .map_err(|e| OrchestratorError::ExecutionFailed(e.to_string()))?;
         let policy_request = PolicyRequest {
             stage_id: stage.name.clone(),
-            envelope: input.clone(),
+            envelope: prepared_input.clone(),
             metrics: metrics.clone(),
         };
-        let policy_decision = self.authority.apply_policy(&policy_request);
+        let stage_context = StageContext {
+            stage_id: stage.name.clone(),
+            model_id: Self::effective_model_id(stage),
+            input_kind: prepared_input.kind.clone(),
+            metrics: metrics.clone(),
+            resource_monitor: self.resource_monitor.clone(),
+            explicit_target: stage.target.clone(),
+            local_availability: Some(availability.clone()),
+            device_class: Some(metrics.canonical_device_class()),
+            device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
+        };
+        // Defense in depth: re-apply the policy restriction right before
+        // dispatch, even though the built-in authorities already did.
+        let StageResolution {
+            policy: policy_decision,
+            target: target_resolution,
+        } = self
+            .authority
+            .resolve_stage(&policy_request, &stage_context)
+            .enforced();
         let policy_allowed = policy_decision.result.is_allowed();
-        let needs_transform = matches!(&policy_decision.result, PolicyOutcome::Transform { .. });
 
         // Emit policy evaluation event
         self.event_bus.publish(OrchestratorEvent::PolicyEvaluated {
@@ -579,26 +569,6 @@ impl Orchestrator {
             policy_allowed,
             Some(&policy_decision.reason),
         );
-
-        // Apply redaction if transforms needed (use policy_engine for actual redaction)
-        let mut redacted_input = input.clone();
-        if needs_transform {
-            self.policy_engine.redact(&mut redacted_input);
-        }
-
-        // Step 3: Resolve target via OrchestrationAuthority
-        let stage_context = StageContext {
-            stage_id: stage.name.clone(),
-            model_id: Self::effective_model_id(stage),
-            input_kind: input.kind.clone(),
-            metrics: metrics.clone(),
-            resource_monitor: self.resource_monitor.clone(),
-            explicit_target: stage.target.clone(),
-            local_availability: Some(availability.clone()),
-            device_class: Some(metrics.canonical_device_class()),
-            device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
-        };
-        let target_resolution = self.authority.resolve_target_with_feedback(&stage_context);
 
         // Convert ResolvedTarget to RoutingDecision for backward compatibility
         let routing_decision =
@@ -623,7 +593,7 @@ impl Orchestrator {
 
         // Execute model in blocking thread pool (adapter execution may be CPU-bound)
         let stage_clone = stage.clone();
-        let redacted_input_clone = redacted_input.clone();
+        let prepared_input_clone = prepared_input.clone();
         let target = routing_decision.target.to_json_string();
 
         self.event_bus.publish(OrchestratorEvent::ExecutionStarted {
@@ -636,7 +606,7 @@ impl Orchestrator {
 
         let mut executor_clone = self.executor.clone();
         let execution_result = task::spawn_blocking(move || {
-            executor_clone.execute_stage(&stage_clone, &redacted_input_clone, &target)
+            executor_clone.execute_prepared(&stage_clone, &prepared_input_clone, &target)
         })
         .await
         .map_err(|e| OrchestratorError::ExecutionFailed(format!("Task join error: {}", e)))?;
@@ -706,10 +676,6 @@ impl Orchestrator {
         );
         self.authority.record_outcome(&outcome);
 
-        // Also record feedback for backward compatibility with routing engine
-        self.routing_engine
-            .record_feedback(&routing_decision, latency_ms);
-
         // Emit stage completion event
         self.event_bus.publish(OrchestratorEvent::StageComplete {
             stage_name: stage.name.clone(),
@@ -729,6 +695,7 @@ impl Orchestrator {
             output,
             routing_decision,
             latency_ms,
+            adapter: stage_metadata.adapter,
         })
     }
 
@@ -848,10 +815,13 @@ impl Orchestrator {
         self.stream_manager.pop_output_chunk()
     }
 
-    /// Load policies into the policy engine.
+    /// Load (replace) the policy bundle used for every subsequent stage decision.
+    ///
+    /// The bundle is validated and compiled before it replaces the active one;
+    /// on error the previous policy stays in effect.
     pub fn load_policies(&mut self, bundle_bytes: Vec<u8>) -> OrchestratorResult<()> {
-        self.policy_engine
-            .load_policies(bundle_bytes)
+        self.authority
+            .load_policies(&bundle_bytes)
             .map_err(OrchestratorError::PolicyEvaluationFailed)
     }
 
@@ -1105,7 +1075,9 @@ mod tests {
             metrics: DeviceMetrics::default(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
-            local_availability: None,
+            // Hysteresis only matters when a local leg exists; without one
+            // the decision is settled earlier as model_unavailable.
+            local_availability: Some(LocalAvailability::new(true)),
             device_class: None,
             device_class_schema_version: None,
         }
@@ -1395,5 +1367,282 @@ mod tests {
         assert_eq!(outcome.category, None);
         drop(recorded);
         assert_no_hysteresis(&authority, "hard-fail-model");
+    }
+
+    // ── Phase 3: policy is a dispatch invariant ─────────────────────────────
+
+    const DENY_TEXT_POLICY: &[u8] = b"deny_cloud_if:\n  - 'input.kind == \"text\"'\n";
+
+    /// A stage that declares `target: cloud` with a DeepSeek provider and no
+    /// local bundle — the shape a policy denial must refuse to run on cloud.
+    fn explicit_cloud_stage() -> StageDescriptor {
+        StageDescriptor::new("llm")
+            .with_model("functiongemma-270m-it")
+            .with_target(crate::pipeline::ExecutionTarget::Cloud)
+            .with_provider(crate::pipeline::IntegrationProvider::DeepSeek)
+    }
+
+    /// Quiet fixed device plus a capturing "cloud" mock, returned so tests can
+    /// assert on how many cloud calls actually happened.
+    fn orchestrator_with_capturing_cloud() -> (Orchestrator, Arc<MockRuntimeAdapter>) {
+        let mut orchestrator =
+            Orchestrator::with_authority(Box::new(LocalAuthority::new().with_resource_provider(
+                Arc::new(FixedResourceProvider::new(ResourceSnapshot::unknown())),
+            )));
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud output").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        orchestrator.executor_mut().register_adapter(cloud.clone());
+        (orchestrator, cloud)
+    }
+
+    fn routing_events(subscription: &crate::event_bus::Subscription) -> Vec<(String, String)> {
+        let mut routed = Vec::new();
+        while let Ok(event) = subscription.try_recv() {
+            if let OrchestratorEvent::RoutingDecided { target, reason, .. } = event {
+                routed.push((target, reason));
+            }
+        }
+        routed
+    }
+
+    fn policy_events(subscription: &crate::event_bus::Subscription) -> Vec<(bool, Option<String>)> {
+        let mut evaluated = Vec::new();
+        while let Ok(event) = subscription.try_recv() {
+            if let OrchestratorEvent::PolicyEvaluated {
+                allowed, reason, ..
+            } = event
+            {
+                evaluated.push((allowed, reason));
+            }
+        }
+        evaluated
+    }
+
+    #[test]
+    fn load_policies_on_default_orchestrator_reaches_authority() {
+        // Regression: `Orchestrator::load_policies` used to write into a dead
+        // engine while decisions came from the authority's own empty one.
+        let mut orchestrator = Orchestrator::new();
+        let mut local = MockRuntimeAdapter::with_text_output("local output").with_name("onnx");
+        local.load_model("/mock/model.onnx").unwrap();
+        orchestrator
+            .executor_mut()
+            .register_adapter(Arc::new(local));
+        orchestrator
+            .load_policies(DENY_TEXT_POLICY.to_vec())
+            .expect("policy loads");
+        let subscription = orchestrator.event_bus().subscribe();
+
+        // Text input, no local model: without the policy this routes to cloud
+        // (model_unavailable). The policy must force it local instead.
+        let result = orchestrator
+            .execute_stage(
+                &StageDescriptor::new("probe"),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(false),
+            )
+            .expect("local mock serves the stage");
+
+        assert_eq!(result.routing_decision.target.as_str(), "local");
+        assert!(
+            result.routing_decision.reason.contains("policy_deny"),
+            "{}",
+            result.routing_decision.reason
+        );
+        assert_eq!(result.adapter, "onnx");
+        let routed = routing_events(&subscription);
+        assert_eq!(routed.len(), 1);
+        assert_eq!(routed[0].0, "local");
+    }
+
+    #[test]
+    fn policy_deny_overrides_explicit_cloud_stage_in_sync_dispatch() {
+        let (mut orchestrator, cloud) = orchestrator_with_capturing_cloud();
+        orchestrator
+            .load_policies(DENY_TEXT_POLICY.to_vec())
+            .expect("policy loads");
+        let subscription = orchestrator.event_bus().subscribe();
+
+        let err = orchestrator
+            .execute_stage(
+                &explicit_cloud_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect_err("no local bundle: must fail locally, never run on cloud");
+
+        assert!(err.to_string().contains("no local bundle"), "{err}");
+        assert_eq!(cloud.call_count(), 0, "cloud must not be contacted");
+        let routed = routing_events(&subscription);
+        assert_eq!(routed.len(), 1);
+        assert_eq!(routed[0].0, "local");
+        assert!(routed[0].1.contains("policy_deny"), "{}", routed[0].1);
+    }
+
+    #[test]
+    fn policy_deny_overrides_explicit_cloud_stage_in_async_dispatch() {
+        let (mut orchestrator, cloud) = orchestrator_with_capturing_cloud();
+        orchestrator
+            .load_policies(DENY_TEXT_POLICY.to_vec())
+            .expect("policy loads");
+        let subscription = orchestrator.event_bus().subscribe();
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let err = runtime
+            .block_on(orchestrator.execute_stage_async(
+                &explicit_cloud_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            ))
+            .expect_err("no local bundle: must fail locally, never run on cloud");
+
+        assert!(err.to_string().contains("no local bundle"), "{err}");
+        assert_eq!(cloud.call_count(), 0, "cloud must not be contacted");
+        let routed = routing_events(&subscription);
+        assert_eq!(routed.len(), 1);
+        assert_eq!(routed[0].0, "local");
+        assert!(routed[0].1.contains("policy_deny"), "{}", routed[0].1);
+    }
+
+    #[test]
+    fn allowed_explicit_cloud_stage_runs_on_cloud_exactly_once() {
+        let (mut orchestrator, cloud) = orchestrator_with_capturing_cloud();
+        let subscription = orchestrator.event_bus().subscribe();
+
+        let result = orchestrator
+            .execute_stage(
+                &explicit_cloud_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect("cloud mock serves the stage");
+
+        assert_eq!(result.routing_decision.target.as_str(), "cloud");
+        assert_eq!(result.adapter, "cloud:deepseek:gateway");
+        assert_eq!(cloud.call_count(), 1);
+        let sent = cloud.captured_inputs();
+        assert_eq!(
+            sent[0].metadata.get("model").map(String::as_str),
+            Some("functiongemma-270m-it")
+        );
+        let evaluated = policy_events(&subscription);
+        assert_eq!(evaluated.len(), 1);
+        assert!(evaluated[0].0, "policy event must say allowed");
+    }
+
+    #[test]
+    fn contradictory_custom_authority_is_normalized_at_dispatch() {
+        // A custom authority that says "deny" but hands back a cloud target —
+        // and overrides `resolve_stage` without enforcing — must not cause
+        // cloud inference.
+        struct ContradictoryAuthority;
+
+        impl OrchestrationAuthority for ContradictoryAuthority {
+            fn apply_policy(&self, _request: &PolicyRequest) -> AuthorityDecision<PolicyOutcome> {
+                AuthorityDecision::local(
+                    PolicyOutcome::Deny {
+                        reason: "contradictory deny".to_string(),
+                    },
+                    "contradictory deny",
+                )
+            }
+
+            fn resolve_target(&self, _context: &StageContext) -> AuthorityDecision<ResolvedTarget> {
+                AuthorityDecision::local(
+                    ResolvedTarget::Cloud {
+                        provider: "xybrid".to_string(),
+                    },
+                    "contradictory cloud",
+                )
+            }
+
+            fn resolve_stage(
+                &self,
+                request: &PolicyRequest,
+                context: &StageContext,
+            ) -> StageResolution {
+                // Deliberately bypass `StageResolution::new` (which enforces).
+                StageResolution {
+                    policy: self.apply_policy(request),
+                    target: TargetResolution::new(
+                        self.resolve_target(context),
+                        context.model_id.clone(),
+                        None,
+                    ),
+                }
+            }
+
+            fn select_model(&self, request: &ModelRequest) -> AuthorityDecision<ModelSelection> {
+                AuthorityDecision::local(
+                    ModelSelection {
+                        model_id: request.model_id.clone(),
+                        variant: None,
+                        source: ModelSource::Cloud {
+                            provider: "xybrid".to_string(),
+                        },
+                    },
+                    "n/a",
+                )
+            }
+
+            fn name(&self) -> &str {
+                "contradictory"
+            }
+        }
+
+        let mut orchestrator = Orchestrator::with_authority(Box::new(ContradictoryAuthority));
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud output").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        orchestrator.executor_mut().register_adapter(cloud.clone());
+        let subscription = orchestrator.event_bus().subscribe();
+
+        let err = orchestrator
+            .execute_stage(
+                &explicit_cloud_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect_err("denied stage without a bundle fails locally");
+
+        assert!(err.to_string().contains("no local bundle"), "{err}");
+        assert_eq!(cloud.call_count(), 0);
+        let routed = routing_events(&subscription);
+        assert_eq!(routed[0].0, "local");
+        assert!(routed[0].1.contains("policy_deny"), "{}", routed[0].1);
+        assert!(routed[0].1.contains("overrode"), "{}", routed[0].1);
+    }
+
+    #[test]
+    fn invalid_policy_reload_is_rejected_and_previous_policy_holds() {
+        let (mut orchestrator, cloud) = orchestrator_with_capturing_cloud();
+        orchestrator
+            .load_policies(DENY_TEXT_POLICY.to_vec())
+            .expect("policy loads");
+
+        let err = orchestrator
+            .load_policies(b"deny_cloud_if:\n  - 'metrics.network_rtt > 1'\n".to_vec())
+            .expect_err("unknown operand is rejected");
+        assert!(
+            matches!(err, OrchestratorError::PolicyEvaluationFailed(ref msg) if msg.contains("unknown operand")),
+            "{err:?}"
+        );
+
+        let err = orchestrator
+            .execute_stage(
+                &explicit_cloud_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect_err("still denied");
+        assert!(err.to_string().contains("no local bundle"), "{err}");
+        assert_eq!(cloud.call_count(), 0);
     }
 }

--- a/crates/xybrid-core/src/orchestrator.rs
+++ b/crates/xybrid-core/src/orchestrator.rs
@@ -1005,6 +1005,18 @@ mod tests {
             self.inner.record_outcome(outcome);
         }
 
+        fn load_policies(&self, bundle: &[u8]) -> Result<(), String> {
+            self.inner.load_policies(bundle)
+        }
+
+        fn resolve_stage(
+            &self,
+            request: &PolicyRequest,
+            context: &StageContext,
+        ) -> StageResolution {
+            self.inner.resolve_stage(request, context)
+        }
+
         fn name(&self) -> &str {
             "recording"
         }
@@ -1107,6 +1119,13 @@ mod tests {
     #[test]
     fn test_execute_single_stage() {
         let mut orchestrator = Orchestrator::new();
+        // Bootstrap registers the real cloud adapter; a provider-free cloud
+        // route needs an explicitly registered "cloud" adapter to serve it.
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud output").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        orchestrator
+            .executor_mut()
+            .register_adapter(Arc::new(cloud));
         let stage = StageDescriptor::new("test_stage");
         let input = text_envelope("Text");
         let metrics = DeviceMetrics::default();
@@ -1164,6 +1183,11 @@ mod tests {
         // actually exists locally. Since there's no actual model for "test_stage",
         // it routes to cloud for execution.
         let mut orchestrator = Orchestrator::new();
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud output").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        orchestrator
+            .executor_mut()
+            .register_adapter(Arc::new(cloud));
         let stage = StageDescriptor::new("test_stage");
         let input = audio_envelope(&[9, 9, 9, 9]);
         let metrics = DeviceMetrics::default();
@@ -1643,6 +1667,320 @@ mod tests {
             )
             .expect_err("still denied");
         assert!(err.to_string().contains("no local bundle"), "{err}");
+        assert_eq!(cloud.call_count(), 0);
+    }
+
+    // ── Phase 8: enforcement matrix with real call counts ───────────────────
+
+    fn stressed_snapshot() -> ResourceSnapshot {
+        let mut snapshot = ResourceSnapshot::unknown();
+        snapshot.memory_pressure = crate::device::MemoryPressure::Critical;
+        snapshot
+    }
+
+    /// A hybrid stage: local model id + DeepSeek cloud leg, `target: auto`.
+    /// No bundle is attached, so a *local* route fails at the executor — the
+    /// intended boundary for a denied input that has no usable local leg.
+    fn hybrid_auto_stage() -> StageDescriptor {
+        let mut options = crate::pipeline::StageOptions::new();
+        options.set("cloud_model", "deepseek-flash");
+        StageDescriptor::new("llm")
+            .with_model("functiongemma-270m-it")
+            .with_provider(crate::pipeline::IntegrationProvider::DeepSeek)
+            .with_target(crate::pipeline::ExecutionTarget::Auto)
+            .with_options(options)
+    }
+
+    /// Orchestrator around a shared `LocalAuthority` (so tests can prime
+    /// hysteresis/history and reload policies through the same instance) with
+    /// a capturing cloud mock and a loaded local mock.
+    fn matrix_orchestrator(
+        snapshot: ResourceSnapshot,
+    ) -> (
+        Orchestrator,
+        Arc<LocalAuthority>,
+        Arc<MockRuntimeAdapter>,
+        Arc<MockRuntimeAdapter>,
+    ) {
+        let inner = Arc::new(
+            LocalAuthority::new()
+                .with_resource_provider(Arc::new(FixedResourceProvider::new(snapshot)))
+                .with_history_bias_k(3),
+        );
+        let mut orchestrator = Orchestrator::with_authority(Box::new(RecordingAuthority::new(
+            inner.clone(),
+            Arc::new(Mutex::new(Vec::new())),
+        )));
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud output").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        orchestrator.executor_mut().register_adapter(cloud.clone());
+        let mut local = MockRuntimeAdapter::with_text_output("local output").with_name("onnx");
+        local.load_model("/mock/model.onnx").unwrap();
+        let local = Arc::new(local);
+        orchestrator.executor_mut().register_adapter(local.clone());
+        (orchestrator, inner, cloud, local)
+    }
+
+    fn prime_local_failures(authority: &LocalAuthority, model_id: &str) {
+        authority.record_abort_for_hysteresis_default_ttl(model_id, AbortReason::StressMemory);
+        for idx in 0..3 {
+            authority.record_outcome(&ExecutionOutcome {
+                stage_id: "llm".to_string(),
+                target: ResolvedTarget::Device,
+                latency_ms: 10,
+                success: false,
+                error: Some(format!("failure-{idx}")),
+                category: Some(OutcomeCategory::HardFail {
+                    reason: "local_failed".to_string(),
+                }),
+                model_id: Some(model_id.to_string()),
+                signal_context: Some(SignalContext::from_metrics(
+                    &DeviceMetrics::default().with_live_snapshot(stressed_snapshot()),
+                )),
+            });
+        }
+    }
+
+    #[test]
+    fn deny_beats_hysteresis_history_stress_and_missing_model_with_zero_cloud_calls() {
+        for (policy, expected_prefix) in [
+            (DENY_TEXT_POLICY.to_vec(), "policy_deny"),
+            (
+                b"rules:\n  - id: scrub\n    expression: 'input.kind == \"text\"'\n    action: redact\n"
+                    .to_vec(),
+                "policy_transform_unsupported",
+            ),
+        ] {
+            let (mut orchestrator, inner, cloud, local) = matrix_orchestrator(stressed_snapshot());
+            orchestrator.load_policies(policy).expect("policy loads");
+            prime_local_failures(&inner, "functiongemma-270m-it");
+            let subscription = orchestrator.event_bus().subscribe();
+
+            for available in [true, false] {
+                let err = orchestrator
+                    .execute_stage(
+                        &hybrid_auto_stage(),
+                        &text_envelope("hello"),
+                        &DeviceMetrics::default(),
+                        &LocalAvailability::new(available),
+                    )
+                    .expect_err("no local bundle: the denied stage must fail locally");
+                assert!(err.to_string().contains("no local bundle"), "{err}");
+            }
+
+            assert_eq!(cloud.call_count(), 0, "{expected_prefix}: cloud must never be called");
+            assert_eq!(local.call_count(), 0, "a raw adapter must not stand in for the bundle");
+            let routed = routing_events(&subscription);
+            assert_eq!(routed.len(), 2);
+            for (target, reason) in routed {
+                assert_eq!(target, "local");
+                assert!(reason.contains(expected_prefix), "{reason}");
+                assert!(!reason.contains("hysteresis") && !reason.contains("history_bias"));
+            }
+        }
+    }
+
+    #[test]
+    fn route_cloud_with_available_local_runs_cloud_exactly_once() {
+        let (mut orchestrator, _inner, cloud, local) =
+            matrix_orchestrator(ResourceSnapshot::unknown());
+        orchestrator
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n".to_vec())
+            .expect("policy loads");
+
+        let result = orchestrator
+            .execute_stage(
+                &hybrid_auto_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect("cloud mock serves the stage");
+
+        assert_eq!(result.routing_decision.target.as_str(), "cloud");
+        assert!(
+            result
+                .routing_decision
+                .reason
+                .contains("policy_route_cloud"),
+            "{}",
+            result.routing_decision.reason
+        );
+        assert_eq!(result.adapter, "cloud:deepseek:gateway");
+        assert_eq!(cloud.call_count(), 1);
+        assert_eq!(local.call_count(), 0);
+        assert_eq!(
+            cloud.captured_inputs()[0]
+                .metadata
+                .get("model")
+                .map(String::as_str),
+            Some("deepseek-flash")
+        );
+    }
+
+    #[test]
+    fn route_cloud_with_explicit_device_target_stays_local() {
+        let (mut orchestrator, _inner, cloud, _local) =
+            matrix_orchestrator(ResourceSnapshot::unknown());
+        orchestrator
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n".to_vec())
+            .expect("policy loads");
+        let subscription = orchestrator.event_bus().subscribe();
+        let mut stage = hybrid_auto_stage();
+        stage.target = Some(crate::pipeline::ExecutionTarget::Device);
+
+        let err = orchestrator
+            .execute_stage(
+                &stage,
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect_err("explicit device without a bundle fails locally");
+
+        assert!(err.to_string().contains("no local bundle"), "{err}");
+        assert_eq!(cloud.call_count(), 0);
+        let routed = routing_events(&subscription);
+        assert_eq!(routed[0].0, "local");
+        assert!(routed[0].1.contains("Explicit"), "{}", routed[0].1);
+    }
+
+    #[test]
+    fn no_policy_quiet_device_defaults_local_and_stressed_device_offloads() {
+        let (mut orchestrator, _inner, cloud, _local) =
+            matrix_orchestrator(ResourceSnapshot::unknown());
+        // No bundle, so the default-local route fails at the executor — but the
+        // decision itself is what this test pins.
+        let subscription = orchestrator.event_bus().subscribe();
+        let _ = orchestrator.execute_stage(
+            &hybrid_auto_stage(),
+            &text_envelope("hello"),
+            &DeviceMetrics::default(),
+            &LocalAvailability::new(true),
+        );
+        let routed = routing_events(&subscription);
+        assert_eq!(routed[0].0, "local");
+        assert!(routed[0].1.contains("default_local"), "{}", routed[0].1);
+        assert_eq!(cloud.call_count(), 0);
+
+        let (mut orchestrator, _inner, cloud, _local) = matrix_orchestrator(stressed_snapshot());
+        let result = orchestrator
+            .execute_stage(
+                &hybrid_auto_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect("stressed device offloads to the cloud mock");
+        assert_eq!(result.routing_decision.target.as_str(), "cloud");
+        assert!(result.routing_decision.reason.contains("stress_memory"));
+        assert_eq!(cloud.call_count(), 1);
+    }
+
+    #[test]
+    fn policy_reload_switches_routing_between_calls() {
+        let (mut orchestrator, _inner, cloud, _local) =
+            matrix_orchestrator(ResourceSnapshot::unknown());
+        let subscription = orchestrator.event_bus().subscribe();
+
+        orchestrator
+            .load_policies(DENY_TEXT_POLICY.to_vec())
+            .expect("deny loads");
+        let _ = orchestrator.execute_stage(
+            &hybrid_auto_stage(),
+            &text_envelope("hello"),
+            &DeviceMetrics::default(),
+            &LocalAvailability::new(true),
+        );
+        assert_eq!(cloud.call_count(), 0);
+
+        orchestrator
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n".to_vec())
+            .expect("route_cloud loads");
+        let result = orchestrator
+            .execute_stage(
+                &hybrid_auto_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            )
+            .expect("cloud serves after reload");
+        assert_eq!(result.routing_decision.target.as_str(), "cloud");
+        assert_eq!(cloud.call_count(), 1);
+
+        let routed = routing_events(&subscription);
+        assert_eq!(routed.len(), 2);
+        assert_eq!(routed[0].0, "local");
+        assert_eq!(routed[1].0, "cloud");
+    }
+
+    /// Alternates snapshots per read. With one snapshot per decision the
+    /// policy and the routing ladder always see the same device state.
+    #[derive(Debug)]
+    struct AlternatingProvider {
+        reads: std::sync::atomic::AtomicUsize,
+    }
+
+    impl crate::device::ResourceSnapshotProvider for AlternatingProvider {
+        fn current_snapshot(&self, _max_age: std::time::Duration) -> ResourceSnapshot {
+            let n = self.reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n.is_multiple_of(2) {
+                ResourceSnapshot::unknown()
+            } else {
+                stressed_snapshot()
+            }
+        }
+    }
+
+    #[test]
+    fn policy_and_routing_see_the_same_snapshot_when_the_device_changes() {
+        let provider = Arc::new(AlternatingProvider {
+            reads: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut orchestrator = Orchestrator::with_authority(Box::new(
+            LocalAuthority::new().with_resource_provider(provider.clone()),
+        ));
+        let mut cloud = MockRuntimeAdapter::with_text_output("cloud output").with_name("cloud");
+        cloud.load_model("/mock/cloud").unwrap();
+        let cloud = Arc::new(cloud);
+        orchestrator.executor_mut().register_adapter(cloud.clone());
+        // Deny cloud whenever memory is critical: the same condition that
+        // would make the stress ladder *prefer* cloud.
+        orchestrator
+            .load_policies(
+                b"deny_cloud_if:\n  - 'metrics.memory_pressure == \"critical\"'\n".to_vec(),
+            )
+            .expect("policy loads");
+        let subscription = orchestrator.event_bus().subscribe();
+
+        for _ in 0..4 {
+            let _ = orchestrator.execute_stage(
+                &hybrid_auto_stage(),
+                &text_envelope("hello"),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(true),
+            );
+        }
+
+        // Every decision consumed exactly one snapshot ...
+        assert_eq!(
+            provider.reads.load(std::sync::atomic::Ordering::SeqCst),
+            4,
+            "one snapshot per stage decision"
+        );
+        // ... and no decision was split across two states: a critical read is
+        // a denial (local), a quiet read is default local; cloud never wins.
+        let routed = routing_events(&subscription);
+        assert_eq!(routed.len(), 4);
+        for (i, (target, reason)) in routed.iter().enumerate() {
+            assert_eq!(target, "local", "decision {i}: {reason}");
+            if i % 2 == 1 {
+                assert!(reason.contains("policy_deny"), "decision {i}: {reason}");
+            } else {
+                assert!(reason.contains("default_local"), "decision {i}: {reason}");
+            }
+        }
         assert_eq!(cloud.call_count(), 0);
     }
 }

--- a/crates/xybrid-core/src/orchestrator/authority/local.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/local.rs
@@ -6,11 +6,22 @@
 //!
 //! ## How It Works
 //!
-//! `LocalAuthority` wraps the existing `PolicyEngine` and `RoutingEngine`:
+//! `LocalAuthority` owns the one policy engine and wraps the routing ladder:
 //!
-//! - **Policy evaluation**: Delegates to `DefaultPolicyEngine`
-//! - **Target resolution**: Delegates to `DefaultRoutingEngine`, respects explicit targets
-//! - **Model selection**: Uses `CacheProvider` to check availability, falls back to registry
+//! - **One prepared decision**: every stage decision takes exactly one live
+//!   resource snapshot and evaluates the policy exactly once, against the
+//!   actual input envelope. The same prepared values drive the policy event,
+//!   the routing decision, and the feedback signal bucket.
+//! - **Policy is an invariant, not a hint**: when the policy denies cloud (or
+//!   requires a transform that cannot be applied) the target is the device —
+//!   ahead of explicit `cloud`/`server` targets, model availability,
+//!   hysteresis, and reliability history. A stage with no usable local leg
+//!   then fails locally rather than leaking to cloud.
+//! - **Target resolution**: explicit target → local availability → policy
+//!   cloud preference → hysteresis → history bias → the routing ladder
+//!   (device stress, default local).
+//! - **Model selection**: Uses `CacheProvider` to check availability, falls
+//!   back to registry.
 //!
 //! ## Cache Provider
 //!
@@ -29,16 +40,19 @@
 use super::types::*;
 use super::OrchestrationAuthority;
 use crate::cache_provider::{CacheProvider, FilesystemCacheProvider};
-use crate::device::ResourceSnapshotProvider;
+use crate::context::DeviceMetrics;
+use crate::device::{ResourceMonitor, ResourceSnapshot, ResourceSnapshotProvider};
 use crate::ir::Envelope;
-use crate::orchestrator::policy_engine::{DefaultPolicyEngine, PolicyEngine};
+use crate::orchestrator::policy_engine::{
+    DefaultPolicyEngine, PolicyBundle, PolicyEngine, PolicyResult,
+};
 use crate::orchestrator::routing_engine::{
     DefaultRoutingEngine, LocalAvailability, LocalReliabilityHint, RouteTarget, RoutingDecision,
     RoutingEngine,
 };
 use crate::pipeline::ExecutionTarget;
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, Instant};
 
 const DEFAULT_HYSTERESIS_TTL: Duration = Duration::from_secs(30);
@@ -46,6 +60,8 @@ const RELIABILITY_WINDOW: usize = 32;
 const DEFAULT_HISTORY_BIAS_K: usize = 3;
 const MAX_HYSTERESIS_KEYS: usize = 256;
 const MAX_RELIABILITY_KEYS: usize = 256;
+/// Maximum age of a cached resource snapshot before it is refreshed.
+const RESOURCE_SNAPSHOT_MAX_AGE: Duration = Duration::from_millis(500);
 
 /// Local orchestration authority - fully functional offline.
 ///
@@ -66,7 +82,9 @@ const MAX_RELIABILITY_KEYS: usize = 256;
 /// # }
 /// ```
 pub struct LocalAuthority {
-    policy_engine: DefaultPolicyEngine,
+    /// The one policy engine. Reads on the per-stage hot path, writes only
+    /// on `load_policies`; a poisoned lock is recovered rather than panicked.
+    policy_engine: RwLock<DefaultPolicyEngine>,
     /// Wrapped in Mutex for interior mutability (RoutingEngine::decide requires &mut self).
     routing_engine: Mutex<DefaultRoutingEngine>,
     /// Cache provider for checking model availability.
@@ -80,9 +98,18 @@ pub struct LocalAuthority {
     history_bias_k: usize,
 }
 
+/// Everything one stage decision needs, computed exactly once: the live
+/// metrics, the signal bucket derived from them, and the policy result for
+/// the actual input. Shared between `LocalAuthority` and `RemoteAuthority` so
+/// the remote path never re-evaluates or re-samples.
+pub(super) struct PreparedStage {
+    pub(super) metrics: DeviceMetrics,
+    pub(super) signal: SignalContext,
+    pub(super) policy: PolicyResult,
+}
+
 impl LocalAuthority {
-    /// Create a new LocalAuthority with default policy, routing, and cache provider.
-    pub fn new() -> Self {
+    fn build(policy_engine: DefaultPolicyEngine, cache_provider: Arc<dyn CacheProvider>) -> Self {
         // Prewarm the static-capability cache. First call to
         // `detect_capabilities()` can take ~1s on macOS/iOS because
         // `MLAllComputeDevices` lazy-loads Core ML. Doing it here keeps
@@ -90,21 +117,7 @@ impl LocalAuthority {
         // hysteresis check measured in tens of ms).
         crate::device::capabilities::prewarm();
         Self {
-            policy_engine: DefaultPolicyEngine::with_default_policy(),
-            routing_engine: Mutex::new(DefaultRoutingEngine::new()),
-            cache_provider: Arc::new(FilesystemCacheProvider::new()),
-            resource_provider: None,
-            hysteresis: Mutex::new(HashMap::new()),
-            reliability: Mutex::new(HashMap::new()),
-            history_bias_k: DEFAULT_HISTORY_BIAS_K,
-        }
-    }
-
-    /// Create a LocalAuthority with a custom cache provider.
-    pub fn with_cache_provider(cache_provider: Arc<dyn CacheProvider>) -> Self {
-        crate::device::capabilities::prewarm();
-        Self {
-            policy_engine: DefaultPolicyEngine::with_default_policy(),
+            policy_engine: RwLock::new(policy_engine),
             routing_engine: Mutex::new(DefaultRoutingEngine::new()),
             cache_provider,
             resource_provider: None,
@@ -114,18 +127,22 @@ impl LocalAuthority {
         }
     }
 
+    /// Create a new LocalAuthority with default policy, routing, and cache provider.
+    pub fn new() -> Self {
+        Self::build(
+            DefaultPolicyEngine::with_default_policy(),
+            Arc::new(FilesystemCacheProvider::new()),
+        )
+    }
+
+    /// Create a LocalAuthority with a custom cache provider.
+    pub fn with_cache_provider(cache_provider: Arc<dyn CacheProvider>) -> Self {
+        Self::build(DefaultPolicyEngine::with_default_policy(), cache_provider)
+    }
+
     /// Create a LocalAuthority with a custom policy engine.
     pub fn with_policy_engine(policy_engine: DefaultPolicyEngine) -> Self {
-        crate::device::capabilities::prewarm();
-        Self {
-            policy_engine,
-            routing_engine: Mutex::new(DefaultRoutingEngine::new()),
-            cache_provider: Arc::new(FilesystemCacheProvider::new()),
-            resource_provider: None,
-            hysteresis: Mutex::new(HashMap::new()),
-            reliability: Mutex::new(HashMap::new()),
-            history_bias_k: DEFAULT_HISTORY_BIAS_K,
-        }
+        Self::build(policy_engine, Arc::new(FilesystemCacheProvider::new()))
     }
 
     /// Create a LocalAuthority with custom policy engine and cache provider.
@@ -133,16 +150,7 @@ impl LocalAuthority {
         policy_engine: DefaultPolicyEngine,
         cache_provider: Arc<dyn CacheProvider>,
     ) -> Self {
-        crate::device::capabilities::prewarm();
-        Self {
-            policy_engine,
-            routing_engine: Mutex::new(DefaultRoutingEngine::new()),
-            cache_provider,
-            resource_provider: None,
-            hysteresis: Mutex::new(HashMap::new()),
-            reliability: Mutex::new(HashMap::new()),
-            history_bias_k: DEFAULT_HISTORY_BIAS_K,
-        }
+        Self::build(policy_engine, cache_provider)
     }
 
     /// Use an injectable resource provider. Intended for tests and embedded
@@ -172,8 +180,26 @@ impl LocalAuthority {
         self.record_abort_for_hysteresis(model_id, reason, DEFAULT_HYSTERESIS_TTL);
     }
 
+    /// Inspect the active policy bundle (e.g. to report its version and rule
+    /// count). The closure runs under the read lock; keep it short.
+    pub fn with_policy_bundle<R>(&self, f: impl FnOnce(Option<&PolicyBundle>) -> R) -> R {
+        f(self.policy_read().bundle())
+    }
+
+    fn policy_read(&self) -> RwLockReadGuard<'_, DefaultPolicyEngine> {
+        self.policy_engine
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn policy_write(&self) -> RwLockWriteGuard<'_, DefaultPolicyEngine> {
+        self.policy_engine
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// Check if a model exists locally using the cache provider.
-    fn check_model_exists(&self, model_id: &str) -> bool {
+    pub(super) fn check_model_exists(&self, model_id: &str) -> bool {
         self.cache_provider.is_model_cached(model_id)
     }
 
@@ -211,7 +237,11 @@ impl LocalAuthority {
             .unwrap_or_default()
     }
 
-    fn reliability_hint(&self, model_id: &str, signal: SignalContext) -> LocalReliabilityHint {
+    pub(super) fn reliability_hint(
+        &self,
+        model_id: &str,
+        signal: SignalContext,
+    ) -> LocalReliabilityHint {
         let history = self.history_snapshot(model_id, signal);
         if history.is_empty() {
             return LocalReliabilityHint::EMPTY;
@@ -275,6 +305,245 @@ impl LocalAuthority {
             reliability.remove(&victim);
         }
     }
+
+    fn live_snapshot(&self, monitor: &ResourceMonitor) -> ResourceSnapshot {
+        self.resource_provider
+            .as_ref()
+            .map(|provider| provider.current_snapshot(RESOURCE_SNAPSHOT_MAX_AGE))
+            .unwrap_or_else(|| monitor.current_snapshot(RESOURCE_SNAPSHOT_MAX_AGE))
+    }
+
+    /// Take one live snapshot and evaluate the policy once against the actual
+    /// input. Every decision path — standalone policy, target-only, and the
+    /// combined stage decision — goes through here.
+    pub(super) fn prepare_stage(
+        &self,
+        stage_id: &str,
+        envelope: &Envelope,
+        base_metrics: &DeviceMetrics,
+        monitor: &ResourceMonitor,
+    ) -> PreparedStage {
+        let metrics = base_metrics.with_live_snapshot(self.live_snapshot(monitor));
+        let signal = SignalContext::from_metrics(&metrics);
+        let policy = self.policy_read().evaluate(stage_id, envelope, &metrics);
+        PreparedStage {
+            metrics,
+            signal,
+            policy,
+        }
+    }
+
+    /// Convert an engine result into the authority's policy decision.
+    pub(super) fn policy_decision(policy: &PolicyResult) -> AuthorityDecision<PolicyOutcome> {
+        let outcome = if !policy.allowed {
+            PolicyOutcome::Deny {
+                reason: policy
+                    .reason
+                    .clone()
+                    .unwrap_or_else(|| "Policy denied".to_string()),
+            }
+        } else if !policy.transforms_applied.is_empty() {
+            PolicyOutcome::Transform {
+                transforms: policy.transforms_applied.clone(),
+            }
+        } else {
+            PolicyOutcome::Allow
+        };
+        AuthorityDecision {
+            result: outcome,
+            reason: policy
+                .reason
+                .clone()
+                .unwrap_or_else(|| "Local policy evaluation".to_string()),
+            source: DecisionSource::Local,
+            confidence: 1.0, // Local decisions are deterministic
+            timestamp_ms: now_ms(),
+        }
+    }
+
+    fn cloud_target() -> ResolvedTarget {
+        ResolvedTarget::Cloud {
+            provider: "xybrid".to_string(),
+        }
+    }
+
+    fn target_from_route(target: RouteTarget) -> ResolvedTarget {
+        match target {
+            RouteTarget::Local => ResolvedTarget::Device,
+            RouteTarget::Cloud => Self::cloud_target(),
+            // Carry the bare fallback id; the reverse-direction
+            // mapping in resolve_routing_decision (and
+            // Orchestrator::resolved_target_to_routing_decision) will
+            // re-wrap it as RouteTarget::Fallback. The "fallback:"
+            // prefix is added back by RouteTarget::to_json_string /
+            // Display, so synthesizing it here produced "fallback:fallback:<id>"
+            // when the resolution round-tripped through telemetry.
+            RouteTarget::Fallback(id) => ResolvedTarget::Server { endpoint: id },
+        }
+    }
+
+    /// Explicit pipeline target, if one was declared. Consulted only after
+    /// the policy has permitted leaving the device.
+    fn explicit_target(context: &StageContext) -> Option<(ResolvedTarget, String)> {
+        let explicit = context.explicit_target.as_ref()?;
+        let target = match explicit {
+            ExecutionTarget::Device => ResolvedTarget::Device,
+            ExecutionTarget::Server => ResolvedTarget::Server {
+                endpoint: "https://api.xybrid.dev".to_string(),
+            },
+            ExecutionTarget::Cloud => Self::cloud_target(),
+            ExecutionTarget::Auto => return None,
+        };
+        Some((
+            target,
+            format!("Explicit target from pipeline YAML: {:?}", explicit),
+        ))
+    }
+
+    /// Resolve the target from an already-prepared decision.
+    ///
+    /// Precedence: policy local-only → explicit target → local availability →
+    /// policy cloud preference → hysteresis → history bias → routing ladder
+    /// (device stress, default local). The policy is not re-evaluated and no
+    /// second snapshot is taken.
+    pub(super) fn resolve_prepared(
+        &self,
+        context: &StageContext,
+        prepared: PreparedStage,
+    ) -> TargetResolution {
+        let PreparedStage {
+            metrics,
+            signal,
+            policy,
+        } = prepared;
+        let model_id = context.model_id.clone();
+        let hint = self.reliability_hint(&model_id, signal);
+        let finish = |decision: AuthorityDecision<ResolvedTarget>| {
+            TargetResolution::new(decision, model_id.clone(), Some(signal))
+                .with_reliability_hint(hint)
+        };
+
+        // 1. Policy forbids leaving the device. This outranks explicit
+        //    targets, availability, hysteresis and history.
+        if policy.requires_local() {
+            let reason = if !policy.allowed {
+                format!(
+                    "policy_deny: {}",
+                    policy
+                        .reason
+                        .as_deref()
+                        .unwrap_or("policy denied cloud execution")
+                )
+            } else {
+                format!(
+                    "policy_transform_unsupported: {}",
+                    policy.transforms_applied.join(",")
+                )
+            };
+            return finish(AuthorityDecision::local(ResolvedTarget::Device, reason));
+        }
+
+        // 2. A permitted explicit target wins over every preference.
+        if let Some((target, reason)) = Self::explicit_target(context) {
+            return finish(AuthorityDecision::local(target, reason));
+        }
+
+        // 3. No local leg: cloud is the only usable target.
+        let availability = context
+            .local_availability
+            .clone()
+            .unwrap_or_else(|| LocalAvailability::new(self.check_model_exists(&model_id)));
+        if !availability.local_model_exists {
+            return finish(AuthorityDecision::new(
+                Self::cloud_target(),
+                "model_unavailable: local model not found",
+                DecisionSource::Local,
+                0.8,
+            ));
+        }
+
+        // 4. The policy asked for cloud and the local leg exists.
+        if policy.prefers_cloud() {
+            return finish(AuthorityDecision::new(
+                Self::cloud_target(),
+                format!(
+                    "policy_route_cloud: {}",
+                    policy
+                        .reason
+                        .as_deref()
+                        .unwrap_or("policy prefers cloud execution")
+                ),
+                DecisionSource::Local,
+                0.9,
+            ));
+        }
+
+        // 5. Sticky cloud after a recent local abort.
+        if let Some(reason) = self.active_hysteresis_for(&model_id) {
+            return finish(AuthorityDecision::new(
+                Self::cloud_target(),
+                format!(
+                    "hysteresis: recent local abort for model '{}' ({})",
+                    model_id, reason
+                ),
+                DecisionSource::Local,
+                0.9,
+            ));
+        }
+
+        // 6. Recent local failures under this signal bucket.
+        if self.history_bias_should_skip_local(&model_id, signal) {
+            return finish(AuthorityDecision::new(
+                Self::cloud_target(),
+                format!(
+                    "history_bias: recent local failure rate {:.0}% over {} samples",
+                    hint.recent_abort_rate * 100.0,
+                    hint.sample_size
+                ),
+                DecisionSource::Local,
+                0.85,
+            ));
+        }
+
+        // 7. Device stress heuristics, default local. Recover from a poisoned
+        //    lock rather than panicking: this is the per-stage routing hot
+        //    path, so a single panic elsewhere must not turn every subsequent
+        //    routing decision into a crash.
+        let decision = {
+            let mut routing_engine = self
+                .routing_engine
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            routing_engine.decide(&context.stage_id, &metrics, &policy, &availability)
+        };
+
+        finish(AuthorityDecision {
+            result: Self::target_from_route(decision.target),
+            reason: decision.reason,
+            source: DecisionSource::Local,
+            confidence: 0.8, // Heuristic-based, slightly lower confidence
+            timestamp_ms: decision.timestamp_ms,
+        })
+    }
+
+    /// Resolve into the routing-engine decision shape for tests and telemetry adapters.
+    pub fn resolve_routing_decision(&self, context: &StageContext) -> Option<RoutingDecision> {
+        let resolution = self.resolve_target_with_feedback(context);
+        let target = match resolution.decision.result {
+            ResolvedTarget::Device => RouteTarget::Local,
+            ResolvedTarget::Cloud { .. } => RouteTarget::Cloud,
+            ResolvedTarget::Server { endpoint } => RouteTarget::Fallback(endpoint),
+        };
+        Some(RoutingDecision {
+            stage: context.stage_id.clone(),
+            target,
+            reason: resolution.decision.reason,
+            timestamp_ms: resolution.decision.timestamp_ms,
+            local_reliability_hint: resolution
+                .local_reliability_hint
+                .unwrap_or(LocalReliabilityHint::EMPTY),
+        })
+    }
 }
 
 impl Default for LocalAuthority {
@@ -284,39 +553,27 @@ impl Default for LocalAuthority {
 }
 
 impl OrchestrationAuthority for LocalAuthority {
+    fn load_policies(&self, bundle: &[u8]) -> Result<(), String> {
+        // Parse and compile the candidate before taking the write lock, and
+        // swap only on success: an invalid reload leaves the active policy
+        // untouched, and in-flight decisions finish on the engine they read.
+        let mut candidate = DefaultPolicyEngine::new();
+        candidate.load_policies(bundle.to_vec())?;
+        *self.policy_write() = candidate;
+        Ok(())
+    }
+
     fn apply_policy(&self, request: &PolicyRequest) -> AuthorityDecision<PolicyOutcome> {
-        let result =
-            self.policy_engine
-                .evaluate(&request.stage_id, &request.envelope, &request.metrics);
-
-        let outcome = if result.allowed {
-            if result.transforms_applied.is_empty() {
-                PolicyOutcome::Allow
-            } else {
-                PolicyOutcome::Transform {
-                    transforms: result.transforms_applied.clone(),
-                }
-            }
-        } else {
-            PolicyOutcome::Deny {
-                reason: result
-                    .reason
-                    .clone()
-                    .unwrap_or_else(|| "Policy denied".to_string()),
-            }
-        };
-
-        let reason = result
-            .reason
-            .unwrap_or_else(|| "Local policy evaluation".to_string());
-
-        AuthorityDecision {
-            result: outcome,
-            reason,
-            source: DecisionSource::Local,
-            confidence: 1.0, // Local decisions are deterministic
-            timestamp_ms: now_ms(),
-        }
+        // No stage context here, so the process-wide monitor supplies the
+        // live snapshot (the injected provider still wins when present).
+        let monitor = ResourceMonitor::global();
+        let prepared = self.prepare_stage(
+            &request.stage_id,
+            &request.envelope,
+            &request.metrics,
+            &monitor,
+        );
+        Self::policy_decision(&prepared.policy)
     }
 
     fn resolve_target(&self, context: &StageContext) -> AuthorityDecision<ResolvedTarget> {
@@ -324,11 +581,28 @@ impl OrchestrationAuthority for LocalAuthority {
     }
 
     fn resolve_target_with_feedback(&self, context: &StageContext) -> TargetResolution {
-        if let Some(resolution) = self.explicit_target_resolution(context) {
-            return resolution;
-        }
+        // Target-only callers have no request envelope; the input kind
+        // carries the payload, so text rules still see the real text.
+        let envelope = Envelope::new(context.input_kind.clone());
+        let prepared = self.prepare_stage(
+            &context.stage_id,
+            &envelope,
+            &context.metrics,
+            &context.resource_monitor,
+        );
+        self.resolve_prepared(context, prepared)
+    }
 
-        self.resolve_with_routing_engine(context)
+    fn resolve_stage(&self, request: &PolicyRequest, context: &StageContext) -> StageResolution {
+        let prepared = self.prepare_stage(
+            &request.stage_id,
+            &request.envelope,
+            &context.metrics,
+            &context.resource_monitor,
+        );
+        let policy = Self::policy_decision(&prepared.policy);
+        let target = self.resolve_prepared(context, prepared);
+        StageResolution::new(policy, target)
     }
 
     fn select_model(&self, request: &ModelRequest) -> AuthorityDecision<ModelSelection> {
@@ -409,179 +683,6 @@ impl OrchestrationAuthority for LocalAuthority {
             }
             Self::prune_reliability(&mut reliability);
         }
-    }
-}
-
-impl LocalAuthority {
-    fn routing_metrics(&self, context: &StageContext) -> crate::context::DeviceMetrics {
-        let snapshot = self
-            .resource_provider
-            .as_ref()
-            .map(|provider| provider.current_snapshot(Duration::from_millis(500)))
-            .unwrap_or_else(|| {
-                context
-                    .resource_monitor
-                    .current_snapshot(Duration::from_millis(500))
-            });
-        context.metrics.with_live_snapshot(snapshot)
-    }
-
-    fn target_from_route(target: RouteTarget) -> ResolvedTarget {
-        match target {
-            RouteTarget::Local => ResolvedTarget::Device,
-            RouteTarget::Cloud => ResolvedTarget::Cloud {
-                provider: "xybrid".to_string(),
-            },
-            // Carry the bare fallback id; the reverse-direction
-            // mapping in resolve_routing_decision (and
-            // Orchestrator::resolved_target_to_routing_decision) will
-            // re-wrap it as RouteTarget::Fallback. The "fallback:"
-            // prefix is added back by RouteTarget::to_json_string /
-            // Display, so synthesizing it here produced "fallback:fallback:<id>"
-            // when the resolution round-tripped through telemetry.
-            RouteTarget::Fallback(id) => ResolvedTarget::Server { endpoint: id },
-        }
-    }
-
-    fn explicit_target_resolution(&self, context: &StageContext) -> Option<TargetResolution> {
-        let explicit = context.explicit_target.as_ref()?;
-        let target = match explicit {
-            ExecutionTarget::Device => ResolvedTarget::Device,
-            ExecutionTarget::Server => ResolvedTarget::Server {
-                endpoint: "https://api.xybrid.dev".to_string(),
-            },
-            ExecutionTarget::Cloud => ResolvedTarget::Cloud {
-                provider: "xybrid".to_string(),
-            },
-            ExecutionTarget::Auto => return None,
-        };
-
-        let metrics = self.routing_metrics(context);
-        Some(TargetResolution::new(
-            AuthorityDecision {
-                result: target,
-                reason: format!("Explicit target from pipeline YAML: {:?}", explicit),
-                source: DecisionSource::Local,
-                confidence: 1.0,
-                timestamp_ms: now_ms(),
-            },
-            context.model_id.clone(),
-            Some(SignalContext::from_metrics(&metrics)),
-        ))
-    }
-
-    /// Internal: resolve target using the routing engine.
-    fn resolve_with_routing_engine(&self, context: &StageContext) -> TargetResolution {
-        let availability = context
-            .local_availability
-            .clone()
-            .unwrap_or_else(|| LocalAvailability::new(self.check_model_exists(&context.model_id)));
-        self.resolve_with_routing_engine_and_availability(context, availability)
-    }
-
-    fn resolve_with_routing_engine_and_availability(
-        &self,
-        context: &StageContext,
-        availability: LocalAvailability,
-    ) -> TargetResolution {
-        // Create a minimal envelope for policy check
-        let envelope = Envelope::new(context.input_kind.clone());
-        let live_metrics = self.routing_metrics(context);
-        let signal = SignalContext::from_metrics(&live_metrics);
-        let hint = self.reliability_hint(&context.model_id, signal);
-
-        let policy_result =
-            self.policy_engine
-                .evaluate(&context.stage_id, &envelope, &live_metrics);
-
-        if policy_result.allowed {
-            if let Some(reason) = self.active_hysteresis_for(&context.model_id) {
-                let decision = AuthorityDecision {
-                    result: ResolvedTarget::Cloud {
-                        provider: "xybrid".to_string(),
-                    },
-                    reason: format!(
-                        "hysteresis: recent local abort for model '{}' ({})",
-                        context.model_id, reason
-                    ),
-                    source: DecisionSource::Local,
-                    confidence: 0.9,
-                    timestamp_ms: now_ms(),
-                };
-                return TargetResolution::new(decision, context.model_id.clone(), Some(signal))
-                    .with_reliability_hint(hint);
-            }
-
-            if self.history_bias_should_skip_local(&context.model_id, signal) {
-                let decision = AuthorityDecision {
-                    result: ResolvedTarget::Cloud {
-                        provider: "xybrid".to_string(),
-                    },
-                    reason: format!(
-                        "history_bias: recent local failure rate {:.0}% over {} samples",
-                        hint.recent_abort_rate * 100.0,
-                        hint.sample_size
-                    ),
-                    source: DecisionSource::Local,
-                    confidence: 0.85,
-                    timestamp_ms: now_ms(),
-                };
-                return TargetResolution::new(decision, context.model_id.clone(), Some(signal))
-                    .with_reliability_hint(hint);
-            }
-        }
-
-        // Use the stored routing engine (locked for interior mutability).
-        // Recover from a poisoned lock rather than panicking: this is the
-        // per-stage routing hot path, so a single panic elsewhere must not
-        // turn every subsequent routing decision into a crash. Matches the
-        // graceful handling used for `hysteresis`/`reliability` in this file
-        // and `target_cache_guard` in `remote.rs`.
-        let decision = {
-            let mut routing_engine = self
-                .routing_engine
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            routing_engine.decide(
-                &context.stage_id,
-                &live_metrics,
-                &policy_result,
-                &availability,
-            )
-        };
-
-        let target = Self::target_from_route(decision.target);
-        TargetResolution::new(
-            AuthorityDecision {
-                result: target,
-                reason: decision.reason,
-                source: DecisionSource::Local,
-                confidence: 0.8, // Heuristic-based, slightly lower confidence
-                timestamp_ms: decision.timestamp_ms,
-            },
-            context.model_id.clone(),
-            Some(signal),
-        )
-        .with_reliability_hint(hint)
-    }
-
-    /// Resolve into the routing-engine decision shape for tests and telemetry adapters.
-    pub fn resolve_routing_decision(&self, context: &StageContext) -> Option<RoutingDecision> {
-        let resolution = self.resolve_target_with_feedback(context);
-        let target = match resolution.decision.result {
-            ResolvedTarget::Device => RouteTarget::Local,
-            ResolvedTarget::Cloud { .. } => RouteTarget::Cloud,
-            ResolvedTarget::Server { endpoint } => RouteTarget::Fallback(endpoint),
-        };
-        Some(RoutingDecision {
-            stage: context.stage_id.clone(),
-            target,
-            reason: resolution.decision.reason,
-            timestamp_ms: resolution.decision.timestamp_ms,
-            local_reliability_hint: resolution
-                .local_reliability_hint
-                .unwrap_or(LocalReliabilityHint::EMPTY),
-        })
     }
 }
 
@@ -1248,5 +1349,264 @@ signature: "test-deny-all"
                 query, dir_name
             );
         }
+    }
+
+    // ── Phase 3: one evaluated decision, policy as an invariant ────────────
+
+    /// Counts how many snapshots a decision takes.
+    #[derive(Debug)]
+    struct CountingProvider {
+        snapshot: ResourceSnapshot,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ResourceSnapshotProvider for CountingProvider {
+        fn current_snapshot(&self, _max_age: Duration) -> ResourceSnapshot {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.snapshot
+        }
+    }
+
+    fn text_request(text: &str) -> PolicyRequest {
+        PolicyRequest {
+            stage_id: "test-stage".to_string(),
+            envelope: text_envelope(text),
+            metrics: default_metrics(),
+        }
+    }
+
+    fn cached_authority() -> LocalAuthority {
+        LocalAuthority::with_cache_provider(Arc::new(CachedProvider))
+    }
+
+    #[test]
+    fn load_policies_via_trait_denies_cloud() {
+        let authority = cached_authority();
+        authority
+            .load_policies(deny_all_text_policy().as_bytes())
+            .expect("deny policy loads");
+
+        let decision = authority.resolve_target(&text_context());
+        assert_eq!(decision.result, ResolvedTarget::Device);
+        assert!(
+            decision.reason.starts_with("policy_deny"),
+            "{}",
+            decision.reason
+        );
+
+        let resolution = authority.resolve_stage(&text_request("hello"), &text_context());
+        assert!(matches!(
+            resolution.policy.result,
+            PolicyOutcome::Deny { .. }
+        ));
+        assert_eq!(resolution.target.decision.result, ResolvedTarget::Device);
+        assert!(resolution.policy_requires_local());
+    }
+
+    #[test]
+    fn load_policies_via_trait_prefers_cloud() {
+        let authority = cached_authority();
+        authority
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n")
+            .expect("route_cloud policy loads");
+
+        let decision = authority.resolve_target(&text_context());
+        assert!(matches!(decision.result, ResolvedTarget::Cloud { .. }));
+        assert!(
+            decision.reason.starts_with("policy_route_cloud"),
+            "{}",
+            decision.reason
+        );
+        let resolution = authority.resolve_stage(&text_request("hello"), &text_context());
+        assert_eq!(resolution.policy.result, PolicyOutcome::Allow);
+        assert!(matches!(
+            resolution.target.decision.result,
+            ResolvedTarget::Cloud { .. }
+        ));
+    }
+
+    #[test]
+    fn load_policies_rejects_invalid_rule_and_keeps_previous() {
+        let authority = cached_authority();
+        authority
+            .load_policies(deny_all_text_policy().as_bytes())
+            .expect("deny policy loads");
+
+        let err = authority
+            .load_policies(b"deny_cloud_if:\n  - 'metrics.network_rtt > 300'\n")
+            .expect_err("unknown operand must be rejected");
+        assert!(err.contains("unknown operand"), "{err}");
+
+        let decision = authority.resolve_target(&text_context());
+        assert_eq!(decision.result, ResolvedTarget::Device);
+        assert!(
+            decision.reason.starts_with("policy_deny"),
+            "{}",
+            decision.reason
+        );
+        authority.with_policy_bundle(|bundle| {
+            assert_eq!(bundle.unwrap().signature, "test-deny-all");
+        });
+    }
+
+    #[test]
+    fn apply_policy_overlays_live_metrics() {
+        let mut snapshot = ResourceSnapshot::unknown();
+        snapshot.memory_pressure = MemoryPressure::Critical;
+        let authority =
+            cached_authority().with_resource_provider(Arc::new(FixedResourceProvider(snapshot)));
+        authority
+            .load_policies(b"deny_cloud_if:\n  - 'metrics.memory_pressure == \"critical\"'\n")
+            .expect("metrics policy loads");
+
+        // The request carries default (unknown) metrics; the live overlay is
+        // what the rule must see.
+        let decision = authority.apply_policy(&text_request("hello"));
+        assert!(
+            matches!(decision.result, PolicyOutcome::Deny { .. }),
+            "{decision:?}"
+        );
+    }
+
+    #[test]
+    fn policy_deny_overrides_explicit_cloud_and_server_targets() {
+        let authority = cached_authority();
+        authority
+            .load_policies(deny_all_text_policy().as_bytes())
+            .expect("deny policy loads");
+
+        for explicit in [ExecutionTarget::Cloud, ExecutionTarget::Server] {
+            let mut context = text_context();
+            context.explicit_target = Some(explicit.clone());
+            let resolution = authority.resolve_stage(&text_request("hello"), &context);
+            assert_eq!(
+                resolution.target.decision.result,
+                ResolvedTarget::Device,
+                "explicit {explicit:?} must not beat a policy denial"
+            );
+            assert!(
+                resolution.target.decision.reason.starts_with("policy_deny"),
+                "{}",
+                resolution.target.decision.reason
+            );
+        }
+    }
+
+    #[test]
+    fn policy_deny_beats_missing_local_model() {
+        let authority = cached_authority();
+        authority
+            .load_policies(deny_all_text_policy().as_bytes())
+            .expect("deny policy loads");
+        let mut context = text_context();
+        context.local_availability = Some(LocalAvailability::new(false));
+
+        let decision = authority.resolve_target(&context);
+
+        assert_eq!(decision.result, ResolvedTarget::Device);
+        assert!(
+            decision.reason.starts_with("policy_deny"),
+            "{}",
+            decision.reason
+        );
+        assert!(!decision.reason.contains("model_unavailable"));
+    }
+
+    #[test]
+    fn policy_transform_overrides_hysteresis_history_and_explicit_cloud() {
+        let authority = cached_authority().with_history_bias_k(1);
+        authority
+            .load_policies(
+                b"rules:\n  - id: scrub\n    expression: 'input.kind == \"text\"'\n    action: redact\n",
+            )
+            .expect("redact policy loads");
+        authority.record_abort_for_hysteresis_default_ttl("test-model", AbortReason::StressMemory);
+        authority.record_outcome(&ExecutionOutcome {
+            stage_id: "test-stage".to_string(),
+            target: ResolvedTarget::Device,
+            latency_ms: 10,
+            success: false,
+            error: Some("boom".to_string()),
+            category: Some(OutcomeCategory::HardFail {
+                reason: "boom".to_string(),
+            }),
+            model_id: Some("test-model".to_string()),
+            signal_context: Some(signal()),
+        });
+        let mut context = text_context();
+        context.explicit_target = Some(ExecutionTarget::Cloud);
+
+        let resolution = authority.resolve_stage(&text_request("hello"), &context);
+
+        assert!(matches!(
+            resolution.policy.result,
+            PolicyOutcome::Transform { .. }
+        ));
+        assert_eq!(resolution.target.decision.result, ResolvedTarget::Device);
+        assert!(
+            resolution
+                .target
+                .decision
+                .reason
+                .starts_with("policy_transform_unsupported"),
+            "{}",
+            resolution.target.decision.reason
+        );
+    }
+
+    #[test]
+    fn explicit_device_beats_policy_route_cloud() {
+        let authority = cached_authority();
+        authority
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n")
+            .expect("route_cloud policy loads");
+        let mut context = text_context();
+        context.explicit_target = Some(ExecutionTarget::Device);
+
+        let decision = authority.resolve_target(&context);
+
+        assert_eq!(decision.result, ResolvedTarget::Device);
+        assert!(decision.reason.contains("Explicit"), "{}", decision.reason);
+    }
+
+    #[test]
+    fn resolve_stage_takes_one_snapshot_and_keeps_policy_and_target_consistent() {
+        let provider = Arc::new(CountingProvider {
+            snapshot: ResourceSnapshot::unknown(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let authority = cached_authority().with_resource_provider(provider.clone());
+        authority
+            .load_policies(deny_all_text_policy().as_bytes())
+            .expect("deny policy loads");
+
+        let resolution = authority.resolve_stage(&text_request("hello"), &text_context());
+
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a combined decision must sample the device exactly once"
+        );
+        assert!(matches!(
+            resolution.policy.result,
+            PolicyOutcome::Deny { .. }
+        ));
+        assert_eq!(resolution.target.decision.result, ResolvedTarget::Device);
+        assert!(resolution.target.signal_context.is_some());
+    }
+
+    #[test]
+    fn resolve_stage_evaluates_the_full_text_payload() {
+        let authority = cached_authority();
+        authority
+            .load_policies(b"deny_cloud_if:\n  - 'input.text contains \"secret\"'\n")
+            .expect("text policy loads");
+
+        let denied = authority.resolve_stage(&text_request("my secret plan"), &text_context());
+        assert!(matches!(denied.policy.result, PolicyOutcome::Deny { .. }));
+        assert_eq!(denied.target.decision.result, ResolvedTarget::Device);
+
+        let allowed = authority.resolve_stage(&text_request("public notes"), &text_context());
+        assert_eq!(allowed.policy.result, PolicyOutcome::Allow);
     }
 }

--- a/crates/xybrid-core/src/orchestrator/authority/mod.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/mod.rs
@@ -23,7 +23,9 @@
 //! | Method | When Evaluated | Notes |
 //! |--------|----------------|-------|
 //! | `apply_policy()` | Per-request | Security critical, always runs |
-//! | `resolve_target()` | Per-stage | Can react to changing conditions |
+//! | `resolve_stage()` | Per-stage | One policy evaluation + one snapshot; policy restricts the target |
+//! | `resolve_target()` | Per-stage | Target only; can react to changing conditions |
+//! | `load_policies()` | On configuration | Atomic swap of the active bundle |
 //! | `select_model()` | Per-pipeline-load | Stable for session |
 
 mod local;
@@ -97,6 +99,46 @@ pub trait OrchestrationAuthority: Send + Sync {
     /// authorities override this to attach signal buckets or effective model ids.
     fn resolve_target_with_feedback(&self, context: &StageContext) -> TargetResolution {
         TargetResolution::new(self.resolve_target(context), context.model_id.clone(), None)
+    }
+
+    /// Load (replace) the active policy bundle.
+    ///
+    /// Authorities that do not own a policy engine keep this default, which
+    /// returns an error so a caller never believes a bundle took effect when
+    /// it did not. Implementations validate the whole bundle before swapping
+    /// it in; a failed load leaves the previous policy active.
+    fn load_policies(&self, _bundle: &[u8]) -> Result<(), String> {
+        Err("policy loading is not supported by this authority".to_string())
+    }
+
+    /// Decide policy and target for one stage in a single call.
+    ///
+    /// Called: **Per-stage**, with the actual input envelope.
+    ///
+    /// The default evaluates `apply_policy` once and, when the outcome
+    /// forbids leaving the device, returns a device target without consulting
+    /// target resolution at all — so no remote advice is requested for a
+    /// denied input. Otherwise it delegates to `resolve_target_with_feedback`.
+    /// The result is always restricted by the policy outcome; orchestrators
+    /// still call [`StageResolution::enforce`] immediately before dispatch as
+    /// defense in depth against custom implementations.
+    fn resolve_stage(&self, request: &PolicyRequest, context: &StageContext) -> StageResolution {
+        let policy = self.apply_policy(request);
+        let target = if let Some(reason) = policy_local_constraint_reason(&policy.result) {
+            TargetResolution::new(
+                AuthorityDecision::new(
+                    ResolvedTarget::Device,
+                    reason,
+                    policy.source.clone(),
+                    policy.confidence,
+                ),
+                context.model_id.clone(),
+                None,
+            )
+        } else {
+            self.resolve_target_with_feedback(context)
+        };
+        StageResolution::new(policy, target)
     }
 
     /// Select which model variant to use.
@@ -204,5 +246,194 @@ mod tests {
         let decision = authority.apply_policy(&request);
         assert!(decision.result.is_allowed());
         assert_eq!(decision.source, DecisionSource::Default); // Fallback
+    }
+
+    /// Minimal custom authority: implements only the required methods so the
+    /// trait defaults are what gets exercised.
+    struct StaticAuthority {
+        policy: PolicyOutcome,
+        target_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl OrchestrationAuthority for StaticAuthority {
+        fn apply_policy(&self, _request: &PolicyRequest) -> AuthorityDecision<PolicyOutcome> {
+            AuthorityDecision::local(self.policy.clone(), "static policy")
+        }
+
+        fn resolve_target(&self, _context: &StageContext) -> AuthorityDecision<ResolvedTarget> {
+            self.target_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            AuthorityDecision::local(
+                ResolvedTarget::Cloud {
+                    provider: "xybrid".to_string(),
+                },
+                "static cloud",
+            )
+        }
+
+        fn select_model(&self, request: &ModelRequest) -> AuthorityDecision<ModelSelection> {
+            AuthorityDecision::local(
+                ModelSelection {
+                    model_id: request.model_id.clone(),
+                    variant: None,
+                    source: ModelSource::Cloud {
+                        provider: "xybrid".to_string(),
+                    },
+                },
+                "static model",
+            )
+        }
+
+        fn name(&self) -> &str {
+            "static"
+        }
+    }
+
+    fn static_context() -> StageContext {
+        StageContext {
+            stage_id: "test".to_string(),
+            model_id: "m".to_string(),
+            input_kind: EnvelopeKind::Text("hello".to_string()),
+            metrics: default_metrics(),
+            resource_monitor: ResourceMonitor::global(),
+            explicit_target: None,
+            local_availability: Some(crate::orchestrator::routing_engine::LocalAvailability::new(
+                true,
+            )),
+            device_class: None,
+            device_class_schema_version: None,
+        }
+    }
+
+    fn static_request() -> PolicyRequest {
+        PolicyRequest {
+            stage_id: "test".to_string(),
+            envelope: text_envelope("hello"),
+            metrics: default_metrics(),
+        }
+    }
+
+    #[test]
+    fn default_load_policies_is_unsupported() {
+        let authority = StaticAuthority {
+            policy: PolicyOutcome::Allow,
+            target_calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let err = authority
+            .load_policies(b"deny_cloud_if:\n  - \"true\"\n")
+            .expect_err("custom authority without an engine must refuse");
+        assert!(err.contains("not supported"), "{err}");
+    }
+
+    #[test]
+    fn default_resolve_stage_skips_target_resolution_when_policy_requires_local() {
+        for policy in [
+            PolicyOutcome::Deny {
+                reason: "no cloud".to_string(),
+            },
+            PolicyOutcome::Transform {
+                transforms: vec!["scrub".to_string()],
+            },
+        ] {
+            let authority = StaticAuthority {
+                policy,
+                target_calls: std::sync::atomic::AtomicUsize::new(0),
+            };
+            let resolution = authority.resolve_stage(&static_request(), &static_context());
+            assert_eq!(resolution.target.decision.result, ResolvedTarget::Device);
+            assert!(resolution.policy_requires_local());
+            assert!(
+                resolution.target.decision.reason.starts_with("policy_"),
+                "{}",
+                resolution.target.decision.reason
+            );
+            assert_eq!(
+                authority
+                    .target_calls
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                0,
+                "target resolution (and any remote advice) must not run for a local-only policy"
+            );
+        }
+    }
+
+    #[test]
+    fn default_resolve_stage_delegates_when_policy_allows() {
+        let authority = StaticAuthority {
+            policy: PolicyOutcome::Allow,
+            target_calls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let resolution = authority.resolve_stage(&static_request(), &static_context());
+        assert!(matches!(
+            resolution.target.decision.result,
+            ResolvedTarget::Cloud { .. }
+        ));
+        assert_eq!(
+            authority
+                .target_calls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[test]
+    fn stage_resolution_enforce_overrides_non_device_targets() {
+        let mut resolution = StageResolution {
+            policy: AuthorityDecision::local(
+                PolicyOutcome::Transform {
+                    transforms: vec!["scrub".to_string()],
+                },
+                "needs scrubbing",
+            ),
+            target: TargetResolution::new(
+                AuthorityDecision::new(
+                    ResolvedTarget::Cloud {
+                        provider: "xybrid".to_string(),
+                    },
+                    "inconsistent custom authority",
+                    DecisionSource::Remote,
+                    0.9,
+                ),
+                "m",
+                None,
+            ),
+        };
+
+        assert!(resolution.enforce());
+        assert_eq!(resolution.target.decision.result, ResolvedTarget::Device);
+        let reason = resolution.target.decision.reason.clone();
+        assert!(
+            reason.starts_with("policy_transform_unsupported: scrub"),
+            "{reason}"
+        );
+        assert!(
+            reason.contains("overrode cloud:xybrid decision"),
+            "{reason}"
+        );
+        assert!(reason.contains("inconsistent custom authority"), "{reason}");
+
+        // Idempotent.
+        assert!(!resolution.enforce());
+        assert_eq!(resolution.target.decision.reason, reason);
+
+        // Allow never overrides.
+        let mut allowed = StageResolution {
+            policy: AuthorityDecision::local(PolicyOutcome::Allow, "ok"),
+            target: TargetResolution::new(
+                AuthorityDecision::local(
+                    ResolvedTarget::Cloud {
+                        provider: "xybrid".to_string(),
+                    },
+                    "cloud",
+                ),
+                "m",
+                None,
+            ),
+        };
+        assert!(!allowed.enforce());
+        assert!(matches!(
+            allowed.target.decision.result,
+            ResolvedTarget::Cloud { .. }
+        ));
     }
 }

--- a/crates/xybrid-core/src/orchestrator/authority/remote.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/remote.rs
@@ -9,6 +9,16 @@
 //! short TTL cache. Policy and model-selection endpoints still fall back to
 //! `LocalAuthority` until the platform exposes those APIs.
 //!
+//! ## Policy comes first
+//!
+//! Remote advice is consulted only for decisions the local policy, an
+//! explicit pipeline target, local availability, or a policy cloud preference
+//! did not already settle. A denied input never triggers an advice request
+//! and never reaches cloud, whatever the cache holds; remote advice that is
+//! not feasible (a device target when no local model exists) is ignored.
+//! Every decision takes one resource snapshot and evaluates the policy once,
+//! shared with the local fallback.
+//!
 //! ## Future Capabilities
 //!
 //! - **Fleet-wide learning**: Decisions informed by similar devices' experiences
@@ -22,10 +32,13 @@
 //! fall back to `LocalAuthority` with `DecisionSource::Default`. This ensures
 //! xybrid always works, even without connectivity.
 
-use super::local::LocalAuthority;
+use super::local::{LocalAuthority, PreparedStage};
 use super::types::*;
 use super::OrchestrationAuthority;
 use crate::context::DeviceMetrics;
+use crate::ir::Envelope;
+use crate::orchestrator::routing_engine::LocalAvailability;
+use crate::pipeline::ExecutionTarget;
 use serde::Deserialize;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Mutex, MutexGuard};
@@ -344,9 +357,86 @@ impl RemoteAuthority {
         let now = now_ms();
         self.target_cache_guard().get_fresh(&key, now)
     }
+
+    /// Remote advice may only decide what the local policy, an explicit
+    /// target, local availability, and a policy cloud preference left open.
+    fn advice_applicable(
+        context: &StageContext,
+        prepared: &PreparedStage,
+        availability: &LocalAvailability,
+    ) -> bool {
+        !prepared.policy.requires_local()
+            && matches!(context.explicit_target, None | Some(ExecutionTarget::Auto))
+            && availability.local_model_exists
+            && !prepared.policy.prefers_cloud()
+    }
+
+    /// Advice that names a target the device cannot honour is discarded.
+    fn advice_is_feasible(
+        decision: &AuthorityDecision<ResolvedTarget>,
+        availability: &LocalAvailability,
+    ) -> bool {
+        match decision.result {
+            ResolvedTarget::Device => availability.local_model_exists,
+            ResolvedTarget::Cloud { .. } | ResolvedTarget::Server { .. } => true,
+        }
+    }
+
+    /// Resolve a target from an already-prepared decision, consulting cached
+    /// or fresh remote advice only when it is applicable.
+    fn resolve_prepared(
+        &self,
+        context: &StageContext,
+        prepared: PreparedStage,
+    ) -> TargetResolution {
+        let availability = context.local_availability.clone().unwrap_or_else(|| {
+            LocalAvailability::new(self.fallback.check_model_exists(&context.model_id))
+        });
+
+        if !Self::advice_applicable(context, &prepared, &availability) {
+            // Settled locally: denied/transform inputs, explicit targets,
+            // missing local models and policy preferences never ask the
+            // backend. The fallback's own precedence produces the reason.
+            return self.fallback.resolve_prepared(context, prepared);
+        }
+
+        let live_context = StageContext {
+            metrics: prepared.metrics.clone(),
+            local_availability: Some(availability.clone()),
+            ..context.clone()
+        };
+        let signal = prepared.signal;
+        let hint = self.fallback.reliability_hint(&context.model_id, signal);
+
+        let advice = self
+            .cached_target_advice(&live_context, &prepared.metrics)
+            .or_else(|| self.fetch_target_advice(&live_context, &prepared.metrics))
+            .filter(|decision| Self::advice_is_feasible(decision, &availability));
+        if let Some(decision) = advice {
+            return TargetResolution::new(decision, context.model_id.clone(), Some(signal))
+                .with_reliability_hint(hint);
+        }
+
+        // Remote unavailable or unusable: resolve locally with the same
+        // prepared metrics and policy result — never re-evaluate or re-sample.
+        let mut resolution = self.fallback.resolve_prepared(&live_context, prepared);
+        resolution.decision.source = DecisionSource::Default;
+        resolution.decision.reason = format!(
+            "Fallback to local (remote unavailable): {}",
+            resolution.decision.reason
+        );
+        resolution
+    }
 }
 
 impl OrchestrationAuthority for RemoteAuthority {
+    fn load_policies(&self, bundle: &[u8]) -> Result<(), String> {
+        // Load first; only a successful load invalidates the advice cache.
+        self.fallback.load_policies(bundle)?;
+        self.target_cache_guard().clear();
+        Ok(())
+    }
+
     fn apply_policy(&self, request: &PolicyRequest) -> AuthorityDecision<PolicyOutcome> {
         // TODO: Call backend endpoint
         // POST /v1/authority/policy
@@ -368,38 +458,31 @@ impl OrchestrationAuthority for RemoteAuthority {
     }
 
     fn resolve_target_with_feedback(&self, context: &StageContext) -> TargetResolution {
-        // Mirror LocalAuthority's live overlay so the SignalContext attached
-        // to a TargetResolution reflects the same real-time resource state
-        // the routing decision is implicitly conditioned on. Without this
-        // overlay, ExecutionOutcome.signal_context is bucketed under stale
-        // pre-run device metrics, and the embedded LocalAuthority's
-        // reliability history grows under buckets that no live request ever
-        // queries — silently disabling the history-bias circuit breaker.
-        let snapshot = context
-            .resource_monitor
-            .current_snapshot(Duration::from_millis(500));
-        let live_metrics = context.metrics.with_live_snapshot(snapshot);
-        let signal = Some(SignalContext::from_metrics(&live_metrics));
-        let live_context = StageContext {
-            metrics: live_metrics.clone(),
-            ..context.clone()
-        };
-
-        if let Some(decision) = self.cached_target_advice(&live_context, &live_metrics) {
-            return TargetResolution::new(decision, context.model_id.clone(), signal);
-        }
-
-        if let Some(decision) = self.fetch_target_advice(&live_context, &live_metrics) {
-            return TargetResolution::new(decision, context.model_id.clone(), signal);
-        }
-
-        let mut resolution = self.fallback.resolve_target_with_feedback(&live_context);
-        resolution.decision.source = DecisionSource::Default;
-        resolution.decision.reason = format!(
-            "Fallback to local (remote unavailable): {}",
-            resolution.decision.reason
+        let envelope = Envelope::new(context.input_kind.clone());
+        let prepared = self.fallback.prepare_stage(
+            &context.stage_id,
+            &envelope,
+            &context.metrics,
+            &context.resource_monitor,
         );
-        resolution
+        self.resolve_prepared(context, prepared)
+    }
+
+    fn resolve_stage(&self, request: &PolicyRequest, context: &StageContext) -> StageResolution {
+        let prepared = self.fallback.prepare_stage(
+            &request.stage_id,
+            &request.envelope,
+            &context.metrics,
+            &context.resource_monitor,
+        );
+        let mut policy = LocalAuthority::policy_decision(&prepared.policy);
+        policy.source = DecisionSource::Default;
+        policy.reason = format!(
+            "Fallback to local (remote not implemented): {}",
+            policy.reason
+        );
+        let target = self.resolve_prepared(context, prepared);
+        StageResolution::new(policy, target)
     }
 
     fn select_model(&self, request: &ModelRequest) -> AuthorityDecision<ModelSelection> {
@@ -441,7 +524,6 @@ mod tests {
     use crate::context::DeviceMetrics;
     use crate::device::ResourceMonitor;
     use crate::ir::{Envelope, EnvelopeKind};
-    use crate::orchestrator::routing_engine::LocalAvailability;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::mpsc;
@@ -463,10 +545,21 @@ mod tests {
             metrics: default_metrics(),
             resource_monitor: ResourceMonitor::global(),
             explicit_target: None,
-            local_availability: None,
+            // Remote advice is only consulted when a local leg exists; a
+            // missing model is settled locally (model_unavailable) first.
+            local_availability: Some(LocalAvailability::new(true)),
             device_class: None,
             device_class_schema_version: None,
         }
+    }
+
+    /// A loopback URL nothing listens on, so the advice request fails fast
+    /// (connection refused) instead of reaching a real host.
+    fn unreachable_endpoint() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind probe port");
+        let addr = listener.local_addr().expect("probe addr");
+        drop(listener);
+        format!("http://{}", addr)
     }
 
     fn context_with_device_class(endpoint_stage: &str, device_class: &str) -> StageContext {
@@ -552,7 +645,7 @@ mod tests {
 
     #[test]
     fn test_remote_authority_target_resolution_fallback() {
-        let authority = RemoteAuthority::new("https://api.xybrid.dev");
+        let authority = RemoteAuthority::new(&unreachable_endpoint());
         let context = default_context("test");
 
         let decision = authority.resolve_target(&context);
@@ -860,5 +953,212 @@ mod tests {
 
         // Should not panic
         authority.record_outcome(&outcome);
+    }
+
+    // ── Phase 3: policy before advice ───────────────────────────────────────
+
+    const DENY_TEXT_POLICY: &[u8] = b"deny_cloud_if:\n  - 'input.kind == \"text\"'\n";
+
+    fn assert_no_request(rx: &mpsc::Receiver<String>) {
+        assert!(
+            rx.recv_timeout(Duration::from_millis(200)).is_err(),
+            "no advice request must reach the backend"
+        );
+    }
+
+    #[test]
+    fn remote_load_policies_forwards_to_fallback_and_clears_cache() {
+        let endpoint = spawn_advice_server(
+            r#"{"target":"cloud","provider":"openai","reason":"fleet prefers cloud","confidence":0.9,"ttl_ms":30000}"#,
+            1,
+        );
+        let authority = RemoteAuthority::new(&endpoint);
+        let context = default_context("reload");
+
+        let primed = authority.resolve_target(&context);
+        assert_eq!(primed.source, DecisionSource::Remote);
+        assert!(!authority.target_cache_guard().entries.is_empty());
+
+        authority
+            .load_policies(DENY_TEXT_POLICY)
+            .expect("deny policy loads through the remote authority");
+        assert!(authority.target_cache_guard().entries.is_empty());
+
+        let denied = authority.resolve_target(&context);
+        assert_eq!(denied.result, ResolvedTarget::Device);
+        assert!(
+            denied.reason.starts_with("policy_deny"),
+            "{}",
+            denied.reason
+        );
+    }
+
+    #[test]
+    fn remote_load_policies_failure_changes_nothing() {
+        let endpoint = spawn_advice_server(
+            r#"{"target":"cloud","provider":"openai","reason":"fleet","confidence":0.9,"ttl_ms":30000}"#,
+            1,
+        );
+        let authority = RemoteAuthority::new(&endpoint);
+        let context = default_context("bad-reload");
+        let _ = authority.resolve_target(&context);
+
+        let err = authority
+            .load_policies(b"deny_cloud_if:\n  - 'metrics.network_rtt > 1'\n")
+            .expect_err("invalid bundle is rejected");
+        assert!(err.contains("unknown operand"), "{err}");
+
+        // Cache untouched: the next resolution is served from it.
+        let cached = authority.resolve_target(&context);
+        assert_eq!(cached.source, DecisionSource::Cached);
+    }
+
+    #[test]
+    fn denied_input_makes_no_advice_request_and_ignores_cached_cloud_advice() {
+        // Prime the cache with cloud advice under an allow-all policy.
+        let (endpoint, first_rx) = spawn_header_capture_advice_server(
+            r#"{"target":"cloud","provider":"xybrid","reason":"fleet prefers cloud","confidence":0.9,"ttl_ms":60000}"#,
+        );
+        let authority = RemoteAuthority::new(&endpoint);
+        let context = default_context("denied");
+        let primed = authority.resolve_target(&context);
+        assert_eq!(primed.source, DecisionSource::Remote);
+        first_rx.recv().expect("priming request reached the server");
+
+        // Manually re-insert cloud advice so a stale cache entry survives the
+        // reload (load_policies clears it; the invariant must not depend on
+        // that clear alone).
+        authority
+            .fallback
+            .load_policies(DENY_TEXT_POLICY)
+            .expect("deny loads");
+        let key = RemoteAuthority::target_cache_key(&context, &context.metrics);
+        authority.target_cache_guard().insert(
+            key,
+            CachedTargetAdvice {
+                decision: AuthorityDecision::new(
+                    ResolvedTarget::Cloud {
+                        provider: "xybrid".to_string(),
+                    },
+                    "stale cached cloud advice",
+                    DecisionSource::Remote,
+                    0.9,
+                ),
+                expires_at_ms: u64::MAX,
+            },
+            now_ms(),
+        );
+
+        let resolution = authority.resolve_stage(
+            &PolicyRequest {
+                stage_id: "denied".to_string(),
+                envelope: text_envelope("hello"),
+                metrics: default_metrics(),
+            },
+            &context,
+        );
+
+        assert!(matches!(
+            resolution.policy.result,
+            PolicyOutcome::Deny { .. }
+        ));
+        assert_eq!(resolution.target.decision.result, ResolvedTarget::Device);
+        assert!(
+            resolution.target.decision.reason.starts_with("policy_deny"),
+            "{}",
+            resolution.target.decision.reason
+        );
+        assert_ne!(resolution.target.decision.source, DecisionSource::Cached);
+        assert_ne!(resolution.target.decision.source, DecisionSource::Remote);
+    }
+
+    #[test]
+    fn denied_input_never_contacts_the_backend() {
+        let (endpoint, rx) = spawn_header_capture_advice_server(
+            r#"{"target":"cloud","provider":"xybrid","reason":"x","confidence":0.9,"ttl_ms":0}"#,
+        );
+        let authority = RemoteAuthority::new(&endpoint);
+        authority
+            .load_policies(DENY_TEXT_POLICY)
+            .expect("deny loads");
+
+        let decision = authority.resolve_target(&default_context("never"));
+
+        assert_eq!(decision.result, ResolvedTarget::Device);
+        assert_no_request(&rx);
+    }
+
+    #[test]
+    fn explicit_target_missing_model_and_policy_preference_are_settled_without_advice() {
+        let (endpoint, rx) = spawn_header_capture_advice_server(
+            r#"{"target":"cloud","provider":"xybrid","reason":"x","confidence":0.9,"ttl_ms":0}"#,
+        );
+        let authority = RemoteAuthority::new(&endpoint);
+
+        let mut explicit = default_context("explicit");
+        explicit.explicit_target = Some(crate::pipeline::ExecutionTarget::Device);
+        let decision = authority.resolve_target(&explicit);
+        assert_eq!(decision.result, ResolvedTarget::Device);
+        assert_eq!(decision.source, DecisionSource::Local);
+
+        let mut missing = default_context("missing");
+        missing.local_availability = Some(LocalAvailability::new(false));
+        let decision = authority.resolve_target(&missing);
+        assert!(matches!(decision.result, ResolvedTarget::Cloud { .. }));
+        assert!(
+            decision.reason.starts_with("model_unavailable"),
+            "{}",
+            decision.reason
+        );
+        assert_eq!(decision.source, DecisionSource::Local);
+
+        authority
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n")
+            .expect("route_cloud loads");
+        let decision = authority.resolve_target(&default_context("prefer"));
+        assert!(matches!(decision.result, ResolvedTarget::Cloud { .. }));
+        assert!(
+            decision.reason.starts_with("policy_route_cloud"),
+            "{}",
+            decision.reason
+        );
+
+        assert_no_request(&rx);
+    }
+
+    #[test]
+    fn infeasible_device_advice_is_not_usable() {
+        let device_advice = AuthorityDecision::new(
+            ResolvedTarget::Device,
+            "fleet says device",
+            DecisionSource::Remote,
+            0.9,
+        );
+        assert!(RemoteAuthority::advice_is_feasible(
+            &device_advice,
+            &LocalAvailability::new(true)
+        ));
+        assert!(!RemoteAuthority::advice_is_feasible(
+            &device_advice,
+            &LocalAvailability::new(false)
+        ));
+    }
+
+    #[test]
+    fn remote_fallback_resolution_carries_prepared_signal() {
+        let authority = RemoteAuthority::new(&unreachable_endpoint());
+        let resolution = authority.resolve_stage(
+            &PolicyRequest {
+                stage_id: "fallback".to_string(),
+                envelope: text_envelope("hello"),
+                metrics: default_metrics(),
+            },
+            &default_context("fallback"),
+        );
+
+        assert_eq!(resolution.policy.result, PolicyOutcome::Allow);
+        assert_eq!(resolution.target.decision.source, DecisionSource::Default);
+        assert!(resolution.target.decision.reason.contains("Fallback"));
+        assert!(resolution.target.signal_context.is_some());
     }
 }

--- a/crates/xybrid-core/src/orchestrator/authority/remote.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/remote.rs
@@ -1161,4 +1161,60 @@ mod tests {
         assert!(resolution.target.decision.reason.contains("Fallback"));
         assert!(resolution.target.signal_context.is_some());
     }
+
+    /// Advice server that waits `delay` before answering, so a request can be
+    /// observed "in flight".
+    fn spawn_slow_advice_server(body: &'static str, delay: Duration) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind slow advice server");
+        let addr = listener.local_addr().expect("local addr");
+        thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buf = [0_u8; 2048];
+            let _ = stream.read(&mut buf);
+            thread::sleep(delay);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
+        format!("http://{}", addr)
+    }
+
+    #[test]
+    fn policy_reload_is_not_blocked_by_an_in_flight_advice_request() {
+        let endpoint = spawn_slow_advice_server(
+            r#"{"target":"cloud","provider":"xybrid","reason":"slow","confidence":0.9,"ttl_ms":0}"#,
+            Duration::from_millis(400),
+        );
+        let authority = std::sync::Arc::new(RemoteAuthority::new(&endpoint));
+
+        let in_flight = {
+            let authority = authority.clone();
+            thread::spawn(move || authority.resolve_target(&default_context("slow")))
+        };
+        // Give the request time to be sent and to start waiting on the server.
+        thread::sleep(Duration::from_millis(100));
+
+        let started = std::time::Instant::now();
+        authority
+            .load_policies(DENY_TEXT_POLICY)
+            .expect("reload succeeds while a fetch is in flight");
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "load_policies waited on the HTTP round-trip: {:?}",
+            started.elapsed()
+        );
+
+        // The in-flight decision finished on the policy it evaluated (allow →
+        // remote advice), and the next decision uses the new one.
+        let earlier = in_flight.join().expect("in-flight resolution completes");
+        assert_eq!(earlier.source, DecisionSource::Remote);
+        let later = authority.resolve_target(&default_context("slow"));
+        assert_eq!(later.result, ResolvedTarget::Device);
+        assert!(later.reason.starts_with("policy_deny"), "{}", later.reason);
+    }
 }

--- a/crates/xybrid-core/src/orchestrator/authority/types.rs
+++ b/crates/xybrid-core/src/orchestrator/authority/types.rs
@@ -362,6 +362,73 @@ impl Default for ExecutionOutcome {
     }
 }
 
+/// One stage decision: the policy outcome and the target it permits.
+///
+/// Produced by [`super::OrchestrationAuthority::resolve_stage`] from a single
+/// policy evaluation and a single resource snapshot, so the policy event, the
+/// routing event, and the dispatch target cannot disagree with each other.
+#[derive(Debug, Clone)]
+pub struct StageResolution {
+    /// The policy outcome for this input.
+    pub policy: AuthorityDecision<PolicyOutcome>,
+    /// The resolved target, already restricted by the policy outcome.
+    pub target: TargetResolution,
+}
+
+impl StageResolution {
+    /// Combine a policy decision and a target resolution, restricting the
+    /// target to the device whenever the policy forbids leaving it.
+    pub fn new(policy: AuthorityDecision<PolicyOutcome>, target: TargetResolution) -> Self {
+        Self { policy, target }.enforced()
+    }
+
+    /// True when the policy forbids inference leaving the device: the input
+    /// was denied, or it requires a transform that nothing can apply yet.
+    pub fn policy_requires_local(&self) -> bool {
+        !matches!(self.policy.result, PolicyOutcome::Allow)
+    }
+
+    /// Restrict the target to the device when the policy requires it.
+    ///
+    /// Idempotent. Returns `true` when a non-device target was overridden;
+    /// the previous target and reason are kept in the new reason so the
+    /// override stays explainable. Orchestrators call this immediately
+    /// before dispatch as defense in depth against custom authorities.
+    pub fn enforce(&mut self) -> bool {
+        if !self.policy_requires_local()
+            || matches!(self.target.decision.result, ResolvedTarget::Device)
+        {
+            return false;
+        }
+        let constraint = policy_local_constraint_reason(&self.policy.result)
+            .unwrap_or_else(|| "policy requires local execution".to_string());
+        let previous = std::mem::replace(&mut self.target.decision.result, ResolvedTarget::Device);
+        let previous_reason = std::mem::take(&mut self.target.decision.reason);
+        self.target.decision.reason =
+            format!("{constraint} (overrode {previous} decision: {previous_reason})");
+        true
+    }
+
+    /// [`Self::enforce`] by value.
+    pub fn enforced(mut self) -> Self {
+        self.enforce();
+        self
+    }
+}
+
+/// Routing-reason prefix for a policy outcome that forbids leaving the
+/// device, or `None` when the outcome permits cloud execution.
+pub fn policy_local_constraint_reason(outcome: &PolicyOutcome) -> Option<String> {
+    match outcome {
+        PolicyOutcome::Allow => None,
+        PolicyOutcome::Deny { reason } => Some(format!("policy_deny: {reason}")),
+        PolicyOutcome::Transform { transforms } => Some(format!(
+            "policy_transform_unsupported: {}",
+            transforms.join(",")
+        )),
+    }
+}
+
 /// Get current timestamp in milliseconds.
 pub fn now_ms() -> u64 {
     SystemTime::now()

--- a/crates/xybrid-core/src/orchestrator/bootstrap.rs
+++ b/crates/xybrid-core/src/orchestrator/bootstrap.rs
@@ -24,8 +24,6 @@ use crate::control_sync::{
 use crate::device::ResourceMonitor;
 use crate::event_bus::{EventBus, OrchestratorEvent};
 use crate::executor::Executor;
-use crate::orchestrator::policy_engine::DefaultPolicyEngine;
-use crate::orchestrator::routing_engine::DefaultRoutingEngine;
 use crate::orchestrator::{
     ExecutionMode, LocalAuthority, OrchestrationAuthority, Orchestrator, OrchestratorError,
 };
@@ -77,8 +75,7 @@ impl Orchestrator {
     /// Bootstrap a new orchestrator instance with registered adapters and telemetry.
     ///
     /// This function initializes all orchestrator components:
-    /// - Policy engine with default policies
-    /// - Routing engine
+    /// - Local orchestration authority (owns the policy engine and routing ladder)
     /// - Executor with registered runtime adapters
     /// - Event bus with subscription enabled
     /// - Telemetry for logging
@@ -125,20 +122,6 @@ impl Orchestrator {
         // Initialize telemetry
         let telemetry = Arc::new(Telemetry::new());
         telemetry.log_bootstrap_start();
-
-        // Initialize policy engine
-        let policy_engine = Box::new(DefaultPolicyEngine::with_default_policy());
-        event_bus.publish(OrchestratorEvent::ComponentInitialized {
-            component: "policy_engine".to_string(),
-            context: Default::default(),
-        });
-
-        // Initialize routing engine
-        let routing_engine = Box::new(DefaultRoutingEngine::new());
-        event_bus.publish(OrchestratorEvent::ComponentInitialized {
-            component: "routing_engine".to_string(),
-            context: Default::default(),
-        });
 
         // Initialize executor
         // Note: Model downloading is handled by the SDK's RegistryClient.
@@ -296,8 +279,6 @@ impl Orchestrator {
         // Create orchestrator instance
         let orchestrator = Orchestrator::with_all(
             authority,
-            policy_engine,
-            routing_engine,
             executor,
             stream_manager,
             event_bus,

--- a/crates/xybrid-core/src/orchestrator/bootstrap.rs
+++ b/crates/xybrid-core/src/orchestrator/bootstrap.rs
@@ -31,7 +31,7 @@ use crate::orchestrator::{
 use crate::runtime_adapter::CoreMLRuntimeAdapter;
 #[cfg(target_os = "android")]
 use crate::runtime_adapter::ONNXMobileRuntimeAdapter;
-use crate::runtime_adapter::{OnnxRuntimeAdapter, RuntimeAdapter};
+use crate::runtime_adapter::{CloudRuntimeAdapter, OnnxRuntimeAdapter, RuntimeAdapter};
 use crate::streaming::manager::StreamManager;
 use crate::telemetry::{Severity, Telemetry};
 use serde_json::json;
@@ -202,7 +202,8 @@ impl Orchestrator {
             }
         }
 
-        // Register cloud adapter (mock for now)
+        // Register the real OpenAI-compatible cloud adapter. Stages routed to
+        // cloud without a provider fail honestly instead of returning fake text.
         if adapter_config.cloud {
             let adapter = Arc::new(CloudRuntimeAdapter::new());
             executor.register_adapter(adapter);
@@ -328,60 +329,6 @@ fn load_config(path: &Path) -> Result<Option<BootstrapConfig>, OrchestratorError
     Ok(Some(config))
 }
 
-/// Cloud runtime adapter (mock implementation).
-///
-/// This adapter simulates cloud inference execution by adding network latency
-/// and returning mock outputs. Future implementations will integrate with
-/// actual cloud inference services (gRPC, REST APIs, etc.).
-struct CloudRuntimeAdapter {
-    // Future: cloud endpoint configuration, auth tokens, etc.
-}
-
-impl CloudRuntimeAdapter {
-    fn new() -> Self {
-        Self {}
-    }
-}
-
-impl RuntimeAdapter for CloudRuntimeAdapter {
-    fn name(&self) -> &str {
-        "cloud"
-    }
-
-    fn supported_formats(&self) -> Vec<&'static str> {
-        vec!["onnx", "tensorflow", "pytorch"]
-    }
-
-    fn load_model(&mut self, _path: &str) -> crate::runtime_adapter::AdapterResult<()> {
-        // Cloud models are loaded remotely, not from local files
-        Ok(())
-    }
-
-    fn execute(
-        &self,
-        input: &crate::ir::Envelope,
-    ) -> crate::runtime_adapter::AdapterResult<crate::ir::Envelope> {
-        // Simulate cloud execution with network latency
-        use crate::ir::EnvelopeKind;
-        use std::thread;
-
-        // Simulate network delay
-        thread::sleep(std::time::Duration::from_millis(50));
-
-        // Mock cloud inference
-        let output = match &input.kind {
-            EnvelopeKind::Audio(_) => EnvelopeKind::Text("cloud-output-transcribed".to_string()),
-            EnvelopeKind::Text(t) => EnvelopeKind::Text(format!("cloud-output-{}", t)),
-            EnvelopeKind::Embedding(_) => EnvelopeKind::Text("cloud-output".to_string()),
-            EnvelopeKind::Image { .. } | EnvelopeKind::MultiPart(_) => {
-                EnvelopeKind::Text("cloud-output-vision-unsupported".to_string())
-            }
-        };
-
-        Ok(crate::ir::Envelope::new(output))
-    }
-}
-
 /// Mock runtime adapter for testing.
 ///
 /// This adapter always returns mock outputs without any real inference.
@@ -445,6 +392,21 @@ mod tests {
             .executor
             .list_adapters()
             .contains(&"onnx".to_string()));
+
+        // The registered cloud adapter is the real one: it declares no file
+        // formats, and a provider-free envelope is rejected before any HTTP
+        // instead of yielding synthetic output.
+        let cloud = orchestrator
+            .executor
+            .get_adapter("cloud")
+            .expect("cloud adapter registered by default");
+        assert!(cloud.supported_formats().is_empty());
+        let err = cloud
+            .execute(&crate::ir::Envelope::new(crate::ir::EnvelopeKind::Text(
+                "hello".to_string(),
+            )))
+            .expect_err("real cloud adapter requires a provider");
+        assert!(err.to_string().contains("provider"), "{err}");
     }
 
     #[test]

--- a/crates/xybrid-core/src/orchestrator/policy_engine.rs
+++ b/crates/xybrid-core/src/orchestrator/policy_engine.rs
@@ -469,10 +469,14 @@ fn compile_expression(expression: &str) -> Result<Expr, String> {
             normalized = "audio".to_string();
         }
         if !allowed.contains(&normalized.as_str()) {
-            return Err(format!(
-                "'{raw}' is not a valid value for '{}' (expected one of: {})",
-                lhs.as_str(),
+            let expected = if lhs == Lhs::InputKind {
+                format!("{} (legacy alias: audioraw)", allowed.join(", "))
+            } else {
                 allowed.join(", ")
+            };
+            return Err(format!(
+                "'{raw}' is not a valid value for '{}' (expected one of: {expected})",
+                lhs.as_str(),
             ));
         }
         Rhs::Str(normalized)
@@ -968,6 +972,7 @@ mod tests {
         let err = load_error("deny_cloud_if:\n  - 'input.kind == \"SensitiveData\"'\n");
         assert!(err.contains("SensitiveData"), "{err}");
         assert!(err.contains("deny_cloud_if_0"), "{err}");
+        assert!(err.contains("legacy alias: audioraw"), "{err}");
     }
 
     // ── input.text / input.text_len ─────────────────────────────────────────

--- a/crates/xybrid-core/src/orchestrator/policy_engine.rs
+++ b/crates/xybrid-core/src/orchestrator/policy_engine.rs
@@ -1,26 +1,105 @@
 //! Policy Engine module - Enforces data-handling and routing rules before inference stages run.
 //!
-//! The Policy Engine ensures that privacy, latency, and cost constraints are respected at runtime
-//! by evaluating allow/deny conditions per stage and optionally applying redaction transforms.
+//! A policy bundle is a small, declarative rule set (YAML or JSON) that the
+//! orchestration authority evaluates once per stage decision, against the
+//! *actual* input envelope and one live device-metrics snapshot. The outcome
+//! constrains routing:
+//!
+//! - `deny`        — cloud execution is forbidden; the stage must run locally.
+//! - `route_cloud` — cloud execution is preferred when it is permitted and a
+//!   cloud leg exists (alias: `prefer_cloud`).
+//! - `redact`      — the input would need a transform before leaving the
+//!   device; transforms are not implemented, so this also forces local
+//!   execution.
+//! - `allow`       — stop evaluating; route normally.
+//!
+//! Rules are evaluated in order and the **first matching rule wins**.
+//!
+//! # Expression language
+//!
+//! Each rule has exactly one expression of the form `<lhs> <op> <rhs>`, or the
+//! bare literal `true` / `false`.
+//!
+//! | Left operand              | Operators                      | Right operand                                                                        |
+//! |---------------------------|--------------------------------|--------------------------------------------------------------------------------------|
+//! | `input.kind`              | `==` `!=`                      | `"audio"` `"text"` `"embedding"` `"image"` `"multipart"` (legacy alias `"audioraw"`) |
+//! | `input.text`              | `contains` `matches` `==` `!=` | `"literal"` (`matches` takes a regex)                                                |
+//! | `input.text_len`          | `==` `!=` `<` `<=` `>` `>=`    | number (Unicode scalar values)                                                       |
+//! | `metrics.battery_level`   | `==` `!=` `<` `<=` `>` `>=`    | number, 0–100                                                                        |
+//! | `metrics.cpu_pct`         | `==` `!=` `<` `<=` `>` `>=`    | number, 0–100                                                                        |
+//! | `metrics.memory_pressure` | `==` `!=`                      | `"unknown"` `"normal"` `"warn"` `"critical"`                                         |
+//! | `metrics.thermal_state`   | `==` `!=`                      | `"normal"` `"warm"` `"hot"` `"critical"`                                             |
+//!
+//! String comparisons on enum-like operands are case-insensitive. `contains`
+//! is a case-sensitive substring test; use `matches` with `(?i)` for
+//! case-insensitive matching. Inside a quoted literal `\"` and `\\` are
+//! decoded; any other backslash sequence is kept verbatim, so regex escapes
+//! such as `\d` pass through unchanged. Text rules inspect only the input `Text`
+//! payload — never system prompts or metadata — and never match non-text
+//! input. A missing CPU reading never matches. Unsupported operands,
+//! operators, literals, or actions are rejected when the bundle is loaded,
+//! not silently ignored at evaluation time.
+//!
+//! # Bundle shape
+//!
+//! ```yaml
+//! version: "1.0.0"          # optional
+//! signature: "unsigned"     # optional, not verified
+//! rules:                    # optional, evaluated first, in order
+//!   - id: keep_audio_on_device
+//!     expression: 'input.kind == "audio"'
+//!     action: deny
+//! deny_cloud_if:            # optional shorthand: each entry is a deny rule
+//!   - 'input.text matches "(?i)password"'
+//! route_cloud_if:           # optional shorthand: each entry is a route_cloud rule
+//!   - "metrics.battery_level < 25"
+//! ```
+//!
+//! Shorthand rules are appended after `rules` in the order shown, so an
+//! earlier explicit `allow` or `route_cloud` can stop a later shorthand
+//! denial — the priority of `deny_cloud_if` over `route_cloud_if` is an
+//! ordering convention, not a global override.
 
 use crate::context::DeviceMetrics;
 use crate::ir::{Envelope, EnvelopeKind};
+use regex::Regex;
+use std::collections::HashSet;
+use std::fmt;
+use std::str::FromStr;
+
+/// Routing preference expressed by a matched rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PolicyRoute {
+    /// No preference; the routing ladder decides.
+    #[default]
+    Unspecified,
+    /// Prefer the cloud leg when cloud execution is permitted and available.
+    PreferCloud,
+}
 
 /// Result of a policy evaluation.
 #[derive(Debug, Clone)]
 pub struct PolicyResult {
+    /// `false` means cloud execution is forbidden for this input.
     pub allowed: bool,
+    /// Human-readable explanation of the decision.
     pub reason: Option<String>,
+    /// Identifiers of `redact` rules that matched. Non-empty means the input
+    /// would need a transform before leaving the device; since transforms are
+    /// not implemented, a non-empty list forces local execution.
     pub transforms_applied: Vec<String>,
+    /// Routing preference expressed by the matched rule, if any.
+    pub route: PolicyRoute,
 }
 
 impl PolicyResult {
-    /// Create a new PolicyResult.
+    /// Create a new PolicyResult with no routing preference.
     pub fn new(allowed: bool, reason: Option<String>) -> Self {
         Self {
             allowed,
             reason,
             transforms_applied: Vec::new(),
+            route: PolicyRoute::Unspecified,
         }
     }
 
@@ -29,10 +108,86 @@ impl PolicyResult {
         Self::new(true, reason)
     }
 
-    /// Create a denied result.
+    /// Create a denied result: cloud execution is forbidden.
     pub fn deny(reason: String) -> Self {
         Self::new(false, Some(reason))
     }
+
+    /// Create an allowed result that prefers the cloud leg.
+    pub fn prefer_cloud(reason: String) -> Self {
+        let mut result = Self::new(true, Some(reason));
+        result.route = PolicyRoute::PreferCloud;
+        result
+    }
+
+    /// True when the matched rule prefers cloud execution.
+    pub fn prefers_cloud(&self) -> bool {
+        self.route == PolicyRoute::PreferCloud
+    }
+
+    /// True when the stage must not leave the device: cloud was denied, or
+    /// the input requires a transform that no component can apply.
+    pub fn requires_local(&self) -> bool {
+        !self.allowed || !self.transforms_applied.is_empty()
+    }
+}
+
+/// Action taken when a rule's expression matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyAction {
+    /// Stop evaluating and allow normal routing.
+    Allow,
+    /// Forbid cloud execution for this input.
+    Deny,
+    /// Prefer cloud execution when it is permitted and available.
+    RouteCloud,
+    /// Require a transform before the input may leave the device.
+    Redact,
+}
+
+impl PolicyAction {
+    /// Canonical lowercase name used in policy files.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PolicyAction::Allow => "allow",
+            PolicyAction::Deny => "deny",
+            PolicyAction::RouteCloud => "route_cloud",
+            PolicyAction::Redact => "redact",
+        }
+    }
+}
+
+impl fmt::Display for PolicyAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PolicyAction {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "allow" => Ok(PolicyAction::Allow),
+            "deny" => Ok(PolicyAction::Deny),
+            "route_cloud" | "prefer_cloud" => Ok(PolicyAction::RouteCloud),
+            "redact" => Ok(PolicyAction::Redact),
+            other => Err(format!(
+                "unknown policy action '{other}' (expected allow, deny, route_cloud, or redact)"
+            )),
+        }
+    }
+}
+
+/// Individual policy rule.
+#[derive(Debug, Clone)]
+pub struct PolicyRule {
+    /// Unique identifier, surfaced in decision reasons and telemetry.
+    pub id: String,
+    /// Source text of the expression (see the module docs for the grammar).
+    pub expression: String,
+    /// Action taken when the expression matches.
+    pub action: PolicyAction,
 }
 
 /// Policy bundle containing rules and metadata.
@@ -40,134 +195,581 @@ impl PolicyResult {
 pub struct PolicyBundle {
     pub version: String,
     pub rules: Vec<PolicyRule>,
+    /// Carried through from the bundle; not verified.
     pub signature: String,
-}
-
-/// Individual policy rule.
-#[derive(Debug, Clone)]
-pub struct PolicyRule {
-    pub id: String,
-    pub expression: String, // CEL or mini-DSL
-    pub action: String,     // "allow" | "deny" | "redact"
 }
 
 /// Policy Engine trait for evaluating policies.
 pub trait PolicyEngine {
-    /// Load and cache signed policy files.
+    /// Parse and activate a policy bundle (YAML or JSON bytes).
+    ///
+    /// The whole bundle is validated and compiled before it replaces the
+    /// active one; on error the previously loaded policy stays in effect.
     fn load_policies(&mut self, bundle_bytes: Vec<u8>) -> Result<(), String>;
 
-    /// Evaluate policy conditions for a stage.
+    /// Evaluate policy conditions for a stage against the actual input and
+    /// the supplied device metrics.
     fn evaluate(&self, stage: &str, envelope: &Envelope, metrics: &DeviceMetrics) -> PolicyResult;
 
-    /// Apply redaction transforms to an envelope.
+    /// Apply redaction transforms to an envelope. Returns whether the
+    /// envelope changed. Not implemented: always `false`, and never relied
+    /// on to authorize cloud transmission.
     fn redact(&self, envelope: &mut Envelope) -> bool;
 }
 
-/// Default implementation of PolicyEngine for MVP.
-///
-/// Currently supports a single expression form: `input.kind == "<value>"`.
-/// The legacy `metrics.network_rtt`/`metrics.battery` comparisons were
-/// dropped together with the speculative routing scalars; if device-state
-/// rules are needed in the future they should target real signals on
-/// `metrics.capabilities` / `metrics.resource`.
-pub struct DefaultPolicyEngine {
-    bundle: Option<PolicyBundle>,
+// ─────────────────────────────────────────────────────────────────────────────
+// Compiled expressions
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Lhs {
+    InputKind,
+    InputText,
+    InputTextLen,
+    BatteryLevel,
+    CpuPct,
+    MemoryPressure,
+    ThermalState,
 }
 
-impl DefaultPolicyEngine {
-    /// Create a new DefaultPolicyEngine instance.
-    pub fn new() -> Self {
-        Self { bundle: None }
+impl Lhs {
+    fn parse(token: &str) -> Result<Self, String> {
+        match token {
+            "input.kind" => Ok(Lhs::InputKind),
+            "input.text" => Ok(Lhs::InputText),
+            "input.text_len" => Ok(Lhs::InputTextLen),
+            "metrics.battery_level" => Ok(Lhs::BatteryLevel),
+            "metrics.cpu_pct" => Ok(Lhs::CpuPct),
+            "metrics.memory_pressure" => Ok(Lhs::MemoryPressure),
+            "metrics.thermal_state" => Ok(Lhs::ThermalState),
+            other => Err(format!(
+                "unknown operand '{other}' (expected input.kind, input.text, input.text_len, \
+                 metrics.battery_level, metrics.cpu_pct, metrics.memory_pressure, or \
+                 metrics.thermal_state)"
+            )),
+        }
     }
 
-    /// Create a new instance with the default policy bundle.
-    ///
-    /// The default bundle is currently empty (allow-all). Callers wanting
-    /// stricter behaviour should `load_policies` an explicit bundle.
-    pub fn with_default_policy() -> Self {
-        let mut engine = Self::new();
-        let default_bundle = PolicyBundle {
-            version: "0.1.0".to_string(),
-            rules: vec![],
-            signature: "default_mvp".to_string(),
+    fn as_str(&self) -> &'static str {
+        match self {
+            Lhs::InputKind => "input.kind",
+            Lhs::InputText => "input.text",
+            Lhs::InputTextLen => "input.text_len",
+            Lhs::BatteryLevel => "metrics.battery_level",
+            Lhs::CpuPct => "metrics.cpu_pct",
+            Lhs::MemoryPressure => "metrics.memory_pressure",
+            Lhs::ThermalState => "metrics.thermal_state",
+        }
+    }
+
+    fn is_numeric(&self) -> bool {
+        matches!(self, Lhs::InputTextLen | Lhs::BatteryLevel | Lhs::CpuPct)
+    }
+
+    /// Accepted literals for enum-like operands (lowercase).
+    fn enum_values(&self) -> Option<&'static [&'static str]> {
+        match self {
+            Lhs::InputKind => Some(&["audio", "text", "embedding", "image", "multipart"]),
+            Lhs::MemoryPressure => Some(&["unknown", "normal", "warn", "critical"]),
+            Lhs::ThermalState => Some(&["normal", "warm", "hot", "critical"]),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Contains,
+    Matches,
+}
+
+impl Op {
+    fn parse(token: &str) -> Result<Self, String> {
+        match token {
+            "==" => Ok(Op::Eq),
+            "!=" => Ok(Op::Ne),
+            "<" => Ok(Op::Lt),
+            "<=" => Ok(Op::Le),
+            ">" => Ok(Op::Gt),
+            ">=" => Ok(Op::Ge),
+            "contains" => Ok(Op::Contains),
+            "matches" => Ok(Op::Matches),
+            other => Err(format!(
+                "unknown operator '{other}' (expected ==, !=, <, <=, >, >=, contains, or matches)"
+            )),
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Op::Eq => "==",
+            Op::Ne => "!=",
+            Op::Lt => "<",
+            Op::Le => "<=",
+            Op::Gt => ">",
+            Op::Ge => ">=",
+            Op::Contains => "contains",
+            Op::Matches => "matches",
+        }
+    }
+
+    fn is_equality(&self) -> bool {
+        matches!(self, Op::Eq | Op::Ne)
+    }
+
+    fn is_numeric(&self) -> bool {
+        matches!(self, Op::Eq | Op::Ne | Op::Lt | Op::Le | Op::Gt | Op::Ge)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Rhs {
+    Str(String),
+    Num(f64),
+    Regex(Regex),
+}
+
+#[derive(Debug, Clone)]
+enum Expr {
+    Literal(bool),
+    Compare { lhs: Lhs, op: Op, rhs: Rhs },
+}
+
+enum RhsToken {
+    Quoted(String),
+    Bare(String),
+}
+
+/// Split off the first whitespace-delimited token; the remainder is
+/// left-trimmed.
+fn split_head(s: &str) -> (&str, &str) {
+    let s = s.trim_start();
+    match s.find(char::is_whitespace) {
+        Some(idx) => (&s[..idx], s[idx..].trim_start()),
+        None => (s, ""),
+    }
+}
+
+/// Parse a double-quoted, backslash-escaped string literal at the start of
+/// `s`. Returns the decoded value and the remainder after the closing quote.
+fn parse_quoted(s: &str) -> Result<(String, &str), String> {
+    let mut chars = s.char_indices();
+    match chars.next() {
+        Some((_, '"')) => {}
+        _ => return Err("expected a double-quoted string".to_string()),
+    }
+    let mut out = String::new();
+    while let Some((idx, ch)) = chars.next() {
+        match ch {
+            '\\' => match chars.next() {
+                Some((_, '"')) => out.push('"'),
+                Some((_, '\\')) => out.push('\\'),
+                // Any other backslash sequence is preserved verbatim so regex
+                // escapes (`\d`, `\s`, `\.`) work without double-escaping.
+                Some((_, other)) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => return Err("unterminated string literal".to_string()),
+            },
+            '"' => return Ok((out, &s[idx + ch.len_utf8()..])),
+            other => out.push(other),
+        }
+    }
+    Err("unterminated string literal".to_string())
+}
+
+fn tokenize(expression: &str) -> Result<(&str, &str, RhsToken), String> {
+    let (lhs, rest) = split_head(expression);
+    if rest.is_empty() {
+        return Err(format!(
+            "expected '<operand> <operator> <value>' or a bare true/false, got '{expression}'"
+        ));
+    }
+    let (op, rest) = split_head(rest);
+    if rest.is_empty() {
+        return Err("missing right operand".to_string());
+    }
+    if rest.starts_with('"') {
+        let (value, remainder) = parse_quoted(rest)?;
+        if !remainder.trim().is_empty() {
+            return Err(format!(
+                "unexpected trailing input '{}' after string literal",
+                remainder.trim()
+            ));
+        }
+        Ok((lhs, op, RhsToken::Quoted(value)))
+    } else {
+        let (value, remainder) = split_head(rest);
+        if !remainder.is_empty() {
+            return Err(format!("unexpected trailing input '{remainder}'"));
+        }
+        Ok((lhs, op, RhsToken::Bare(value.to_string())))
+    }
+}
+
+/// Compile one expression, enforcing operand/operator/literal compatibility.
+fn compile_expression(expression: &str) -> Result<Expr, String> {
+    let trimmed = expression.trim();
+    match trimmed {
+        "" => return Err("expression is empty".to_string()),
+        "true" => return Ok(Expr::Literal(true)),
+        "false" => return Ok(Expr::Literal(false)),
+        _ => {}
+    }
+
+    let (lhs_token, op_token, rhs_token) = tokenize(trimmed)?;
+    let lhs = Lhs::parse(lhs_token)?;
+    let op = Op::parse(op_token)?;
+
+    let rhs = if lhs.is_numeric() {
+        if !op.is_numeric() {
+            return Err(format!(
+                "operator '{}' is not valid for numeric operand '{}'",
+                op.as_str(),
+                lhs.as_str()
+            ));
+        }
+        let RhsToken::Bare(raw) = rhs_token else {
+            return Err(format!(
+                "operand '{}' must be compared against a number, not a quoted string",
+                lhs.as_str()
+            ));
         };
-        engine.bundle = Some(default_bundle);
-        engine
+        let number: f64 = raw
+            .parse()
+            .map_err(|_| format!("'{raw}' is not a number"))?;
+        if !number.is_finite() {
+            return Err(format!("'{raw}' is not a finite number"));
+        }
+        Rhs::Num(number)
+    } else if let Some(allowed) = lhs.enum_values() {
+        if !op.is_equality() {
+            return Err(format!(
+                "operator '{}' is not valid for operand '{}' (use == or !=)",
+                op.as_str(),
+                lhs.as_str()
+            ));
+        }
+        let RhsToken::Quoted(raw) = rhs_token else {
+            return Err(format!(
+                "operand '{}' must be compared against a quoted string",
+                lhs.as_str()
+            ));
+        };
+        let mut normalized = raw.to_ascii_lowercase();
+        // Legacy label from the MVP policy format.
+        if lhs == Lhs::InputKind && normalized == "audioraw" {
+            normalized = "audio".to_string();
+        }
+        if !allowed.contains(&normalized.as_str()) {
+            return Err(format!(
+                "'{raw}' is not a valid value for '{}' (expected one of: {})",
+                lhs.as_str(),
+                allowed.join(", ")
+            ));
+        }
+        Rhs::Str(normalized)
+    } else {
+        debug_assert_eq!(lhs, Lhs::InputText);
+        let RhsToken::Quoted(raw) = rhs_token else {
+            return Err(format!(
+                "operand '{}' must be compared against a quoted string",
+                lhs.as_str()
+            ));
+        };
+        match op {
+            Op::Matches => {
+                Rhs::Regex(Regex::new(&raw).map_err(|e| format!("invalid regex '{raw}': {e}"))?)
+            }
+            Op::Eq | Op::Ne | Op::Contains => Rhs::Str(raw),
+            other => {
+                return Err(format!(
+                "operator '{}' is not valid for operand '{}' (use ==, !=, contains, or matches)",
+                other.as_str(),
+                lhs.as_str()
+            ))
+            }
+        }
+    };
+
+    Ok(Expr::Compare { lhs, op, rhs })
+}
+
+fn kind_name(kind: &EnvelopeKind) -> &'static str {
+    match kind {
+        EnvelopeKind::Audio(_) => "audio",
+        EnvelopeKind::Text(_) => "text",
+        EnvelopeKind::Embedding(_) => "embedding",
+        EnvelopeKind::Image { .. } => "image",
+        EnvelopeKind::MultiPart(_) => "multipart",
+    }
+}
+
+fn battery_level(metrics: &DeviceMetrics) -> f64 {
+    metrics
+        .resource
+        .battery_pct
+        .map(f64::from)
+        .unwrap_or_else(|| f64::from(metrics.capabilities.battery_level()))
+}
+
+fn compare_enum(actual: &str, op: Op, rhs: &Rhs) -> bool {
+    let Rhs::Str(expected) = rhs else {
+        return false;
+    };
+    let equal = actual.eq_ignore_ascii_case(expected);
+    match op {
+        Op::Eq => equal,
+        Op::Ne => !equal,
+        _ => false,
+    }
+}
+
+fn compare_text(actual: &str, op: Op, rhs: &Rhs) -> bool {
+    match (op, rhs) {
+        (Op::Contains, Rhs::Str(needle)) => actual.contains(needle.as_str()),
+        (Op::Matches, Rhs::Regex(regex)) => regex.is_match(actual),
+        (Op::Eq, Rhs::Str(expected)) => actual == expected,
+        (Op::Ne, Rhs::Str(expected)) => actual != expected,
+        _ => false,
+    }
+}
+
+fn compare_number(actual: f64, op: Op, rhs: &Rhs) -> bool {
+    let Rhs::Num(expected) = rhs else {
+        return false;
+    };
+    match op {
+        Op::Eq => actual == *expected,
+        Op::Ne => actual != *expected,
+        Op::Lt => actual < *expected,
+        Op::Le => actual <= *expected,
+        Op::Gt => actual > *expected,
+        Op::Ge => actual >= *expected,
+        _ => false,
+    }
+}
+
+impl Expr {
+    fn evaluate(&self, envelope: &Envelope, metrics: &DeviceMetrics) -> bool {
+        match self {
+            Expr::Literal(value) => *value,
+            Expr::Compare { lhs, op, rhs } => match lhs {
+                Lhs::InputKind => compare_enum(kind_name(&envelope.kind), *op, rhs),
+                Lhs::MemoryPressure => {
+                    compare_enum(metrics.resource.memory_pressure.as_str(), *op, rhs)
+                }
+                Lhs::ThermalState => {
+                    compare_enum(metrics.resource.thermal_state.as_str(), *op, rhs)
+                }
+                Lhs::InputText => envelope
+                    .as_text()
+                    .map(|text| compare_text(text, *op, rhs))
+                    .unwrap_or(false),
+                Lhs::InputTextLen => envelope
+                    .as_text()
+                    .map(|text| compare_number(text.chars().count() as f64, *op, rhs))
+                    .unwrap_or(false),
+                Lhs::BatteryLevel => compare_number(battery_level(metrics), *op, rhs),
+                Lhs::CpuPct => metrics
+                    .resource
+                    .cpu_pct
+                    .map(|pct| compare_number(f64::from(pct), *op, rhs))
+                    .unwrap_or(false),
+            },
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bundle parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn string_field(value: &serde_yaml::Value, key: &str) -> Result<String, String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| format!("'{key}' must be a string"))
+}
+
+fn expression_value(value: &serde_yaml::Value, location: &str) -> Result<String, String> {
+    match value {
+        serde_yaml::Value::String(s) => Ok(s.clone()),
+        serde_yaml::Value::Bool(b) => Ok(b.to_string()),
+        _ => Err(format!("{location}: expression must be a string")),
+    }
+}
+
+fn mapping_key<'a>(value: &'a serde_yaml::Value, location: &str) -> Result<&'a str, String> {
+    value
+        .as_str()
+        .ok_or_else(|| format!("{location}: keys must be strings"))
+}
+
+/// Parse and compile a complete bundle. Pure: nothing is activated until the
+/// caller swaps the result in.
+fn parse_bundle(bytes: &[u8]) -> Result<(PolicyBundle, Vec<Expr>), String> {
+    let value: serde_yaml::Value = serde_yaml::from_slice(bytes)
+        .map_err(|e| format!("failed to parse policy bundle as YAML or JSON: {e}"))?;
+    let map = value
+        .as_mapping()
+        .ok_or_else(|| "policy bundle must be a mapping at the top level".to_string())?;
+
+    let mut version = "1.0.0".to_string();
+    let mut signature = "unsigned".to_string();
+
+    for (key, field) in map {
+        match mapping_key(key, "policy bundle")? {
+            "version" => version = string_field(field, "version")?,
+            "signature" => signature = string_field(field, "signature")?,
+            "rules" | "deny_cloud_if" | "route_cloud_if" => {}
+            other => {
+                return Err(format!(
+                    "unknown policy bundle key '{other}' (expected version, signature, rules, \
+                     deny_cloud_if, or route_cloud_if)"
+                ))
+            }
+        }
     }
 
-    /// Evaluate a single expression against the context.
-    fn evaluate_expression(
-        &self,
-        expression: &str,
-        envelope: &Envelope,
-        _metrics: &DeviceMetrics,
-    ) -> bool {
-        // MVP: Simple expression evaluation
-        // Supports:
-        // - input.kind == "value"
+    let mut raw_rules: Vec<(String, String, PolicyAction)> = Vec::new();
 
-        let expr = expression.trim();
-
-        // Check for equality comparisons: input.kind == "value"
-        if expr.contains("input.kind ==") {
-            let parts: Vec<&str> = expr.split("==").collect();
-            if parts.len() == 2 {
-                let value = parts[1].trim().trim_matches('"').trim();
-
-                // Direct comparison against metadata label if provided.
-                if let Some(label) = envelope.get_metadata("kind_label") {
-                    if label == value {
-                        return true;
-                    }
-                }
-
-                // Compare against the textual payload for text envelopes.
-                if let EnvelopeKind::Text(text) = &envelope.kind {
-                    if text == value {
-                        return true;
-                    }
-                }
-
-                // Compare against the high-level variant name (Audio/Text/Embedding).
-                if envelope.kind_str() == value {
-                    return true;
-                }
-
-                // Backwards compatibility: treat legacy labels as variant aliases.
-                match &envelope.kind {
-                    EnvelopeKind::Audio(_) => {
-                        if value.eq_ignore_ascii_case("audioraw")
-                            || value.eq_ignore_ascii_case("audio")
-                        {
-                            return true;
-                        }
-                    }
-                    EnvelopeKind::Text(_) => {
-                        if value.eq_ignore_ascii_case("text") {
-                            return true;
-                        }
-                    }
-                    EnvelopeKind::Embedding(_) => {
-                        if value.eq_ignore_ascii_case("embedding") {
-                            return true;
-                        }
-                    }
-                    EnvelopeKind::Image { .. } => {
-                        if value.eq_ignore_ascii_case("image") {
-                            return true;
-                        }
-                    }
-                    EnvelopeKind::MultiPart(_) => {
-                        if value.eq_ignore_ascii_case("multipart") {
-                            return true;
-                        }
+    if let Some(rules) = map.get("rules") {
+        let sequence = rules
+            .as_sequence()
+            .ok_or_else(|| "'rules' must be a sequence".to_string())?;
+        for (idx, item) in sequence.iter().enumerate() {
+            let location = format!("rules[{idx}]");
+            let rule = item
+                .as_mapping()
+                .ok_or_else(|| format!("{location} must be a mapping"))?;
+            for key in rule.keys() {
+                match mapping_key(key, &location)? {
+                    "id" | "expression" | "action" => {}
+                    other => {
+                        return Err(format!(
+                            "{location}: unknown key '{other}' (expected id, expression, action)"
+                        ))
                     }
                 }
             }
+            let id = rule
+                .get("id")
+                .ok_or_else(|| format!("{location}: missing required field 'id'"))
+                .and_then(|v| string_field(v, &format!("{location}.id")))?;
+            let expression = rule
+                .get("expression")
+                .ok_or_else(|| format!("rule '{id}': missing required field 'expression'"))
+                .and_then(|v| expression_value(v, &format!("rule '{id}'")))?;
+            let action = rule
+                .get("action")
+                .ok_or_else(|| format!("rule '{id}': missing required field 'action'"))
+                .and_then(|v| string_field(v, &format!("rule '{id}'.action")))
+                .and_then(|s| {
+                    s.parse::<PolicyAction>()
+                        .map_err(|e| format!("rule '{id}': {e}"))
+                })?;
+            raw_rules.push((id, expression, action));
         }
+    }
 
-        // If we can't parse it, default to false (no match → no deny).
-        false
+    for (key, action) in [
+        ("deny_cloud_if", PolicyAction::Deny),
+        ("route_cloud_if", PolicyAction::RouteCloud),
+    ] {
+        if let Some(entries) = map.get(key) {
+            let sequence = entries
+                .as_sequence()
+                .ok_or_else(|| format!("'{key}' must be a sequence of expressions"))?;
+            for (idx, item) in sequence.iter().enumerate() {
+                let location = format!("{key}[{idx}]");
+                let expression = expression_value(item, &location)?;
+                raw_rules.push((format!("{key}_{idx}"), expression, action));
+            }
+        }
+    }
+
+    if raw_rules.is_empty() {
+        return Err("policy bundle contains no rules".to_string());
+    }
+
+    let mut seen = HashSet::new();
+    for (id, _, _) in &raw_rules {
+        if !seen.insert(id.as_str()) {
+            return Err(format!("duplicate policy rule id '{id}'"));
+        }
+    }
+
+    let mut rules = Vec::with_capacity(raw_rules.len());
+    let mut compiled = Vec::with_capacity(raw_rules.len());
+    for (id, expression, action) in raw_rules {
+        let expr = compile_expression(&expression).map_err(|e| format!("rule '{id}': {e}"))?;
+        rules.push(PolicyRule {
+            id,
+            expression,
+            action,
+        });
+        compiled.push(expr);
+    }
+
+    Ok((
+        PolicyBundle {
+            version,
+            rules,
+            signature,
+        },
+        compiled,
+    ))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Default engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Default implementation of [`PolicyEngine`].
+///
+/// Expressions are compiled when a bundle is loaded; evaluation is a linear
+/// scan over the compiled rules with first-match-wins semantics.
+pub struct DefaultPolicyEngine {
+    bundle: Option<PolicyBundle>,
+    /// Compiled form of `bundle.rules`, index-aligned.
+    compiled: Vec<Expr>,
+}
+
+impl DefaultPolicyEngine {
+    /// Create an engine with no bundle loaded (allow-all).
+    pub fn new() -> Self {
+        Self {
+            bundle: None,
+            compiled: Vec::new(),
+        }
+    }
+
+    /// Create an engine with the default (empty, allow-all) bundle.
+    ///
+    /// Callers wanting stricter behaviour should `load_policies` an explicit
+    /// bundle.
+    pub fn with_default_policy() -> Self {
+        Self {
+            bundle: Some(PolicyBundle {
+                version: "0.1.0".to_string(),
+                rules: vec![],
+                signature: "default_mvp".to_string(),
+            }),
+            compiled: Vec::new(),
+        }
+    }
+
+    /// The currently active bundle, if any.
+    pub fn bundle(&self) -> Option<&PolicyBundle> {
+        self.bundle.as_ref()
     }
 }
 
@@ -179,288 +781,638 @@ impl Default for DefaultPolicyEngine {
 
 impl PolicyEngine for DefaultPolicyEngine {
     fn load_policies(&mut self, bundle_bytes: Vec<u8>) -> Result<(), String> {
-        // Try to parse as YAML first
-        let yaml_result: Result<serde_yaml::Value, _> = serde_yaml::from_slice(&bundle_bytes);
-
-        if let Ok(yaml_value) = yaml_result {
-            self.parse_yaml_policy(yaml_value)?;
-            return Ok(());
-        }
-
-        // Try to parse as JSON
-        let json_result: Result<serde_json::Value, _> = serde_json::from_slice(&bundle_bytes);
-
-        if let Ok(json_value) = json_result {
-            self.parse_json_policy(json_value)?;
-            return Ok(());
-        }
-
-        Err("Failed to parse policy bundle as YAML or JSON".to_string())
+        let (bundle, compiled) = parse_bundle(&bundle_bytes)?;
+        self.bundle = Some(bundle);
+        self.compiled = compiled;
+        Ok(())
     }
 
     fn evaluate(&self, _stage: &str, envelope: &Envelope, metrics: &DeviceMetrics) -> PolicyResult {
-        // If no policy bundle is loaded, default to allow
         let Some(ref bundle) = self.bundle else {
             return PolicyResult::allow(Some("no policy loaded".to_string()));
         };
 
-        // Evaluate each rule
-        for rule in &bundle.rules {
-            let matches = self.evaluate_expression(&rule.expression, envelope, metrics);
-
-            if matches {
-                match rule.action.as_str() {
-                    "deny" => {
-                        let reason =
-                            format!("Policy rule '{}' matched: {}", rule.id, rule.expression);
-                        return PolicyResult::deny(reason);
-                    }
-                    "redact" => {
-                        // For redact, we'll mark it in the result but still allow
-                        // The actual redaction is applied by the redact() method
-                        let mut result = PolicyResult::allow(Some(format!(
-                            "Rule '{}' requires redaction",
-                            rule.id
-                        )));
-                        result.transforms_applied.push(rule.id.clone());
-                        return result;
-                    }
-                    _ => {
-                        // "allow" or unknown action - continue to next rule
-                    }
+        for (rule, expr) in bundle.rules.iter().zip(&self.compiled) {
+            if !expr.evaluate(envelope, metrics) {
+                continue;
+            }
+            match rule.action {
+                PolicyAction::Allow => {
+                    return PolicyResult::allow(Some(format!(
+                        "policy rule '{}' allowed: {}",
+                        rule.id, rule.expression
+                    )));
+                }
+                PolicyAction::Deny => {
+                    return PolicyResult::deny(format!(
+                        "Policy rule '{}' matched: {}",
+                        rule.id, rule.expression
+                    ));
+                }
+                PolicyAction::RouteCloud => {
+                    return PolicyResult::prefer_cloud(format!(
+                        "policy rule '{}' prefers cloud: {}",
+                        rule.id, rule.expression
+                    ));
+                }
+                PolicyAction::Redact => {
+                    let mut result =
+                        PolicyResult::allow(Some(format!("Rule '{}' requires redaction", rule.id)));
+                    result.transforms_applied.push(rule.id.clone());
+                    return result;
                 }
             }
         }
 
-        // No denying rules matched, allow
         PolicyResult::allow(Some("all policy checks passed".to_string()))
     }
 
     fn redact(&self, _envelope: &mut Envelope) -> bool {
-        // MVP: Simple redaction - just log for now
-        // TODO: Implement actual redaction transforms (text filtering, truncation, etc.)
-        // For now, this is a no-op but returns false to indicate no changes
+        // Redaction transforms are not implemented. Callers must treat a
+        // non-empty `transforms_applied` as "stay local", never as
+        // "redacted, safe to send".
         false
-    }
-}
-
-impl DefaultPolicyEngine {
-    /// Parse a YAML policy structure.
-    fn parse_yaml_policy(&mut self, value: serde_yaml::Value) -> Result<(), String> {
-        let mut rules = Vec::new();
-        let mut version = "1.0.0".to_string();
-        let mut signature = "unsigned".to_string();
-
-        // Parse version if present
-        if let Some(v) = value.get("version").and_then(|v| v.as_str()) {
-            version = v.to_string();
-        }
-
-        // Parse signature if present
-        if let Some(s) = value.get("signature").and_then(|s| s.as_str()) {
-            signature = s.to_string();
-        }
-
-        // Parse deny_cloud_if rules (MVP format)
-        if let Some(deny_rules) = value.get("deny_cloud_if").and_then(|v| v.as_sequence()) {
-            for (idx, rule_value) in deny_rules.iter().enumerate() {
-                if let Some(expr) = rule_value.as_str() {
-                    rules.push(PolicyRule {
-                        id: format!("deny_rule_{}", idx),
-                        expression: expr.to_string(),
-                        action: "deny".to_string(),
-                    });
-                }
-            }
-        }
-
-        // Parse rules array if present (more structured format)
-        if let Some(rules_array) = value.get("rules").and_then(|v| v.as_sequence()) {
-            for rule_value in rules_array {
-                if let Some(id) = rule_value.get("id").and_then(|v| v.as_str()) {
-                    let expression = rule_value
-                        .get("expression")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let action = rule_value
-                        .get("action")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("deny")
-                        .to_string();
-
-                    rules.push(PolicyRule {
-                        id: id.to_string(),
-                        expression,
-                        action,
-                    });
-                }
-            }
-        }
-
-        if rules.is_empty() {
-            return Err("No valid rules found in policy bundle".to_string());
-        }
-
-        self.bundle = Some(PolicyBundle {
-            version,
-            rules,
-            signature,
-        });
-
-        Ok(())
-    }
-
-    /// Parse a JSON policy structure.
-    fn parse_json_policy(&mut self, value: serde_json::Value) -> Result<(), String> {
-        let mut rules = Vec::new();
-        let mut version = "1.0.0".to_string();
-        let mut signature = "unsigned".to_string();
-
-        // Parse version if present
-        if let Some(v) = value.get("version").and_then(|v| v.as_str()) {
-            version = v.to_string();
-        }
-
-        // Parse signature if present
-        if let Some(s) = value.get("signature").and_then(|s| s.as_str()) {
-            signature = s.to_string();
-        }
-
-        // Parse deny_cloud_if rules (MVP format)
-        if let Some(deny_rules) = value.get("deny_cloud_if").and_then(|v| v.as_array()) {
-            for (idx, rule_value) in deny_rules.iter().enumerate() {
-                if let Some(expr) = rule_value.as_str() {
-                    rules.push(PolicyRule {
-                        id: format!("deny_rule_{}", idx),
-                        expression: expr.to_string(),
-                        action: "deny".to_string(),
-                    });
-                }
-            }
-        }
-
-        // Parse rules array if present (more structured format)
-        if let Some(rules_array) = value.get("rules").and_then(|v| v.as_array()) {
-            for rule_value in rules_array {
-                if let Some(id) = rule_value.get("id").and_then(|v| v.as_str()) {
-                    let expression = rule_value
-                        .get("expression")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let action = rule_value
-                        .get("action")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("deny")
-                        .to_string();
-
-                    rules.push(PolicyRule {
-                        id: id.to_string(),
-                        expression,
-                        action,
-                    });
-                }
-            }
-        }
-
-        if rules.is_empty() {
-            return Err("No valid rules found in policy bundle".to_string());
-        }
-
-        self.bundle = Some(PolicyBundle {
-            version,
-            rules,
-            signature,
-        });
-
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::device::{MemoryPressure, ResourceSnapshot, ThermalState};
     use crate::ir::{Envelope, EnvelopeKind};
 
-    fn text_envelope(value: &str) -> Envelope {
+    fn text(value: &str) -> Envelope {
         Envelope::new(EnvelopeKind::Text(value.to_string()))
     }
 
-    fn audio_envelope(bytes: &[u8]) -> Envelope {
-        Envelope::new(EnvelopeKind::Audio(bytes.to_vec()))
+    fn audio() -> Envelope {
+        Envelope::new(EnvelopeKind::Audio(vec![0, 1, 2]))
     }
 
-    #[test]
-    fn test_default_policy_allows_text() {
-        let engine = DefaultPolicyEngine::with_default_policy();
-        let envelope = text_envelope("Text");
-        let metrics = DeviceMetrics::default();
-
-        let result = engine.evaluate("test_stage", &envelope, &metrics);
-        assert!(result.allowed);
+    fn embedding() -> Envelope {
+        Envelope::new(EnvelopeKind::Embedding(vec![0.1, 0.2]))
     }
 
-    #[test]
-    fn test_default_policy_allows_audio_raw() {
-        let engine = DefaultPolicyEngine::with_default_policy();
-        let envelope = audio_envelope(&[0, 1, 2]);
-        let metrics = DeviceMetrics::default();
-
-        let result = engine.evaluate("test_stage", &envelope, &metrics);
-        assert!(result.allowed);
-        assert!(result.reason.is_some());
-        assert!(result.reason.unwrap().contains("all policy checks passed"));
+    fn multipart() -> Envelope {
+        Envelope::new(EnvelopeKind::MultiPart(vec![text("a"), text("b")]))
     }
 
-    #[test]
-    fn test_load_yaml_policy_input_kind_rule() {
-        let yaml_content = r#"
-version: "0.1.0"
-deny_cloud_if:
-  - input.kind == "SensitiveData"
-signature: "test"
-"#;
+    fn metrics() -> DeviceMetrics {
+        DeviceMetrics::default()
+    }
 
+    fn metrics_with(
+        battery_pct: Option<u8>,
+        cpu_pct: Option<f32>,
+        memory_pressure: MemoryPressure,
+        thermal_state: ThermalState,
+    ) -> DeviceMetrics {
+        let mut snapshot = ResourceSnapshot::unknown();
+        snapshot.battery_pct = battery_pct;
+        snapshot.cpu_pct = cpu_pct;
+        snapshot.memory_pressure = memory_pressure;
+        snapshot.thermal_state = thermal_state;
+        DeviceMetrics::default().with_live_snapshot(snapshot)
+    }
+
+    fn engine(bundle: &str) -> DefaultPolicyEngine {
         let mut engine = DefaultPolicyEngine::new();
-        let result = engine.load_policies(yaml_content.as_bytes().to_vec());
-        assert!(result.is_ok());
-
-        let envelope = text_envelope("SensitiveData");
-        let metrics = DeviceMetrics::default();
-
-        let policy_result = engine.evaluate("test", &envelope, &metrics);
-        assert!(!policy_result.allowed);
+        engine
+            .load_policies(bundle.as_bytes().to_vec())
+            .unwrap_or_else(|e| panic!("bundle should load: {e}\n{bundle}"));
+        engine
     }
 
-    #[test]
-    fn test_load_json_policy_input_kind_rule() {
-        let json_content = r#"{
-            "version": "0.1.0",
-            "deny_cloud_if": [
-                "input.kind == \"AudioRaw\""
-            ],
-            "signature": "test"
-        }"#;
-
+    fn load_error(bundle: &str) -> String {
         let mut engine = DefaultPolicyEngine::new();
-        let result = engine.load_policies(json_content.as_bytes().to_vec());
-        assert!(result.is_ok());
+        engine
+            .load_policies(bundle.as_bytes().to_vec())
+            .expect_err("bundle should be rejected")
+    }
 
-        let envelope = audio_envelope(&[1, 2, 3]);
-        let metrics = DeviceMetrics::default();
+    fn deny_if(expression: &str) -> DefaultPolicyEngine {
+        engine(&format!("deny_cloud_if:\n  - '{expression}'\n"))
+    }
 
-        let policy_result = engine.evaluate("test", &envelope, &metrics);
-        assert!(!policy_result.allowed);
+    fn matches(expression: &str, envelope: &Envelope, metrics: &DeviceMetrics) -> bool {
+        !deny_if(expression)
+            .evaluate("stage", envelope, metrics)
+            .allowed
+    }
+
+    // ── defaults ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn default_policy_allows_everything() {
+        let engine = DefaultPolicyEngine::with_default_policy();
+        for envelope in [text("Text"), audio(), embedding(), multipart()] {
+            let result = engine.evaluate("stage", &envelope, &metrics());
+            assert!(result.allowed);
+            assert!(!result.requires_local());
+            assert!(!result.prefers_cloud());
+            assert_eq!(result.reason.as_deref(), Some("all policy checks passed"));
+        }
     }
 
     #[test]
-    fn test_no_policy_allows() {
+    fn no_policy_loaded_allows() {
         let engine = DefaultPolicyEngine::new();
-        let envelope = text_envelope("Text");
-        let metrics = DeviceMetrics::default();
-
-        let result = engine.evaluate("test_stage", &envelope, &metrics);
+        let result = engine.evaluate("stage", &text("hello"), &metrics());
         assert!(result.allowed);
+        assert_eq!(result.reason.as_deref(), Some("no policy loaded"));
+        assert!(engine.bundle().is_none());
+    }
+
+    // ── input.kind ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn input_kind_matches_variant_not_payload() {
+        assert!(matches(
+            r#"input.kind == "text""#,
+            &text("audio"),
+            &metrics()
+        ));
+        assert!(!matches(
+            r#"input.kind == "audio""#,
+            &text("audio"),
+            &metrics()
+        ));
+        assert!(matches(r#"input.kind == "audio""#, &audio(), &metrics()));
+        assert!(matches(
+            r#"input.kind == "embedding""#,
+            &embedding(),
+            &metrics()
+        ));
+        assert!(matches(
+            r#"input.kind == "multipart""#,
+            &multipart(),
+            &metrics()
+        ));
+        assert!(matches(r#"input.kind != "text""#, &audio(), &metrics()));
+        assert!(!matches(r#"input.kind != "text""#, &text("x"), &metrics()));
+    }
+
+    #[test]
+    fn input_kind_is_case_insensitive_and_accepts_legacy_audioraw() {
+        assert!(matches(r#"input.kind == "TEXT""#, &text("x"), &metrics()));
+        assert!(matches(r#"input.kind == "AudioRaw""#, &audio(), &metrics()));
+        assert!(!matches(
+            r#"input.kind == "AudioRaw""#,
+            &text("x"),
+            &metrics()
+        ));
+    }
+
+    #[test]
+    fn input_kind_rejects_unknown_values_at_load() {
+        let err = load_error("deny_cloud_if:\n  - 'input.kind == \"SensitiveData\"'\n");
+        assert!(err.contains("SensitiveData"), "{err}");
+        assert!(err.contains("deny_cloud_if_0"), "{err}");
+    }
+
+    // ── input.text / input.text_len ─────────────────────────────────────────
+
+    #[test]
+    fn input_text_contains_is_case_sensitive_substring() {
+        assert!(matches(
+            r#"input.text contains "secret""#,
+            &text("my secret"),
+            &metrics()
+        ));
+        assert!(!matches(
+            r#"input.text contains "secret""#,
+            &text("my SECRET"),
+            &metrics()
+        ));
+        assert!(!matches(
+            r#"input.text contains "secret""#,
+            &audio(),
+            &metrics()
+        ));
+    }
+
+    #[test]
+    fn input_text_matches_uses_regex() {
+        let m = metrics();
+        assert!(matches(
+            r#"input.text matches "(?i)password|ssn""#,
+            &text("My PASSWORD"),
+            &m
+        ));
+        assert!(!matches(r#"input.text matches "^\d+$""#, &text("abc"), &m));
+        assert!(matches(r#"input.text matches "^\d+$""#, &text("123"), &m));
+        assert!(!matches(r#"input.text matches ".*""#, &audio(), &m));
+    }
+
+    #[test]
+    fn input_text_equality_is_exact() {
+        assert!(matches(r#"input.text == "hi""#, &text("hi"), &metrics()));
+        assert!(!matches(r#"input.text == "hi""#, &text("Hi"), &metrics()));
+        assert!(matches(r#"input.text != "hi""#, &text("Hi"), &metrics()));
+        assert!(!matches(r#"input.text != "hi""#, &audio(), &metrics()));
+    }
+
+    #[test]
+    fn input_text_escaped_literals() {
+        let m = metrics();
+        assert!(matches(
+            r#"input.text contains "say \"hi\"""#,
+            &text(r#"please say "hi" now"#),
+            &m
+        ));
+        assert!(matches(
+            r#"input.text contains "a\\b""#,
+            &text(r"x a\b y"),
+            &m
+        ));
+        // Unknown escapes pass through verbatim, so regex escapes need no
+        // double-escaping and a literal `\n` sequence stays two characters.
+        assert!(matches(
+            r#"input.text matches "^\d{3}-\d{4}$""#,
+            &text("555-1234"),
+            &m
+        ));
+        assert!(matches(
+            r#"input.text matches "v1\.2""#,
+            &text("release v1.2"),
+            &m
+        ));
+        assert!(!matches(
+            r#"input.text matches "v1\.2""#,
+            &text("release v1x2"),
+            &m
+        ));
+        assert!(matches(
+            r#"input.text contains "line\nbreak""#,
+            &text(r"line\nbreak"),
+            &m
+        ));
+        assert!(!matches(
+            r#"input.text contains "line\nbreak""#,
+            &text("line\nbreak"),
+            &m
+        ));
+    }
+
+    #[test]
+    fn input_text_len_counts_unicode_scalars() {
+        let m = metrics();
+        assert!(matches("input.text_len == 5", &text("héllo"), &m));
+        assert!(matches("input.text_len == 2", &text("😀😀"), &m));
+        assert!(matches("input.text_len > 800", &text(&"x".repeat(801)), &m));
+        assert!(!matches(
+            "input.text_len > 800",
+            &text(&"x".repeat(800)),
+            &m
+        ));
+        assert!(matches(
+            "input.text_len >= 800",
+            &text(&"x".repeat(800)),
+            &m
+        ));
+        assert!(matches("input.text_len < 3", &text("ab"), &m));
+        assert!(matches("input.text_len <= 2", &text("ab"), &m));
+        assert!(matches("input.text_len != 2", &text("abc"), &m));
+        assert!(!matches("input.text_len >= 0", &audio(), &m));
+    }
+
+    // ── metrics.* ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn battery_prefers_live_snapshot_then_capabilities() {
+        let live = metrics_with(Some(10), None, MemoryPressure::Normal, ThermalState::Normal);
+        assert!(matches("metrics.battery_level < 25", &text("x"), &live));
+        assert!(!matches("metrics.battery_level >= 25", &text("x"), &live));
+
+        // No live reading: fall back to capabilities (default 100).
+        let fallback = metrics();
+        assert!(matches(
+            "metrics.battery_level == 100",
+            &text("x"),
+            &fallback
+        ));
+        assert!(!matches(
+            "metrics.battery_level < 25",
+            &text("x"),
+            &fallback
+        ));
+    }
+
+    #[test]
+    fn cpu_missing_never_matches() {
+        let missing = metrics_with(None, None, MemoryPressure::Normal, ThermalState::Normal);
+        assert!(!matches("metrics.cpu_pct > 0", &text("x"), &missing));
+        assert!(!matches("metrics.cpu_pct <= 100", &text("x"), &missing));
+        let hot = metrics_with(
+            None,
+            Some(96.5),
+            MemoryPressure::Normal,
+            ThermalState::Normal,
+        );
+        assert!(matches("metrics.cpu_pct > 95", &text("x"), &hot));
+        assert!(matches("metrics.cpu_pct >= 96.5", &text("x"), &hot));
+        assert!(!matches("metrics.cpu_pct < 96.5", &text("x"), &hot));
+    }
+
+    #[test]
+    fn memory_pressure_and_thermal_state_compare_case_insensitively() {
+        let m = metrics_with(None, None, MemoryPressure::Critical, ThermalState::Hot);
+        assert!(matches(
+            r#"metrics.memory_pressure == "CRITICAL""#,
+            &text("x"),
+            &m
+        ));
+        assert!(matches(
+            r#"metrics.memory_pressure != "normal""#,
+            &text("x"),
+            &m
+        ));
+        assert!(matches(r#"metrics.thermal_state == "hot""#, &text("x"), &m));
+        assert!(!matches(
+            r#"metrics.thermal_state == "critical""#,
+            &text("x"),
+            &m
+        ));
+        let unknown = metrics_with(None, None, MemoryPressure::Unknown, ThermalState::Normal);
+        assert!(matches(
+            r#"metrics.memory_pressure == "unknown""#,
+            &text("x"),
+            &unknown
+        ));
+    }
+
+    // ── literals, actions, ordering ─────────────────────────────────────────
+
+    #[test]
+    fn boolean_literals() {
+        assert!(matches("true", &audio(), &metrics()));
+        assert!(!matches("false", &audio(), &metrics()));
+        // Unquoted YAML booleans are accepted too.
+        let engine = engine("deny_cloud_if:\n  - true\n");
+        assert!(!engine.evaluate("s", &text("x"), &metrics()).allowed);
+    }
+
+    #[test]
+    fn first_matching_rule_wins() {
+        let allow_first = engine(
+            r#"
+rules:
+  - id: allow_all
+    expression: "true"
+    action: allow
+  - id: deny_all
+    expression: "true"
+    action: deny
+"#,
+        );
+        let result = allow_first.evaluate("s", &text("x"), &metrics());
+        assert!(result.allowed);
+        assert!(result.reason.unwrap().contains("allow_all"));
+
+        let deny_first = engine(
+            r#"
+rules:
+  - id: deny_all
+    expression: "true"
+    action: deny
+  - id: allow_all
+    expression: "true"
+    action: allow
+"#,
+        );
+        let result = deny_first.evaluate("s", &text("x"), &metrics());
+        assert!(!result.allowed);
+        assert!(result.reason.unwrap().contains("deny_all"));
+    }
+
+    #[test]
+    fn route_cloud_and_alias_prefer_cloud() {
+        for action in ["route_cloud", "prefer_cloud"] {
+            let engine = engine(&format!(
+                "rules:\n  - id: offload\n    expression: \"true\"\n    action: {action}\n"
+            ));
+            let result = engine.evaluate("s", &text("x"), &metrics());
+            assert!(result.allowed);
+            assert!(result.prefers_cloud());
+            assert!(!result.requires_local());
+            assert!(result.reason.unwrap().contains("offload"));
+            assert_eq!(
+                engine.bundle().unwrap().rules[0].action,
+                PolicyAction::RouteCloud
+            );
+        }
+        let shorthand = engine("route_cloud_if:\n  - \"true\"\n");
+        assert!(shorthand
+            .evaluate("s", &text("x"), &metrics())
+            .prefers_cloud());
+    }
+
+    #[test]
+    fn redact_requires_local() {
+        let engine = engine(
+            "rules:\n  - id: scrub\n    expression: 'input.kind == \"text\"'\n    action: redact\n",
+        );
+        let result = engine.evaluate("s", &text("x"), &metrics());
+        assert!(result.allowed);
+        assert_eq!(result.transforms_applied, vec!["scrub".to_string()]);
+        assert!(result.requires_local());
+        assert!(!result.prefers_cloud());
+    }
+
+    #[test]
+    fn shorthand_rules_follow_explicit_rules_in_order() {
+        // Explicit allow stops evaluation before the shorthand denial.
+        let engine_allow = engine(
+            r#"
+rules:
+  - id: allow_text
+    expression: 'input.kind == "text"'
+    action: allow
+deny_cloud_if:
+  - "true"
+"#,
+        );
+        assert!(engine_allow.evaluate("s", &text("x"), &metrics()).allowed);
+        assert!(!engine_allow.evaluate("s", &audio(), &metrics()).allowed);
+
+        // deny_cloud_if is appended before route_cloud_if.
+        let engine_both = engine("deny_cloud_if:\n  - \"true\"\nroute_cloud_if:\n  - \"true\"\n");
+        let result = engine_both.evaluate("s", &text("x"), &metrics());
+        assert!(!result.allowed);
+        assert!(!result.prefers_cloud());
+        let ids: Vec<_> = engine_both
+            .bundle()
+            .unwrap()
+            .rules
+            .iter()
+            .map(|r| r.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["deny_cloud_if_0", "route_cloud_if_0"]);
+    }
+
+    #[test]
+    fn json_bundles_parse_like_yaml() {
+        let engine = engine(
+            r#"{
+  "version": "0.1.0",
+  "signature": "test",
+  "deny_cloud_if": ["input.kind == \"AudioRaw\""],
+  "rules": [{"id": "long", "expression": "input.text_len > 3", "action": "route_cloud"}]
+}"#,
+        );
+        let bundle = engine.bundle().unwrap();
+        assert_eq!(bundle.version, "0.1.0");
+        assert_eq!(bundle.signature, "test");
+        assert!(!engine.evaluate("s", &audio(), &metrics()).allowed);
+        assert!(engine
+            .evaluate("s", &text("long text"), &metrics())
+            .prefers_cloud());
+        assert!(engine.evaluate("s", &text("hi"), &metrics()).allowed);
+    }
+
+    // ── load-time rejection ────────────────────────────────────────────────
+
+    #[test]
+    fn rejects_unknown_operand_operator_and_type_mismatches() {
+        let cases = [
+            ("metrics.network_rtt > 300", "unknown operand"),
+            ("input.kind ~= \"text\"", "unknown operator"),
+            (
+                "metrics.battery_level contains \"x\"",
+                "not valid for numeric operand",
+            ),
+            (
+                "metrics.battery_level < \"low\"",
+                "must be compared against a number",
+            ),
+            ("metrics.battery_level < abc", "is not a number"),
+            ("metrics.battery_level < inf", "not a finite number"),
+            ("metrics.cpu_pct > NaN", "not a finite number"),
+            (
+                "input.kind == text",
+                "must be compared against a quoted string",
+            ),
+            ("input.kind < \"text\"", "use == or !="),
+            ("metrics.memory_pressure == \"high\"", "not a valid value"),
+            ("metrics.thermal_state == \"boiling\"", "not a valid value"),
+            ("input.text > \"x\"", "use ==, !=, contains, or matches"),
+            ("input.text matches \"(unclosed\"", "invalid regex"),
+            (
+                "input.text contains \"unterminated",
+                "unterminated string literal",
+            ),
+            (
+                "input.text contains \"a\" extra",
+                "unexpected trailing input",
+            ),
+            ("input.text_len > 1 2", "unexpected trailing input"),
+            ("input.kind", "expected '<operand> <operator> <value>'"),
+            ("input.kind ==", "missing right operand"),
+            ("", "expression is empty"),
+        ];
+        for (expression, expected) in cases {
+            let err = load_error(&format!("deny_cloud_if:\n  - '{expression}'\n"));
+            assert!(
+                err.contains(expected),
+                "expression `{expression}` should fail with `{expected}`, got: {err}"
+            );
+            assert!(err.contains("rule 'deny_cloud_if_0'"), "{err}");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_bundles() {
+        let cases = [
+            ("- just\n- a\n- list\n", "must be a mapping at the top level"),
+            ("version: \"1\"\n", "contains no rules"),
+            ("unexpected: 1\n", "unknown policy bundle key 'unexpected'"),
+            ("rules: notalist\n", "'rules' must be a sequence"),
+            ("deny_cloud_if: \"true\"\n", "'deny_cloud_if' must be a sequence"),
+            ("deny_cloud_if:\n  - 5\n", "expression must be a string"),
+            ("rules:\n  - \"true\"\n", "rules[0] must be a mapping"),
+            (
+                "rules:\n  - expression: \"true\"\n    action: deny\n",
+                "missing required field 'id'",
+            ),
+            ("rules:\n  - id: r\n    action: deny\n", "missing required field 'expression'"),
+            ("rules:\n  - id: r\n    expression: \"true\"\n", "missing required field 'action'"),
+            (
+                "rules:\n  - id: r\n    expression: \"true\"\n    action: explode\n",
+                "unknown policy action 'explode'",
+            ),
+            (
+                "rules:\n  - id: r\n    expression: \"true\"\n    action: deny\n    extra: 1\n",
+                "unknown key 'extra'",
+            ),
+            (
+                "rules:\n  - id: dup\n    expression: \"true\"\n    action: deny\n  - id: dup\n    expression: \"true\"\n    action: allow\n",
+                "duplicate policy rule id 'dup'",
+            ),
+            (
+                "rules:\n  - id: deny_cloud_if_0\n    expression: \"true\"\n    action: allow\ndeny_cloud_if:\n  - \"true\"\n",
+                "duplicate policy rule id 'deny_cloud_if_0'",
+            ),
+            ("version: 1\n", "'version' must be a string"),
+            ("{not valid yaml: [", "failed to parse policy bundle"),
+        ];
+        for (bundle, expected) in cases {
+            let err = load_error(bundle);
+            assert!(
+                err.contains(expected),
+                "bundle should fail with `{expected}`, got: {err}\n{bundle}"
+            );
+        }
+    }
+
+    #[test]
+    fn failed_reload_keeps_previous_policy() {
+        let mut engine = engine("deny_cloud_if:\n  - 'input.kind == \"text\"'\n");
+        assert!(!engine.evaluate("s", &text("x"), &metrics()).allowed);
+
+        let err = engine
+            .load_policies(b"deny_cloud_if:\n  - 'metrics.network_rtt > 300'\n".to_vec())
+            .expect_err("invalid reload must fail");
+        assert!(err.contains("unknown operand"), "{err}");
+
+        // Still the old bundle, still denying text.
+        assert!(!engine.evaluate("s", &text("x"), &metrics()).allowed);
+        assert_eq!(engine.bundle().unwrap().rules[0].id, "deny_cloud_if_0");
+    }
+
+    #[test]
+    fn successful_reload_replaces_policy() {
+        let mut engine = engine("deny_cloud_if:\n  - 'input.kind == \"text\"'\n");
+        engine
+            .load_policies(b"route_cloud_if:\n  - \"true\"\n".to_vec())
+            .expect("valid reload");
+        let result = engine.evaluate("s", &text("x"), &metrics());
+        assert!(result.allowed);
+        assert!(result.prefers_cloud());
+    }
+
+    #[test]
+    fn redact_is_a_no_op() {
+        let engine = DefaultPolicyEngine::with_default_policy();
+        let mut envelope = text("keep me");
+        assert!(!engine.redact(&mut envelope));
+        assert_eq!(envelope.as_text(), Some("keep me"));
+    }
+
+    #[test]
+    fn policy_action_round_trips() {
+        for action in [
+            PolicyAction::Allow,
+            PolicyAction::Deny,
+            PolicyAction::RouteCloud,
+            PolicyAction::Redact,
+        ] {
+            assert_eq!(action.as_str().parse::<PolicyAction>().unwrap(), action);
+            assert_eq!(action.to_string(), action.as_str());
+        }
+        assert_eq!(
+            "PREFER_CLOUD".parse::<PolicyAction>().unwrap(),
+            PolicyAction::RouteCloud
+        );
+        assert!("maybe".parse::<PolicyAction>().is_err());
     }
 }

--- a/crates/xybrid-core/src/orchestrator/routing_engine.rs
+++ b/crates/xybrid-core/src/orchestrator/routing_engine.rs
@@ -146,17 +146,28 @@ pub trait RoutingEngine {
 /// Default implementation of RoutingEngine using heuristic-based routing.
 ///
 /// The ladder is *evidence-only cloud, default-local*: we route to cloud only
-/// when (a) policy forbids local, (b) the local model isn't available, or (c)
-/// a current observation of device stress (memory, sustained CPU, throttle)
-/// argues that local will fail. Anything else stays local.
+/// when (a) the local model isn't available, (b) the policy prefers cloud, or
+/// (c) a current observation of device stress (memory, sustained CPU,
+/// throttle) argues that local will fail. Anything else stays local. A policy
+/// that forbids cloud wins over everything, including model absence — a
+/// stage with no usable local leg then fails locally rather than leaking to
+/// cloud.
 ///
 /// Order, first match wins:
-/// 1. `policy.allowed == false` → Local
-/// 2. `!availability.local_model_exists` → Cloud
-/// 3. `capabilities.should_throttle()` (battery low or thermal Hot/Critical) → Cloud
-/// 4. `resource.memory_pressure == Critical` → Cloud
-/// 5. Sustained CPU ≥ 95 % for N samples → Cloud
-/// 6. Default → Local
+/// 1. `policy.allowed == false` → Local (`policy_deny`)
+/// 2. `!policy.transforms_applied.is_empty()` → Local
+///    (`policy_transform_unsupported`; redaction is not implemented, so a
+///    required transform means the input must not leave the device)
+/// 3. `!availability.local_model_exists` → Cloud (`model_unavailable`)
+/// 4. `policy.prefers_cloud()` → Cloud (`policy_route_cloud`)
+/// 5. `capabilities.should_throttle()` (battery low or thermal Hot/Critical) → Cloud
+/// 6. `resource.memory_pressure == Critical` → Cloud
+/// 7. Sustained CPU ≥ 95 % for N samples → Cloud
+/// 8. Default → Local
+///
+/// This ladder is defense in depth: the orchestration authority applies the
+/// same policy restrictions before any of its own early returns (explicit
+/// targets, hysteresis, history, remote advice).
 pub struct DefaultRoutingEngine {
     cpu_sustain_samples: usize,
     cpu_sustain_threshold_pct: f32,
@@ -259,7 +270,20 @@ impl RoutingEngine for DefaultRoutingEngine {
             return decision;
         }
 
-        // Step 2: if the local model is absent, cloud is the only usable target.
+        // Step 2: a required transform also keeps execution local. Redaction
+        // is not implemented, so "needs redacting before leaving the device"
+        // must fail closed rather than send the raw input to cloud.
+        if !policy.transforms_applied.is_empty() {
+            let reason = format!(
+                "policy_transform_unsupported: {}",
+                policy.transforms_applied.join(",")
+            );
+            let decision = Self::decision(stage, RouteTarget::Local, reason, timestamp_ms);
+            self.log_decision(&decision);
+            return decision;
+        }
+
+        // Step 3: if the local model is absent, cloud is the only usable target.
         if !availability.local_model_exists {
             let decision = Self::decision(
                 stage,
@@ -271,7 +295,22 @@ impl RoutingEngine for DefaultRoutingEngine {
             return decision;
         }
 
-        // Step 3: route stressed devices to cloud when policy allows it.
+        // Step 4: the policy asked for cloud and the local leg exists, so the
+        // preference is honoured ahead of any device-stress heuristics.
+        if policy.prefers_cloud() {
+            let reason = format!(
+                "policy_route_cloud: {}",
+                policy
+                    .reason
+                    .as_deref()
+                    .unwrap_or("policy prefers cloud execution")
+            );
+            let decision = Self::decision(stage, RouteTarget::Cloud, reason, timestamp_ms);
+            self.log_decision(&decision);
+            return decision;
+        }
+
+        // Step 5+: route stressed devices to cloud when policy allows it.
         if metrics.capabilities.should_throttle() {
             let reason = format!(
                 "stress_throttle: battery {}%, thermal {:?}",
@@ -355,6 +394,139 @@ mod tests {
         assert_eq!(decision.target, RouteTarget::Local);
         assert!(decision.reason.contains("policy_deny"));
         assert_eq!(decision.stage, "test_stage");
+    }
+
+    fn stressed_metrics() -> DeviceMetrics {
+        metrics_with_live_state(10, ThermalState::Hot, MemoryPressure::Critical, Some(99.0))
+    }
+
+    fn transform_policy() -> PolicyResult {
+        let mut policy = PolicyResult::allow(Some("needs scrubbing".to_string()));
+        policy.transforms_applied.push("scrub".to_string());
+        policy
+    }
+
+    #[test]
+    fn policy_deny_beats_missing_model_and_stress() {
+        let mut engine = DefaultRoutingEngine::new();
+        let policy = PolicyResult::deny("no cloud".to_string());
+        let availability = LocalAvailability::new(false);
+
+        // Two samples so the sustained-CPU rule would also have fired.
+        let _ = engine.decide("s", &stressed_metrics(), &policy, &availability);
+        let decision = engine.decide("s", &stressed_metrics(), &policy, &availability);
+
+        assert_eq!(decision.target, RouteTarget::Local);
+        assert!(
+            decision.reason.starts_with("policy_deny"),
+            "{}",
+            decision.reason
+        );
+    }
+
+    #[test]
+    fn policy_transform_routes_local() {
+        let mut engine = DefaultRoutingEngine::new();
+        let availability = LocalAvailability::new(true);
+
+        let decision = engine.decide(
+            "s",
+            &DeviceMetrics::default(),
+            &transform_policy(),
+            &availability,
+        );
+
+        assert_eq!(decision.target, RouteTarget::Local);
+        assert!(
+            decision.reason.starts_with("policy_transform_unsupported"),
+            "{}",
+            decision.reason
+        );
+        assert!(decision.reason.contains("scrub"));
+    }
+
+    #[test]
+    fn policy_transform_beats_missing_model_and_stress() {
+        let mut engine = DefaultRoutingEngine::new();
+        let availability = LocalAvailability::new(false);
+
+        let _ = engine.decide("s", &stressed_metrics(), &transform_policy(), &availability);
+        let decision = engine.decide("s", &stressed_metrics(), &transform_policy(), &availability);
+
+        assert_eq!(decision.target, RouteTarget::Local);
+        assert!(
+            decision.reason.starts_with("policy_transform_unsupported"),
+            "{}",
+            decision.reason
+        );
+    }
+
+    #[test]
+    fn policy_route_cloud_routes_cloud_when_model_available() {
+        let mut engine = DefaultRoutingEngine::new();
+        let policy = PolicyResult::prefer_cloud("rule 'offload' prefers cloud".to_string());
+        let availability = LocalAvailability::new(true);
+        let metrics =
+            metrics_with_live_state(80, ThermalState::Normal, MemoryPressure::Normal, Some(20.0));
+
+        let decision = engine.decide("s", &metrics, &policy, &availability);
+
+        assert_eq!(decision.target, RouteTarget::Cloud);
+        assert!(
+            decision.reason.starts_with("policy_route_cloud"),
+            "{}",
+            decision.reason
+        );
+        assert!(decision.reason.contains("offload"));
+    }
+
+    #[test]
+    fn model_unavailable_reason_wins_over_policy_route_cloud() {
+        let mut engine = DefaultRoutingEngine::new();
+        let policy = PolicyResult::prefer_cloud("prefers cloud".to_string());
+        let availability = LocalAvailability::new(false);
+
+        let decision = engine.decide("s", &DeviceMetrics::default(), &policy, &availability);
+
+        assert_eq!(decision.target, RouteTarget::Cloud);
+        assert!(
+            decision.reason.starts_with("model_unavailable"),
+            "{}",
+            decision.reason
+        );
+    }
+
+    #[test]
+    fn policy_route_cloud_is_reported_ahead_of_stress() {
+        let mut engine = DefaultRoutingEngine::new();
+        let policy = PolicyResult::prefer_cloud("prefers cloud".to_string());
+        let availability = LocalAvailability::new(true);
+
+        let decision = engine.decide("s", &stressed_metrics(), &policy, &availability);
+
+        assert_eq!(decision.target, RouteTarget::Cloud);
+        assert!(
+            decision.reason.starts_with("policy_route_cloud"),
+            "{}",
+            decision.reason
+        );
+    }
+
+    #[test]
+    fn unknown_readings_alone_route_local() {
+        let mut engine = DefaultRoutingEngine::new();
+        let policy = PolicyResult::allow(Some("policy passed".to_string()));
+        let availability = LocalAvailability::new(true);
+        let metrics = DeviceMetrics::default().with_live_snapshot(ResourceSnapshot::unknown());
+
+        let decision = engine.decide("s", &metrics, &policy, &availability);
+
+        assert_eq!(decision.target, RouteTarget::Local);
+        assert!(
+            decision.reason.contains("default_local"),
+            "{}",
+            decision.reason
+        );
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -117,7 +117,10 @@ impl CloudRuntimeAdapter {
     ///   DeepSeek, OpenRouter, Custom): the same transport pointed at the
     ///   provider's documented base URL (`gateway_url` may override; Custom
     ///   requires it).
-    /// - `backend: direct` with any other provider: the native direct client.
+    /// - `backend: direct` with Anthropic: the native direct client, using
+    ///   the provider's documented base URL (a stage `gateway_url` overrides)
+    ///   and its explicit `api_key` when set, then `$ANTHROPIC_API_KEY`.
+    ///   Google and ElevenLabs have no native client and are rejected here.
     ///
     /// Credentials are scoped to the destination: an explicit `api_key` always
     /// wins; otherwise the provider's own `$<PROVIDER>_API_KEY` is selected
@@ -129,8 +132,9 @@ impl CloudRuntimeAdapter {
     /// # Errors
     ///
     /// [`AdapterError::InvalidInput`] for an unknown `backend`, a malformed or
-    /// non-HTTP URL, `custom` + `direct` without a `gateway_url`, or a known
-    /// provider origin without a usable key.
+    /// non-HTTP URL, `custom` + `direct` without a `gateway_url`, a provider
+    /// with no native direct client, or a known provider origin without a
+    /// usable key.
     fn build_config(
         &self,
         envelope: &Envelope,
@@ -183,12 +187,24 @@ impl CloudRuntimeAdapter {
                 };
             }
             Some("direct") => {
-                // Native direct client (Anthropic, Google, ElevenLabs): unchanged.
+                // Native direct client. Only the providers LlmClient can
+                // actually serve; OpenAI-compatible providers were handled
+                // above and ride the gateway transport.
+                if !native_direct_supported(provider) {
+                    return Err(AdapterError::InvalidInput(format!(
+                        "provider '{}' with backend 'direct' is not supported: the native \
+                         direct client serves anthropic only. Use backend 'gateway' with an \
+                         explicit gateway_url, or an OpenAI-compatible provider (openai, \
+                         deepseek, openrouter, custom)",
+                        provider
+                    )));
+                }
                 config.backend = CloudBackend::Direct;
                 config.direct_provider = Some(provider.as_str().to_string());
-                if let Some(url) = explicit_url {
-                    config.gateway_url = url;
-                }
+                config.direct_base_url = match explicit_url {
+                    Some(url) => Some(normalize_gateway_url(&url)?),
+                    None => None,
+                };
                 config.api_key = explicit_key;
                 return Ok(config);
             }
@@ -386,6 +402,14 @@ fn openai_compatible(provider: IntegrationProvider) -> bool {
             | IntegrationProvider::OpenRouter
             | IntegrationProvider::Custom
     )
+}
+
+/// Providers the native direct client (`LlmClient`) can serve.
+///
+/// OpenAI and the OpenAI-compatible providers never reach this check: they
+/// ride the gateway transport.
+fn native_direct_supported(provider: IntegrationProvider) -> bool {
+    matches!(provider, IntegrationProvider::Anthropic)
 }
 
 const KNOWN_PROVIDERS: [IntegrationProvider; 6] = [
@@ -1349,6 +1373,45 @@ mod tests {
             .expect("anthropic direct");
         assert_eq!(config.backend, CloudBackend::Direct);
         assert_eq!(config.direct_provider.as_deref(), Some("anthropic"));
+        // No explicit URL/key: provider default URL and env-var fallback.
+        assert_eq!(config.direct_base_url, None);
+        assert_eq!(config.api_key, None);
+
+        // Explicit URL and key are stored (normalized) for the native client.
+        let config = adapter
+            .build_config(
+                &text_with(&[
+                    ("provider", "anthropic"),
+                    ("backend", "direct"),
+                    ("gateway_url", "http://127.0.0.1:8080/v1/"),
+                    ("api_key", "$ANTHROPIC_API_KEY"),
+                ]),
+                IntegrationProvider::Anthropic,
+            )
+            .expect("anthropic direct with overrides");
+        assert_eq!(
+            config.direct_base_url.as_deref(),
+            Some("http://127.0.0.1:8080/v1")
+        );
+        assert_eq!(config.api_key.as_deref(), Some("$ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn direct_native_providers_without_a_client_are_rejected() {
+        let adapter = CloudRuntimeAdapter::new();
+
+        for provider in [IntegrationProvider::Google, IntegrationProvider::ElevenLabs] {
+            let err = adapter
+                .build_config(
+                    &text_with(&[("provider", provider.as_str()), ("backend", "direct")]),
+                    provider,
+                )
+                .expect_err("no native client for this provider");
+            assert!(matches!(err, AdapterError::InvalidInput(_)), "{err:?}");
+            let message = err.to_string();
+            assert!(message.contains(provider.as_str()), "{message}");
+            assert!(message.contains("anthropic"), "{message}");
+        }
     }
 
     #[test]

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -19,8 +19,8 @@
 //! ```
 
 use crate::cloud::{
-    openai_chat_body, parse_gateway_usage, Cloud, CloudBackend, CloudConfig, CompletionRequest,
-    CompletionResponse, MissingModel, ThinkingMode, Usage,
+    openai_chat_body, parse_gateway_usage, same_origin, Cloud, CloudBackend, CloudConfig,
+    CompletionRequest, CompletionResponse, MissingModel, ThinkingMode, Usage,
 };
 use crate::gateway::ChatCompletionChunk;
 use crate::ir::{Envelope, EnvelopeKind};
@@ -103,23 +103,39 @@ impl CloudRuntimeAdapter {
             .metadata
             .get("provider")
             .ok_or_else(|| AdapterError::InvalidInput("Missing 'provider' in metadata".into()))?;
-
-        // Parse provider string
-        match provider_str.to_lowercase().as_str() {
-            "openai" => Ok(IntegrationProvider::OpenAI),
-            "anthropic" => Ok(IntegrationProvider::Anthropic),
-            "google" => Ok(IntegrationProvider::Google),
-            "deepseek" => Ok(IntegrationProvider::DeepSeek),
-            "elevenlabs" => Ok(IntegrationProvider::ElevenLabs),
-            other => Err(AdapterError::InvalidInput(format!(
-                "Unknown provider: {}",
-                other
-            ))),
-        }
+        provider_str
+            .parse::<IntegrationProvider>()
+            .map_err(AdapterError::InvalidInput)
     }
 
     /// Builds CloudConfig from envelope metadata.
-    fn build_config(&self, envelope: &Envelope) -> CloudConfig {
+    ///
+    /// Transport selection:
+    /// - `backend` omitted or `gateway`: the adapter's gateway URL (or the
+    ///   `gateway_url` override) over the OpenAI-compatible transport.
+    /// - `backend: direct` with an OpenAI-compatible provider (OpenAI,
+    ///   DeepSeek, OpenRouter, Custom): the same transport pointed at the
+    ///   provider's documented base URL (`gateway_url` may override; Custom
+    ///   requires it).
+    /// - `backend: direct` with any other provider: the native direct client.
+    ///
+    /// Credentials are scoped to the destination: an explicit `api_key` always
+    /// wins; otherwise the provider's own `$<PROVIDER>_API_KEY` is selected
+    /// when the destination is that provider's origin; the Xybrid platform key
+    /// is supplied only for the configured platform gateway origin (see
+    /// [`CloudConfig::resolve_api_key`]); anything else is anonymous. A known
+    /// provider origin with no resolvable key fails here, before any HTTP.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::InvalidInput`] for an unknown `backend`, a malformed or
+    /// non-HTTP URL, `custom` + `direct` without a `gateway_url`, or a known
+    /// provider origin without a usable key.
+    fn build_config(
+        &self,
+        envelope: &Envelope,
+        provider: IntegrationProvider,
+    ) -> AdapterResult<CloudConfig> {
         let mut config = CloudConfig {
             gateway_url: self.gateway_url.clone(),
             timeout_ms: self.timeout_ms,
@@ -127,41 +143,82 @@ impl CloudRuntimeAdapter {
             ..Default::default()
         };
 
-        // Override with metadata if present
-        if let Some(gateway_url) = envelope.metadata.get("gateway_url") {
-            config.gateway_url = gateway_url.clone();
-        }
-
-        if let Some(api_key) = envelope.metadata.get("api_key") {
-            config.api_key = Some(api_key.clone());
-        }
-
         if let Some(timeout_str) = envelope.metadata.get("timeout_ms") {
             if let Ok(timeout) = timeout_str.parse::<u32>() {
                 config.timeout_ms = timeout;
             }
         }
-
         if let Some(debug_str) = envelope.metadata.get("debug") {
             config.debug = debug_str == "true";
         }
 
-        // Backend selection
-        if let Some(backend) = envelope.metadata.get("backend") {
-            match backend.to_lowercase().as_str() {
-                "direct" => {
-                    config.backend = CloudBackend::Direct;
-                    if let Some(provider) = envelope.metadata.get("provider") {
-                        config.direct_provider = Some(provider.clone());
+        let explicit_url = envelope.metadata.get("gateway_url").cloned();
+        let explicit_key = envelope.metadata.get("api_key").cloned();
+        let backend = envelope
+            .metadata
+            .get("backend")
+            .map(|b| b.trim().to_ascii_lowercase());
+
+        match backend.as_deref() {
+            None | Some("gateway") => {
+                config.backend = CloudBackend::Gateway;
+                if let Some(url) = explicit_url {
+                    config.gateway_url = url;
+                }
+            }
+            Some("direct") if openai_compatible(provider) => {
+                config.backend = CloudBackend::Gateway;
+                config.gateway_url = match explicit_url {
+                    Some(url) => url,
+                    None => {
+                        let base = provider.default_base_url();
+                        if base.is_empty() {
+                            return Err(AdapterError::InvalidInput(format!(
+                                "provider '{}' with backend 'direct' requires a 'gateway_url'",
+                                provider
+                            )));
+                        }
+                        base.to_string()
                     }
+                };
+            }
+            Some("direct") => {
+                // Native direct client (Anthropic, Google, ElevenLabs): unchanged.
+                config.backend = CloudBackend::Direct;
+                config.direct_provider = Some(provider.as_str().to_string());
+                if let Some(url) = explicit_url {
+                    config.gateway_url = url;
                 }
-                _ => {
-                    config.backend = CloudBackend::Gateway;
-                }
+                config.api_key = explicit_key;
+                return Ok(config);
+            }
+            Some(other) => {
+                return Err(AdapterError::InvalidInput(format!(
+                    "unknown backend '{}' (expected 'gateway' or 'direct')",
+                    other
+                )));
             }
         }
 
-        config
+        config.gateway_url = normalize_gateway_url(&config.gateway_url)?;
+        config.api_key = match explicit_key {
+            Some(key) => Some(key),
+            None => provider_key_for_destination(provider, &config.gateway_url),
+        };
+
+        // Fail fast: a request to a known provider origin without a usable key
+        // would only produce a 401 after the round trip.
+        if let Some(origin_provider) = provider_for_origin(&config.gateway_url) {
+            if config.resolve_api_key().is_none() {
+                return Err(AdapterError::InvalidInput(format!(
+                    "no API key for {}: set {} or the stage's 'api_key'",
+                    origin_provider,
+                    origin_provider.api_key_env_var()
+                )));
+            }
+        }
+
+        Ok(config)
     }
 
     /// Builds CompletionRequest from envelope metadata.
@@ -273,7 +330,7 @@ impl RuntimeAdapter for CloudRuntimeAdapter {
         trace::add_metadata("adapter", "cloud");
 
         // Build configuration
-        let config = self.build_config(input);
+        let config = self.build_config(input, provider)?;
         let backend_str = match config.backend {
             CloudBackend::Gateway => "gateway",
             CloudBackend::Direct => "direct",
@@ -319,6 +376,62 @@ impl RuntimeAdapter for CloudRuntimeAdapter {
     }
 }
 
+/// Providers whose API speaks the OpenAI chat-completions dialect and can be
+/// reached over the gateway transport with a bearer key.
+fn openai_compatible(provider: IntegrationProvider) -> bool {
+    matches!(
+        provider,
+        IntegrationProvider::OpenAI
+            | IntegrationProvider::DeepSeek
+            | IntegrationProvider::OpenRouter
+            | IntegrationProvider::Custom
+    )
+}
+
+const KNOWN_PROVIDERS: [IntegrationProvider; 6] = [
+    IntegrationProvider::OpenAI,
+    IntegrationProvider::Anthropic,
+    IntegrationProvider::Google,
+    IntegrationProvider::DeepSeek,
+    IntegrationProvider::ElevenLabs,
+    IntegrationProvider::OpenRouter,
+];
+
+/// The provider whose documented origin `url` points at, if any. Compared by
+/// origin (scheme + host + port), never by substring.
+fn provider_for_origin(url: &str) -> Option<IntegrationProvider> {
+    KNOWN_PROVIDERS
+        .into_iter()
+        .find(|candidate| same_origin(url, candidate.default_base_url()))
+}
+
+/// Automatic credential for `destination`: the provider's own environment
+/// variable, and only when the destination is *that* provider's origin. A
+/// platform gateway, a different provider's origin, a lookalike host or a
+/// loopback server gets nothing here (the platform key is handled by
+/// [`CloudConfig::resolve_api_key`]).
+fn provider_key_for_destination(
+    provider: IntegrationProvider,
+    destination: &str,
+) -> Option<String> {
+    (provider_for_origin(destination) == Some(provider))
+        .then(|| format!("${}", provider.api_key_env_var()))
+}
+
+/// Validate an `http(s)` base URL and strip trailing slashes so
+/// `/chat/completions` can be appended without a double slash.
+fn normalize_gateway_url(url: &str) -> AdapterResult<String> {
+    let trimmed = url.trim();
+    let parsed = url::Url::parse(trimmed)
+        .map_err(|e| AdapterError::InvalidInput(format!("invalid gateway_url '{trimmed}': {e}")))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(AdapterError::InvalidInput(format!(
+            "invalid gateway_url '{trimmed}': expected an http(s) URL"
+        )));
+    }
+    Ok(trimmed.trim_end_matches('/').to_string())
+}
+
 /// Cloud adapter trait for emitting response tokens incrementally.
 ///
 /// `execute_streaming` is the seam the SDK uses to thread cloud retries
@@ -357,7 +470,7 @@ impl CloudStreaming for CloudRuntimeAdapter {
         trace::add_metadata("adapter", "cloud");
         trace::add_metadata("streaming", "sse");
 
-        let config = self.build_config(input);
+        let config = self.build_config(input, provider)?;
         let backend_str = match config.backend {
             CloudBackend::Gateway => "gateway",
             CloudBackend::Direct => "direct",
@@ -1073,5 +1186,385 @@ mod tests {
         });
 
         (format!("http://{}", addr), rx)
+    }
+
+    /// One-shot JSON server: captures the raw request (headers + body) and
+    /// answers with `body` under `status`.
+    fn start_json_server(body: &'static str, status: u16) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = mpsc::channel();
+
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut buf = [0; 1024];
+            loop {
+                let read = stream.read(&mut buf).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..read]);
+                if let Some(header_end) = request
+                    .windows(4)
+                    .position(|w| w == b"\r\n\r\n")
+                    .map(|pos| pos + 4)
+                {
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    while request.len() < header_end + content_length {
+                        let read = stream.read(&mut buf).unwrap();
+                        if read == 0 {
+                            break;
+                        }
+                        request.extend_from_slice(&buf[..read]);
+                    }
+                    break;
+                }
+            }
+            tx.send(String::from_utf8_lossy(&request).into_owned())
+                .unwrap();
+
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        (format!("http://{}", addr), rx)
+    }
+
+    const FAKE_DEEPSEEK_BODY: &str = r#"{"id":"chatcmpl-1","model":"deepseek-flash","choices":[{"index":0,"message":{"role":"assistant","content":"FAKE_DEEPSEEK_REPLY"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}"#;
+
+    /// A `$VAR` reference that no environment will have set.
+    const SURELY_UNSET_KEY_REF: &str = "$XYBRID_TEST_SURELY_UNSET_KEY_7f3a";
+
+    fn text_with(pairs: &[(&str, &str)]) -> Envelope {
+        let mut envelope = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+        for (key, value) in pairs {
+            envelope.metadata.insert(key.to_string(), value.to_string());
+        }
+        envelope
+    }
+
+    fn header_value<'a>(request: &'a str, name: &str) -> Option<&'a str> {
+        request.lines().find_map(|line| {
+            let (candidate, value) = line.split_once(':')?;
+            candidate.eq_ignore_ascii_case(name).then(|| value.trim())
+        })
+    }
+
+    // ── Phase 7: provider parsing, transport mapping, credential scoping ───
+
+    #[test]
+    fn get_provider_uses_from_str_aliases_and_rejects_unknown() {
+        let adapter = CloudRuntimeAdapter::new();
+        for (raw, expected) in [
+            ("deepseek", IntegrationProvider::DeepSeek),
+            ("Deep_Seek", IntegrationProvider::DeepSeek),
+            ("openrouter", IntegrationProvider::OpenRouter),
+            ("custom", IntegrationProvider::Custom),
+            ("claude", IntegrationProvider::Anthropic),
+        ] {
+            let provider = adapter
+                .get_provider(&text_with(&[("provider", raw)]))
+                .unwrap_or_else(|e| panic!("{raw}: {e}"));
+            assert_eq!(provider, expected);
+        }
+        let err = adapter
+            .get_provider(&text_with(&[("provider", "nope")]))
+            .expect_err("unknown provider");
+        assert!(matches!(err, AdapterError::InvalidInput(_)), "{err:?}");
+    }
+
+    #[test]
+    fn direct_openai_compatible_providers_use_the_gateway_transport_at_the_provider_origin() {
+        let adapter = CloudRuntimeAdapter::new();
+        for (name, provider) in [
+            ("deepseek", IntegrationProvider::DeepSeek),
+            ("openai", IntegrationProvider::OpenAI),
+            ("openrouter", IntegrationProvider::OpenRouter),
+        ] {
+            // Explicit literal key keeps the check independent of the env.
+            let envelope =
+                text_with(&[("provider", name), ("backend", "direct"), ("api_key", "k")]);
+            let config = adapter
+                .build_config(&envelope, provider)
+                .unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(config.backend, CloudBackend::Gateway, "{name}");
+            assert_eq!(config.gateway_url, provider.default_base_url(), "{name}");
+            assert_eq!(config.api_key.as_deref(), Some("k"), "{name}");
+            assert_eq!(config.direct_provider, None, "{name}");
+        }
+    }
+
+    #[test]
+    fn direct_custom_requires_a_gateway_url() {
+        let adapter = CloudRuntimeAdapter::new();
+        let err = adapter
+            .build_config(
+                &text_with(&[("provider", "custom"), ("backend", "direct")]),
+                IntegrationProvider::Custom,
+            )
+            .expect_err("custom without a URL");
+        assert!(err.to_string().contains("gateway_url"), "{err}");
+
+        let config = adapter
+            .build_config(
+                &text_with(&[
+                    ("provider", "custom"),
+                    ("backend", "direct"),
+                    ("gateway_url", "http://127.0.0.1:9/v1/"),
+                ]),
+                IntegrationProvider::Custom,
+            )
+            .expect("custom with a URL");
+        assert_eq!(config.backend, CloudBackend::Gateway);
+        assert_eq!(config.gateway_url, "http://127.0.0.1:9/v1");
+        // Loopback: anonymous unless a key is given explicitly.
+        assert_eq!(config.api_key, None);
+    }
+
+    #[test]
+    fn direct_anthropic_keeps_the_native_direct_backend() {
+        let adapter = CloudRuntimeAdapter::new();
+        let config = adapter
+            .build_config(
+                &text_with(&[("provider", "anthropic"), ("backend", "direct")]),
+                IntegrationProvider::Anthropic,
+            )
+            .expect("anthropic direct");
+        assert_eq!(config.backend, CloudBackend::Direct);
+        assert_eq!(config.direct_provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn explicit_gateway_url_and_api_key_override_provider_defaults() {
+        let adapter = CloudRuntimeAdapter::new();
+        let config = adapter
+            .build_config(
+                &text_with(&[
+                    ("provider", "deepseek"),
+                    ("backend", "direct"),
+                    ("gateway_url", "http://127.0.0.1:9/v1/"),
+                    ("api_key", "k"),
+                ]),
+                IntegrationProvider::DeepSeek,
+            )
+            .expect("overrides accepted");
+        assert_eq!(config.backend, CloudBackend::Gateway);
+        assert_eq!(config.gateway_url, "http://127.0.0.1:9/v1");
+        assert_eq!(config.api_key.as_deref(), Some("k"));
+
+        // Backend omitted + explicit provider URL behaves the same.
+        let config = adapter
+            .build_config(
+                &text_with(&[
+                    ("provider", "deepseek"),
+                    ("gateway_url", "https://api.deepseek.com/v1/"),
+                    ("api_key", "k"),
+                ]),
+                IntegrationProvider::DeepSeek,
+            )
+            .expect("provider url accepted");
+        assert_eq!(config.gateway_url, "https://api.deepseek.com/v1");
+    }
+
+    #[test]
+    fn unknown_backend_and_malformed_urls_are_rejected() {
+        let adapter = CloudRuntimeAdapter::new();
+        let cases: [(&[(&str, &str)], &str); 3] = [
+            (
+                &[("provider", "openai"), ("backend", "proxy")],
+                "unknown backend",
+            ),
+            (
+                &[("provider", "openai"), ("gateway_url", "ftp://x/v1")],
+                "http(s)",
+            ),
+            (
+                &[("provider", "openai"), ("gateway_url", "not a url")],
+                "invalid gateway_url",
+            ),
+        ];
+        for (pairs, expected) in cases {
+            let err = adapter
+                .build_config(&text_with(pairs), IntegrationProvider::OpenAI)
+                .expect_err("rejected");
+            assert!(matches!(err, AdapterError::InvalidInput(_)), "{err:?}");
+            assert!(err.to_string().contains(expected), "{err}");
+        }
+    }
+
+    #[test]
+    fn provider_key_is_selected_only_for_that_providers_origin() {
+        assert_eq!(
+            provider_key_for_destination(
+                IntegrationProvider::DeepSeek,
+                "https://api.deepseek.com/v1/"
+            )
+            .as_deref(),
+            Some("$DEEPSEEK_API_KEY")
+        );
+        assert_eq!(
+            provider_key_for_destination(IntegrationProvider::OpenAI, "https://api.openai.com/v1")
+                .as_deref(),
+            Some("$OPENAI_API_KEY")
+        );
+        // A different provider's origin, lookalikes, other ports and loopback
+        // get nothing automatically.
+        for destination in [
+            "https://api.openai.com/v1",
+            "https://api.deepseek.com.evil.example/v1",
+            "https://api.deepseek.com:8443/v1",
+            "http://api.deepseek.com/v1",
+            "http://127.0.0.1:3001/v1",
+            "https://api.xybrid.dev/v1",
+        ] {
+            assert_eq!(
+                provider_key_for_destination(IntegrationProvider::DeepSeek, destination),
+                None,
+                "{destination}"
+            );
+        }
+        assert_eq!(
+            provider_for_origin("https://API.DeepSeek.com:443/v1"),
+            Some(IntegrationProvider::DeepSeek)
+        );
+        assert_eq!(provider_for_origin("https://api.xybrid.dev/v1"), None);
+    }
+
+    #[test]
+    fn provider_origin_without_a_resolvable_key_fails_before_http() {
+        let adapter = CloudRuntimeAdapter::new();
+        let err = adapter
+            .build_config(
+                &text_with(&[
+                    ("provider", "deepseek"),
+                    ("backend", "direct"),
+                    ("api_key", SURELY_UNSET_KEY_REF),
+                ]),
+                IntegrationProvider::DeepSeek,
+            )
+            .expect_err("no key for the provider origin");
+        assert!(matches!(err, AdapterError::InvalidInput(_)), "{err:?}");
+        let message = err.to_string();
+        assert!(message.contains("DEEPSEEK_API_KEY"), "{message}");
+        assert!(message.contains("deepseek"), "{message}");
+
+        // Same check when the provider origin comes from an explicit URL with
+        // the backend omitted.
+        let err = adapter
+            .build_config(
+                &text_with(&[
+                    ("provider", "openai"),
+                    ("gateway_url", "https://api.openai.com/v1"),
+                    ("api_key", SURELY_UNSET_KEY_REF),
+                ]),
+                IntegrationProvider::OpenAI,
+            )
+            .expect_err("no key for the provider origin");
+        assert!(err.to_string().contains("OPENAI_API_KEY"), "{err}");
+    }
+
+    #[test]
+    fn execute_posts_an_openai_shaped_chat_completion_with_bearer_and_thinking() {
+        let (url, rx) = start_json_server(FAKE_DEEPSEEK_BODY, 200);
+        let adapter = CloudRuntimeAdapter::new();
+        let envelope = text_with(&[
+            ("provider", "deepseek"),
+            ("model", "deepseek-flash"),
+            ("backend", "direct"),
+            ("gateway_url", &format!("{url}/v1/")),
+            ("api_key", "test-key"),
+            ("thinking", "disabled"),
+            ("system_prompt", "Be terse."),
+            ("temperature", "0"),
+            ("max_tokens", "16"),
+        ]);
+
+        let output = adapter.execute(&envelope).expect("fake provider answers");
+
+        assert_eq!(output.as_text(), Some("FAKE_DEEPSEEK_REPLY"));
+        assert_eq!(
+            output.metadata.get("backend").map(String::as_str),
+            Some("gateway")
+        );
+        assert_eq!(
+            output.metadata.get("provider").map(String::as_str),
+            Some("deepseek")
+        );
+
+        let request = rx.recv().expect("request captured");
+        assert!(
+            request.starts_with("POST /v1/chat/completions "),
+            "{request}"
+        );
+        assert_eq!(
+            header_value(&request, "authorization"),
+            Some("Bearer test-key")
+        );
+        let body_start = request.find("\r\n\r\n").unwrap() + 4;
+        let body: serde_json::Value = serde_json::from_str(&request[body_start..]).unwrap();
+        assert_eq!(body["model"], "deepseek-flash");
+        assert_eq!(body["thinking"], json!({"type": "disabled"}));
+        assert_eq!(body["max_tokens"], 16);
+        assert_eq!(body["temperature"], 0.0);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][0]["content"], "Be terse.");
+        assert_eq!(body["messages"][1]["role"], "user");
+        assert_eq!(body["messages"][1]["content"], "hello");
+        // The batch body never asks for a stream (the key is omitted when false).
+        assert_ne!(body.get("stream"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn anonymous_loopback_gateway_sends_no_authorization_header() {
+        let (url, rx) = start_json_server(FAKE_DEEPSEEK_BODY, 200);
+        let adapter = CloudRuntimeAdapter::with_gateway(&url);
+        let envelope = text_with(&[("provider", "openai"), ("model", "deepseek-flash")]);
+
+        let output = adapter.execute(&envelope).expect("anonymous fake answers");
+        assert_eq!(output.as_text(), Some("FAKE_DEEPSEEK_REPLY"));
+
+        let request = rx.recv().expect("request captured");
+        assert!(request.starts_with("POST /chat/completions "), "{request}");
+        assert_eq!(
+            header_value(&request, "authorization"),
+            None,
+            "a loopback gateway must not inherit any credential: {request}"
+        );
+    }
+
+    #[test]
+    fn execute_surfaces_an_unauthorized_response_as_an_error() {
+        let (url, _rx) = start_json_server(r#"{"error":{"message":"bad key"}}"#, 401);
+        let adapter = CloudRuntimeAdapter::with_gateway(&url);
+        let envelope = text_with(&[
+            ("provider", "openai"),
+            ("model", "deepseek-flash"),
+            ("api_key", "wrong"),
+        ]);
+
+        let err = adapter.execute(&envelope).expect_err("401 is an error");
+        let message = err.to_string();
+        assert!(
+            message.contains("401") || message.contains("bad key"),
+            "{message}"
+        );
+        assert!(!message.contains("FAKE_DEEPSEEK_REPLY"));
     }
 }

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -118,16 +118,22 @@ impl CloudRuntimeAdapter {
     ///   provider's documented base URL (`gateway_url` may override; Custom
     ///   requires it).
     /// - `backend: direct` with Anthropic: the native direct client, using
-    ///   the provider's documented base URL (a stage `gateway_url` overrides)
-    ///   and its explicit `api_key` when set, then `$ANTHROPIC_API_KEY`.
-    ///   Google and ElevenLabs have no native client and are rejected here.
+    ///   the provider's documented base URL (a stage `gateway_url` overrides).
+    ///   Credentials are destination-scoped in the native client: an explicit
+    ///   `api_key` always wins; without one, `$ANTHROPIC_API_KEY` is used only
+    ///   when the effective base URL is Anthropic's own origin. A custom
+    ///   destination requires an explicit key — the native-client construction
+    ///   in `cloud::client` fails before any HTTP rather than attaching the
+    ///   ambient provider key to an unrelated endpoint. Google and ElevenLabs
+    ///   have no native client and are rejected here.
     ///
-    /// Credentials are scoped to the destination: an explicit `api_key` always
-    /// wins; otherwise the provider's own `$<PROVIDER>_API_KEY` is selected
-    /// when the destination is that provider's origin; the Xybrid platform key
-    /// is supplied only for the configured platform gateway origin (see
-    /// [`CloudConfig::resolve_api_key`]); anything else is anonymous. A known
-    /// provider origin with no resolvable key fails here, before any HTTP.
+    /// Gateway credentials are scoped the same way: an explicit `api_key`
+    /// always wins; otherwise the provider's own `$<PROVIDER>_API_KEY` is
+    /// selected when the destination is that provider's origin; the Xybrid
+    /// platform key is supplied only for the configured platform gateway
+    /// origin (see [`CloudConfig::resolve_api_key`]); anything else is
+    /// anonymous. A known provider origin with no resolvable key fails here,
+    /// before any HTTP.
     ///
     /// # Errors
     ///

--- a/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
+++ b/crates/xybrid-core/src/runtime_adapter/cloud/mod.rs
@@ -19,8 +19,8 @@
 //! ```
 
 use crate::cloud::{
-    parse_gateway_usage, Cloud, CloudBackend, CloudConfig, CompletionRequest, CompletionResponse,
-    Role, Usage,
+    openai_chat_body, parse_gateway_usage, Cloud, CloudBackend, CloudConfig, CompletionRequest,
+    CompletionResponse, MissingModel, ThinkingMode, Usage,
 };
 use crate::gateway::ChatCompletionChunk;
 use crate::ir::{Envelope, EnvelopeKind};
@@ -30,7 +30,6 @@ use crate::runtime_adapter::types::{
 };
 use crate::runtime_adapter::{AdapterError, AdapterResult, RuntimeAdapter};
 use crate::tracing as trace;
-use serde_json::json;
 use std::io::{BufRead, BufReader};
 use std::time::{Duration, Instant};
 
@@ -166,7 +165,18 @@ impl CloudRuntimeAdapter {
     }
 
     /// Builds CompletionRequest from envelope metadata.
-    fn build_request(&self, input_text: &str, envelope: &Envelope) -> CompletionRequest {
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::InvalidInput`] when `thinking` metadata is present for a
+    /// provider other than DeepSeek, or holds anything but `enabled` /
+    /// `disabled` (case-insensitive).
+    fn build_request(
+        &self,
+        input_text: &str,
+        envelope: &Envelope,
+        provider: IntegrationProvider,
+    ) -> AdapterResult<CompletionRequest> {
         let mut request = CompletionRequest::new(input_text);
 
         // Model
@@ -208,7 +218,21 @@ impl CloudRuntimeAdapter {
             }
         }
 
-        request
+        // Thinking mode: a DeepSeek request capability (`"thinking": {"type":
+        // ...}`), not a generic OpenAI field. Rejecting it for other providers
+        // keeps a stage option from being silently dropped on the floor.
+        if let Some(raw) = envelope.metadata.get("thinking") {
+            if provider != IntegrationProvider::DeepSeek {
+                return Err(AdapterError::InvalidInput(format!(
+                    "'thinking' is only supported for provider 'deepseek', not '{}'",
+                    provider
+                )));
+            }
+            let mode: ThinkingMode = raw.parse().map_err(AdapterError::InvalidInput)?;
+            request = request.with_thinking(mode);
+        }
+
+        Ok(request)
     }
 }
 
@@ -273,7 +297,7 @@ impl RuntimeAdapter for CloudRuntimeAdapter {
         };
 
         // Build and execute request
-        let request = self.build_request(&input_text, input);
+        let request = self.build_request(&input_text, input, provider)?;
 
         let response = {
             let _llm_span = trace::SpanGuard::new("llm_inference");
@@ -350,7 +374,7 @@ impl CloudStreaming for CloudRuntimeAdapter {
             }
         };
 
-        let request = self.build_request(&input_text, input);
+        let request = self.build_request(&input_text, input, provider)?;
 
         let response = {
             let _llm_span = trace::SpanGuard::new("llm_inference");
@@ -552,70 +576,26 @@ fn stream_with_gateway_sse(
     })
 }
 
-/// Build the OpenAI-compatible chat body for the gateway.
+/// Build the SSE variant of the OpenAI-compatible chat body.
 ///
-/// # Errors
-///
-/// Returns [`AdapterError::InvalidInput`] when neither the request nor the
-/// config names a model. This used to fall back to `"gpt-4o-mini"`, which the
-/// gateway routes to OpenAI — so a caller that simply forgot the model silently
-/// billed a third-party provider instead of running the model it asked for.
-/// That exact default is what made a missing `model` look like a gateway 502
-/// rather than a client bug.
+/// Thin wrapper over the shared [`openai_chat_body`] builder (also used by the
+/// batch transport) that forces `stream: true` and maps a missing model to
+/// [`AdapterError::InvalidInput`]. This used to fall back to `"gpt-4o-mini"`,
+/// which the gateway routes to OpenAI — so a caller that simply forgot the
+/// model silently billed a third-party provider instead of running the model it
+/// asked for.
 fn gateway_chat_body(
     request: &CompletionRequest,
     config: &CloudConfig,
     force_stream: bool,
 ) -> AdapterResult<serde_json::Value> {
-    let messages: Vec<serde_json::Value> = request
-        .to_messages()
-        .into_iter()
-        .map(|m| {
-            json!({
-                "role": match m.role {
-                    Role::System => "system",
-                    Role::User => "user",
-                    Role::Assistant => "assistant",
-                },
-                "content": m.content,
-            })
-        })
-        .collect();
-
-    let model = request
-        .model
-        .clone()
-        .or_else(|| config.default_model.clone())
-        .ok_or_else(|| {
-            AdapterError::InvalidInput(
-                "no model specified for the cloud request: set it on the envelope's `model` \
-                 metadata or via CloudConfig::default_model"
-                    .to_string(),
-            )
-        })?;
-
-    let mut body = json!({
-        "model": model,
-        "messages": messages,
-    });
-
-    if let Some(max_tokens) = request.max_tokens {
-        body["max_tokens"] = json!(max_tokens);
-    }
-    if let Some(temperature) = request.temperature {
-        body["temperature"] = json!(temperature);
-    }
-    if let Some(top_p) = request.top_p {
-        body["top_p"] = json!(top_p);
-    }
-    if let Some(stop) = request.stop.as_ref() {
-        body["stop"] = json!(stop);
-    }
-    if force_stream || request.stream {
-        body["stream"] = json!(true);
-    }
-
-    Ok(body)
+    openai_chat_body(request, config, force_stream || request.stream).map_err(|MissingModel| {
+        AdapterError::InvalidInput(
+            "no model specified for the cloud request: set it on the envelope's `model` \
+             metadata or via CloudConfig::default_model"
+                .to_string(),
+        )
+    })
 }
 
 fn gateway_stream_error(error: ureq::Error, timeout_ms: u32) -> AdapterError {
@@ -649,6 +629,7 @@ fn stream_usage_from_json(data: &str) -> Option<Usage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::mpsc;
@@ -711,7 +692,9 @@ mod tests {
             r#"["STOP","END"]"#.to_string(),
         );
 
-        let request = adapter.build_request("hello", &input);
+        let request = adapter
+            .build_request("hello", &input, IntegrationProvider::OpenAI)
+            .unwrap();
 
         assert!((request.top_p.unwrap() - 0.72).abs() < 1e-6);
         assert_eq!(
@@ -729,9 +712,61 @@ mod tests {
             .metadata
             .insert(STOP_SEQUENCES_METADATA_KEY.to_string(), String::new());
 
-        let request = adapter.build_request("hello", &input);
+        let request = adapter
+            .build_request("hello", &input, IntegrationProvider::OpenAI)
+            .unwrap();
 
         assert!(request.stop.is_none());
+    }
+
+    #[test]
+    fn build_request_parses_thinking_for_deepseek_only() {
+        let adapter = CloudRuntimeAdapter::new();
+        let mut input = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+        input
+            .metadata
+            .insert("thinking".to_string(), "Disabled".to_string());
+
+        let request = adapter
+            .build_request("hello", &input, IntegrationProvider::DeepSeek)
+            .unwrap();
+        assert_eq!(request.thinking, Some(ThinkingMode::Disabled));
+
+        input
+            .metadata
+            .insert("thinking".to_string(), "enabled".to_string());
+        let request = adapter
+            .build_request("hello", &input, IntegrationProvider::DeepSeek)
+            .unwrap();
+        assert_eq!(request.thinking, Some(ThinkingMode::Enabled));
+
+        // Other providers reject the option instead of dropping it.
+        let err = adapter
+            .build_request("hello", &input, IntegrationProvider::OpenAI)
+            .expect_err("thinking is DeepSeek-only");
+        assert!(
+            matches!(err, AdapterError::InvalidInput(ref m) if m.contains("deepseek") && m.contains("openai")),
+            "unexpected error: {err:?}"
+        );
+
+        // Unknown values are rejected.
+        input
+            .metadata
+            .insert("thinking".to_string(), "maybe".to_string());
+        let err = adapter
+            .build_request("hello", &input, IntegrationProvider::DeepSeek)
+            .expect_err("invalid thinking value");
+        assert!(
+            matches!(err, AdapterError::InvalidInput(ref m) if m.contains("maybe")),
+            "unexpected error: {err:?}"
+        );
+
+        // Absent metadata leaves the field unset (provider default applies).
+        input.metadata.remove("thinking");
+        let request = adapter
+            .build_request("hello", &input, IntegrationProvider::DeepSeek)
+            .unwrap();
+        assert_eq!(request.thinking, None);
     }
 
     /// End to end through the body serialiser: metadata in, wire fields out.
@@ -751,11 +786,47 @@ mod tests {
             r#"["STOP","END"]"#.to_string(),
         );
 
-        let request = adapter.build_request("hello", &input);
+        let request = adapter
+            .build_request("hello", &input, IntegrationProvider::OpenAI)
+            .unwrap();
         let body = gateway_chat_body(&request, &config, false).expect("model is set");
 
         assert!((body["top_p"].as_f64().unwrap() - 0.72).abs() < 1e-6);
         assert_eq!(body["stop"], json!(["STOP", "END"]));
+    }
+
+    /// Batch and SSE share one body builder: the only difference on the wire
+    /// is `stream`, and `thinking` plus every generation option ride both.
+    #[test]
+    fn batch_and_sse_bodies_match_except_stream() {
+        let config = CloudConfig::gateway();
+        let request = CompletionRequest::new("hello")
+            .with_model("deepseek-flash")
+            .with_system("You are terse.")
+            .with_temperature(0.0)
+            .with_max_tokens(16)
+            .with_top_p(0.9)
+            .with_stop(vec!["END".to_string()])
+            .with_thinking(ThinkingMode::Disabled);
+
+        let batch = openai_chat_body(&request, &config, request.stream).expect("model is set");
+        let mut sse = gateway_chat_body(&request, &config, true).expect("model is set");
+
+        assert!(batch.get("stream").is_none());
+        assert_eq!(sse["stream"], true);
+        sse.as_object_mut().unwrap().remove("stream");
+        assert_eq!(batch, sse);
+
+        assert_eq!(batch["model"], "deepseek-flash");
+        assert_eq!(batch["thinking"], json!({ "type": "disabled" }));
+        assert_eq!(batch["messages"][0]["role"], "system");
+        assert_eq!(batch["messages"][0]["content"], "You are terse.");
+        assert_eq!(batch["messages"][1]["role"], "user");
+        assert_eq!(batch["messages"][1]["content"], "hello");
+        assert_eq!(batch["max_tokens"], 16);
+        assert_eq!(batch["temperature"], 0.0);
+        assert!((batch["top_p"].as_f64().unwrap() - 0.9).abs() < 1e-6);
+        assert_eq!(batch["stop"], json!(["END"]));
     }
 
     #[test]

--- a/crates/xybrid-core/src/testing/mocks.rs
+++ b/crates/xybrid-core/src/testing/mocks.rs
@@ -242,6 +242,12 @@ impl MockOnnxOutputs {
 /// # }
 /// ```
 pub struct MockRuntimeAdapter {
+    /// Adapter name reported to the executor (defaults to `"mock"`).
+    ///
+    /// The executor keys its default local/cloud adapters on the names
+    /// `"onnx"` and `"cloud"`, so tests that register more than one adapter
+    /// should name them explicitly with [`MockRuntimeAdapter::with_name`].
+    name: String,
     /// The output to return from execute()
     output: MockOutput,
     /// Track the number of executions (thread-safe for RuntimeAdapter: Send + Sync)
@@ -250,37 +256,47 @@ pub struct MockRuntimeAdapter {
     is_loaded: Mutex<bool>,
     /// Simulate an error if set
     error: Option<String>,
+    /// Every envelope passed to `execute()`, in order.
+    captured_inputs: Mutex<Vec<Envelope>>,
 }
 
 impl MockRuntimeAdapter {
-    /// Create a mock adapter that returns text output (for ASR-like behavior).
-    pub fn with_text_output(text: impl Into<String>) -> Self {
+    fn from_output(output: MockOutput) -> Self {
         Self {
-            output: MockOutput::Text(text.into()),
+            name: "mock".to_string(),
+            output,
             call_count: Mutex::new(0),
             is_loaded: Mutex::new(false),
             error: None,
+            captured_inputs: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Create a mock adapter that returns text output (for ASR-like behavior).
+    pub fn with_text_output(text: impl Into<String>) -> Self {
+        Self::from_output(MockOutput::Text(text.into()))
     }
 
     /// Create a mock adapter that returns audio output (for TTS-like behavior).
     pub fn with_audio_output(bytes: Vec<u8>) -> Self {
-        Self {
-            output: MockOutput::Audio(bytes),
-            call_count: Mutex::new(0),
-            is_loaded: Mutex::new(false),
-            error: None,
-        }
+        Self::from_output(MockOutput::Audio(bytes))
     }
 
     /// Create a mock adapter that returns embedding output.
     pub fn with_embedding_output(values: Vec<f32>) -> Self {
-        Self {
-            output: MockOutput::Embedding(values),
-            call_count: Mutex::new(0),
-            is_loaded: Mutex::new(false),
-            error: None,
-        }
+        Self::from_output(MockOutput::Embedding(values))
+    }
+
+    /// Register under a specific adapter name (e.g. `"onnx"` or `"cloud"`)
+    /// so the executor's default-adapter selection is deterministic.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Every input envelope `execute()` received so far, oldest first.
+    pub fn captured_inputs(&self) -> Vec<Envelope> {
+        self.captured_inputs.lock().unwrap().clone()
     }
 
     /// Configure the mock to simulate an error on execute.
@@ -302,7 +318,7 @@ impl MockRuntimeAdapter {
 
 impl RuntimeAdapter for MockRuntimeAdapter {
     fn name(&self) -> &str {
-        "mock"
+        &self.name
     }
 
     fn supported_formats(&self) -> Vec<&'static str> {
@@ -314,7 +330,9 @@ impl RuntimeAdapter for MockRuntimeAdapter {
         Ok(())
     }
 
-    fn execute(&self, _input: &Envelope) -> AdapterResult<Envelope> {
+    fn execute(&self, input: &Envelope) -> AdapterResult<Envelope> {
+        self.captured_inputs.lock().unwrap().push(input.clone());
+
         if let Some(ref err) = self.error {
             return Err(AdapterError::RuntimeError(err.clone()));
         }

--- a/crates/xybrid-core/tests/integration_hiiipe.rs
+++ b/crates/xybrid-core/tests/integration_hiiipe.rs
@@ -1,436 +1,392 @@
 //! Integration tests for the HIIIPE pipeline.
 //!
-//! These tests simulate the full Hiiipe demo workflow:
-//! Mic Input (AudioRaw) → Local ASR (wav2vec2@1.0) → Cloud Motivator (motivator-llm@5) → Local TTS (xtts-mini@0.6)
+//! These tests simulate the Hiiipe demo workflow:
+//! Mic Input (audio) → Local ASR → Cloud Motivator → Local TTS
 //!
-//! The tests verify:
-//! - Policy enforcement (no raw audio off-device)
-//! - Dynamic routing (local vs cloud)
-//! - Telemetry emission
-//! - End-to-end pipeline execution
-//!
-//! NOTE: These tests are currently ignored due to routing assertion mismatches
-//! ("cloud" vs "local") that need investigation. See CI run 21957103431.
+//! They drive the public `Orchestrator` with named mock adapters for both legs
+//! and a fixed, quiet device snapshot, so every assertion is about routing and
+//! policy — not about the machine the test happens to run on and not about any
+//! network. The tests verify:
+//! - Policy enforcement (raw audio never leaves the device)
+//! - Dynamic routing (local vs cloud) and the adapter that actually ran
+//! - Event emission
+//! - End-to-end pipeline execution, including the default bootstrapped
+//!   orchestrator honouring `load_policies`
 
+use std::sync::Arc;
+use std::time::Duration;
 use xybrid_core::context::{DeviceMetrics, Envelope, EnvelopeKind, StageDescriptor};
+use xybrid_core::device::{ResourceSnapshot, ResourceSnapshotProvider};
 use xybrid_core::event_bus::OrchestratorEvent;
 use xybrid_core::orchestrator::routing_engine::LocalAvailability;
-use xybrid_core::orchestrator::{ExecutionMode, Orchestrator};
+use xybrid_core::orchestrator::{ExecutionMode, LocalAuthority, Orchestrator};
+use xybrid_core::runtime_adapter::RuntimeAdapter;
+use xybrid_core::testing::mocks::MockRuntimeAdapter;
+
+/// Raw audio must stay on the device.
+const AUDIO_STAYS_LOCAL_POLICY: &[u8] = b"deny_cloud_if:\n  - 'input.kind == \"audio\"'\n";
+
+/// A device with no observed stress, so the default-local rule applies.
+#[derive(Debug)]
+struct QuietDevice;
+
+impl ResourceSnapshotProvider for QuietDevice {
+    fn current_snapshot(&self, _max_age: Duration) -> ResourceSnapshot {
+        ResourceSnapshot::unknown()
+    }
+}
 
 fn audio_envelope() -> Envelope {
     Envelope::new(EnvelopeKind::Audio(vec![0u8; 1600]))
 }
 
-fn assert_text_contains(envelope: &Envelope, needle: &str) {
-    match &envelope.kind {
-        EnvelopeKind::Text(text) => {
-            assert!(
-                text.contains(needle),
-                "expected text envelope to contain '{}', got '{}'",
-                needle,
-                text
-            );
-        }
-        other => panic!("expected text envelope, got {:?}", other),
+fn text_of(envelope: &Envelope) -> &str {
+    envelope
+        .as_text()
+        .unwrap_or_else(|| panic!("expected text envelope, got {:?}", envelope.kind))
+}
+
+fn loaded_mock(name: &str, output: &str) -> Arc<MockRuntimeAdapter> {
+    let mut adapter = MockRuntimeAdapter::with_text_output(output).with_name(name);
+    adapter.load_model("/mock/model").unwrap();
+    Arc::new(adapter)
+}
+
+struct Harness {
+    orchestrator: Orchestrator,
+    local: Arc<MockRuntimeAdapter>,
+    cloud: Arc<MockRuntimeAdapter>,
+}
+
+/// Orchestrator on a quiet device with the audio-stays-local policy loaded and
+/// one named mock adapter per leg.
+fn hiiipe_harness() -> Harness {
+    let authority = LocalAuthority::new().with_resource_provider(Arc::new(QuietDevice));
+    let mut orchestrator = Orchestrator::with_authority(Box::new(authority));
+    orchestrator
+        .load_policies(AUDIO_STAYS_LOCAL_POLICY.to_vec())
+        .expect("policy loads");
+    let local = loaded_mock("onnx", "local output");
+    let cloud = loaded_mock("cloud", "cloud output");
+    orchestrator.executor_mut().register_adapter(local.clone());
+    orchestrator.executor_mut().register_adapter(cloud.clone());
+    Harness {
+        orchestrator,
+        local,
+        cloud,
     }
 }
 
-/// Test the complete Hiiipe pipeline with batch execution.
+fn hiiipe_stages() -> Vec<StageDescriptor> {
+    vec![
+        StageDescriptor::new("asr"),
+        StageDescriptor::new("motivator"),
+        StageDescriptor::new("tts"),
+    ]
+}
+
+/// ASR and TTS are cached locally; the motivator LLM exists only in the cloud.
+fn hiiipe_availability(stage: &str) -> LocalAvailability {
+    LocalAvailability::new(matches!(stage, "asr" | "tts"))
+}
+
 #[test]
-#[ignore = "routing assertions need investigation"]
 fn test_hiiipe_pipeline() {
-    // Setup: Create orchestrator with default components
-    let mut orchestrator = Orchestrator::new();
+    let Harness {
+        mut orchestrator,
+        local,
+        cloud,
+    } = hiiipe_harness();
 
-    // Define the Hiiipe pipeline stages
-    let stages = vec![
-        StageDescriptor::new("asr"),       // whisper-tiny@1.2 (local)
-        StageDescriptor::new("motivator"), // motivator-llm@5 (cloud)
-        StageDescriptor::new("tts"),       // xtts-mini@0.6 (local)
-    ];
-
-    // Simulate mic input (raw audio)
-    let mic_input = audio_envelope();
-
-    // Simulate device metrics (good conditions for cloud routing)
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
-    // Define model availability function
-    // ASR and TTS available locally, Motivator only in cloud
-    let availability_fn = |stage: &str| -> LocalAvailability {
-        match stage {
-            "asr" => LocalAvailability::new(true), // whisper-tiny available locally
-            "tts" => LocalAvailability::new(true), // xtts-mini available locally
-            "motivator" => LocalAvailability::new(false), // motivator-llm only in cloud
-            _ => LocalAvailability::new(false),
-        }
-    };
-
-    // Execute the pipeline
     let results = orchestrator
-        .execute_pipeline(&stages, &mic_input, &metrics, &availability_fn)
-        .expect("Pipeline execution should succeed");
-
-    // Verify we got results for all three stages
-    assert_eq!(results.len(), 3, "Should have results for all 3 stages");
-
-    // Verify ASR stage (stage 0)
-    let asr_result = &results[0];
-    assert_eq!(asr_result.stage, "asr");
-    // ASR should route to local (policy denies AudioRaw for cloud)
-    assert_eq!(asr_result.routing_decision.target.as_str(), "local");
-    assert_text_contains(&asr_result.output, "asr");
-    // Latency is tracked (u32, always >= 0)
-
-    // Verify Motivator stage (stage 1)
-    let motivator_result = &results[1];
-    assert_eq!(motivator_result.stage, "motivator");
-    // Motivator should route to cloud (not available locally, policy allows)
-    assert_eq!(motivator_result.routing_decision.target.as_str(), "cloud");
-    assert_text_contains(&motivator_result.output, "motivator");
-    // Latency is tracked (u32, always >= 0)
-
-    // Verify TTS stage (stage 2)
-    let tts_result = &results[2];
-    assert_eq!(tts_result.stage, "tts");
-    // TTS may route to cloud or local depending on conditions
-    // When available locally and conditions are good, routing engine may choose cloud
-    assert!(
-        tts_result.routing_decision.target.as_str() == "local"
-            || tts_result.routing_decision.target.as_str() == "cloud"
-    );
-    assert_text_contains(&tts_result.output, "tts");
-    // Latency is tracked (u32, always >= 0)
-
-    // Verify the output chain: ASR output becomes Motivator input
-    assert_text_contains(&asr_result.output, "asr_output");
-    assert_text_contains(&motivator_result.output, "motivator_output");
-
-    // Verify the output chain: Motivator output becomes TTS input
-    assert_text_contains(&tts_result.output, "tts_output");
-}
-
-/// Test that policy correctly denies raw audio for cloud execution.
-#[test]
-#[ignore = "routing assertions need investigation"]
-fn test_hiiipe_policy_enforcement() {
-    let mut orchestrator = Orchestrator::new();
-
-    let stage = StageDescriptor::new("asr");
-
-    // AudioRaw should trigger policy denial for cloud
-    let audio_input = audio_envelope();
-
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
-    let availability = LocalAvailability::new(true);
-
-    let result = orchestrator
-        .execute_stage(&stage, &audio_input, &metrics, &availability)
-        .expect("Stage execution should succeed");
-
-    // Policy should deny cloud execution, forcing local routing
-    assert_eq!(result.routing_decision.target.as_str(), "local");
-    assert!(
-        result.routing_decision.reason.contains("policy_deny")
-            || result.routing_decision.reason.contains("AudioRaw")
-    );
-}
-
-/// Test Hiiipe pipeline with event bus subscription.
-#[test]
-#[ignore = "routing assertions need investigation"]
-fn test_hiiipe_pipeline_with_events() {
-    let mut orchestrator = Orchestrator::new();
-
-    // Subscribe to events to verify event emission
-    let event_bus = orchestrator.event_bus();
-    let subscription = event_bus.subscribe();
-
-    let stages = vec![
-        StageDescriptor::new("asr"),
-        StageDescriptor::new("motivator"),
-        StageDescriptor::new("tts"),
-    ];
-
-    let mic_input = audio_envelope();
-
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
-    let availability_fn = |stage: &str| -> LocalAvailability {
-        match stage {
-            "asr" | "tts" => LocalAvailability::new(true),
-            _ => LocalAvailability::new(false),
-        }
-    };
-
-    // Execute pipeline
-    let results = orchestrator
-        .execute_pipeline(&stages, &mic_input, &metrics, &availability_fn)
-        .expect("Pipeline execution should succeed");
+        .execute_pipeline(
+            &hiiipe_stages(),
+            &audio_envelope(),
+            &DeviceMetrics::default(),
+            &hiiipe_availability,
+        )
+        .expect("pipeline executes");
 
     assert_eq!(results.len(), 3);
 
-    // Collect events (non-blocking)
-    let mut events_received = 0;
-    while let Ok(event) = subscription.try_recv() {
-        events_received += 1;
-        // Verify event types
-        match event {
-            OrchestratorEvent::StageStart { .. } => {}
-            OrchestratorEvent::StageComplete { .. } => {}
-            OrchestratorEvent::PolicyEvaluated { .. } => {}
-            OrchestratorEvent::RoutingDecided { .. } => {}
-            OrchestratorEvent::ExecutionStarted { .. } => {}
-            OrchestratorEvent::ExecutionCompleted { .. } => {}
-            OrchestratorEvent::PipelineStart { .. } => {}
-            OrchestratorEvent::PipelineComplete { .. } => {}
-            _ => {}
-        }
-    }
-
-    // Should have received multiple events (at least pipeline start/complete + stage events)
-    assert!(
-        events_received >= 2,
-        "Should receive pipeline and stage events"
-    );
-}
-
-/// Test Hiiipe pipeline with different network conditions.
-#[test]
-#[ignore = "routing assertions need investigation"]
-fn test_hiiipe_pipeline_high_latency() {
-    let mut orchestrator = Orchestrator::new();
-
-    let stages = vec![
-        StageDescriptor::new("asr"),
-        StageDescriptor::new("motivator"),
-        StageDescriptor::new("tts"),
-    ];
-
-    let mic_input = audio_envelope();
-
-    // High network latency should force local routing for motivator
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
-    let availability_fn = |stage: &str| -> LocalAvailability {
-        match stage {
-            "asr" | "tts" => LocalAvailability::new(true),
-            "motivator" => LocalAvailability::new(true), // Also available locally as fallback
-            _ => LocalAvailability::new(false),
-        }
-    };
-
-    let results = orchestrator
-        .execute_pipeline(&stages, &mic_input, &metrics, &availability_fn)
-        .expect("Pipeline execution should succeed");
-
-    assert_eq!(results.len(), 3);
-
-    // With high latency, motivator might route locally if available
-    // But policy might still deny if AudioRaw data is being sent
-    // For this test, ASR should definitely route locally (policy deny)
-    assert_eq!(results[0].routing_decision.target.as_str(), "local");
-
-    // Motivator should route locally due to high latency (if available)
-    // or cloud if forced (depending on policy)
-    let motivator_target = results[1].routing_decision.target.as_str();
-    assert!(motivator_target == "local" || motivator_target == "cloud");
-
-    // TTS may route locally or cloud depending on conditions
-    assert!(
-        results[2].routing_decision.target.as_str() == "local"
-            || results[2].routing_decision.target.as_str() == "cloud"
-    );
-}
-
-/// Test streaming execution mode for Hiiipe pipeline.
-#[test]
-#[ignore = "routing assertions need investigation"]
-fn test_hiiipe_pipeline_streaming() {
-    use xybrid_core::streaming::StreamManagerConfig;
-
-    // Create orchestrator in streaming mode
-    let config = StreamManagerConfig::default();
-    let mut orchestrator = Orchestrator::with_streaming(config);
-
-    assert_eq!(*orchestrator.execution_mode(), ExecutionMode::Streaming);
-
-    let stage = StageDescriptor::new("asr");
-
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
-    let availability = LocalAvailability::new(true);
-
-    // Push streaming chunks
-    let chunk1 = Envelope::new(EnvelopeKind::Audio(vec![0u8; 4]));
-    let chunk2 = Envelope::new(EnvelopeKind::Audio(vec![1u8; 4]));
-
-    orchestrator.push_stream_chunk(chunk1, false).unwrap();
-    orchestrator.push_stream_chunk(chunk2, true).unwrap(); // Last chunk
-
-    // Process first chunk
-    let result1 = orchestrator
-        .execute_streaming_stage(&stage, &metrics, &availability)
-        .expect("Streaming stage execution should succeed");
-
-    assert!(result1.is_some());
-    let exec_result1 = result1.unwrap();
-    assert_eq!(exec_result1.stage, "asr");
-    assert_text_contains(&exec_result1.output, "asr_output");
-
-    // Check output buffer
-    let output_chunk = orchestrator.pop_stream_output();
-    assert!(output_chunk.is_some());
-    let chunk = output_chunk.unwrap();
-    assert_text_contains(&chunk.data, "asr_output");
-    assert!(!chunk.is_last); // First chunk
-
-    // Process second chunk (last)
-    let result2 = orchestrator
-        .execute_streaming_stage(&stage, &metrics, &availability)
-        .expect("Streaming stage execution should succeed");
-
-    assert!(result2.is_some());
-    let exec_result2 = result2.unwrap();
-    assert_eq!(exec_result2.stage, "asr");
-
-    let output_chunk2 = orchestrator.pop_stream_output();
-    assert!(output_chunk2.is_some());
-    let chunk2 = output_chunk2.unwrap();
-    assert!(chunk2.is_last); // Last chunk
-}
-
-/// Test complete Hiiipe pipeline with realistic model availability.
-#[test]
-#[ignore = "routing assertions need investigation"]
-fn test_hiiipe_complete_workflow() {
-    let mut orchestrator = Orchestrator::new();
-
-    // Simulate the complete Hiiipe demo workflow
-    let stages = vec![
-        StageDescriptor::new("wav2vec2@1.0"),    // ASR model
-        StageDescriptor::new("motivator-llm@5"), // Motivator model
-        StageDescriptor::new("xtts-mini@0.6"),   // TTS model
-    ];
-
-    // Mic input (raw audio)
-    let mic_input = audio_envelope();
-
-    // Good device conditions
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
-    // Model availability matching the demo
-    let availability_fn = |stage: &str| -> LocalAvailability {
-        match stage {
-            "wav2vec2@1.0" => LocalAvailability::new(true), // ASR available locally
-            "xtts-mini@0.6" => LocalAvailability::new(true), // TTS available locally
-            "motivator-llm@5" => LocalAvailability::new(false), // Motivator only in cloud
-            _ => LocalAvailability::new(false),
-        }
-    };
-
-    // Execute the complete workflow
-    let results = orchestrator
-        .execute_pipeline(&stages, &mic_input, &metrics, &availability_fn)
-        .expect("Complete workflow should succeed");
-
-    // Verify all stages executed
-    assert_eq!(results.len(), 3);
-
-    // Stage 1: ASR (wav2vec2) - should route locally
+    // ASR: raw audio in, policy forbids cloud → local.
     let asr = &results[0];
-    assert_eq!(asr.stage, "wav2vec2@1.0");
+    assert_eq!(asr.stage, "asr");
     assert_eq!(asr.routing_decision.target.as_str(), "local");
     assert!(
-        asr.routing_decision.reason.contains("policy_deny")
-            || asr.routing_decision.reason.contains("AudioRaw")
+        asr.routing_decision.reason.contains("policy_deny"),
+        "{}",
+        asr.routing_decision.reason
     );
+    assert_eq!(asr.adapter, "onnx");
+    assert_eq!(text_of(&asr.output), "local output");
 
-    // Stage 2: Motivator (llm) - should route to cloud
+    // Motivator: text in, no local model → cloud.
     let motivator = &results[1];
-    assert_eq!(motivator.stage, "motivator-llm@5");
+    assert_eq!(motivator.stage, "motivator");
     assert_eq!(motivator.routing_decision.target.as_str(), "cloud");
     assert!(
         motivator
             .routing_decision
             .reason
-            .contains("optimal_conditions")
-            || motivator
-                .routing_decision
-                .reason
-                .contains("model_unavailable")
+            .contains("model_unavailable"),
+        "{}",
+        motivator.routing_decision.reason
     );
+    assert_eq!(motivator.adapter, "cloud");
+    assert_eq!(text_of(&motivator.output), "cloud output");
 
-    // Stage 3: TTS (xtts-mini) - may route locally or cloud depending on conditions
+    // TTS: text in, local model, quiet device → default local.
     let tts = &results[2];
-    assert_eq!(tts.stage, "xtts-mini@0.6");
-    // With good network conditions, routing engine may choose cloud even if local available
-    // This is valid behavior - the routing engine optimizes for conditions
+    assert_eq!(tts.stage, "tts");
+    assert_eq!(tts.routing_decision.target.as_str(), "local");
     assert!(
-        tts.routing_decision.target.as_str() == "local"
-            || tts.routing_decision.target.as_str() == "cloud"
+        tts.routing_decision.reason.contains("default_local"),
+        "{}",
+        tts.routing_decision.reason
     );
+    assert_eq!(tts.adapter, "onnx");
 
-    // Verify latency tracking (latency_ms is u32, always non-negative)
-    for result in &results {
-        assert!(
-            result.latency_ms < 10000,
-            "Latency should be reasonable (< 10s)"
-        );
-    }
-
-    // Verify output transformation chain
-    assert_text_contains(&asr.output, "wav2vec2");
-    assert_text_contains(&motivator.output, "motivator-llm");
-    assert_text_contains(&tts.output, "xtts-mini");
+    assert_eq!(local.call_count(), 2);
+    assert_eq!(cloud.call_count(), 1);
 }
 
-/// Test that pipeline handles policy changes correctly.
 #[test]
-#[ignore = "routing assertions need investigation"]
-fn test_hiiipe_with_policy_loading() {
-    let mut orchestrator = Orchestrator::new();
+fn test_hiiipe_policy_enforcement() {
+    let Harness {
+        mut orchestrator,
+        local,
+        cloud,
+    } = hiiipe_harness();
 
-    // Load a custom policy
-    let policy_yaml = r#"
-version: "0.1.0"
-deny_cloud_if:
-  - input.kind == "AudioRaw"
-  - metrics.network_rtt > 300
-signature: "test_policy"
-"#;
+    // Even when the ASR model is NOT available locally, raw audio must not go
+    // to the cloud: the stage is routed local and served by the local adapter
+    // (a stage with a provider and no bundle would fail locally instead).
+    for available in [true, false] {
+        let result = orchestrator
+            .execute_stage(
+                &StageDescriptor::new("asr"),
+                &audio_envelope(),
+                &DeviceMetrics::default(),
+                &LocalAvailability::new(available),
+            )
+            .expect("stage executes locally");
 
-    orchestrator
-        .load_policies(policy_yaml.as_bytes().to_vec())
-        .expect("Policy loading should succeed");
+        assert_eq!(result.routing_decision.target.as_str(), "local");
+        assert!(
+            result.routing_decision.reason.contains("policy_deny"),
+            "{}",
+            result.routing_decision.reason
+        );
+        assert_eq!(result.adapter, "onnx");
+    }
+    assert_eq!(local.call_count(), 2);
+    assert_eq!(
+        cloud.call_count(),
+        0,
+        "raw audio must never reach the cloud adapter"
+    );
+}
+
+#[test]
+fn test_hiiipe_pipeline_with_events() {
+    let Harness {
+        mut orchestrator, ..
+    } = hiiipe_harness();
+    let subscription = orchestrator.event_bus().subscribe();
+
+    let results = orchestrator
+        .execute_pipeline(
+            &hiiipe_stages(),
+            &audio_envelope(),
+            &DeviceMetrics::default(),
+            &hiiipe_availability,
+        )
+        .expect("pipeline executes");
+    assert_eq!(results.len(), 3);
+
+    let mut policy_events = Vec::new();
+    let mut routing_events = Vec::new();
+    let mut pipeline_start = 0;
+    let mut pipeline_complete = 0;
+    while let Ok(event) = subscription.try_recv() {
+        match event {
+            OrchestratorEvent::PolicyEvaluated {
+                stage_name,
+                allowed,
+                ..
+            } => policy_events.push((stage_name, allowed)),
+            OrchestratorEvent::RoutingDecided {
+                stage_name, target, ..
+            } => routing_events.push((stage_name, target)),
+            OrchestratorEvent::PipelineStart { .. } => pipeline_start += 1,
+            OrchestratorEvent::PipelineComplete { .. } => pipeline_complete += 1,
+            _ => {}
+        }
+    }
+
+    assert_eq!(pipeline_start, 1);
+    assert_eq!(pipeline_complete, 1);
+    assert_eq!(
+        policy_events,
+        vec![
+            ("asr".to_string(), false),
+            ("motivator".to_string(), true),
+            ("tts".to_string(), true),
+        ]
+    );
+    assert_eq!(
+        routing_events,
+        vec![
+            ("asr".to_string(), "local".to_string()),
+            ("motivator".to_string(), "cloud".to_string()),
+            ("tts".to_string(), "local".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_hiiipe_pipeline_streaming() {
+    let Harness {
+        mut orchestrator,
+        local,
+        cloud,
+    } = hiiipe_harness();
+    orchestrator.set_execution_mode(ExecutionMode::Streaming);
+    assert_eq!(*orchestrator.execution_mode(), ExecutionMode::Streaming);
 
     let stage = StageDescriptor::new("asr");
-
-    let audio_input = audio_envelope();
-
-    let metrics = DeviceMetrics {
-        ..DeviceMetrics::default()
-    };
-
+    let metrics = DeviceMetrics::default();
     let availability = LocalAvailability::new(true);
 
-    let result = orchestrator
-        .execute_stage(&stage, &audio_input, &metrics, &availability)
-        .expect("Stage execution should succeed");
+    orchestrator
+        .push_stream_chunk(Envelope::new(EnvelopeKind::Audio(vec![0u8; 4])), false)
+        .unwrap();
+    orchestrator
+        .push_stream_chunk(Envelope::new(EnvelopeKind::Audio(vec![1u8; 4])), true)
+        .unwrap();
 
-    // Loaded policy should still deny AudioRaw for cloud
-    assert_eq!(result.routing_decision.target.as_str(), "local");
+    let first = orchestrator
+        .execute_streaming_stage(&stage, &metrics, &availability)
+        .expect("first chunk executes")
+        .expect("a chunk was queued");
+    assert_eq!(first.stage, "asr");
+    assert_eq!(first.routing_decision.target.as_str(), "local");
+    assert_eq!(text_of(&first.output), "local output");
+    let chunk = orchestrator
+        .pop_stream_output()
+        .expect("first output chunk");
+    assert!(!chunk.is_last);
+
+    let second = orchestrator
+        .execute_streaming_stage(&stage, &metrics, &availability)
+        .expect("second chunk executes")
+        .expect("a chunk was queued");
+    assert_eq!(second.routing_decision.target.as_str(), "local");
+    let chunk = orchestrator
+        .pop_stream_output()
+        .expect("second output chunk");
+    assert!(chunk.is_last);
+
+    assert_eq!(local.call_count(), 2);
+    assert_eq!(cloud.call_count(), 0);
+}
+
+#[test]
+fn test_hiiipe_complete_workflow() {
+    let Harness {
+        mut orchestrator, ..
+    } = hiiipe_harness();
+
+    let stages = vec![
+        StageDescriptor::new("wav2vec2@1.0"),
+        StageDescriptor::new("motivator-llm@5"),
+        StageDescriptor::new("xtts-mini@0.6"),
+    ];
+    let availability = |stage: &str| -> LocalAvailability {
+        LocalAvailability::new(matches!(stage, "wav2vec2@1.0" | "xtts-mini@0.6"))
+    };
+
+    let results = orchestrator
+        .execute_pipeline(
+            &stages,
+            &audio_envelope(),
+            &DeviceMetrics::default(),
+            &availability,
+        )
+        .expect("complete workflow executes");
+
+    let targets: Vec<&str> = results
+        .iter()
+        .map(|r| r.routing_decision.target.as_str())
+        .collect();
+    assert_eq!(targets, vec!["local", "cloud", "local"]);
+    let adapters: Vec<&str> = results.iter().map(|r| r.adapter.as_str()).collect();
+    assert_eq!(adapters, vec!["onnx", "cloud", "onnx"]);
+    for result in &results {
+        assert!(result.latency_ms < 10_000, "latency should be reasonable");
+    }
+}
+
+/// The default bootstrapped orchestrator must honour `load_policies` — this
+/// used to be silently ignored because the bundle went to an engine nothing
+/// consulted.
+#[test]
+fn test_hiiipe_with_policy_loading() {
+    let mut orchestrator = Orchestrator::new();
+    // Replace the bootstrapped adapters with loaded mocks under the same names.
+    let local = loaded_mock("onnx", "local output");
+    let cloud = loaded_mock("cloud", "cloud output");
+    orchestrator.executor_mut().register_adapter(local.clone());
+    orchestrator.executor_mut().register_adapter(cloud.clone());
+
+    // Legacy label still accepted as an alias for `audio`.
+    orchestrator
+        .load_policies(b"version: \"0.1.0\"\ndeny_cloud_if:\n  - 'input.kind == \"AudioRaw\"'\nsignature: \"test_policy\"\n".to_vec())
+        .expect("policy loads");
+
+    // Audio with no local model would route to cloud without the policy.
+    let denied = orchestrator
+        .execute_stage(
+            &StageDescriptor::new("asr"),
+            &audio_envelope(),
+            &DeviceMetrics::default(),
+            &LocalAvailability::new(false),
+        )
+        .expect("local mock serves the stage");
+    assert_eq!(denied.routing_decision.target.as_str(), "local");
+    assert!(
+        denied.routing_decision.reason.contains("policy_deny"),
+        "{}",
+        denied.routing_decision.reason
+    );
+    assert_eq!(cloud.call_count(), 0);
+
+    // Text is not covered by the policy: no local model → cloud.
+    let allowed = orchestrator
+        .execute_stage(
+            &StageDescriptor::new("motivator"),
+            &Envelope::new(EnvelopeKind::Text("hello".to_string())),
+            &DeviceMetrics::default(),
+            &LocalAvailability::new(false),
+        )
+        .expect("cloud mock serves the stage");
+    assert_eq!(allowed.routing_decision.target.as_str(), "cloud");
+    assert_eq!(cloud.call_count(), 1);
+
+    // An invalid reload is rejected and the audio denial still holds.
+    let err = orchestrator
+        .load_policies(b"deny_cloud_if:\n  - 'metrics.network_rtt > 300'\n".to_vec())
+        .expect_err("unknown operand is rejected");
+    assert!(err.to_string().contains("unknown operand"), "{err}");
+    let still_denied = orchestrator
+        .execute_stage(
+            &StageDescriptor::new("asr"),
+            &audio_envelope(),
+            &DeviceMetrics::default(),
+            &LocalAvailability::new(false),
+        )
+        .expect("local mock serves the stage");
+    assert_eq!(still_denied.routing_decision.target.as_str(), "local");
+    assert_eq!(cloud.call_count(), 1);
 }

--- a/crates/xybrid-sdk/examples/cloud_fallback_demo.rs
+++ b/crates/xybrid-sdk/examples/cloud_fallback_demo.rs
@@ -22,7 +22,7 @@
 //!    `http://localhost:3001/v1`, which is the local-dev port the Xybrid
 //!    gateway listens on. The gateway dispatches to whichever upstream
 //!    provider it has credentials for (e.g. DeepSeek, OpenAI, Anthropic);
-//!    the demo sends `model = "deepseek-chat"` to match a gateway
+//!    the demo sends `model = "deepseek-flash"` to match a gateway
 //!    configured with `DEEPSEEK_API_KEY`. Pick a different `model` (and
 //!    matching `provider` metadata) below if your gateway exposes
 //!    different upstream keys.
@@ -34,15 +34,21 @@
 //!    export XYBRID_API_KEY=sk_live_…
 //!    ```
 //!
-//!    To override the gateway URL (staging / production / your own
-//!    OpenAI-compatible endpoint):
+//!    Credentials are scoped to the destination: the Xybrid key is sent
+//!    automatically only to the *configured platform gateway* origin. To
+//!    point the demo at a staging / self-hosted gateway and keep the key
+//!    flowing, configure the platform gateway itself rather than just the
+//!    adapter URL:
 //!
 //!    ```bash
-//!    export XYBRID_CLOUD_URL=https://your-gateway.example.com/v1
+//!    export XYBRID_GATEWAY_URL=https://your-gateway.example.com/v1
 //!    ```
 //!
-//!    The cloud client appends `/chat/completions`, so `XYBRID_CLOUD_URL`
-//!    must end at the API version prefix (`…/v1`), not the bare host.
+//!    `XYBRID_CLOUD_URL` still overrides the adapter's URL alone; a URL
+//!    that is not the platform origin is then called anonymously unless you
+//!    add an `api_key` entry to the envelope metadata. The cloud client
+//!    appends `/chat/completions`, so either URL must end at the API version
+//!    prefix (`…/v1`), not the bare host.
 //!
 //! # Run
 //!
@@ -179,7 +185,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //    The local leg ignores the cloud-only keys.
     let mut envelope = Envelope::new(EnvelopeKind::Text(PROMPT.to_string()));
     // The local platform backend resolves the upstream provider from the
-    //    `model` name (`deepseek-chat` → DeepSeek), so the `provider` field is
+    //    `model` name (`deepseek-flash` → DeepSeek), so the `provider` field is
     //    SDK-side bookkeeping only and never crosses the wire to the gateway.
     //    Match it to the model so traces stay honest.
     envelope
@@ -187,7 +193,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .insert("provider".to_string(), "deepseek".to_string());
     envelope
         .metadata
-        .insert("model".to_string(), "deepseek-chat".to_string());
+        .insert("model".to_string(), "deepseek-flash".to_string());
     envelope
         .metadata
         .insert("max_tokens".to_string(), "200".to_string());

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -389,6 +389,23 @@ fn stage_descriptor_with_bundle_path(
     stage_descriptor
 }
 
+/// Apply the stage's shared generation options to the streaming input.
+///
+/// The streaming fast path bypasses [`Orchestrator::execute_pipeline`], which
+/// is where the batch path runs [`xybrid_core::executor::prepare_stage_input`].
+/// Without this call, YAML `system_prompt` / `temperature` / `max_tokens` /
+/// `top_p` would be ignored by streaming and invalid values would skip
+/// validation entirely. Input metadata still wins over the YAML options, and
+/// errors surface before any generation or token callback begins.
+#[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+fn prepare_streaming_fast_path_input(
+    stage: &StageDescriptor,
+    envelope: &Envelope,
+) -> PipelineResult<Envelope> {
+    xybrid_core::executor::prepare_stage_input(stage, envelope)
+        .map_err(|e| SdkError::pipeline(format!("stage '{}': {}", stage.name, e)))
+}
+
 #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
 #[derive(Debug, Clone)]
 struct StreamingFastPathRoute {
@@ -1505,6 +1522,11 @@ impl Xybrid {
                         xybrid_core::execution::ExecutionTemplate::Gguf { .. }
                     ) {
                         let model_id = metadata.model_id.clone();
+                        // The fast path bypasses the orchestrator, so it must
+                        // run the same shared generation-option merge (and
+                        // validation) the batch path does.
+                        let prepared =
+                            prepare_streaming_fast_path_input(&stage_descriptor, envelope)?;
                         let metrics = pipeline_metrics(options);
                         let authority = LocalAuthority::with_cache_provider(Arc::new(
                             StreamingFastPathCacheProvider::new(
@@ -1516,7 +1538,7 @@ impl Xybrid {
                             &authority,
                             &stage_descriptor,
                             &model_id,
-                            envelope,
+                            &prepared,
                             &metrics,
                         );
 
@@ -1550,7 +1572,7 @@ impl Xybrid {
 
                         let start_time = std::time::Instant::now();
                         let output = executor
-                            .execute_streaming(&metadata, envelope, on_token, None)
+                            .execute_streaming(&metadata, &prepared, on_token, None)
                             .map_err(|e| {
                                 SdkError::inference_src("LLM streaming execution failed", e)
                             })?;
@@ -2111,5 +2133,93 @@ id: asr
         let input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
         let err = xybrid_core::executor::prepare_stage_input(&stage, &input).unwrap_err();
         assert!(err.to_string().contains("a string"), "{err}");
+    }
+
+    /// Build the same stage shape the streaming fast path uses from YAML.
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    fn streaming_stage(yaml: &str) -> StageDescriptor {
+        let ref_ = PipelineRef::from_yaml(yaml).unwrap();
+        let stage_config = &ref_.config.stages[0];
+        StageDescriptor::new(stage_config.stage_id())
+            .with_options(Pipeline::convert_options(&stage_config.options()))
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_input_gets_the_same_options_as_batch() {
+        let stage = streaming_stage(
+            r#"
+stages:
+  - id: llm
+    model: streaming-options-model
+    max_tokens: 16
+    temperature: 0
+    top_p: 0.9
+    system_prompt: "Be terse."
+"#,
+        );
+
+        let prepared = prepare_streaming_fast_path_input(
+            &stage,
+            &Envelope::new(EnvelopeKind::Text("hi".to_string())),
+        )
+        .expect("valid options");
+
+        assert_eq!(
+            prepared.metadata.get("max_tokens").map(String::as_str),
+            Some("16")
+        );
+        assert_eq!(
+            prepared.metadata.get("temperature").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            prepared.metadata.get("top_p").map(String::as_str),
+            Some("0.9")
+        );
+        assert_eq!(
+            prepared.metadata.get("system_prompt").map(String::as_str),
+            Some("Be terse.")
+        );
+    }
+
+    #[cfg(any(feature = "llm-mistral", feature = "llm-llamacpp"))]
+    #[test]
+    fn streaming_fast_path_input_keeps_overrides_and_rejects_invalid_options() {
+        let stage = streaming_stage(
+            r#"
+stages:
+  - id: llm
+    model: streaming-options-model
+    max_tokens: 16
+"#,
+        );
+        let mut input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
+        input
+            .metadata
+            .insert("max_tokens".to_string(), "1".to_string());
+
+        let prepared = prepare_streaming_fast_path_input(&stage, &input).unwrap();
+        assert_eq!(
+            prepared.metadata.get("max_tokens").map(String::as_str),
+            Some("1")
+        );
+
+        let invalid = streaming_stage(
+            r#"
+stages:
+  - id: llm
+    model: streaming-options-model
+    max_tokens: 0
+"#,
+        );
+        let err = prepare_streaming_fast_path_input(
+            &invalid,
+            &Envelope::new(EnvelopeKind::Text("hi".to_string())),
+        )
+        .expect_err("invalid max_tokens must fail before generation");
+        let message = err.to_string();
+        assert!(message.contains("stage 'llm'"), "{message}");
+        assert!(message.contains("positive integer"), "{message}");
     }
 }

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -682,27 +682,17 @@ impl Pipeline {
         }
     }
 
+    /// Build [`StageOptions`] from parsed YAML options without a numeric
+    /// round-trip.
+    ///
+    /// Values are copied verbatim: YAML integers stay integers, floats stay
+    /// floats, and malformed values are preserved so the owning validator
+    /// ([`xybrid_core::executor::prepare_stage_input`]) rejects them with a
+    /// useful error instead of silently dropping them.
     fn convert_options(options: &HashMap<String, serde_json::Value>) -> StageOptions {
-        let mut stage_options = StageOptions::new();
-        for (key, value) in options {
-            match value {
-                serde_json::Value::Number(n) => {
-                    if let Some(f) = n.as_f64() {
-                        stage_options.set(key, f);
-                    } else if let Some(i) = n.as_u64() {
-                        stage_options.set(key, i as u32);
-                    }
-                }
-                serde_json::Value::String(s) => {
-                    stage_options.set(key, s.clone());
-                }
-                serde_json::Value::Bool(b) => {
-                    stage_options.set(key, *b);
-                }
-                _ => {}
-            }
+        StageOptions {
+            values: options.clone(),
         }
-        stage_options
     }
 
     /// Resolve stage information from the registry.
@@ -2009,4 +1999,117 @@ id: asr
     // LLM metrics now ride on `PlatformEvent.stages[].spans[].metadata`
     // via `xybrid_core::tracing::add_metadata`, which is covered by the
     // consuming platform's own span-extraction tests.
+
+    /// Parsed-YAML options for the numeric-type regression tests.
+    fn numeric_option_map() -> HashMap<String, serde_json::Value> {
+        [
+            ("max_tokens", serde_json::json!(16)),
+            ("temperature", serde_json::json!(0)),
+            ("top_p", serde_json::json!(0.9)),
+            ("system_prompt", serde_json::json!("Be terse.")),
+            ("debug", serde_json::json!(true)),
+            ("timeout_ms", serde_json::json!(1234)),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+    }
+
+    #[test]
+    fn convert_options_preserves_yaml_numeric_types() {
+        let converted = Pipeline::convert_options(&numeric_option_map());
+
+        assert!(
+            converted.values["max_tokens"].is_u64(),
+            "integer must not become a float: {:?}",
+            converted.values["max_tokens"]
+        );
+        assert_eq!(converted.values["max_tokens"].as_u64(), Some(16));
+        assert!(converted.values["temperature"].is_u64());
+        assert_eq!(converted.values["top_p"].as_f64(), Some(0.9));
+        assert_eq!(converted.values["timeout_ms"].as_u64(), Some(1234));
+        assert_eq!(
+            converted.values["system_prompt"].as_str(),
+            Some("Be terse.")
+        );
+        assert_eq!(converted.values["debug"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn converted_integer_options_reach_prepare_stage_input() {
+        let stage = StageDescriptor::new("llm")
+            .with_options(Pipeline::convert_options(&numeric_option_map()));
+        let input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
+
+        let prepared = xybrid_core::executor::prepare_stage_input(&stage, &input)
+            .expect("integer options are valid");
+
+        assert_eq!(
+            prepared.metadata.get("max_tokens").map(String::as_str),
+            Some("16")
+        );
+        assert_eq!(
+            prepared.metadata.get("temperature").map(String::as_str),
+            Some("0")
+        );
+        assert_eq!(
+            prepared.metadata.get("top_p").map(String::as_str),
+            Some("0.9")
+        );
+        assert_eq!(
+            prepared.metadata.get("system_prompt").map(String::as_str),
+            Some("Be terse.")
+        );
+    }
+
+    #[test]
+    fn input_metadata_overrides_converted_yaml_options() {
+        let stage = StageDescriptor::new("llm")
+            .with_options(Pipeline::convert_options(&numeric_option_map()));
+        let mut input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
+        input
+            .metadata
+            .insert("max_tokens".to_string(), "7".to_string());
+
+        let prepared = xybrid_core::executor::prepare_stage_input(&stage, &input).unwrap();
+
+        assert_eq!(
+            prepared.metadata.get("max_tokens").map(String::as_str),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn converted_malformed_options_are_preserved_and_rejected() {
+        for value in [
+            serde_json::json!(0),
+            serde_json::json!(-1),
+            serde_json::json!(1.5),
+            serde_json::json!("16"),
+        ] {
+            let options: HashMap<String, serde_json::Value> =
+                [("max_tokens".to_string(), value.clone())]
+                    .into_iter()
+                    .collect();
+            let stage =
+                StageDescriptor::new("llm").with_options(Pipeline::convert_options(&options));
+            let input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
+
+            let err = xybrid_core::executor::prepare_stage_input(&stage, &input)
+                .expect_err("malformed token limit must fail");
+            assert!(
+                err.to_string().contains("positive integer"),
+                "{value}: {err}"
+            );
+        }
+
+        let options: HashMap<String, serde_json::Value> =
+            [("system_prompt".to_string(), serde_json::json!(3))]
+                .into_iter()
+                .collect();
+        let stage = StageDescriptor::new("llm").with_options(Pipeline::convert_options(&options));
+        let input = Envelope::new(EnvelopeKind::Text("hi".to_string()));
+        let err = xybrid_core::executor::prepare_stage_input(&stage, &input).unwrap_err();
+        assert!(err.to_string().contains("a string"), "{err}");
+    }
 }

--- a/crates/xybrid-sdk/src/pipeline/mod.rs
+++ b/crates/xybrid-sdk/src/pipeline/mod.rs
@@ -409,15 +409,11 @@ fn resolve_streaming_fast_path_route(
     envelope: &Envelope,
     metrics: &DeviceMetrics,
 ) -> StreamingFastPathRoute {
-    let policy_decision = authority.apply_policy(&PolicyRequest {
+    let request = PolicyRequest {
         stage_id: stage.name.clone(),
         envelope: envelope.clone(),
         metrics: metrics.clone(),
-    });
-    let policy_allowed = policy_decision.result.is_allowed();
-    let policy_transform = matches!(policy_decision.result, PolicyOutcome::Transform { .. });
-    let policy_reason = Some(policy_decision.reason.clone());
-
+    };
     let context = StageContext {
         stage_id: stage.name.clone(),
         model_id: model_id.to_string(),
@@ -429,15 +425,21 @@ fn resolve_streaming_fast_path_route(
         device_class: Some(metrics.canonical_device_class()),
         device_class_schema_version: Some(DEVICE_CLASS_SCHEMA_VERSION),
     };
-    let resolution = authority.resolve_target_with_feedback(&context);
-    let target = match &resolution.decision.result {
+    // One decision, one resource snapshot: the policy event and the target
+    // cannot disagree, and the target is restricted if the policy requires it.
+    let resolution = authority.resolve_stage(&request, &context).enforced();
+    let policy_allowed = resolution.policy.result.is_allowed();
+    let policy_transform = matches!(resolution.policy.result, PolicyOutcome::Transform { .. });
+    let policy_reason = Some(resolution.policy.reason.clone());
+
+    let target = match &resolution.target.decision.result {
         ResolvedTarget::Device => "local".to_string(),
         ResolvedTarget::Cloud { .. } => "cloud".to_string(),
         ResolvedTarget::Server { endpoint } => format!("fallback:{endpoint}"),
     };
-    let hint = resolution.local_reliability_hint.unwrap_or_default();
+    let hint = resolution.target.local_reliability_hint.unwrap_or_default();
     let can_stream_locally = policy_allowed
-        && matches!(resolution.decision.result, ResolvedTarget::Device)
+        && matches!(resolution.target.decision.result, ResolvedTarget::Device)
         && stage.is_locally_runnable()
         && !policy_transform;
 
@@ -447,9 +449,9 @@ fn resolve_streaming_fast_path_route(
         target,
         reason: format!(
             "[{}] {} (confidence: {:.0}%)",
-            resolution.decision.source,
-            resolution.decision.reason,
-            resolution.decision.confidence * 100.0
+            resolution.target.decision.source,
+            resolution.target.decision.reason,
+            resolution.target.decision.confidence * 100.0
         ),
         recent_abort_rate: hint.recent_abort_rate,
         sample_size: hint.sample_size,

--- a/crates/xybrid-sdk/tests/pipeline_numeric_options.rs
+++ b/crates/xybrid-sdk/tests/pipeline_numeric_options.rs
@@ -1,0 +1,213 @@
+//! SDK pipeline numeric-option regression: YAML integers must survive option
+//! conversion and reach the provider as integers.
+//!
+//! Model-free: a cloud-only DeepSeek stage is pointed at a loopback httpmock
+//! server that serves both the registry resolve response and the fake
+//! completion endpoint. The assertions are about the wire body: `max_tokens`
+//! must be the integer `16`, never the float `16.0`.
+//!
+//! The registry stub and completion endpoint are explicitly loopback; captured
+//! request assertions verify those endpoints, not process-wide isolation.
+
+use httpmock::prelude::*;
+use httpmock::Mock;
+use xybrid_sdk::ir::{Envelope, EnvelopeKind};
+use xybrid_sdk::Xybrid;
+
+const FAKE_REPLY: &str = "FAKE_NUMERIC_REPLY";
+
+fn completion_body() -> serde_json::Value {
+    serde_json::json!({
+        "id": "chatcmpl-1",
+        "model": "deepseek-flash",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": FAKE_REPLY },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7 }
+    })
+}
+
+/// Loopback registry stub. The stage is cloud-only (`provider` set), so the
+/// only registry call is the `is_cached` probe; this keeps that probe local.
+fn registry_resolve_mock(server: &MockServer) -> Mock<'_> {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path_contains("/v1/models/sdk-numeric-model/resolve");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "mask": "sdk-numeric-model",
+                "platform": "test",
+                "resolved": {
+                    "hf_repo": "xybrid-test/sdk-numeric-model",
+                    "file": "model.xyb",
+                    "download_url": "http://127.0.0.1:9/model.xyb",
+                    "format": "xyb",
+                    "quantization": "none",
+                    "size_bytes": 1,
+                    "sha256": ""
+                }
+            }));
+    })
+}
+
+/// Flatten an error and its sources into one string, so SDK wrappers that
+/// keep the detail in `source()` are still assertable.
+fn error_chain(err: &dyn std::error::Error) -> String {
+    let mut message = err.to_string();
+    let mut current = err.source();
+    while let Some(source) = current {
+        message.push_str(": ");
+        message.push_str(&source.to_string());
+        current = source.source();
+    }
+    message
+}
+
+fn pipeline_yaml(server: &MockServer, extra_stage: &str) -> String {
+    format!(
+        r#"name: sdk-numeric-options
+registry: {base}
+stages:
+  - id: llm
+    model: sdk-numeric-model
+    target: cloud
+    provider: deepseek
+    gateway_url: {base}/v1
+    api_key: dummy-key
+{extra_stage}"#,
+        base = server.base_url()
+    )
+}
+
+/// Completion mock that only matches an integer `max_tokens`.
+fn integer_max_tokens_mock(server: &MockServer, tokens: u64) -> Mock<'_> {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/chat/completions")
+            .json_body_partial(format!(r#"{{"max_tokens":{tokens}}}"#));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(completion_body());
+    })
+}
+
+/// Guard mock that fires only if `max_tokens` was serialized as a float.
+fn float_max_tokens_guard(server: &MockServer) -> Mock<'_> {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/chat/completions")
+            .json_body_partial(r#"{"max_tokens":16.0}"#);
+        then.status(599).body("max_tokens must remain an integer");
+    })
+}
+
+#[test]
+fn run_pipeline_sends_integer_max_tokens() {
+    let server = MockServer::start();
+    let _registry = registry_resolve_mock(&server);
+    let integer_mock = integer_max_tokens_mock(&server, 16);
+    let float_guard = float_max_tokens_guard(&server);
+
+    let yaml = pipeline_yaml(&server, "    max_tokens: 16\n");
+    let envelope = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+
+    let result = Xybrid::run_pipeline(&yaml, &envelope).expect("pipeline runs");
+
+    assert_eq!(result.text(), Some(FAKE_REPLY));
+    assert_eq!(integer_mock.hits(), 1, "integer 16 must reach the wire");
+    assert_eq!(
+        float_guard.hits(),
+        0,
+        "max_tokens must not be serialized as 16.0"
+    );
+}
+
+#[test]
+fn input_metadata_override_reaches_the_wire() {
+    let server = MockServer::start();
+    let _registry = registry_resolve_mock(&server);
+    let yaml_mock = integer_max_tokens_mock(&server, 16);
+    let override_mock = integer_max_tokens_mock(&server, 7);
+
+    let yaml = pipeline_yaml(&server, "    max_tokens: 16\n");
+    let mut envelope = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+    envelope
+        .metadata
+        .insert("max_tokens".to_string(), "7".to_string());
+
+    let result = Xybrid::run_pipeline(&yaml, &envelope).expect("pipeline runs");
+
+    assert_eq!(result.text(), Some(FAKE_REPLY));
+    assert_eq!(override_mock.hits(), 1, "input override must win");
+    assert_eq!(
+        yaml_mock.hits(),
+        0,
+        "YAML value must not override input metadata"
+    );
+}
+
+#[test]
+fn invalid_options_fail_before_any_completion_request() {
+    let cases = [
+        ("    max_tokens: 0\n", "positive integer"),
+        ("    max_tokens: 1.5\n", "positive integer"),
+        ("    max_tokens: \"16\"\n", "positive integer"),
+        ("    system_prompt: 3\n", "a string"),
+    ];
+
+    for (extra_stage, expected) in cases {
+        let server = MockServer::start();
+        let _registry = registry_resolve_mock(&server);
+        let completion = server.mock(|when, then| {
+            when.method(POST).path("/v1/chat/completions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(completion_body());
+        });
+
+        let yaml = pipeline_yaml(&server, extra_stage);
+        let envelope = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+
+        let err = Xybrid::run_pipeline(&yaml, &envelope).expect_err("invalid option must fail");
+        let chain = error_chain(&err);
+
+        assert!(
+            chain.contains(expected),
+            "{extra_stage}: expected '{expected}' in: {chain}"
+        );
+        assert_eq!(
+            completion.hits(),
+            0,
+            "{extra_stage}: no completion request may be made"
+        );
+    }
+}
+
+#[test]
+fn async_run_uses_the_same_prepared_options() {
+    let server = MockServer::start();
+    let _registry = registry_resolve_mock(&server);
+    let integer_mock = integer_max_tokens_mock(&server, 16);
+    let float_guard = float_max_tokens_guard(&server);
+
+    let yaml = pipeline_yaml(&server, "    max_tokens: 16\n");
+    let envelope = Envelope::new(EnvelopeKind::Text("hello".to_string()));
+
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let result = runtime
+        .block_on(async {
+            let pipeline = Xybrid::pipeline(&yaml)
+                .expect("pipeline parses")
+                .load()
+                .expect("pipeline loads");
+            pipeline.run_async(&envelope).await
+        })
+        .expect("async pipeline runs");
+
+    assert_eq!(result.text(), Some(FAKE_REPLY));
+    assert_eq!(integer_mock.hits(), 1, "async path sends integer 16");
+    assert_eq!(float_guard.hits(), 0, "async path must not send 16.0");
+}

--- a/crates/xybrid-sdk/tests/streaming_fast_path.rs
+++ b/crates/xybrid-sdk/tests/streaming_fast_path.rs
@@ -1,0 +1,250 @@
+//! Model-enabled regression: the SDK streaming fast path must honor the same
+//! YAML generation options as batch execution.
+//!
+//! Requires the real `functiongemma-270m-it` fixture. With
+//! `XYBRID_REQUIRE_MODELS=1` a missing fixture fails; otherwise the tests
+//! skip. Run explicitly:
+//!
+//! ```bash
+//! XYBRID_REQUIRE_MODELS=1 cargo test -p xybrid-sdk --features llm-llamacpp \
+//!   --test streaming_fast_path -- --nocapture
+//! ```
+//!
+//! The registry stub is explicitly loopback; the fixture is staged into an
+//! SDK cache directory configured for the test process, so no network access
+//! happens beyond the loopback registry probe.
+#![cfg(all(feature = "llm-llamacpp", unix))]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use httpmock::prelude::*;
+use xybrid_core::runtime_adapter::types::{PartialToken, StreamingCallback};
+use xybrid_core::testing::model_fixtures;
+use xybrid_sdk::ir::{Envelope, EnvelopeKind};
+use xybrid_sdk::run_options::RunOptions;
+use xybrid_sdk::Xybrid;
+
+const MODEL_ID: &str = "functiongemma-270m-it";
+const PROMPT: &str = "Reply with the single word hello.";
+
+fn fixture_dir_or_skip() -> Option<PathBuf> {
+    match model_fixtures::model_or_skip(MODEL_ID) {
+        Some(dir) => Some(dir),
+        None => {
+            assert!(
+                std::env::var_os("XYBRID_REQUIRE_MODELS").is_none(),
+                "XYBRID_REQUIRE_MODELS is set but model '{MODEL_ID}' is not available"
+            );
+            None
+        }
+    }
+}
+
+/// One SDK cache for the whole test binary: `init_sdk_cache_dir` is a
+/// process-global `OnceLock`, so every test in this file must share the root.
+fn shared_cache_root() -> &'static Path {
+    static CACHE: OnceLock<tempfile::TempDir> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let temp = tempfile::tempdir().expect("temp cache dir");
+            xybrid_sdk::init_sdk_cache_dir(temp.path().join("models"));
+            temp
+        })
+        .path()
+}
+
+fn link_or_copy(source: &Path, destination: &Path) {
+    if std::fs::hard_link(source, destination).is_ok() {
+        return;
+    }
+    std::fs::copy(source, destination)
+        .unwrap_or_else(|err| panic!("failed to materialize {}: {err}", source.display()));
+}
+
+/// Stage the real fixture into `<cache>/extracted/<id>/` once.
+fn staged_model_dir() -> PathBuf {
+    static STAGED: OnceLock<PathBuf> = OnceLock::new();
+    STAGED
+        .get_or_init(|| {
+            let fixture = fixture_dir_or_skip().expect("fixture checked before staging");
+            let extracted = shared_cache_root().join("extracted").join(MODEL_ID);
+            std::fs::create_dir_all(&extracted).unwrap();
+            link_or_copy(
+                &fixture.join("model_metadata.json"),
+                &extracted.join("model_metadata.json"),
+            );
+            let metadata: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(fixture.join("model_metadata.json")).unwrap(),
+            )
+            .unwrap();
+            for file in metadata["files"].as_array().expect("metadata.files") {
+                let name = file.as_str().expect("file name");
+                link_or_copy(&fixture.join(name), &extracted.join(name));
+            }
+            extracted
+        })
+        .clone()
+}
+
+/// Loopback registry stub: makes `is_cached` / `resolve` local. The model is
+/// already staged in the SDK cache, so `fetch_extracted` short-circuits to the
+/// extracted directory and the download URL is never followed.
+fn registry_resolve_mock(server: &MockServer) -> httpmock::Mock<'_> {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path_contains(format!("/v1/models/{MODEL_ID}/resolve"));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "mask": MODEL_ID,
+                "platform": "test",
+                "resolved": {
+                    "hf_repo": "ggml-org/functiongemma-270m-it-GGUF",
+                    "file": "functiongemma-270m-it-q8_0.gguf",
+                    "download_url": "http://127.0.0.1:9/never-followed.gguf",
+                    "format": "gguf",
+                    "quantization": "Q8_0",
+                    "size_bytes": 1,
+                    "sha256": ""
+                }
+            }));
+    })
+}
+
+fn pipeline_yaml(server: &MockServer, extra_stage: &str) -> String {
+    format!(
+        r#"name: sdk-streaming-options
+registry: {base}
+stages:
+  - id: llm
+    model: {MODEL_ID}
+    target: device
+{extra_stage}"#,
+        base = server.base_url()
+    )
+}
+
+fn error_chain(err: &dyn std::error::Error) -> String {
+    let mut message = err.to_string();
+    let mut current = err.source();
+    while let Some(source) = current {
+        message.push_str(": ");
+        message.push_str(&source.to_string());
+        current = source.source();
+    }
+    message
+}
+
+fn run_streaming(yaml: &str, envelope: &Envelope) -> (Vec<PartialToken>, String) {
+    let tokens: Arc<Mutex<Vec<PartialToken>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = tokens.clone();
+    let callback: StreamingCallback<'_> = Box::new(move |token| {
+        sink.lock().unwrap().push(token);
+        Ok(())
+    });
+
+    let result = Xybrid::run_pipeline_streaming_with_options(
+        yaml,
+        envelope,
+        &RunOptions::default(),
+        callback,
+    )
+    .expect("streaming fast path runs");
+
+    let collected = tokens.lock().unwrap().clone();
+    (collected, result.text().unwrap_or_default().to_string())
+}
+
+fn generated_tokens(tokens: &[PartialToken]) -> Vec<&PartialToken> {
+    tokens
+        .iter()
+        .filter(|token| !token.token.is_empty())
+        .collect()
+}
+
+#[test]
+fn yaml_max_tokens_caps_streaming_generation() {
+    let Some(_) = fixture_dir_or_skip() else {
+        return;
+    };
+    let _ = staged_model_dir();
+    let server = MockServer::start();
+    let _registry = registry_resolve_mock(&server);
+
+    let yaml = pipeline_yaml(
+        &server,
+        "    max_tokens: 1\n    temperature: 0\n    top_p: 0.9\n    system_prompt: \"Be terse.\"\n",
+    );
+    let envelope = Envelope::new(EnvelopeKind::Text(PROMPT.to_string()));
+
+    let (tokens, text) = run_streaming(&yaml, &envelope);
+    let generated = generated_tokens(&tokens);
+
+    assert_eq!(
+        generated.len(),
+        1,
+        "max_tokens: 1 must stop at one token: {tokens:?}"
+    );
+    assert!(!text.is_empty(), "generation must produce output");
+}
+
+#[test]
+fn envelope_metadata_overrides_yaml_in_streaming() {
+    let Some(_) = fixture_dir_or_skip() else {
+        return;
+    };
+    let _ = staged_model_dir();
+    let server = MockServer::start();
+    let _registry = registry_resolve_mock(&server);
+
+    let yaml = pipeline_yaml(&server, "    max_tokens: 4\n");
+    let mut envelope = Envelope::new(EnvelopeKind::Text(PROMPT.to_string()));
+    envelope
+        .metadata
+        .insert("max_tokens".to_string(), "1".to_string());
+
+    let (tokens, _) = run_streaming(&yaml, &envelope);
+    let generated = generated_tokens(&tokens);
+
+    assert_eq!(
+        generated.len(),
+        1,
+        "input metadata must beat the YAML cap: {tokens:?}"
+    );
+}
+
+#[test]
+fn invalid_yaml_option_fails_before_any_token() {
+    let Some(_) = fixture_dir_or_skip() else {
+        return;
+    };
+    let _ = staged_model_dir();
+    let server = MockServer::start();
+    let _registry = registry_resolve_mock(&server);
+
+    let yaml = pipeline_yaml(&server, "    max_tokens: 0\n");
+    let envelope = Envelope::new(EnvelopeKind::Text(PROMPT.to_string()));
+
+    let tokens: Arc<Mutex<Vec<PartialToken>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = tokens.clone();
+    let callback: StreamingCallback<'_> = Box::new(move |token| {
+        sink.lock().unwrap().push(token);
+        Ok(())
+    });
+
+    let err = Xybrid::run_pipeline_streaming_with_options(
+        &yaml,
+        &envelope,
+        &RunOptions::default(),
+        callback,
+    )
+    .expect_err("invalid option must fail before generation");
+
+    let chain = error_chain(&err);
+    assert!(chain.contains("positive integer"), "{chain}");
+    assert!(
+        tokens.lock().unwrap().is_empty(),
+        "no token callback may fire for an invalid option"
+    );
+}

--- a/docs/content/docs/cli/reference/run.mdx
+++ b/docs/content/docs/cli/reference/run.mdx
@@ -24,7 +24,7 @@ xybrid run --pipeline <name> --dry-run
 | `--input-audio` | | Path to an audio file for audio-based models (ASR) — WAV, MP3, OGG, or FLAC |
 | `--target` | | Force model format (`onnx`, `coreml`, `tflite`); auto-detected if omitted |
 | `--dry-run` | | Simulate routing without execution |
-| `--policy` | | Load an additional policy bundle |
+| `--policy` | | Load a policy bundle (YAML/JSON) that constrains routing — see [Hybrid Execution › Policies](/docs/concepts/hybrid-execution#policies) |
 | `--trace` | | Enable execution tracing with flame graph + LLM metrics output |
 | `--trace-export` | | Export the trace to a JSON file (Chrome trace format) |
 
@@ -34,7 +34,7 @@ xybrid run --pipeline <name> --dry-run
 2. Runs policy → routing → execution loop
 3. Prints stage latency and routing summaries
 
-In dry-run mode, the CLI prints routing decisions and simulated outputs without invoking adapters.
+In dry-run mode the CLI decides the first stage (policy and route) exactly as a real run would, at the current device snapshot, without running inference. Later stages are reported as unknown: their input is the previous stage's output, which does not exist without execution.
 
 ## Examples
 
@@ -60,36 +60,46 @@ Looks for `hiiipe.yml` or `hiiipe.yaml` in:
 xybrid run --pipeline hiiipe --dry-run
 ```
 
-Output shows routing decisions without actual execution:
+Output shows the first-stage decision without running inference:
 
 ```
-▶️ Stage: whisper-tiny@1.2 → would route to: local
-▶️ Stage: gpt-4o-mini → would route to: integration
-▶️ Stage: kokoro-82m@0.1 → would route to: local
+  Stage 1 llm
+  Declared         target: auto
+  Provider         deepseek
+  Policy           ALLOWED
+  Reason           all policy checks passed
+  Routing          local (default_local)
+
+  Stage 2 tts
+  Policy           UNKNOWN
+  Routing          UNKNOWN
+  Output           upstream output unavailable without execution
 ```
 
-### With custom policy
+### With a policy
 
 ```bash
-xybrid run --pipeline hiiipe --policy ./policies/strict-privacy.yaml
+DEEPSEEK_API_KEY=sk-... xybrid run \
+  -c crates/xybrid-cli/examples/hybrid-deepseek.yaml \
+  --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
+  --input-text "Summarise the plot of Dune in two sentences." -v
 ```
+
+Swap in `policies/local-only.yaml` to keep the same prompt on the device, or
+`policies/privacy.yaml` to route by content. `-v` also prints the raw
+`routing_decision` JSON line.
 
 ## Sample Output
 
 ```
-▶️ Stage: whisper-tiny@1.2 → local
-🎯 Routing: local (fast path)
-⚙️ Execution complete (52ms)
+  Stage 1 llm
+  Routing          cloud
+  Reason           [local] policy_route_cloud: policy rule 'route_cloud_if_0' prefers cloud: true (confidence: 90%)
+  Backend          cloud:deepseek:gateway
+  Time             842ms
+  Output           Text
 
-▶️ Stage: gpt-4o-mini → integration
-🎯 Routing: integration (OpenAI)
-⚙️ Execution complete (340ms)
-
-▶️ Stage: kokoro-82m@0.1 → local
-🎯 Routing: local (fast path)
-⚙️ Execution complete (89ms)
-
-🎉 Pipeline complete (total 481ms)
+    Dune follows Paul Atreides ...
 ```
 
 ## Pipeline Format

--- a/docs/content/docs/cli/reference/run.mdx
+++ b/docs/content/docs/cli/reference/run.mdx
@@ -65,7 +65,7 @@ Output shows the first-stage decision without running inference:
 ```
   Stage 1 llm
   Declared         target: auto
-  Provider         deepseek
+  Provider         openai
   Policy           ALLOWED
   Reason           all policy checks passed
   Routing          local (default_local)
@@ -76,11 +76,15 @@ Output shows the first-stage decision without running inference:
   Output           upstream output unavailable without execution
 ```
 
-### With a policy
+### With a policy and Xybrid Platform
+
+The primary hybrid example keeps the local model on the device and uses
+Xybrid Platform for cloud inference. Only the Xybrid API key belongs on the
+device; the upstream provider credentials are configured on the platform.
 
 ```bash
-DEEPSEEK_API_KEY=sk-... xybrid run \
-  -c crates/xybrid-cli/examples/hybrid-deepseek.yaml \
+XYBRID_API_KEY="<your-xybrid-api-key>" xybrid run \
+  -c crates/xybrid-cli/examples/hybrid-platform.yaml \
   --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
   --input-text "Summarise the plot of Dune in two sentences." -v
 ```
@@ -89,13 +93,23 @@ Swap in `policies/local-only.yaml` to keep the same prompt on the device, or
 `policies/privacy.yaml` to route by content. `-v` also prints the raw
 `routing_decision` JSON line.
 
+Use `--platform-url <base-url>` for a staging or self-hosted platform. The
+example uses `gpt-4o-mini`, which the platform must have configured upstream.
+
+### Direct provider testing
+
+`crates/xybrid-cli/examples/hybrid-deepseek.yaml` uses `backend: direct` and
+`DEEPSEEK_API_KEY` for direct DeepSeek calls. Keep it for manual provider checks;
+automated policy-routing tests use a loopback fake DeepSeek endpoint with dummy
+credentials.
+
 ## Sample Output
 
 ```
   Stage 1 llm
   Routing          cloud
   Reason           [local] policy_route_cloud: policy rule 'route_cloud_if_0' prefers cloud: true (confidence: 90%)
-  Backend          cloud:deepseek:gateway
+  Backend          cloud:openai:gateway
   Time             842ms
   Output           Text
 

--- a/docs/content/docs/cli/reference/run.zh.mdx
+++ b/docs/content/docs/cli/reference/run.zh.mdx
@@ -24,7 +24,7 @@ xybrid run --pipeline <name> --dry-run
 | `--input-audio` | | 音频模型（ASR）的音频文件路径 — 支持 WAV、MP3、OGG、FLAC |
 | `--target` | | 强制指定模型格式（`onnx`、`coreml`、`tflite`）；省略时自动检测 |
 | `--dry-run` | | 模拟路由决策但不执行推理 |
-| `--policy` | | 加载附加策略 Bundle |
+| `--policy` | | 加载约束路由的策略 Bundle（YAML/JSON）— 见 [混合执行 › 策略](/docs/concepts/hybrid-execution#策略) |
 | `--trace` | | 启用执行追踪，输出火焰图与 LLM 指标 |
 | `--trace-export` | | 将追踪导出为 JSON 文件（Chrome trace 格式） |
 
@@ -34,7 +34,7 @@ xybrid run --pipeline <name> --dry-run
 2. 执行策略 → 路由 → 推理的循环
 3. 打印各阶段延迟与路由摘要
 
-在 dry-run 模式下，CLI 仅打印路由决策与模拟输出，不会调用适配器。
+在 dry-run 模式下，CLI 会像真实运行一样在当前设备快照下决策第一个阶段（策略与路由），但不执行推理。后续阶段标记为未知：它们的输入是上一阶段的输出，在未执行时并不存在。
 
 ## 示例
 
@@ -60,36 +60,45 @@ xybrid run --pipeline hiiipe
 xybrid run --pipeline hiiipe --dry-run
 ```
 
-输出显示路由决策，不执行实际推理：
+输出显示第一个阶段的决策，不执行推理：
 
 ```
-▶️ Stage: whisper-tiny@1.2 → would route to: local
-▶️ Stage: gpt-4o-mini → would route to: integration
-▶️ Stage: kokoro-82m@0.1 → would route to: local
+  Stage 1 llm
+  Declared         target: auto
+  Provider         deepseek
+  Policy           ALLOWED
+  Reason           all policy checks passed
+  Routing          local (default_local)
+
+  Stage 2 tts
+  Policy           UNKNOWN
+  Routing          UNKNOWN
+  Output           upstream output unavailable without execution
 ```
 
-### 使用自定义策略
+### 使用策略
 
 ```bash
-xybrid run --pipeline hiiipe --policy ./policies/strict-privacy.yaml
+DEEPSEEK_API_KEY=sk-... xybrid run \
+  -c crates/xybrid-cli/examples/hybrid-deepseek.yaml \
+  --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
+  --input-text "Summarise the plot of Dune in two sentences." -v
 ```
+
+换成 `policies/local-only.yaml` 可让同一提示词留在设备上，换成 `policies/privacy.yaml`
+则按内容路由。`-v` 还会打印原始的 `routing_decision` JSON 行。
 
 ## 示例输出
 
 ```
-▶️ Stage: whisper-tiny@1.2 → local
-🎯 Routing: local (fast path)
-⚙️ Execution complete (52ms)
+  Stage 1 llm
+  Routing          cloud
+  Reason           [local] policy_route_cloud: policy rule 'route_cloud_if_0' prefers cloud: true (confidence: 90%)
+  Backend          cloud:deepseek:gateway
+  Time             842ms
+  Output           Text
 
-▶️ Stage: gpt-4o-mini → integration
-🎯 Routing: integration (OpenAI)
-⚙️ Execution complete (340ms)
-
-▶️ Stage: kokoro-82m@0.1 → local
-🎯 Routing: local (fast path)
-⚙️ Execution complete (89ms)
-
-🎉 Pipeline complete (total 481ms)
+    Dune follows Paul Atreides ...
 ```
 
 ## 流水线格式

--- a/docs/content/docs/cli/reference/run.zh.mdx
+++ b/docs/content/docs/cli/reference/run.zh.mdx
@@ -65,7 +65,7 @@ xybrid run --pipeline hiiipe --dry-run
 ```
   Stage 1 llm
   Declared         target: auto
-  Provider         deepseek
+  Provider         openai
   Policy           ALLOWED
   Reason           all policy checks passed
   Routing          local (default_local)
@@ -76,11 +76,14 @@ xybrid run --pipeline hiiipe --dry-run
   Output           upstream output unavailable without execution
 ```
 
-### 使用策略
+### 使用策略与 Xybrid Platform
+
+主混合示例在设备端运行本地模型，并通过 Xybrid Platform 执行云端推理。
+设备端只需要 Xybrid API 密钥，上游提供商凭据配置在平台上。
 
 ```bash
-DEEPSEEK_API_KEY=sk-... xybrid run \
-  -c crates/xybrid-cli/examples/hybrid-deepseek.yaml \
+XYBRID_API_KEY="<your-xybrid-api-key>" xybrid run \
+  -c crates/xybrid-cli/examples/hybrid-platform.yaml \
   --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
   --input-text "Summarise the plot of Dune in two sentences." -v
 ```
@@ -88,13 +91,22 @@ DEEPSEEK_API_KEY=sk-... xybrid run \
 换成 `policies/local-only.yaml` 可让同一提示词留在设备上，换成 `policies/privacy.yaml`
 则按内容路由。`-v` 还会打印原始的 `routing_decision` JSON 行。
 
+使用 `--platform-url <base-url>` 可连接预发布或自托管平台。示例使用 `gpt-4o-mini`，
+平台需要配置其上游提供商。
+
+### 直连提供商测试
+
+`crates/xybrid-cli/examples/hybrid-deepseek.yaml` 使用 `backend: direct` 和
+`DEEPSEEK_API_KEY` 直接调用 DeepSeek，可用于手动检查提供商连接。
+自动化策略路由测试使用回环地址上的模拟 DeepSeek 端点和测试凭据。
+
 ## 示例输出
 
 ```
   Stage 1 llm
   Routing          cloud
   Reason           [local] policy_route_cloud: policy rule 'route_cloud_if_0' prefers cloud: true (confidence: 90%)
-  Backend          cloud:deepseek:gateway
+  Backend          cloud:openai:gateway
   Time             842ms
   Output           Text
 

--- a/docs/content/docs/concepts/hybrid-execution.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.mdx
@@ -25,6 +25,36 @@ stages:
     provider: openai
 ```
 
+### Hybrid stages
+
+A stage with `target: auto` **and** a `provider` has two legs: the local model
+named by `model`, and the provider's model named by `cloud_model` (defaults to
+`model`). The policy and the device state pick one leg per request. Shared
+options (`system_prompt`, `temperature`, `max_tokens`, `top_p`) apply to
+whichever leg runs.
+
+```yaml
+stages:
+  - id: llm
+    model: functiongemma-270m-it      # local leg
+    target: auto
+    provider: deepseek                # cloud leg
+    cloud_model: deepseek-flash
+    backend: direct                   # OpenAI-compatible call to api.deepseek.com with $DEEPSEEK_API_KEY
+    thinking: disabled                # DeepSeek only: answer tokens, no hidden reasoning
+    system_prompt: "You are a concise assistant."
+    max_tokens: 128
+```
+
+`backend: direct` with an OpenAI-compatible provider (`openai`, `deepseek`,
+`openrouter`, `custom`) sends the request straight to that provider's API;
+an explicit `gateway_url` / `api_key` pair overrides the defaults. Credentials
+are scoped to the destination: the Xybrid platform key goes only to the
+configured platform gateway, a provider's key only to that provider's origin,
+and any other endpoint is anonymous unless `api_key` is set. A denied stage
+whose local model is missing fails on the device — it never falls through to
+the cloud.
+
 ## How `auto` decides
 
 For `auto` stages the orchestrator weighs:
@@ -32,7 +62,7 @@ For `auto` stages the orchestrator weighs:
 - **Model availability** — is the model cached locally, or available in the registry for this platform?
 - **Device capabilities** — CPU features, memory, and accelerators
 - **Host signals** — battery level and thermal state reported by the platform
-- **Policies** — user-defined rules that allow or deny routes
+- **Policies** — user-defined rules that forbid the cloud leg or prefer it (see [Policies](#policies))
 
 Preview decisions without executing:
 
@@ -73,30 +103,74 @@ An explicit `api_key` field also accepts an environment reference (`$OPENAI_API_
 
 ## Policies
 
-Policies are YAML rule sets that constrain routing. Rules are evaluated in order; the first match wins:
+A policy is a YAML (or JSON) rule set passed with `--policy`. It is evaluated
+once per stage, against the actual input and one live device snapshot, and it
+**constrains** routing rather than advising it: a denial keeps the stage on the
+device even when the YAML says `target: cloud`, when the local model is missing
+(the stage then fails locally instead of leaking to the cloud), and when device
+stress would otherwise offload it.
+
+Rules are evaluated in order; the first match wins.
+
+| Action | Effect |
+|--------|--------|
+| `deny` | Cloud is forbidden; the stage must run on the device. |
+| `route_cloud` (alias `prefer_cloud`) | Prefer the cloud leg when it is permitted and the local model exists. |
+| `redact` | The input would need a transform before leaving the device. Transforms are not implemented yet, so this also forces the device. |
+| `allow` | Stop evaluating and route normally. |
 
 ```yaml
 # policy.yaml
 version: "1.0.0"
 rules:
-  - id: "keep_audio_on_device"
-    expression: "input.kind == \"AudioRaw\""
-    action: "deny"          # deny this route for raw audio input
+  - id: keep_audio_on_device
+    expression: 'input.kind == "audio"'
+    action: deny
+  - id: keep_secrets_on_device
+    expression: 'input.text matches "(?i)confidential|ssn|password"'
+    action: deny
+  - id: offload_when_hot
+    expression: 'metrics.thermal_state == "hot"'
+    action: route_cloud
 
-  - id: "avoid_slow_networks"
-    expression: "metrics.network_rtt > 300"
-    action: "deny"          # don't go to cloud on a slow network
-
-  - id: "allow_all"
-    expression: "true"
-    action: "allow"
+# Shorthand lists are appended after `rules`, denials first:
+deny_cloud_if:
+  - "input.text_len > 4000"
+route_cloud_if:
+  - "metrics.battery_level < 25"
 ```
+
+Expressions are `<operand> <operator> <value>`, or a bare `true` / `false`:
+
+| Operand | Operators | Value |
+|---------|-----------|-------|
+| `input.kind` | `==` `!=` | `"audio"` `"text"` `"embedding"` `"image"` `"multipart"` |
+| `input.text` | `contains` `matches` `==` `!=` | quoted literal (`matches` takes a regex) |
+| `input.text_len` | `==` `!=` `<` `<=` `>` `>=` | number of characters |
+| `metrics.battery_level`, `metrics.cpu_pct` | `==` `!=` `<` `<=` `>` `>=` | number, 0–100 |
+| `metrics.memory_pressure` | `==` `!=` | `"unknown"` `"normal"` `"warn"` `"critical"` |
+| `metrics.thermal_state` | `==` `!=` | `"normal"` `"warm"` `"hot"` `"critical"` |
+
+Text rules inspect only the input text — never system prompts or metadata —
+and never match non-text input. Anything outside this table is rejected when
+the bundle is loaded, so a typo cannot silently disable a rule.
 
 ```bash
-xybrid run --config pipeline.yaml --input-audio q.wav --policy policy.yaml
+xybrid run --config pipeline.yaml --input-text "..." --policy policy.yaml
 ```
 
-Expressions can reference the input envelope (`input.kind`) and live device metrics (`metrics.network_rtt`).
+The results show the decision and what actually ran:
+
+```
+  Routing          cloud
+  Reason           [local] policy_route_cloud: policy rule 'offload_when_hot' prefers cloud: ... (confidence: 90%)
+  Backend          cloud:deepseek:gateway
+```
+
+`--dry-run --policy policy.yaml` decides the first stage the same way, at the
+current device snapshot, without running inference; later stages depend on
+upstream output and are reported as unknown. Ready-made bundles live in
+`crates/xybrid-cli/examples/policies/` next to `hybrid-deepseek.yaml`.
 
 ## Fallback
 

--- a/docs/content/docs/concepts/hybrid-execution.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.mdx
@@ -33,6 +33,8 @@ named by `model`, and the provider's model named by `cloud_model` (defaults to
 options (`system_prompt`, `temperature`, `max_tokens`, `top_p`) apply to
 whichever leg runs.
 
+Hybrid stages are currently supported by `xybrid run`. The Flutter and Rust SDK pipeline APIs treat `target: auto` with a `provider` as cloud-only and do not load the local model.
+
 ```yaml
 stages:
   - id: llm

--- a/docs/content/docs/concepts/hybrid-execution.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.mdx
@@ -35,29 +35,26 @@ whichever leg runs.
 
 Hybrid stages are currently supported by `xybrid run`. The Flutter and Rust SDK pipeline APIs treat `target: auto` with a `provider` as cloud-only and do not load the local model.
 
+The primary example uses Xybrid Platform for the cloud leg. The device needs
+only `XYBRID_API_KEY`; the platform holds the upstream provider credentials.
+
 ```yaml
 stages:
   - id: llm
     model: functiongemma-270m-it      # local leg
     target: auto
-    provider: deepseek                # cloud leg
-    cloud_model: deepseek-flash
-    backend: direct                   # OpenAI-compatible call to api.deepseek.com with $DEEPSEEK_API_KEY
-    thinking: disabled                # DeepSeek only: answer tokens, no hidden reasoning
+    provider: openai                  # upstream provider behind Xybrid Platform
+    cloud_model: gpt-4o-mini
+    backend: gateway                  # Xybrid Platform, authenticated with XYBRID_API_KEY
     system_prompt: "You are a concise assistant."
     max_tokens: 128
 ```
 
-`backend: direct` with an OpenAI-compatible provider (`openai`, `deepseek`,
-`openrouter`, `custom`) sends the request straight to that provider's API;
-an explicit `gateway_url` / `api_key` pair overrides the defaults. `anthropic`
-uses the native direct client with the same `gateway_url` / `api_key` handling;
-`google` and `elevenlabs` have no direct client and are rejected at load.
-Credentials are scoped to the destination: the Xybrid platform key goes only
-to the configured platform gateway, a provider's key only to that provider's
-origin, and any other endpoint is anonymous unless `api_key` is set. A denied
-stage whose local model is missing fails on the device — it never falls
-through to the cloud.
+This is `crates/xybrid-cli/examples/hybrid-platform.yaml`. Its cloud model must
+be supported by the platform, with the corresponding provider configured there.
+A policy denial also forbids sending inference to Xybrid Platform. If the
+local model is unusable, the stage fails locally. An uncached local model may
+still need to be downloaded before inference.
 
 ## How `auto` decides
 
@@ -78,20 +75,38 @@ To force a route, set `target: device` or `target: cloud` on the stage in the pi
 
 ## Cloud execution
 
-Cloud stages stream responses over OpenAI-compatible SSE. There are two ways to reach a provider:
+Cloud stages use OpenAI-compatible chat requests; supported providers also offer SSE streaming. There are two ways to reach a provider:
 
 ### Through the Xybrid gateway (default)
 
-By default cloud stages route through the Xybrid gateway at `https://api.xybrid.dev/v1`. The gateway holds provider credentials for you, so devices never embed provider API keys.
+With `backend: gateway` (the default), cloud stages send requests to Xybrid
+Platform at `https://api.xybrid.dev/v1`. The platform authenticates your Xybrid
+key and calls the upstream using its own configured provider credentials.
 
-```dart
-// Use a custom or self-hosted gateway
-await Xybrid.init(gatewayUrl: 'https://my-gateway.example.com');
+```bash
+export XYBRID_API_KEY="<your-xybrid-api-key>"
+xybrid run -c crates/xybrid-cli/examples/hybrid-platform.yaml \
+  --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
+  --input-text "Summarise the plot of Dune in two sentences."
 ```
 
-### Directly to a provider
+For a staging or self-hosted platform, pass `--platform-url <base-url>` or set
+`XYBRID_PLATFORM_URL`; the CLI appends `/v1` for chat requests. The Xybrid key
+is scoped to the configured platform origin.
 
-Stages with a `provider` can call the provider API directly. API keys are resolved from environment variables:
+### Direct provider testing
+
+Use `crates/xybrid-cli/examples/hybrid-deepseek.yaml` to test a direct provider
+connection. It selects `backend: direct`, `provider: deepseek`,
+`cloud_model: deepseek-flash`, and `thinking: disabled`, and authenticates with
+`DEEPSEEK_API_KEY`. Running that example makes a real provider request when
+cloud is selected. Automated policy-routing tests use a loopback fake DeepSeek
+endpoint and dummy credentials.
+
+`backend: direct` with `openai`, `deepseek`, `openrouter`, or `custom` uses the
+provider's OpenAI-compatible API. `custom` requires an explicit `gateway_url`.
+Anthropic uses its native direct client; Google and ElevenLabs have no native
+direct client. Direct-provider keys are resolved from environment variables:
 
 | Provider | Environment variable |
 |----------|----------------------|
@@ -104,6 +119,10 @@ Stages with a `provider` can call the provider API directly. API keys are resolv
 | `custom` | `CUSTOM_API_KEY` |
 
 An explicit `api_key` field also accepts an environment reference (`$OPENAI_API_KEY`) — avoid hardcoding raw keys in pipeline files.
+
+Automatic provider credentials are scoped to that provider's origin. A custom
+OpenAI-compatible endpoint receives no automatic credential; a native Anthropic
+call to a custom endpoint requires an explicit `api_key`.
 
 ## Policies
 
@@ -168,17 +187,21 @@ The results show the decision and what actually ran:
 ```
   Routing          cloud
   Reason           [local] policy_route_cloud: policy rule 'offload_when_hot' prefers cloud: ... (confidence: 90%)
-  Backend          cloud:deepseek:gateway
+  Backend          cloud:openai:gateway
 ```
 
 `--dry-run --policy policy.yaml` decides the first stage the same way, at the
 current device snapshot, without running inference; later stages depend on
 upstream output and are reported as unknown. Ready-made bundles live in
-`crates/xybrid-cli/examples/policies/` next to `hybrid-deepseek.yaml`.
+`crates/xybrid-cli/examples/policies/` next to the primary `hybrid-platform.yaml`
+and the direct-provider `hybrid-deepseek.yaml` example.
 
 ## Fallback
 
-When a preferred route fails — a model fails to load, or the network drops mid-stream — the orchestrator can fall back to the other target. In the Flutter SDK, `runStreamingWithFallback` exposes this directly for LLM streaming.
+The CLI selects a route before executing each stage. SDK streaming fallback
+can restart in the cloud after a configured resource-driven local abort, when
+policy permits it. In the Flutter SDK, `runStreamingWithFallback` exposes this
+behavior for LLM streaming.
 
 Every routing decision is recorded in telemetry; inspect them with [`xybrid trace`](/docs/cli/reference/trace).
 

--- a/docs/content/docs/concepts/hybrid-execution.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.mdx
@@ -48,12 +48,14 @@ stages:
 
 `backend: direct` with an OpenAI-compatible provider (`openai`, `deepseek`,
 `openrouter`, `custom`) sends the request straight to that provider's API;
-an explicit `gateway_url` / `api_key` pair overrides the defaults. Credentials
-are scoped to the destination: the Xybrid platform key goes only to the
-configured platform gateway, a provider's key only to that provider's origin,
-and any other endpoint is anonymous unless `api_key` is set. A denied stage
-whose local model is missing fails on the device — it never falls through to
-the cloud.
+an explicit `gateway_url` / `api_key` pair overrides the defaults. `anthropic`
+uses the native direct client with the same `gateway_url` / `api_key` handling;
+`google` and `elevenlabs` have no direct client and are rejected at load.
+Credentials are scoped to the destination: the Xybrid platform key goes only
+to the configured platform gateway, a provider's key only to that provider's
+origin, and any other endpoint is anonymous unless `api_key` is set. A denied
+stage whose local model is missing fails on the device — it never falls
+through to the cloud.
 
 ## How `auto` decides
 

--- a/docs/content/docs/concepts/hybrid-execution.zh.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.zh.mdx
@@ -25,6 +25,32 @@ stages:
     provider: openai
 ```
 
+### 混合阶段
+
+同时声明 `target: auto` **和** `provider` 的阶段拥有两条分支：`model` 指定的本地模型，
+以及 `cloud_model`（默认与 `model` 相同）指定的云端模型。策略与设备状态为每次请求
+选择其中一条。共享选项（`system_prompt`、`temperature`、`max_tokens`、`top_p`）对
+实际运行的分支都生效。
+
+```yaml
+stages:
+  - id: llm
+    model: functiongemma-270m-it      # 本地分支
+    target: auto
+    provider: deepseek                # 云端分支
+    cloud_model: deepseek-flash
+    backend: direct                   # 直接以 OpenAI 兼容协议调用 api.deepseek.com，使用 $DEEPSEEK_API_KEY
+    thinking: disabled                # 仅 DeepSeek：只返回回答，不产生隐藏推理 token
+    system_prompt: "You are a concise assistant."
+    max_tokens: 128
+```
+
+对 OpenAI 兼容的提供方（`openai`、`deepseek`、`openrouter`、`custom`）使用
+`backend: direct` 会把请求直接发往该提供方的 API；显式的 `gateway_url` / `api_key`
+可以覆盖默认值。凭据按目标作用域解析：Xybrid 平台密钥只发往已配置的平台网关，
+提供方密钥只发往该提供方自己的源，其他端点除非设置了 `api_key`，否则匿名访问。
+被策略拒绝且本地模型缺失的阶段会在设备上失败，绝不会回落到云端。
+
 ## `auto` 如何决策
 
 对于 `auto` 阶段，编排器会综合权衡：
@@ -32,7 +58,7 @@ stages:
 - **模型可用性** — 模型是否已缓存到本地，或注册表中是否有适合当前平台的版本？
 - **设备能力** — CPU 特性、内存与加速器
 - **宿主信号** — 平台上报的电池电量与散热状态
-- **策略** — 用户定义的允许/拒绝路由规则
+- **策略** — 用户定义的规则，禁止或优先使用云端分支（见[策略](#策略)）
 
 预览路由决策而不实际执行：
 
@@ -73,30 +99,70 @@ await Xybrid.init(gatewayUrl: 'https://my-gateway.example.com');
 
 ## 策略
 
-策略是约束路由的 YAML 规则集。规则按顺序求值，首条匹配生效：
+策略是通过 `--policy` 传入的 YAML（或 JSON）规则集。它在每个阶段对真实输入和一次
+实时设备快照求值一次，并且**约束**路由而非仅仅建议：即使 YAML 写了 `target: cloud`、
+即使本地模型缺失（此时阶段在本地失败而不是泄露到云端）、即使设备压力本会触发卸载，
+一条拒绝规则都会把阶段留在设备上。
+
+规则按顺序求值，首条匹配生效。
+
+| 动作 | 效果 |
+|------|------|
+| `deny` | 禁止云端；阶段必须在设备上运行。 |
+| `route_cloud`（别名 `prefer_cloud`） | 在允许且本地模型存在时优先使用云端分支。 |
+| `redact` | 输入需要先脱敏才能离开设备。脱敏尚未实现，因此同样强制设备执行。 |
+| `allow` | 停止求值，按正常方式路由。 |
 
 ```yaml
 # policy.yaml
 version: "1.0.0"
 rules:
-  - id: "keep_audio_on_device"
-    expression: "input.kind == \"AudioRaw\""
-    action: "deny"          # 原始音频输入拒绝走该路由
+  - id: keep_audio_on_device
+    expression: 'input.kind == "audio"'
+    action: deny
+  - id: keep_secrets_on_device
+    expression: 'input.text matches "(?i)confidential|ssn|password"'
+    action: deny
+  - id: offload_when_hot
+    expression: 'metrics.thermal_state == "hot"'
+    action: route_cloud
 
-  - id: "avoid_slow_networks"
-    expression: "metrics.network_rtt > 300"
-    action: "deny"          # 网络慢时不走云端
-
-  - id: "allow_all"
-    expression: "true"
-    action: "allow"
+# 简写列表追加在 `rules` 之后，先拒绝规则：
+deny_cloud_if:
+  - "input.text_len > 4000"
+route_cloud_if:
+  - "metrics.battery_level < 25"
 ```
+
+表达式形如 `<操作数> <运算符> <值>`，或单独的 `true` / `false`：
+
+| 操作数 | 运算符 | 值 |
+|--------|--------|----|
+| `input.kind` | `==` `!=` | `"audio"` `"text"` `"embedding"` `"image"` `"multipart"` |
+| `input.text` | `contains` `matches` `==` `!=` | 带引号的字面量（`matches` 接受正则） |
+| `input.text_len` | `==` `!=` `<` `<=` `>` `>=` | 字符数 |
+| `metrics.battery_level`、`metrics.cpu_pct` | `==` `!=` `<` `<=` `>` `>=` | 0–100 的数字 |
+| `metrics.memory_pressure` | `==` `!=` | `"unknown"` `"normal"` `"warn"` `"critical"` |
+| `metrics.thermal_state` | `==` `!=` | `"normal"` `"warm"` `"hot"` `"critical"` |
+
+文本规则只检查输入文本——不包括系统提示词或元数据——且对非文本输入永不匹配。
+表格之外的任何写法都会在加载 Bundle 时被拒绝，拼写错误不会悄悄让规则失效。
 
 ```bash
-xybrid run --config pipeline.yaml --input-audio q.wav --policy policy.yaml
+xybrid run --config pipeline.yaml --input-text "..." --policy policy.yaml
 ```
 
-表达式可以引用输入 Envelope（`input.kind`）和实时设备指标（`metrics.network_rtt`）。
+结果会同时显示决策和实际运行的后端：
+
+```
+  Routing          cloud
+  Reason           [local] policy_route_cloud: policy rule 'offload_when_hot' prefers cloud: ... (confidence: 90%)
+  Backend          cloud:deepseek:gateway
+```
+
+`--dry-run --policy policy.yaml` 以同样方式在当前设备快照下决策第一个阶段而不执行推理；
+后续阶段依赖上游输出，因此标记为未知。现成的策略文件位于
+`crates/xybrid-cli/examples/policies/`，与 `hybrid-deepseek.yaml` 放在一起。
 
 ## 回退
 

--- a/docs/content/docs/concepts/hybrid-execution.zh.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.zh.mdx
@@ -34,24 +34,24 @@ stages:
 
 混合阶段目前由 `xybrid run` 支持。Flutter 与 Rust SDK 的流水线 API 会把 `target: auto` 搭配 `provider` 视为纯云端阶段，不会加载本地模型。
 
+主示例通过 Xybrid Platform 执行云端分支。设备端只需要 `XYBRID_API_KEY`，
+上游提供商的凭据由平台保管。
+
 ```yaml
 stages:
   - id: llm
     model: functiongemma-270m-it      # 本地分支
     target: auto
-    provider: deepseek                # 云端分支
-    cloud_model: deepseek-flash
-    backend: direct                   # 直接以 OpenAI 兼容协议调用 api.deepseek.com，使用 $DEEPSEEK_API_KEY
-    thinking: disabled                # 仅 DeepSeek：只返回回答，不产生隐藏推理 token
+    provider: openai                  # Xybrid Platform 后面的上游提供商
+    cloud_model: gpt-4o-mini
+    backend: gateway                  # 通过 XYBRID_API_KEY 访问 Xybrid Platform
     system_prompt: "You are a concise assistant."
     max_tokens: 128
 ```
 
-对 OpenAI 兼容的提供方（`openai`、`deepseek`、`openrouter`、`custom`）使用
-`backend: direct` 会把请求直接发往该提供方的 API；显式的 `gateway_url` / `api_key`
-可以覆盖默认值。凭据按目标作用域解析：Xybrid 平台密钥只发往已配置的平台网关，
-提供方密钥只发往该提供方自己的源，其他端点除非设置了 `api_key`，否则匿名访问。
-被策略拒绝且本地模型缺失的阶段会在设备上失败，绝不会回落到云端。
+该示例位于 `crates/xybrid-cli/examples/hybrid-platform.yaml`。云端模型必须受平台支持，
+且平台需要配置对应的提供商。策略拒绝云端时，也禁止向 Xybrid Platform 发送推理请求。
+如果本地模型不可用，阶段会在本地失败。尚未缓存的本地模型仍可能需要在推理前下载。
 
 ## `auto` 如何决策
 
@@ -72,20 +72,34 @@ xybrid run --config pipeline.yaml --input-audio q.wav --dry-run
 
 ## 云端执行
 
-云端阶段通过 OpenAI 兼容的 SSE 流式返回响应。访问提供商有两种方式：
+云端阶段使用 OpenAI 兼容的聊天请求；受支持的提供商也提供 SSE 流式响应。访问提供商有两种方式：
 
 ### 通过 Xybrid 网关（默认）
 
-默认情况下，云端阶段通过 Xybrid 网关（`https://api.xybrid.dev/v1`）路由。网关代为保管提供商凭证，设备端无需内嵌任何提供商 API Key。
+使用 `backend: gateway`（默认值）时，云端阶段向 Xybrid Platform 的
+`https://api.xybrid.dev/v1` 发送请求。平台验证 Xybrid 密钥，并使用平台配置的提供商凭据
+调用上游。
 
-```dart
-// 使用自定义或自托管网关
-await Xybrid.init(gatewayUrl: 'https://my-gateway.example.com');
+```bash
+export XYBRID_API_KEY="<your-xybrid-api-key>"
+xybrid run -c crates/xybrid-cli/examples/hybrid-platform.yaml \
+  --policy crates/xybrid-cli/examples/policies/prefer-cloud.yaml \
+  --input-text "Summarise the plot of Dune in two sentences."
 ```
 
-### 直连提供商
+对于预发布或自托管平台，可传入 `--platform-url <base-url>` 或设置
+`XYBRID_PLATFORM_URL`；CLI 会为聊天请求追加 `/v1`。Xybrid 密钥仅发送到所配置的平台源。
 
-带有 `provider` 的阶段可以直接调用提供商 API。API Key 从环境变量解析：
+### 直连提供商测试
+
+使用 `crates/xybrid-cli/examples/hybrid-deepseek.yaml` 测试提供商直连。
+它设置 `backend: direct`、`provider: deepseek`、`cloud_model: deepseek-flash`
+和 `thinking: disabled`，通过 `DEEPSEEK_API_KEY` 认证。运行该示例并选择云端时会发出
+真实的提供商请求。自动化策略路由测试使用回环地址上的模拟 DeepSeek 端点和测试凭据。
+
+对 `openai`、`deepseek`、`openrouter` 或 `custom` 使用 `backend: direct` 会调用提供商的
+OpenAI 兼容 API。`custom` 必须显式设置 `gateway_url`。Anthropic 使用原生直连客户端；
+Google 和 ElevenLabs 没有原生直连客户端。直连凭据从环境变量解析：
 
 | 提供商 | 环境变量 |
 |--------|----------|
@@ -98,6 +112,9 @@ await Xybrid.init(gatewayUrl: 'https://my-gateway.example.com');
 | `custom` | `CUSTOM_API_KEY` |
 
 显式的 `api_key` 字段也接受环境变量引用（`$OPENAI_API_KEY`）— 避免在流水线文件中硬编码明文密钥。
+
+自动解析的提供商凭据只发送到该提供商自己的源。自定义 OpenAI 兼容端点不会自动获得凭据；
+Anthropic 原生客户端访问自定义端点时必须显式设置 `api_key`。
 
 ## 策略
 
@@ -159,16 +176,19 @@ xybrid run --config pipeline.yaml --input-text "..." --policy policy.yaml
 ```
   Routing          cloud
   Reason           [local] policy_route_cloud: policy rule 'offload_when_hot' prefers cloud: ... (confidence: 90%)
-  Backend          cloud:deepseek:gateway
+  Backend          cloud:openai:gateway
 ```
 
 `--dry-run --policy policy.yaml` 以同样方式在当前设备快照下决策第一个阶段而不执行推理；
 后续阶段依赖上游输出，因此标记为未知。现成的策略文件位于
-`crates/xybrid-cli/examples/policies/`，与 `hybrid-deepseek.yaml` 放在一起。
+`crates/xybrid-cli/examples/policies/`，与主示例 `hybrid-platform.yaml` 和直连提供商示例
+`hybrid-deepseek.yaml` 放在一起。
 
 ## 回退
 
-当首选路由失败时 — 模型加载失败，或流式过程中断网 — 编排器可以回退到另一个目标。在 Flutter SDK 中，`runStreamingWithFallback` 为 LLM 流式输出直接暴露了这一能力。
+CLI 在执行每个阶段之前选择路由。SDK 流式回退可以在已配置的资源信号导致本地执行中止后，
+在策略允许的情况下于云端重新开始。在 Flutter SDK 中，`runStreamingWithFallback`
+为 LLM 流式输出提供这一行为。
 
 每个路由决策都会记录到遥测中；使用 [`xybrid trace`](/docs/cli/reference/trace) 查看。
 

--- a/docs/content/docs/concepts/hybrid-execution.zh.mdx
+++ b/docs/content/docs/concepts/hybrid-execution.zh.mdx
@@ -32,6 +32,8 @@ stages:
 选择其中一条。共享选项（`system_prompt`、`temperature`、`max_tokens`、`top_p`）对
 实际运行的分支都生效。
 
+混合阶段目前由 `xybrid run` 支持。Flutter 与 Rust SDK 的流水线 API 会把 `target: auto` 搭配 `provider` 视为纯云端阶段，不会加载本地模型。
+
 ```yaml
 stages:
   - id: llm

--- a/docs/content/docs/concepts/pipelines.mdx
+++ b/docs/content/docs/concepts/pipelines.mdx
@@ -73,6 +73,10 @@ stages:
 | `execution_provider` | ONNX Runtime override: `cpu`, `coreml`, `coreml-ane`, `coreml-gpu` (auto-selected if unset) |
 | *(any other key)* | Passed to the stage as an option — `system_prompt`, `max_tokens`, `temperature`, `top_p` apply to both legs of a hybrid stage |
 
+<Callout type="info">
+Hybrid stages (`target: auto` with a `provider`) are currently supported by `xybrid run`. The Flutter and Rust SDK pipeline APIs treat this combination as cloud-only and do not load its local model.
+</Callout>
+
 ## Mixing device and cloud stages
 
 A pipeline can route each stage independently — keep audio on-device for privacy and latency, and burst to the cloud for a bigger model:

--- a/docs/content/docs/concepts/pipelines.mdx
+++ b/docs/content/docs/concepts/pipelines.mdx
@@ -67,7 +67,7 @@ stages:
 | `target` | Where to run: `device`, `cloud`, or `auto` (default) — see [Hybrid Execution](/docs/concepts/hybrid-execution). `auto` **with** a `provider` is a hybrid stage: local model plus a cloud leg, chosen per request by policy and device state |
 | `provider` | Cloud provider for cloud or hybrid stages: `openai`, `anthropic`, `google`, `deepseek`, `elevenlabs`, `openrouter`, `custom` |
 | `cloud_model` | Model name sent to the provider on the cloud leg of a hybrid stage (defaults to `model`) |
-| `backend` | `gateway` (default) or `direct`; `direct` with an OpenAI-compatible provider calls the provider's API with `$<PROVIDER>_API_KEY` |
+| `backend` | `gateway` (default) uses Xybrid Platform with `XYBRID_API_KEY`; `direct` with an OpenAI-compatible provider calls the provider's API with `$<PROVIDER>_API_KEY` |
 | `gateway_url`, `api_key` | Explicit endpoint and credential for the cloud leg (`api_key` accepts `$ENV_VAR`); credentials are never inherited across origins |
 | `thinking` | DeepSeek only: `enabled` or `disabled` (DeepSeek reasons by default; `disabled` keeps `max_tokens` for the answer) |
 | `execution_provider` | ONNX Runtime override: `cpu`, `coreml`, `coreml-ane`, `coreml-gpu` (auto-selected if unset) |
@@ -76,6 +76,9 @@ stages:
 <Callout type="info">
 Hybrid stages (`target: auto` with a `provider`) are currently supported by `xybrid run`. The Flutter and Rust SDK pipeline APIs treat this combination as cloud-only and do not load its local model.
 </Callout>
+
+Use `crates/xybrid-cli/examples/hybrid-platform.yaml` for the primary platform
+integration. `hybrid-deepseek.yaml` is the separate direct-provider testing example.
 
 ## Mixing device and cloud stages
 

--- a/docs/content/docs/concepts/pipelines.mdx
+++ b/docs/content/docs/concepts/pipelines.mdx
@@ -64,10 +64,14 @@ stages:
 | `id` | Stage identifier (defaults to the model ID) |
 | `model` | Model ID from the registry, or a provider model name for cloud stages |
 | `version` | Model version (e.g. `"1.0"`) |
-| `target` | Where to run: `device`, `cloud`, or `auto` (default) — see [Hybrid Execution](/docs/concepts/hybrid-execution) |
-| `provider` | Cloud provider for cloud stages: `openai`, `anthropic`, `google`, `deepseek`, `elevenlabs`, `openrouter`, `custom` |
+| `target` | Where to run: `device`, `cloud`, or `auto` (default) — see [Hybrid Execution](/docs/concepts/hybrid-execution). `auto` **with** a `provider` is a hybrid stage: local model plus a cloud leg, chosen per request by policy and device state |
+| `provider` | Cloud provider for cloud or hybrid stages: `openai`, `anthropic`, `google`, `deepseek`, `elevenlabs`, `openrouter`, `custom` |
+| `cloud_model` | Model name sent to the provider on the cloud leg of a hybrid stage (defaults to `model`) |
+| `backend` | `gateway` (default) or `direct`; `direct` with an OpenAI-compatible provider calls the provider's API with `$<PROVIDER>_API_KEY` |
+| `gateway_url`, `api_key` | Explicit endpoint and credential for the cloud leg (`api_key` accepts `$ENV_VAR`); credentials are never inherited across origins |
+| `thinking` | DeepSeek only: `enabled` or `disabled` (DeepSeek reasons by default; `disabled` keeps `max_tokens` for the answer) |
 | `execution_provider` | ONNX Runtime override: `cpu`, `coreml`, `coreml-ane`, `coreml-gpu` (auto-selected if unset) |
-| *(any other key)* | Passed to the stage as an option — common ones: `system_prompt`, `max_tokens`, `temperature` |
+| *(any other key)* | Passed to the stage as an option — `system_prompt`, `max_tokens`, `temperature`, `top_p` apply to both legs of a hybrid stage |
 
 ## Mixing device and cloud stages
 

--- a/docs/content/docs/concepts/pipelines.zh.mdx
+++ b/docs/content/docs/concepts/pipelines.zh.mdx
@@ -67,7 +67,7 @@ stages:
 | `target` | 运行位置：`device`、`cloud` 或 `auto`（默认）— 参见[混合执行](/docs/concepts/hybrid-execution)。`auto` **同时**声明 `provider` 即为混合阶段：本地模型加一条云端分支，由策略与设备状态按请求选择 |
 | `provider` | 云端或混合阶段的提供商：`openai`、`anthropic`、`google`、`deepseek`、`elevenlabs`、`openrouter`、`custom` |
 | `cloud_model` | 混合阶段云端分支发送给提供商的模型名（默认与 `model` 相同） |
-| `backend` | `gateway`（默认）或 `direct`；对 OpenAI 兼容提供商使用 `direct` 会以 `$<PROVIDER>_API_KEY` 直接调用其 API |
+| `backend` | `gateway`（默认）通过 `XYBRID_API_KEY` 访问 Xybrid Platform；对 OpenAI 兼容提供商使用 `direct` 会以 `$<PROVIDER>_API_KEY` 直接调用其 API |
 | `gateway_url`、`api_key` | 云端分支的显式端点与凭据（`api_key` 接受 `$ENV_VAR`）；凭据绝不会跨源继承 |
 | `thinking` | 仅 DeepSeek：`enabled` 或 `disabled`（DeepSeek 默认开启推理；`disabled` 把 `max_tokens` 留给回答） |
 | `execution_provider` | ONNX Runtime 覆盖：`cpu`、`coreml`、`coreml-ane`、`coreml-gpu`（不设置则自动选择） |
@@ -76,6 +76,9 @@ stages:
 <Callout type="info">
 混合阶段（`target: auto` 搭配 `provider`）目前由 `xybrid run` 支持。Flutter 与 Rust SDK 的流水线 API 会把该组合视为纯云端阶段，不会加载其本地模型。
 </Callout>
+
+主平台集成示例为 `crates/xybrid-cli/examples/hybrid-platform.yaml`；
+`hybrid-deepseek.yaml` 是独立的直连提供商测试示例。
 
 ## 混合设备端与云端阶段
 

--- a/docs/content/docs/concepts/pipelines.zh.mdx
+++ b/docs/content/docs/concepts/pipelines.zh.mdx
@@ -64,8 +64,12 @@ stages:
 | `id` | 阶段标识符（默认为模型 ID） |
 | `model` | 注册表中的模型 ID，云端阶段则为提供商的模型名 |
 | `version` | 模型版本（如 `"1.0"`） |
-| `target` | 运行位置：`device`、`cloud` 或 `auto`（默认）— 参见[混合执行](/docs/concepts/hybrid-execution) |
-| `provider` | 云端阶段的提供商：`openai`、`anthropic`、`google`、`deepseek`、`elevenlabs`、`openrouter`、`custom` |
+| `target` | 运行位置：`device`、`cloud` 或 `auto`（默认）— 参见[混合执行](/docs/concepts/hybrid-execution)。`auto` **同时**声明 `provider` 即为混合阶段：本地模型加一条云端分支，由策略与设备状态按请求选择 |
+| `provider` | 云端或混合阶段的提供商：`openai`、`anthropic`、`google`、`deepseek`、`elevenlabs`、`openrouter`、`custom` |
+| `cloud_model` | 混合阶段云端分支发送给提供商的模型名（默认与 `model` 相同） |
+| `backend` | `gateway`（默认）或 `direct`；对 OpenAI 兼容提供商使用 `direct` 会以 `$<PROVIDER>_API_KEY` 直接调用其 API |
+| `gateway_url`、`api_key` | 云端分支的显式端点与凭据（`api_key` 接受 `$ENV_VAR`）；凭据绝不会跨源继承 |
+| `thinking` | 仅 DeepSeek：`enabled` 或 `disabled`（DeepSeek 默认开启推理；`disabled` 把 `max_tokens` 留给回答） |
 | `execution_provider` | ONNX Runtime 覆盖：`cpu`、`coreml`、`coreml-ane`、`coreml-gpu`（不设置则自动选择） |
 | *（其他任意键）* | 作为阶段选项传递 — 常用：`system_prompt`、`max_tokens`、`temperature` |
 

--- a/docs/content/docs/concepts/pipelines.zh.mdx
+++ b/docs/content/docs/concepts/pipelines.zh.mdx
@@ -73,6 +73,10 @@ stages:
 | `execution_provider` | ONNX Runtime 覆盖：`cpu`、`coreml`、`coreml-ane`、`coreml-gpu`（不设置则自动选择） |
 | *（其他任意键）* | 作为阶段选项传递 — 常用：`system_prompt`、`max_tokens`、`temperature` |
 
+<Callout type="info">
+混合阶段（`target: auto` 搭配 `provider`）目前由 `xybrid run` 支持。Flutter 与 Rust SDK 的流水线 API 会把该组合视为纯云端阶段，不会加载其本地模型。
+</Callout>
+
 ## 混合设备端与云端阶段
 
 流水线可以为每个阶段独立选择路由 — 音频留在设备端以保证隐私和延迟，需要更大模型时切到云端：

--- a/integration-tests/tests/system_validation.rs
+++ b/integration-tests/tests/system_validation.rs
@@ -13,13 +13,19 @@ use std::process::Command;
 use tempfile::TempDir;
 use xybrid_sdk::run_pipeline;
 
-/// Test 2: xybrid_sdk::run_pipeline() executes successfully and returns 3 stage results
+/// Test 2: `xybrid_sdk::run_pipeline()` fails honestly for cloud-routed stages
+/// that name no provider.
+///
+/// Legacy configs list bare model ids with no resolved local bundle, so every
+/// stage routes to cloud. The bootstrapped orchestrator registers the real
+/// OpenAI-compatible cloud adapter, which rejects a stage without a provider
+/// before any HTTP request — it no longer returns synthetic text after a fake
+/// delay. This test pins that contract without touching the network.
 #[test]
 fn test_sdk_pipeline_execution() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🚀 Test 2: SDK pipeline execution");
+    println!("🚀 Test 2: SDK pipeline execution (provider-less cloud stage fails closed)");
     println!("{}", "=".repeat(60));
 
-    // Create a test pipeline config
     let temp_dir = TempDir::new()?;
     let config_path = temp_dir.path().join("hiiipe_test.yml");
 
@@ -34,6 +40,7 @@ stages:
 input:
   kind: "Text"
 
+# Legacy fields: still required by the parser, ignored at runtime.
 metrics:
   network_rtt: 100
   battery: 80
@@ -48,41 +55,22 @@ availability:
     fs::write(&config_path, config_content)?;
     println!("   Created test config: {}", config_path.display());
 
-    // Execute the pipeline
-    println!("   Executing pipeline...");
-    let result = run_pipeline(config_path.to_str().unwrap())?;
-
-    println!("   Pipeline name: {:?}", result.name);
-    println!("   Total latency: {}ms", result.total_latency_ms);
-    println!("   Final output: {}", result.final_output);
-    println!("   Stage count: {}", result.stages.len());
-
-    // Assertions
-    assert_eq!(
-        result.stages.len(),
-        3,
-        "Pipeline should return exactly 3 stage results"
-    );
-
-    // Verify each stage has valid data
-    for (i, stage) in result.stages.iter().enumerate() {
-        println!(
-            "   Stage {}: {} → {} ({}ms)",
-            i + 1,
-            stage.name,
-            stage.target,
-            stage.latency_ms
-        );
-        assert!(!stage.name.is_empty(), "Stage name should not be empty");
-        assert!(!stage.target.is_empty(), "Stage target should not be empty");
-    }
+    let Err(err) = run_pipeline(config_path.to_str().unwrap()) else {
+        panic!("a cloud-routed stage without a provider must not succeed with fake output");
+    };
+    let message = err.to_string();
+    println!("   Pipeline error (expected): {message}");
 
     assert!(
-        !result.final_output.is_empty(),
-        "Final output should not be empty"
+        message.to_lowercase().contains("provider"),
+        "error should explain that the cloud stage has no provider, got: {message}"
+    );
+    assert!(
+        !message.contains("cloud-output"),
+        "the fake cloud adapter output must be gone: {message}"
     );
 
-    println!("   ✅ SDK pipeline execution successful");
+    println!("   ✅ SDK pipeline fails closed without a provider");
     println!();
     Ok(())
 }
@@ -102,7 +90,7 @@ fn test_cli_policy_loading() -> Result<(), Box<dyn std::error::Error>> {
 version: "0.1.0"
 rules:
   - id: "test_rule"
-    expression: "input.kind == \"SensitiveData\""
+    expression: "input.kind == \"audio\""
     action: "deny"
 signature: "test-signature"
 "#;


### PR DESCRIPTION
## Summary

Make pipeline policies control where inference actually runs. Previously,
`xybrid run --policy` loaded rules into an engine that routing did not consult,
and executor selection could disagree with the reported routing decision.

A hybrid CLI stage now declares both a local model and a cloud model. For
example, the same stage can run FunctionGemma on the device under a local-only
policy or use Xybrid Platform under a prefer-cloud policy.

Xybrid Platform is the primary integration: the device uses `XYBRID_API_KEY`,
while the platform holds upstream provider credentials. A separate direct
DeepSeek example supports provider testing.

## What changes

- **Enforce policy through dispatch.** Evaluate each stage against its actual
  input and one device snapshot. Cloud denial takes precedence over explicit
  targets, device stress, history, and remote advice. If local execution is
  unavailable, a denied stage fails locally.
- **Compile and validate policy rules at load time.** Support content and
  device conditions, cloud preferences, and denial. Invalid reloads preserve
  the previous policy; unsupported required transformations prevent cloud
  dispatch.
- **Execute the selected route.** Replace the placeholder cloud adapter with
  real transport and dispatch according to the resolved target. Extract
  downloaded models before treating them as locally available.
- **Keep credentials scoped to their destination.** Resolve platform,
  provider, and explicit credentials consistently, including native Anthropic
  requests to custom endpoints.
- **Preserve generation options.** Apply shared options to local and cloud
  execution, preserve YAML numeric types, and prepare SDK streaming inputs
  consistently with batch execution. Add typed DeepSeek thinking options.
- **Make CLI output explain execution.** Show Routing, Reason, and Backend.
  Dry-run evaluates the first stage without inference and reports dependent
  downstream stages as UNKNOWN.

Includes platform and direct-provider examples, policy bundles, English/Chinese
documentation, and regression coverage for stage-event ordering.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --features ort-download`
- Four CLI E2E tests covering real GGUF inference, loopback DeepSeek requests,
  policy-aware dry-run, and cold-cache download/extraction.
- Three real-GGUF SDK streaming tests and 60 SDK pipeline unit tests.
- The actual platform example against a loopback server: verified the Xybrid
  bearer credential, model, request options, and returned output; local-only
  execution ran the GGUF without an additional platform inference request.

Model-dependent suites ran with `llm-llamacpp`, `XYBRID_REQUIRE_MODELS=1`,
and required test-name checks. The new CI workflow applies those same guards
to prevent missing features or fixtures from producing an empty success.

Cloud E2E fixtures use dummy credentials and local servers; they do not
validate live provider authentication, billing, or TLS. The documentation
site build was not run because its dependencies are not installed locally.

## Compatibility and scope

- Hybrid stages are currently a `xybrid run` feature. Rust and Flutter SDK
  pipeline APIs still treat `target: auto` with a provider as cloud-only.
- CLI routing happens before execution; this does not introduce automatic
  cloud retries for every local failure.
- Core API changes include orchestrator constructors, typed policy actions,
  and additional policy/completion fields. See the changelog for migration
  details.
- The primary example uses `gpt-4o-mini`, which the platform model router
  recognizes. This PR does not change the xybrid-platform backend.
- Real-model CLI E2E coverage is Unix-gated; live multi-stage hybrid execution
  and real-provider SSE remain outside this coverage.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Refactor

## Checklist

- [x] Tests pass locally
- [x] Code follows project style
- [x] Documentation updated
- [x] Breaking changes documented
